### PR TITLE
(DOCSP-8371): Recaps

### DIFF
--- a/source/crud/collections.txt
+++ b/source/crud/collections.txt
@@ -62,10 +62,11 @@ are usually **live**:
 - Live results collections always reflect the current results of the associated query.
 - Live lists always reflect the current state of the relationship on the realm.
 
-There are only two cases when a collection is **not** live:
+There are three cases when a collection is **not** live:
 
+- The collection is unmanaged, e.g. a List property of a Realm object that has not been added to a realm yet or that has been copied from a realm.
+- The collection is :ref:`frozen <frozen-objects>`.
 - The collection is part of a snapshot (JavaScript and Java SDKs only).
-- The collection is unmanaged, e.g. a List property of a Realm object that has not been added to a realm yet.
 
 Combined with :ref:`collection notifications
 <collection-notifications>`, live collections enable clean,
@@ -82,7 +83,7 @@ validate that it is up-to-date.
    store the positional index of an object in the collection
    or the count of objects in a collection. The stored index
    or count value could be outdated by the time you use
-   them.
+   it.
 
 .. _lazy-evaluated-results:
 
@@ -128,7 +129,7 @@ When you need a collection, you can use the following rule
 of thumb to determine whether a list or a results collection
 is appropriate:
 
-- When you define the properties of your Realm objects, use lists to define to-many relationships except :doc:`implicit inverse relationships </data-model/relationships>`.
+- When you define the properties of your Realm objects, use lists to define :ref:`to-many relationships <to-many-relationship>` except :doc:`implicit inverse relationships </data-model/relationships>`.
 - Use results everywhere else.
 
 To understand these different use cases, consider whether
@@ -165,3 +166,11 @@ are determined by a query.
    or remove objects from such a collection directly.
    Therefore, the type of such a one-to-many relationship
    property is actually a results collection, not a list.
+
+Summary
+-------
+
+- A realm **collection** is a homogenous container of zero or more instances of one :doc:`Realm type </data-model/objects>`.
+- Collections are :ref:`live <live-object>`, i.e. auto-updating, unless they are :ref:`frozen <frozen-objects>` or not part of a realm.
+- Lazy evaluation of results collections means there is no need to design a special query to get limited or paginated results. Perform the query and read from the results collection as needed.
+- There are two main kinds of collection: **lists** and **results**. Lists define the :ref:`to-many relationships <to-many-relationship>` of your Realm types, while results represent the lazily-loaded output of a :doc:`read operation </crud/reads>`.

--- a/source/crud/notifications.txt
+++ b/source/crud/notifications.txt
@@ -52,6 +52,11 @@ receives no information about the change.
 
 This is useful when you want to know that there has been a
 change but do not care to know specifically what changed.
+For example, proof of concept apps often use this
+notification type and simply refresh the entire UI when
+anything changes. As the app becomes more sophisticated and
+performance-sensitive, the app developers shift to more
+granular notifications.
 
 .. example::
 
@@ -112,3 +117,10 @@ and whether the object was deleted.
 .. example::
 
    .. include:: /examples/Notifications/ObjectNotification.rst
+
+Summary
+-------
+
+- Notifications allow you to watch for and react to changes on your objects, collections, and realms.
+- When you add a notification handler to an object, collection, or realm that you wish to observe, you receive a token. Retain this token as long as you wish to keep observing.
+- Realm has three notification types: realm, collection, and object notifications. Realm notifications only tell you that something changed, while collection and object notifications allow for more granular observation.

--- a/source/crud/query-engine.txt
+++ b/source/crud/query-engine.txt
@@ -337,3 +337,9 @@ object.
    - Projects with any top priority tasks.
 
    .. include:: /examples/Query/Set.rst
+
+Summary
+-------
+
+- Each SDK has its own language-idiomatic implementation of the query engine.
+- There are several categories of **operators** available to filter results: comparison, logical, string, aggregate, and set operators.

--- a/source/crud/reads.txt
+++ b/source/crud/reads.txt
@@ -20,8 +20,8 @@ task crunches numbers based on the same information. If
 every data consumer had to wait their turn to read, the app
 would not feel graceful at all. Realm enables smooth user
 experiences by allowing many simultaneous readers thanks to
