### PR TITLE
Remove `pgp-version` from snooty.toml

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -2,4 +2,3 @@ name = "realm"
 
 [constants]
 package-name-org = "docs-realm"
-pgp-version = "{+version+}"


### PR DESCRIPTION
Currently `pgp-version` references the `version` variable that was removed in 0db23f4ac6c8dcbe0f664689a4f91d4b3b682861