### PR TITLE
(DOCSP-7491, 7072): Realm by Example: Observe and Kotlin examples

### DIFF
--- a/source/by-example/observe-changes.txt
+++ b/source/by-example/observe-changes.txt
@@ -1,0 +1,31 @@
+===============
+Observe Changes
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+The following examples demonstrate how to use Realm's
+:doc:`notification system </crud/notifications>` to create
+reactive apps.
+
+Observe Changes on a Realm
+==========================
+
+.. include:: /examples/Notifications/RealmNotification.rst
+
+Observe Changes on a Collection
+===============================
+
+.. include:: /examples/Notifications/CollectionNotification.rst
+
+Observe Changes on an Object
+============================
+
+.. include:: /examples/Notifications/ObjectNotification.rst
+

--- a/source/crud/notifications.txt
+++ b/source/crud/notifications.txt
@@ -55,13 +55,6 @@ change but do not care to know specifically what changed.
 
 .. example::
 
-   Suppose you are writing a real-time collaborative app. To
-   give the sense that your app is buzzing with
-   collaborative activity, you want to have an indicator
-   that lights up when any change is made. In that case, a
-   realm notification handler would be a great way to drive
-   the code that controls the indicator.
-   
    .. include:: /examples/Notifications/RealmNotification.rst
 
 .. _collection-notifications:
@@ -100,9 +93,6 @@ list or other view that represents the collection in the UI.
 
 .. example::
 
-   The following code shows how to observe a collection for
-   changes in order to update the UI.
-
    .. include:: /examples/Notifications/CollectionNotification.rst
 
 .. _object-notifications:
@@ -120,9 +110,5 @@ The handler receives information about what fields changed
 and whether the object was deleted.
 
 .. example::
-
-   The following code shows how to open a default realm,
-   create a new instance of a class, and observe that
-   instance for changes.
 
    .. include:: /examples/Notifications/ObjectNotification.rst