-its :wikipedia:`multiversion concurrency control (MVCC)
-<Multiversion_concurrency_control>` architecture.
+its :ref:`multiversion concurrency control (MVCC)
+<mvcc>` architecture.
 
 This page details the key characteristics of read operations
 in Realm and how to access your data.
@@ -172,3 +172,10 @@ results are sorted.
    alphabetical order (i.e. "descending" order).
 
    .. include:: /examples/CRUD/Sort.rst
+
+Summary
+-------
+
+- When you read from Realm, the results are not copies. Instead, through memory mapping, results point directly to the version on disk.
+- Queries are lazily-evaluated.
+- To read, first get all objects of a certain type from the realm, then filter using the query engine, then (optionally) sort the results.

--- a/source/crud/writes.txt
+++ b/source/crud/writes.txt
@@ -71,21 +71,23 @@ Realm represents each transaction as a callback function
 that contains zero or more read and write operations. To run
 a transaction, define a transaction callback and pass it to
 the realm's ``write`` method. Within this callback, you are
-free to create, update, and delete Realm objects. If the
-code in the callback throws an exception when Realm runs it,
-Realm cancels the transaction. Otherwise, Realm commits the
-transaction immediately after the callback.
+free to create, update, and delete Realm objects as well as
+read them. If the code in the callback throws an exception
+when Realm runs it, Realm cancels the transaction.
+Otherwise, Realm commits the transaction immediately after
+the callback.
 
 .. admonition:: Concurrency Concerns
    :class: important
 
    Since transactions block each other, it is best to avoid
    opening transactions on both the UI thread and a
-   background thread. If you are using Sync, avoid opening
-   transactions on the UI thread altogether, as Realm
-   processes synchronizations on a background thread. If a
-   background transaction blocks your UI thread's
-   transaction, your app may appear unresponsive.
+   background thread. If you are using :doc:`Sync
+   </sync/sync-overview>`, avoid opening transactions on the
+   UI thread altogether, as Realm processes synchronizations
+   on a background thread. If a background transaction
+   blocks your UI thread's transaction, your app may appear
+   unresponsive.
 
 .. example::
 
@@ -276,3 +278,9 @@ quickly clearing out your realm while prototyping.
 
    .. include:: /examples/CRUD/DeleteAll.rst
 
+Summary
+-------
+
+- Realm handles writes in terms of **transactions**. All writes must occur in a transaction.
+- Realm transactions are ACID compliant.
+- To write to realm, define the transaction in a callback function that you pass to the realm's ``write`` method.

--- a/source/crud/writes.txt
+++ b/source/crud/writes.txt
@@ -71,11 +71,10 @@ Realm represents each transaction as a callback function
 that contains zero or more read and write operations. To run
 a transaction, define a transaction callback and pass it to
 the realm's ``write`` method. Within this callback, you are
-free to create, update, and delete Realm objects as well as
-read them. If the code in the callback throws an exception
-when Realm runs it, Realm cancels the transaction.
-Otherwise, Realm commits the transaction immediately after
-the callback.
+free to create, read, update, and delete on the realm. If
+the code in the callback throws an exception when Realm runs
+it, Realm cancels the transaction. Otherwise, Realm commits
+the transaction immediately after the callback.
 
 .. admonition:: Concurrency Concerns
    :class: important

--- a/source/data-model/migrations.txt
+++ b/source/data-model/migrations.txt
@@ -28,13 +28,14 @@ Key Concepts
 Local Migration
 ~~~~~~~~~~~~~~~
 
-A **local migration** is a migration for a realm that does not
-automatically sync with another realm. Local migrations have access to
-the existing realm schema, version, and objects and define logic that
-incrementally updates the realm to its new schema version. To perform a
-local migration you must specify a new schema version that is higher
-than the current version and provide a migration function when you open
-the out-of-date realm.
+A **local migration** is a migration for a realm that does
+not automatically :doc:`sync </sync/sync-overview>` with
+another realm. Local migrations have access to the existing
+realm schema, version, and objects and define logic that
+incrementally updates the realm to its new schema version.
+To perform a local migration you must specify a new schema
+version that is higher than the current version and provide
+a migration function when you open the out-of-date realm.
 
 Realm automatically migrates certain changes, such as new and deleted
 properties, but does not automatically set values for new properties
