### PR TITLE
(DOCSP-7078): Add support files page

### DIFF
--- a/source/data-model/auxiliary-files.txt
+++ b/source/data-model/auxiliary-files.txt
@@ -1,6 +1,6 @@
-=============
-Support Files
-=============
+===============
+Auxiliary Files
+===============
 
 .. default-domain:: mongodb
 
@@ -13,18 +13,17 @@ Support Files
 Overview
 --------
 
-Realm stores data on the filesystem in **support files**.
-Generally, you should not interact with these files
-directly. Instead, access these files through the Realm SDK
-or Realm Studio. In advanced cases, you might need to manually
-delete the support files. Otherwise, these are
-implementation details that you can safely ignore, presented
-here only for the curious.
+Realm stores data on the filesystem in **auxiliary files**.
+You can access these files through the Realm SDK or Realm
+Studio. In some error situations detailed below, you might
+need to manually delete the auxiliary files. Otherwise,
+these are implementation details that you can safely ignore,
+presented here only for the curious.
 
-Support File Types
-------------------
+Auxiliary File Types
+--------------------
 
-Realm's internal operation depends on several support file
+Realm's internal operation depends on several auxiliary file
 types:
 
 ``<path>.realm``:
@@ -39,23 +38,22 @@ types:
 ``<name>.realm.note``:
   The **note file** is a :wikipedia:`named pipe
   <Named_pipe>` for inter-thread and inter-process
-  notifications. While usually completely internal, it has
-  been known to cause the "unsupported resource found" error
-  in iOS builds when it is accidentally added to the app
-  bundle, e.g. when bundling a realm file with the app. If
-  that happens, delete the pipe.
+  notifications. While usually completely internal, the note
+  file can cause the "unsupported resource found" error in
+  iOS builds if you accidentally add it to the app bundle.
+  If you see this error, delete the pipe.
 
 ``<name>.realm.management``:
   The **management directory** contains internal files for
   the realm's state management.
 
-Manually Deleting Support Files
--------------------------------
+Manually Deleting Auxiliary Files
+---------------------------------
 
-In some circumstances, you might need to delete the support
-files. You may delete support files when the realm is
+In some circumstances, you might need to delete the
+auxiliary files. You may auxiliary files when the realm is
 closed. Deleting any of a realm's files while the realm is
-open may corrupt the realm or disrupt :doc:`Sync
+open might corrupt the realm or disrupt :doc:`Sync
 </sync/sync-overview>`.
 
 Client Reset Scenario
@@ -72,8 +70,7 @@ In other words, the client app must carry out a client reset
 on a given synced realm if the server is restored to a
 version older than the version on the client.
 
-On the client app side, the client reset procedure is as follows:
-
+To perform a client reset, follow these steps:
 1. Create a backup of the local realm file.
 #. Delete the local realm file.
-#. The next time the app connects to the server and opens that realm, the app will download a fresh copy of the realm file. The local changes made since the backup on the server are not reflected in the new file.
+#. The next time the app connects to the server and opens that realm, the app dowloads a fresh copy of the realm file. The local changes made since the backup on the server are not reflected in the new file.

--- a/source/data-model/auxiliary-files.txt
+++ b/source/data-model/auxiliary-files.txt
@@ -51,7 +51,7 @@ Manually Deleting Auxiliary Files
 ---------------------------------
 
 In some circumstances, you might need to delete the
-auxiliary files. You may auxiliary files when the realm is
+auxiliary files. You may delete auxiliary files when the realm is
 closed. Deleting any of a realm's files while the realm is
 open might corrupt the realm or disrupt :doc:`Sync
 </sync/sync-overview>`.

--- a/source/data-model/support-files.txt
+++ b/source/data-model/support-files.txt
@@ -70,7 +70,7 @@ app must perform in the following situation:
 
 In other words, the client app must carry out a client reset
 on a given synced realm if the server is restored to a
-version before the version on the client.
+version older than the version on the client.
 
 On the client app side, the client reset procedure is as follows:
 

--- a/source/data-model/support-files.txt
+++ b/source/data-model/support-files.txt
@@ -52,7 +52,7 @@ types:
 Manually Deleting Support Files
 -------------------------------
 
-In some circumstances, you may need to delete the support
+In some circumstances, you might need to delete the support
 files. You may delete support files when the realm is
 closed. Deleting any of a realm's files while the realm is
 open may corrupt the realm or disrupt :doc:`Sync

--- a/source/data-model/support-files.txt
+++ b/source/data-model/support-files.txt
@@ -16,7 +16,7 @@ Overview
 Realm stores data on the filesystem in **support files**.
 Generally, you should not interact with these files
 directly. Instead, access these files through the Realm SDK
-or Realm Studio. In advanced cases, you may need to manually
+or Realm Studio. In advanced cases, you might need to manually
 delete the support files. Otherwise, these are
 implementation details that you can safely ignore, presented
 here only for the curious.