--- a/source/examples/Notifications/CollectionNotification.kt
+++ b/source/examples/Notifications/CollectionNotification.kt
@@ -1,3 +1,5 @@
+import io.realm.kotlin.*
+
 // Implement a RecycleView Adapter that observes a collection for changes.
 // This is just an example. Prefer RealmRecyclerViewAdapter for convenience.
 class DogsRecyclerAdapter(

--- a/source/examples/Notifications/CollectionNotification.kt
+++ b/source/examples/Notifications/CollectionNotification.kt
@@ -1,0 +1,38 @@
+// Implement a RecycleView Adapter that observes a collection for changes.
+// This is just an example. Prefer RealmRecyclerViewAdapter for convenience.
+class DogsRecyclerAdapter(
+    realm: Realm // The constructor takes an open Realm.
+): RecyclerView.Adapter<*>() {
+    private var dogs: RealmResults<Dog>
+
+    init {
+        // Set up the collection notification handler.
+        val changeListener = OrderedRealmCollectionChangeListener<RealmResults<Dog>> { dogs, changeSet ->
+            // `null`  means the async query returns the first time.
+            if (changeSet == null) {
+                notifyDataSetChanged()
+                return@OrderedRealmCollectionChangeListener
+            }
+            // For deletions, the adapter has to be notified in reverse order.
+            val deletions = changeSet.getDeletionRanges()
+            for (i in deletions.indices.reversed()) {
+                val range = deletions[i]
+                notifyItemRangeRemoved(range.startIndex, range.length)
+            }
+
+            val insertions = changeSet.getInsertionRanges()
+            for (range in insertions) {
+                notifyItemRangeInserted(range.startIndex, range.length)
+            }
+
+            val modifications = changeSet.getChangeRanges()
+            for (range in modifications) {
+                notifyItemRangeChanged(range.startIndex, range.length)
+            }
+        }
+        dogs = realm.where<Dog>().findAll()
+        // Observe collection notifications.
+        dogs.addChangeListener(changeListener)
+    }
+    // ...
+}

--- a/source/examples/Notifications/CollectionNotification.rst
+++ b/source/examples/Notifications/CollectionNotification.rst
@@ -36,7 +36,7 @@ changes in order to update the UI.
 
       .. literalinclude:: /examples/Notifications/CollectionNotification.kt
          :language: kotlin
-         :emphasize-lines: 35
+         :emphasize-lines: 37
 
    .. tab::
       :tabid: objective-c

--- a/source/examples/Notifications/CollectionNotification.rst
+++ b/source/examples/Notifications/CollectionNotification.rst
@@ -1,3 +1,6 @@
+The following code shows how to observe a collection for
+changes in order to update the UI.
+
 .. tabs-realm-languages::
 
    .. tab::
@@ -27,6 +30,13 @@
       .. literalinclude:: /examples/Notifications/CollectionNotification.java
          :language: java
          :emphasize-lines: 34
+
+   .. tab::
+      :tabid: kotlin
+
+      .. literalinclude:: /examples/Notifications/CollectionNotification.kt
+         :language: kotlin
+         :emphasize-lines: 35
 
    .. tab::
       :tabid: objective-c

--- a/source/examples/Notifications/ObjectNotification.kt
+++ b/source/examples/Notifications/ObjectNotification.kt
@@ -1,0 +1,47 @@
+// Dog.kt
+open class Dog(
+    var name: String = ""
+): RealmObject()
+
+// MyActivity.kt
+class MyActivity : Activity() {
+    private lateinit var realm: Realm
+    private lateinit var listener: RealmObjectChangeListener<Dog>
+    private lateinit var dog: Dog
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        realm = Realm.getDefaultInstance()
+        // Create a dog in the realm.
+        realm.executeTransaction { r ->
+            dog = realm.createObject(Dog::class.java)
+            dog.name = "Max"
+        }
+
+        // Set up the listener.
+        listener = RealmObjectChangeListener { dog, changeSet ->
+            if (changeSet.isDeleted()) {
+                // Dog was deleted
+                return@RealmObjectChangeListener
+            }
+
+            for (fieldName in changeSet.getChangedFields()) {
+                // "Field '$fieldName' changed."
+            }
+        }
+
+        // Observe object notifications.
+        dog.addChangeListener(listener)
+
+        // Update the dog to see the effect.
+        realm.executeTransaction { r ->
+            dog.name = "Wolfie" // -> "Field 'name' was changed."
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Close the Realm instance.
+        realm.close()
+    }
+}

--- a/source/examples/Notifications/ObjectNotification.kt
+++ b/source/examples/Notifications/ObjectNotification.kt
@@ -13,7 +13,7 @@ class MyActivity : Activity() {
         super.onCreate(savedInstanceState)
         realm = Realm.getDefaultInstance()
         // Create a dog in the realm.
-        realm.executeTransaction { r ->
+        realm.executeTransaction { realm ->
             dog = realm.createObject(Dog::class.java)
             dog.name = "Max"
         }
@@ -34,7 +34,7 @@ class MyActivity : Activity() {
         dog.addChangeListener(listener)
 
         // Update the dog to see the effect.
-        realm.executeTransaction { r ->
+        realm.executeTransaction { realm ->
             dog.name = "Wolfie" // -> "Field 'name' was changed."
         }
     }

--- a/source/examples/Notifications/ObjectNotification.rst
+++ b/source/examples/Notifications/ObjectNotification.rst
@@ -1,3 +1,7 @@
+The following code shows how to open a default realm, create
+a new instance of a class, and observe that instance for
+changes.
+
 .. tabs-realm-languages::
 
    .. tab::
@@ -27,6 +31,13 @@
       .. literalinclude:: /examples/Notifications/ObjectNotification.java
          :language: java
          :emphasize-lines: 38
+
+   .. tab::
+      :tabid: kotlin
+
+      .. literalinclude:: /examples/Notifications/ObjectNotification.kt
+         :language: kotlin
+         :emphasize-lines: 34
 
    .. tab::
       :tabid: objective-c

--- a/source/examples/Notifications/RealmNotification.kt
+++ b/source/examples/Notifications/RealmNotification.kt
@@ -1,0 +1,22 @@
+class MyActivity : Activity() {
+    private lateinit var realm: Realm
+    private lateinit var realmListener: RealmChangeListener<Realm>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        realm = Realm.getDefaultInstance()
+        realmListener = RealmChangeListener {
+            // ... do something with the updates (UI, etc.) ...
+        }
+        // Observe realm notifications.
+        realm.addChangeListener(realmListener)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Remove the listener.
+        realm.removeChangeListener(realmListener)
+        // Close the Realm instance.
+        realm.close()
+    }
+}

--- a/source/examples/Notifications/RealmNotification.m
+++ b/source/examples/Notifications/RealmNotification.m
@@ -1,7 +1,8 @@
-// Observe realm notifications.
+// Observe realm notifications. Keep a strong reference to the notification token
+// or the observation will stop.
 token = [realm addNotificationBlock:^(NSString *notification, RLMRealm *realm) {
-    // update UI...
+    // Update UI...
 }];
 
-// later
+// Later, explicitly stop observing.
 [token invalidate];

--- a/source/examples/Notifications/RealmNotification.rst
+++ b/source/examples/Notifications/RealmNotification.rst
@@ -1,3 +1,10 @@
+Suppose you are writing a real-time collaborative app. To
+give the sense that your app is buzzing with collaborative
+activity, you want to have an indicator that lights up when
+any change is made. In that case, a realm notification
+handler would be a great way to drive the code that controls
+the indicator.
+
 .. tabs-realm-languages::
 
    .. tab::
@@ -27,6 +34,13 @@
       .. literalinclude:: /examples/Notifications/RealmNotification.java
          :language: java
          :emphasize-lines: 16
+
+   .. tab::
+      :tabid: kotlin
+
+      .. literalinclude:: /examples/Notifications/RealmNotification.kt
+         :language: kotlin
+         :emphasize-lines: 12
 
    .. tab::
       :tabid: objective-c

--- a/source/examples/Notifications/RealmNotification.swift
+++ b/source/examples/Notifications/RealmNotification.swift
@@ -7,5 +7,5 @@ let token = realm.observe { notification, realm in
     viewController.updateUI()
 }
 
-// later
+// Later, explicitly stop observing.
 token.invalidate()

--- a/source/index.txt
+++ b/source/index.txt
@@ -30,3 +30,9 @@ MongoDB Realm
    Collections  </crud/collections>
    Writes  </crud/writes>
    Notifications  </crud/notifications>
+
+.. toctree::
+   :titlesonly:
+   :caption: Realm by Example
+
+   Observe Changes  </by-example/observe-changes>


### PR DESCRIPTION
- Adds Kotlin examples to the Notifications page.
- Adds "Observe" by example page. Reusing Notifications page examples.
- Putting in place for now and we can rework the divide between manual content
("Notifications") and example content ("By Example") later.

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/observe-by-example/by-example/observe-changes.html

## JIRA
https://jira.mongodb.org/browse/DOCSP-7491
https://jira.mongodb.org/browse/DOCSP-7072