@@ -70,10 +71,11 @@ deletes it.
 Synced Migration
 ~~~~~~~~~~~~~~~~
 
-A **synced migration** is a migration for a realm that automatically
-syncs with another remote realm. Realm automatically handles all synce
-schema migrations and does not allow you to specify a migration
-function.
+A **synced migration** is a migration for a realm that
+automatically :doc:`syncs </sync/sync-overview>` with
+another remote realm. Realm automatically handles all synced
+schema migrations and does not allow you to specify a
+migration function.
 
 Synced realms represent multiple end users and devices that will likely
 not all immediately update to the most recent version of an application.
@@ -124,3 +126,10 @@ Realm handles synced migrations using the following framework:
        - Changing a property’s type but keeping the same name.
        - Changing an object type's :ref:`primary key <primary-key>`.
        - Changing a property from optional to required (or vice-versa).
+
+Summary
+-------
+
+- A **migration** transforms an existing realm and its objects from its current schema version to a later one.
+- Realm allows you to specify migration functions for **local migrations**, i.e. migrations where the realm is not :doc:`synced </sync/sync-overview>` with a remote realm.
+- Realm automatically handles **synced migration**, i.e. migrations where the realm is synced. Realm does not allow migration functions for such migrations.

--- a/source/data-model/objects.txt
+++ b/source/data-model/objects.txt
@@ -18,7 +18,7 @@ that each contain one or more primitive data types or other Realm
 objects. Realm objects are essentially the same as regular objects in
 most programming languages, but they also include additional features
 like :ref:`real-time updating data views <live-object>` and reactive
-change event handlers.
+:doc:`change event handlers </crud/notifications>`.
 
 Every Realm object has an *object type* that refers to the object's
 class. Objects of the same type share an :ref:`object schema
@@ -43,11 +43,13 @@ Key Concepts
 Live Object
 ~~~~~~~~~~~
 
-Objects in Realm applications are **live objects** that update
-automatically to reflect data changes, including synced remote changes,
-and emit notification events that you can subscribe to whenever their
-underlying data changes. You can use live objects to work with
-object-oriented data natively without an :wikipedia:`ORM
+Objects in Realm applications are **live objects** that
+update automatically to reflect data changes, including
+:doc:`synced </sync/sync-overview>` remote changes, and emit
+:doc:`notification events </crud/notifications>` that you
+can subscribe to whenever their underlying data changes. You
+can use live objects to work with object-oriented data
+natively without an :wikipedia:`ORM
 <Object-relational_mapping>` tool.
 
 Live objects are direct proxies to the underlying stored data, which
@@ -166,3 +168,11 @@ You can configure the following constraints for a given property:
        operations. Indexes are particularly useful for equality
        comparison, such as querying for an object based on the value of
        a property.
+
+Summary
+-------
+
+- Realm objects are of a **type** defined as you would any other class in the given programming language.
+- Realm objects are **live**: they always reflect the latest version on disk and update automatically when the underlying object changes.
+- A realm object type may have a **primary key** property to uniquely identify each instance of the object type.
+- The realm object's **schema** defines the properties of the object and which properties are optional, which properties have a default value, and which properties are indexed.

--- a/source/data-model/realms.txt
+++ b/source/data-model/realms.txt
@@ -17,12 +17,14 @@ A **realm** is a set of related objects that conform to a pre-defined
 schema and share user-level access permissions. Realms may contain more
 than one type of data as long as a schema exists for each type.
 