--- a/source/data-model/support-files.txt
+++ b/source/data-model/support-files.txt
@@ -30,7 +30,7 @@ types:
 ``<path>.realm``:
   The **realm file** contains the data and metadata of the
   realm at the given :ref:`Realm path <realm-path>`. Each
-  app may have several realms at different paths, each with
+  app can have several realms at different paths, each with
   their own realm file.
 
 ``<name>.realm.lock``:

--- a/source/data-model/support-files.txt
+++ b/source/data-model/support-files.txt
@@ -65,7 +65,7 @@ When using :doc:`Realm Sync </sync/sync-overview>`, a **client
 reset** is a serious error recovery task that your client
 app must perform in the following situation:
 
-- The given synced realm on the server was restored from a backup, e.g. due to a Realm server crash.
+- The given synced realm on the server was restored from a backup. For example, due to a Realm server crash.
 - The client app made changes to that realm since the backup was made, but did not sync those changes back to the server before the server was restored.
 
 In other words, the client app must carry out a client reset

--- a/source/data-model/support-files.txt
+++ b/source/data-model/support-files.txt
@@ -1,0 +1,79 @@
+=============
+Support Files
+=============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+Realm stores data on the filesystem in **support files**.
+Generally, you should not interact with these files
+directly. Instead, access these files through the Realm SDK
+or Realm Studio. In advanced cases, you may need to manually
+delete the support files. Otherwise, these are
+implementation details that you can safely ignore, presented
+here only for the curious.
+
+Support File Types
+------------------
+
+Realm's internal operation depends on several support file
+types:
+
+``<path>.realm``:
+  The **realm file** contains the data and metadata of the
+  realm at the given :ref:`Realm path <realm-path>`. Each
+  app may have several realms at different paths, each with
+  their own realm file.
+
+``<name>.realm.lock``:
+  The **lock file** enables synchronization between writes.
+
+``<name>.realm.note``:
+  The **note file** is a :wikipedia:`named pipe
+  <Named_pipe>` for inter-thread and inter-process
+  notifications. While usually completely internal, it has
+  been known to cause the "unsupported resource found" error
+  in iOS builds when it is accidentally added to the app
+  bundle, e.g. when bundling a realm file with the app. If
+  that happens, delete the pipe.
+
+``<name>.realm.management``:
+  The **management directory** contains internal files for
+  the realm's state management.
+
+Manually Deleting Support Files
+-------------------------------
+
+In some circumstances, you may need to delete the support
+files. You may delete support files when the realm is
+closed. Deleting any of a realm's files while the realm is
+open may corrupt the realm or disrupt :doc:`Sync
+</sync/sync-overview>`.
+
+Client Reset Scenario
+~~~~~~~~~~~~~~~~~~~~~
+
+When using :doc:`Realm Sync </sync/sync-overview>`, a **client
+reset** is a serious error recovery task that your client
+app must perform in the following situation:
+
+- The given synced realm on the server was restored from a backup, e.g. due to a Realm server crash.
+- The client app made changes to that realm since the backup was made, but did not sync those changes back to the server before the server was restored.
+
+In other words, the client app must carry out a client reset
+on a given synced realm if the server is restored to a
+version before the version on the client.
+
+On the client app side, the client reset procedure is as follows:
+
+1. Create a backup of the local realm file.
+#. Delete the local realm file.
+#. The next time the app connects to the server and opens that realm, the app will download a fresh copy of the realm file. The local changes made since the backup on the server are not reflected in the new file.

--- a/source/examples/CRUD/Sort.swift
+++ b/source/examples/CRUD/Sort.swift
@@ -2,5 +2,5 @@ let projectsSorted = projects.sorted(byKeyPath: "name", ascending: false)
 
 // You can also sort on the members of linked objects. In this example,
 // we sort the dogs by dog's owner's name.
-let dogs = realm.where<Dog>()
+let dogs = realm.objects(Dog.self)
 let ownersByName = dogs.sorted(byKeyPath: "owner.name")

--- a/source/index.txt
+++ b/source/index.txt
@@ -21,6 +21,7 @@ MongoDB Realm
    Relationships  </data-model/relationships>
    Migrations  </data-model/migrations>
    Threading  </data-model/threading>
+   Support Files  </data-model/support-files>
 
 .. toctree::
    :titlesonly:

--- a/source/index.txt
+++ b/source/index.txt
@@ -21,7 +21,7 @@ MongoDB Realm
    Relationships  </data-model/relationships>
    Migrations  </data-model/migrations>
    Threading  </data-model/threading>
-   Support Files  </data-model/support-files>
+   Auxiliary Files  </data-model/auxiliary-files>
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
(DOCSP-7078): Add support files page

- Added under Data Model section, but that may easily change
- Still lacking some info and this may change, so this is a
quick surface-level attempt to get something in place.
- The client reset section may no longer be relevant,
and will most likely move to another page about troubleshooting.

Bonus: PR includes code fix for Swift snippet that got past me earlier

## JIRA
https://jira.mongodb.org/browse/DOCSP-7078

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/realm-files/data-model/support-files.html

