### PR TITLE
(DOCSP-8764): Port auth provider: Facebook

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -64,6 +64,7 @@ extlinks = {
     # MongoDB Docs Sites
     'manual': ('http://docs.mongodb.org/manual%s', ''),
     'atlas': ('https://docs.atlas.mongodb.com%s',''),
+    'fb-dev-docs': ('https://developers.facebook.com/docs/%s', ''),
     'mms-docs': ('https://docs.cloud.mongodb.com%s', ''),
     'mms-home': ('https://cloud.mongodb.com%s', ''),
     'guides': ('https://docs.mongodb.com/guides%s', ''),

--- a/source/authentication/facebook.txt
+++ b/source/authentication/facebook.txt
@@ -1,0 +1,210 @@
+=======================
+Facebook Authentication
+=======================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+The Facebook authentication provider allows users to log in
+with their existing Facebook account through a companion
+Facebook application. When a user logs in, Facebook provides
+Realm with an `OAuth 2.0 access token
+<https://www.oauth.com/oauth2-servers/access-tokens/>`_ for
+the user. Realm uses the token to identify the user and
+access approved data from the Facebook API on their behalf.
+For more information on Facebook Login, see `Facebook Login
+for Apps
+<https://developers.facebook.com/docs/facebook-login/overview>`_.
+
+.. _auth-facebook-configuration:
+
+Configuration
+-------------
+
+.. tabs-stitch-interfaces::
+
+   tabs:
+     - id: stitch-ui
+       content: |
+         You can enable and configure the Facebook authentication
+         provider from the Realm UI by selecting :guilabel:`Facebook`
+         from the :guilabel:`Users > Providers` page.
+
+     - id: import-export
+       content: |
+         You can enable and configure the Facebook authentication
+         provider with :doc:`realm-cli
+         </deploy/realm-cli-reference>` by importing an
+         application directory that contains a :ref:`configuration file
+         <appschema-authentication-providers>` for the provider.
+
+         The configuration file must be named ``oauth2-facebook.json``
+         and stored in the ``/auth_providers`` directory. Configuration
+         files for the Facebook authentication provider have the
+         following form:
+
+         .. cssclass:: wide-container
+         .. code-block:: none
+            :caption: ``/auth_providers/oauth2-facebook.json``
+
+            {
+              "name": "oauth2-facebook",
+              "type": "oauth2-facebook",
+              "disabled": <boolean>,
+              "config": {
+                "clientId": <string>
+              },
+              "secret_config": {
+                "clientSecret": <string>
+              },
+              "metadata_fields": [<document>, ...],
+              "redirect_uris": [<string>, ...],
+              "domain_restrictions": [<string>, ...]
+            }
+
+The Facebook authentication provider has the following configuration
+options:
+
+.. cssclass:: auth-table
+.. list-table::
+   :header-rows: 1
+   :widths: 15 30
+
+   * - Field
+     - Description
+
+   * - :guilabel:`Client ID`
+
+       .. tab-content:: tabs-stitch-interfaces
+          :tab-id: import-export
+
+          | *config.clientId*
+
+     - Required. The :guilabel:`App ID` of the Facebook app.
+
+       See :ref:`auth-facebook-app-setup` for information about setting
+       up your Facebook app and finding the :guilabel:`App ID`.
+
+   * - :guilabel:`Client Secret`
+
+       .. tab-content:: tabs-stitch-interfaces
+          :tab-id: import-export
+
+          | *secret_config.clientSecret*
+
+
+     - Required. The name of a :ref:`Secret <app-secret>` that stores
+       the :guilabel:`App Secret` of the Facebook app.
+
+       See :ref:`auth-facebook-app-setup` for information about setting
+       up your Facebook app and finding the :guilabel:`App Secret`.
+
+   * - :guilabel:`Metadata Fields`
+
+       .. tab-content:: tabs-stitch-interfaces
+          :tab-id: import-export
+
+          | *metadata_fields*
+
+     - Optional. A list of fields describing the authenticated user that
+       your application will request from the :fb-dev-docs:`Facebook
+       Graph API <graph-api/reference/user/>`.
+
+       All metadata fields are omitted by default and can be
+       required on a field-by-field basis. Users must
+       explicitly grant your app permission to access each
+       required field. If a metadata field is required and
+       exists for a particular user, it will be included in
+       their user object.
+
+
+       .. tab-content:: tabs-stitch-interfaces
+          :tab-id: import-export
+
+          To require a metadata field from an import/export
+          configuration file, add an entry for the field to
+          the ``metadata_fields`` array. Each entry should
+          be a document of the following form:
+
+          .. code-block:: javascript
+
+             { name: "<metadata field name>", required: "<boolean>" }
+
+   * - :guilabel:`Redirect URIs`
+
+       .. tab-content:: tabs-stitch-interfaces
+          :tab-id: import-export
+
+          | *redirect_uris*
+
+     - Required for web applications.
+       A list of allowed redirect :abbr:`URIs (Uniform Resource
+       Identifiers)`.
+
+       Once a user completes the authentication process on
+       Facebook, Realm redirects them back to either a
+       specified redirect URI or, if no redirect URI is
+       specified, the URL that they initiated the
+       authentication request from. Realm will only redirect
+       a user to a URI that exactly matches an entry in this
+       list, including the protocol and any trailing
+       slashes.
+
+   * - :guilabel:`Domain Restrictions`
+
+       .. tab-content:: tabs-stitch-interfaces
+          :tab-id: import-export
+
+          | *domain_restrictions*
+
+     - Optional. A list of approved :wikipedia:`domains <Domain_name>`
+       for user accounts.
+
+       If specified, the provider checks the domain of a
+       user's primary email address on Facebook and only
+       allows them to authenticate if the domain matches an
+       entry in this list.
+
+       For example, if ``example1.com`` and ``example2.com``
+       are listed, a Facebook user with a primary email of
+       ``joe.schmoe@example1.com`` would be allowed to log
+       in, while a user with a primary email of
+       ``joe.schmoe@example3.com`` would not be allowed to
+       log in.
+
+       .. note::
+
+          If you've specified any domain restrictions, you
+          must also require the email address field in the
+          :guilabel:`Metadata Fields` setting.
+
+Usage
+-----
+
+.. _auth-facebook-app-setup:
+
+Set Up a Facebook App
+~~~~~~~~~~~~~~~~~~~~~
+
+The Facebook authentication provider requires a `Facebook
+app <https://developers.facebook.com/docs/apps>`_ to manage
+authentication and user permissions. The following steps
+walk through creating the app, setting up Facebook Login,
+and configuring the provider to connect with the app.
+
+.. include:: /includes/steps/auth-facebook-app-setup.rst
+
+.. _auth-facebook-client-sdks:
+
+Authenticate a User
+~~~~~~~~~~~~~~~~~~~
+
+TBD.

--- a/source/includes/deployment-region-auth-callback-urls.rst
+++ b/source/includes/deployment-region-auth-callback-urls.rst
@@ -4,7 +4,7 @@
    :widths: 1 4
 
    * - Region
-     - Stitch Authentication Callback URL
+     - Realm Authentication Callback URL
 
    * - | **Global**
      - .. code-block:: none

--- a/source/includes/deployment-region-auth-callback-urls.rst
+++ b/source/includes/deployment-region-auth-callback-urls.rst
@@ -1,0 +1,36 @@
+.. cssclass:: config-table
+.. list-table::
+   :header-rows: 1
+   :widths: 1 4
+
+   * - Region
+     - Stitch Authentication Callback URL
+
+   * - | **Global**
+     - .. code-block:: none
+
+          https://stitch.mongodb.com/api/client/v2.0/auth/callback
+
+   * - | **Virginia**
+       | (``us-east-1``)
+     - .. code-block:: none
+
+          https://us-east-1.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+
+   * - | **Oregon**
+       | (``us-west-2``)
+     - .. code-block:: none
+
+          https://us-west-2.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+
+   * - | **Ireland**
+       | (``eu-west-1``)
+     - .. code-block:: none
+
+          https://eu-west-1.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
+
+   * - | **Sydney**
+       | (``ap-southeast-2``)
+     - .. code-block:: none
+
+          https://ap-southeast-2.aws.stitch.mongodb.com/api/client/v2.0/auth/callback

--- a/source/includes/deployment-region-auth-callback-urls.rst
+++ b/source/includes/deployment-region-auth-callback-urls.rst
@@ -7,30 +7,30 @@
      - Realm Authentication Callback URL
 
    * - | **Global**
-     - .. code-block:: none
+     - .. code-block:: text
 
           https://stitch.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Virginia**
        | (``us-east-1``)
-     - .. code-block:: none
+     - .. code-block:: text
 
           https://us-east-1.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Oregon**
        | (``us-west-2``)
-     - .. code-block:: none
+     - .. code-block:: text
 
           https://us-west-2.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Ireland**
        | (``eu-west-1``)
-     - .. code-block:: none
+     - .. code-block:: text
 
           https://eu-west-1.aws.stitch.mongodb.com/api/client/v2.0/auth/callback
 
    * - | **Sydney**
        | (``ap-southeast-2``)
-     - .. code-block:: none
+     - .. code-block:: text
 
           https://ap-southeast-2.aws.stitch.mongodb.com/api/client/v2.0/auth/callback

--- a/source/includes/steps-auth-facebook-app-setup.yaml
+++ b/source/includes/steps-auth-facebook-app-setup.yaml
@@ -1,0 +1,47 @@
+title: Create a Facebook App
+ref: auth-create-facebook-app
+content: |
+   Follow Facebook's `official guide
+   <https://developers.facebook.com/quickstarts/>`_ to create a new
+   Facebook app.
+---
+title: Enable Facebook Login
+ref: auth-enable-facebook-login
+content: |
+  From the app's :guilabel:`Dasboard` view, find the :guilabel:`Facebook
+  Login` card and click :guilabel:`Set Up`. You should see a list of
+  quickstart guides for each platform. Follow the guide for your
+  platform to enable Facebook Login.
+
+  .. note::
+
+     Stitch web applications do not require you to install the Facebook
+     SDK to use the Facebook authentication provider. If you are
+     incorporating Facebook Login into a web application you can skip
+     any steps in the quickstart related to setting up the Facebook SDK
+     for Javascript.
+---
+title: Add Stitch as a Valid OAuth Redirect URI
+ref: auth-add-stitch-as-valid-oauth-redirect-uri
+content: |
+  When a user completes the login flow for your Facebook app they need
+  to be redirected back to Stitch. Facebook Login will only allow users
+  to redirect to a pre-approved list of URIs.
+
+  From the :guilabel:`Facebook Login > Settings` page, add a Stitch
+  authentication callback URL that corresponds to the :doc:`deployment
+  region </admin/deployment-models-and-regions>` of your application to
+  the list of :guilabel:`Valid OAuth Redirect URIs`.
+  The following table lists the callback URL for each region:
+
+  .. include:: /includes/deployment-region-auth-callback-urls.rst
+---
+title: Configure the Facebook Authentication Provider
+ref: auth-configure-facebook-auth-provider
+content: |
+
+  To connect your Facebook app to Stitch, find your Facebook app's
+  :guilabel:`App ID` and :guilabel:`App Secret` values on the
+  :guilabel:`Settings > Basic` page and add them to your authentication
+  provider :ref:`configuration <auth-facebook-configuration>`.
+...

--- a/source/index.txt
+++ b/source/index.txt
@@ -44,7 +44,8 @@ MongoDB Realm
    :titlesonly:
    :caption: Authentication
 
-   Authentication Providers </authentication/providers>
+   Authentication Providers  </authentication/providers>
+   Facebook Authentication  </authentication/facebook>
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
- Example SDK snippets cut... for now
- Step files to be replaced

## JIRA
https://jira.mongodb.org/browse/DOCSP-8764

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker/port-fb/authentication/facebook