-Realms allow you to partition data according to who uses it and when
-they use it. Every realm stores data in a separate realm file that
-contains a binary encoding of each object in the realm. You can
-automatically synchronize realms across multiple devices and set up
-:doc:`reactive event handlers </crud/notifications>` that call a
-function any time an object in a realm is created, modified, or deleted.
+Realms allow you to partition data according to who uses it
+and when they use it. Every realm stores data in a separate
+realm file that contains a binary encoding of each object in
+the realm. You can automatically :doc:`synchronize realms
+across multiple devices </sync/sync-overview>` and set up
+:doc:`reactive event handlers </crud/notifications>` that
+call a function any time an object in a realm is created,
+modified, or deleted.
 
 Comparison with Other Databases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -225,3 +227,11 @@ each type of realm path:
              :copyable: False
              
              /~/someUserRealm
+
+Summary
+-------
+
+- A **realm** is a collection of objects that conform to a schema. It is not a single, application-wide database. There can and usually will be more than one realm per application.
+- A **realm schema** is a versioned specification of the object types used in the realm.
+- Realm **permissions** define who can read, write, or manage the realm and apply to the realm as a whole.
+- A realm **path** is a realm's unique ID and indicates whether the realm is public or private.

--- a/source/data-model/relationships.txt
+++ b/source/data-model/relationships.txt
@@ -137,3 +137,10 @@ implicit.
           keep track of each dog's owner in its ``owner`` property:
           
           .. include:: /examples/Relationships/ImplicitInverse/ImplicitInverse.rst
+
+Summary
+-------
+
+- A **relationship** is when a Realm object property references another Realm object.
+- Relationships are direct references. You can access a related object directly through the relationship property of another object.
+- Realm supports to-one, to-many, explicit inverse and implicit inverse relationships.

--- a/source/data-model/threading.txt
+++ b/source/data-model/threading.txt
@@ -45,13 +45,15 @@ Don't lock to read:
   since each thread might need to wait its turn before
   reading.
 
-If you write on a background thread, avoid writes on the UI thread:
+Avoid writes on the UI thread if you write on a background thread:
   You can :doc:`write </crud/writes>` to a realm from any
   thread, but there can be only one writer at a time.
   Consequently, write transactions block each other. A write
   on the UI thread may result in your app appearing
   unresponsive while it waits for a write on a background
-  thread to complete.
+  thread to complete. If you are using :doc:`Sync
+  </sync/sync-overview>`, avoid writing on the UI thread as
+  Sync writes on a background thread.
 
 Don't pass live objects, collections, or realms to other threads:
   Live objects, collections, and realm instances are
@@ -115,7 +117,7 @@ refresh. Realms on the UI thread -- more precisely, on any
 <https://developer.android.com/reference/android/os/Looper>`__
 (Android)) -- automatically refresh themselves at the
 beginning of that thread's loop. However, you must manually
-refresh realm instances that exist on non-loop threads or
+refresh realm instances that do not exist on loop threads or
 that have auto-refresh disabled.
 
 .. _frozen-objects:
@@ -252,3 +254,14 @@ the actual disk, not a copy of it. This is the basis for
 :ref:`live objects <live-object>`. This is also why a Realm
 head pointer can be set to point to the new version after
 the write to disk has been validated.
+
+Summary
+-------
+
+- Realm enables simple and safe multithreaded code when you follow three rules: don't lock to read; avoid writes on the UI thread if you write on background threads or use :doc:`Sync </sync/sync-overview>`; and don't pass live objects to other threads.
+- There is a proper way to share objects across threads for each use case.
+- In order to see changes made on other threads in your realm instance, you must manually **refresh** realm instances that do not exist on "loop" threads or that have auto-refresh disabled.
+- For apps based on reactive, event-stream-based architectures, you can **freeze** objects, collections, and realms in order to pass shallow copies around efficiently to different threads for processing.
+- Realm's multiversion concurrency control (MVCC) architecture is similar to Git's. Unlike Git, Realm has only one true latest version.
+- Realm commits in two stages to guarantee isolation and durability.
+


### PR DESCRIPTION
- Adds "Summary" section to the bottom of the content pages so far
- Added some missing links, other minor tweaks

## JIRA
https://jira.mongodb.org/browse/DOCSP-8371

## Staged
Starting on:
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/recaps/data-model/realms.html

And on each page of the "Data Model" and "Read & Write" sections.

