### PR TITLE
(DOCSP-8768): User Accounts & Identities

### DIFF
--- a/source/authentication.txt
+++ b/source/authentication.txt
@@ -70,12 +70,14 @@ logic in a Realm function.
 User Accounts
 ~~~~~~~~~~~~~
 
-A **user account** represents a single, distinct user of your
-application. Every user account has a unique ID and is associated with
-at least one authentication provider identity. Realm automatically
-sources user metadata, such as their email address or birthday, from
-authentication providers and allows you to associate each user with
-:doc:`custom data </users/define-custom-user-data>` stored in a MongoDB
+A **user account** represents a single, distinct user of
+your application. Every user account has a unique ID and is
+associated with at least one :ref:`authentication provider
+identity <authentication-provider-identities>`. Realm
+automatically sources user metadata, such as their email
+address or birthday, from authentication providers and
+allows you to associate each user with :doc:`custom data
+</users/define-custom-user-data>` stored in a MongoDB
 collection.
 
 .. admonition:: Link Multiple Identities to One User Account
@@ -89,56 +91,81 @@ collection.
    providers. For more information, see :doc:`Link a New Identity to a
    User Account </authentication/link>`.
 
+
+.. _authentication-provider-identities:
+
+Authentication Provider Identities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An **authentication provider identity** is a set of metadata
+about a user that Realm obtains from each authentication
+provider used to authenticate that user. A single user
+account can have multiple identities if the user associates
+their account with multiple authentication providers.
+
+When a user first logs in with an authentication provider,
+Realm associates the user with an identity object that
+contains a unique identifier and :ref:`additional,
+provider-specific metadata <user-metadata>` about the user.
+On subsequent logins, Realm refreshes the existing identity
+data but does not create a new identity.
+
 .. _active-user:
 
 Active User
 ~~~~~~~~~~~
 
-The **active user** is a user account associated with an application
-request. When Realm receives a request from a client application, it
-executes the request in the context of the active user, replacing any
-dynamic references to the user (e.g. :json-expansion:`%%user` in a JSON
-expression) with the active user's information.
+In the Realm SDKs, multiple users can log in simultaneously,
+but only one account can be **active** at any given time.
+The **active user** is a user account associated with an
+application request. When Realm receives a request from a
+client application, it executes the request in the context
+of the active user, replacing any dynamic references to the
+user (e.g. :json-expansion:`%%user` in a JSON expression)
+with the active user's information.
 
-In most circumstances, the active user is the authenticated user that
-issued a request. You can also configure a specific active user for
-functions, triggers, and webhooks or choose to use a :ref:`system user
-<system-users>` instead.
+In most circumstances, the active user is the authenticated
+user that issued a request. You can also configure a
+specific active user for Functions, Triggers, and webhooks
+or choose to use the :ref:`system user <system-users>`
+instead.
 
-In the Realm SDKs, multiple users can log in simultaneously, but only
-one account can be active at any given time. For more information on
-managing multiple logged in users in a client application, see
-:doc:`Work with Multiple User Accounts
+To manage multiple logged-in users in a client application,
+see :doc:`Work with Multiple User Accounts
 </authentication/work-with-multiple-user-accounts>`.
 
-.. _system-users:
+.. _system-user:
 
-System Users
-~~~~~~~~~~~~
+System User
+~~~~~~~~~~~
 
-A **system user** is an internal user that has advanced privileges and
-automatically bypasses all rules. You can configure :doc:`Functions
-</functions>` and :ref:`incoming webhooks <incoming-webhooks>` to run in
-the context of a system user instead of the user account that issued a
-request. Triggers always run in the context of a system user.
+The **system user** is an internal user that has advanced
+privileges and automatically bypasses all rules. You can
+configure :doc:`Functions </functions>` and :ref:`incoming
+webhooks <incoming-webhooks>` to run in the context of the
+system user instead of the user account that issued a
+request. Triggers always run in the context of the system
+user.
 
-System users are useful for administrative tasks that need to circumvent
-rules and queries that need :doc:`unrestricted access
-</mongodb/mongodb-service-limitations>` to MongoDB CRUD and aggregation
-operations.
+The system user is useful for administrative tasks that need
+to circumvent rules and queries that need :doc:`unrestricted
+access </mongodb/mongodb-service-limitations>` to MongoDB
+CRUD and aggregation operations.
 
 .. admonition:: Security Warning
    :class: important
 
-   Rules do not apply to system users, which means that functions and
-   webhooks that run as a system user can be a security liability.
-   Ensure that you do not expose these functions to unauthorized users.
+   Rules do not apply to the system user, which means that
+   functions and webhooks that run as the system user can be
+   a security liability. Ensure that you do not expose these
+   functions to unauthorized users.
    
-   For example, instead of calling a system function directly from a
-   client application, you could call it inside of a second, non-system
-   function that you call from the client. The non-system Function can
-   use :ref:`function context <context-user>` to check if the active
-   user is allowed to call the system function, e.g.:
+   For example, instead of calling a system function
+   directly from a client application, you could call it
+   inside of a second, non-system function that you call
+   from the client. The non-system Function can use
+   :ref:`function context <context-user>` to check if the
+   active user is allowed to call the system function, e.g.:
 
    .. code-block:: javascript
 
@@ -151,3 +178,63 @@ operations.
           throw Error("This user is not allowed to execute the system function")
         }
       }
+
+.. _user-sessions:
+
+User Sessions
+~~~~~~~~~~~~~
+
+A **user session** is a user's state of being authenticated
+with your app for a certain period of time. While a user is
+authenticated, they can interact with app data without
+needing to enter their password or otherwise
+re-authenticate.
+
+Sessions are managed with access tokens and a refresh token
+provided by Realm. The client SDKs implement the logic of
+managing these tokens and providing them to Realm when
+making requests.
+
+For web browsers, the JavaScript SDK stores these tokens in
+`HTML5 local storage <https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API>`_.
+In the Android SDK, they are stored in
+`Shared Preferences <https://developer.android.com/guide/topics/data/data-storage.html#pref>`_.
+In the iOS SDK, they are stored in the
+`Keychain <https://developer.apple.com/documentation/security/keychain_services>`_.
+
+The access token for a session expires after thirty minutes.
+However, a new session can be started by retrieving a new
+access token from Realm using the refresh token. The SDKs
+automatically take care of refreshing access tokens, so you
+do not need to worry about this when implementing client
+applications.
+
+You can invalidate a refresh token by calling the
+``logout()`` method on the client, which does two things: 
+
+- It locally deletes current session information by deleting both the access and refresh tokens.
+- It invalidates the refresh token on the Realm server.
+
+.. note::
+
+   The ``logout()`` method provided by the SDKs does **NOT** invalidate
+   any active sessions on the server. This means that if an access
+   token is leaked out of storage before ``logout()`` is called, that
+   access token can be theoretically used by an attacker to continue
+   making requests on behalf of the user who "logged out" for up to
+   thirty minutes (until that access token expires).
+
+The user list under the :guilabel:`Users` tab, on the
+:guilabel:`Users` page of the Realm admin console, provides a way to
+revoke all sessions for a specific user. This will
+invalidate all access tokens and refresh tokens for that user. See the
+:ref:`Revoking User Sessions <revoke-user-sessions>` page for the specific
+steps.
+
+Summary
+-------
+
+- Realm supports authentication and user accounts through a variety of :doc:`authentication providers </authentication/providers>`. Users can associate themselves with multiple authentication providers and have identity information from multiple providers.
+- Realm supports having multiple users logged in at the same time. There is only one **active user** at a time.
+- The **system user** is a special user on the Realm server that bypasses all rules.
+- Realm handles the access tokens and refresh tokens that comprise a **user session** automatically.

--- a/source/authentication.txt
+++ b/source/authentication.txt
@@ -212,17 +212,19 @@ applications.
 You can invalidate a refresh token by calling the
 ``logout()`` method on the client, which does two things: 
 
-- It locally deletes current session information by deleting both the access and refresh tokens.
+- It deletes the local session information by deleting both the access and refresh tokens.
 - It invalidates the refresh token on the Realm server.
 
 .. note::
 
-   The ``logout()`` method provided by the SDKs does **NOT** invalidate
-   any active sessions on the server. This means that if an access
-   token is leaked out of storage before ``logout()`` is called, that
-   access token can be theoretically used by an attacker to continue
-   making requests on behalf of the user who "logged out" for up to
-   thirty minutes (until that access token expires).
+   The ``logout()`` method provided by the SDKs does **NOT**
+   invalidate any active sessions on the server. This means
+   that if you somehow expose the access token to a
+   malicious user before ``logout()`` is called, the
+   malicious user could theoretically use the token to
+   continue making requests on behalf of the user who
+   "logged out" for up to thirty minutes (that is, until
+   that access token expires).
 
 The user list under the :guilabel:`Users` tab, on the
 :guilabel:`Users` page of the Realm admin console, provides a way to

--- a/source/authentication/providers.txt
+++ b/source/authentication/providers.txt
@@ -86,3 +86,81 @@ available in Realm:
    * - :ref:`Custom Function <custom-function-authentication>`
      - Allows users to log in with arbitrary credentials according to
        custom authentication logic that you define.
+
+
+.. _user-metadata:
+
+User Metadata
+-------------
+
+Each authentication provider can associate a distinct set of metadata
+fields with an application user. Some providers (such as Email/Password)
+always add specific fields, whereas others allow you to configure the
+data to associate with each user. The following table describes the
+metadata fields that each authentication provider includes in a user
+object:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   
+   * - Authentication Provider
+     - Details
+   
+   * - :doc:`Anonymous </authentication/anonymous>`
+     - Anonymous users are not associated with any metadata.
+   
+   * - :doc:`Email/Password </authentication/userpass>`
+     - Email/Password users are always associated with the following
+       metadata fields:
+   
+       .. cssclass:: config-table
+       .. list-table::
+          :header-rows: 1
+          :widths: 10 20
+          
+          * - Field
+            - Description
+          
+          * - ``email``
+            - The user's email address.
+   
+   * - :doc:`API Key (Server & User) </authentication/api-key>`
+     - API Key users are always associated with the following metadata
+       fields:
+   
+       .. cssclass:: config-table
+       .. list-table::
+          :header-rows: 1
+          :widths: 10 20
+          
+          * - Field
+            - Description
+          
+          * - ``name``
+            - The name associated with the API key that the user
+              authenticated with.
+   
+   * - OAuth 2.0 (:doc:`Facebook </authentication/facebook>` & :doc:`Google </authentication/google>`)
+     - OAuth 2.0 users can be associated with data provided by the
+       external authentication service according to the provider's
+       :guilabel:`Metadata Fields` configuration. Users must explicitly
+       grant your application permission to access the data.
+   
+   * - :doc:`Custom Function </authentication/custom-function>`
+     - Custom Function authentication users are not automatically
+       associated with any data.
+   
+   * - :doc:`Custom JWT </authentication/custom-token>`
+     - Custom JWT authentication users can be associated with any data
+       included in the JWT returned from the external authentication
+       system. The provider's :guilabel:`Metadata Fields` configuration
+       maps fields in the JWT to fields that appear in the user object's
+       ``data`` and ``identity`` fields.
+
+Summary
+-------
+
+- Realm supports various **authentication providers** to allow users to log in to your app.
+- You can :doc:`link </authentication/link>` a specific user across multiple providers.
+- Each authentication provider has different metadata about a user's identity.

--- a/source/authentication/user-objects.txt
+++ b/source/authentication/user-objects.txt
@@ -1,0 +1,75 @@
+.. _user-objects:
+
+------------
+User Objects
+------------
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+Realm represents each application user internally with a
+**User Object** that includes a unique ID and additional
+metadata that describes the user. You can access user
+objects in the following ways:
+
+- In a :doc:`Function </functions>` by accessing :ref:`context.user
+  <context-user>`.
+
+- In :doc:`rule expressions </services/json-expressions>` with the
+  :json-expansion:`%%user` expansion.
+
+- In client applications with the RealmAuth interface
+
+Schema
+------
+
+User objects have the following form:
+
+.. code-block:: json
+
+   {
+     "id": "<Unique User ID>",
+     "type": "<User Type>",
+     "data": {
+       "<Metdata Field>": <Value>,
+       ...
+     },
+     "custom_data": {
+       "<Custom Data Field>": <Value>,
+       ...
+     },
+     "identities": [
+       {
+         "id": <Unique Identity ID>,
+         "provider_type": "<Authentication Provider>",
+         "data": {
+           "<Metdata Field>": <Value>,
+           ...
+         }
+       }
+     ]
+   }
+
+.. include:: /includes/user-object-fields.rst
+
+.. note::
+
+   In general, Realm creates a user object for a given user
+   the first time that they authenticate. If you create a
+   test :doc:`Email/Password </authentication/userpass>`
+   user through the Realm UI, Realm creates that user's user
+   object immediately.
+
+Summary
+-------
+
+- The user object contains relevant information about the user that you can use in your app logic.
+- The exact information contained in the user object depends on the :doc:`authentication providers </authentication/providers>` used.

--- a/source/includes/user-object-fields.rst
+++ b/source/includes/user-object-fields.rst
@@ -1,0 +1,123 @@
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10 80
+
+   * - Field
+     - Type
+     - Description
+
+   * - ``id``
+     - string
+     - A string representation of the :manual:`ObjectId
+       </reference/bson-types/#objectid>` that uniquely identifies the
+       user.
+
+   * - ``type``
+     - string
+     - The type of the user. The following types are possible:
+
+       .. list-table::
+          :header-rows: 1
+          :widths: 30 70
+
+          * - Type
+            - Description
+
+          * - "normal"
+            - The user is an :doc:`application user </users>` logged in
+              through an authentication provider other than the
+              :doc:`API Key </authentication/api-key>` provider.
+
+          * - "server"
+            - The user is a server process logged in with any type of
+              :doc:`Realm API Key </authentication/api-key>`.
+
+          * - "system"
+            - The user is the :ref:`system user <system-users>` that
+              bypasses all rules.
+
+   * - ``data``
+     - document
+     
+     - A document that contains metadata that describes the
+       user. This field combines the data for all ``identities``
+       associated with the user, so the exact field names and values
+       depend on which :doc:`authentication providers </authentication>`
+       the user has authenticated with.
+
+       .. admonition:: System Functions Have No User Data
+          :class: note
+          
+          In :ref:`system functions <system-functions>`, the ``user.data``
+          object is empty. Use :method:`context.runningAsSystem()` to test if
+          the function is running as a system user.
+
+   * - ``custom_data``
+     - document
+     
+     - A document from your application's :doc:`custom user
+       data collection </users/configure-custom-user-data>` that
+       specifies the user's ID. You can use the customer user data
+       collection to store arbitrary data about your application's
+       users. Realm automatically fetches a new copy of the data
+       whenever a user refreshes their access token, such as when they
+       log in. The underlying data is a regular MongoDB document, so you
+       can use standard CRUD operations through the :doc:`MongoDB Atlas
+       service </mongodb>` to define and modify the user's custom data.
+       
+       .. admonition:: Avoid Storing Large Custom User Data
+          :class: note
+          
+          Custom user data is limited to ``16MB``, the maximum size of a
+          MongoDB document. To avoid hitting this limit, consider
+          storing small and relatively static user data in each custom
+          user data document, such as the user's preferred language or
+          the URL of their avatar image. For data that is large,
+          unbounded, or frequently updated, consider only storing a
+          reference to the data in the custom user document or storing
+          the data with a reference to the user's ID rather than in the
+          custom user document.
+   
+   * - ``identities``
+     - array
+     - A list of authentication provider identities associated with the
+       user. When a user first logs in with a specific provider, Realm
+       associates the user with an identity object that contains a
+       unique identifier and additional metadata about the user from the
+       provider. For subsequent logins, Realm refreshes the existing
+       identity data but does not create a new identity. Identity
+       objects have the following form:
+
+       .. code-block:: json
+          
+          {
+            "id": "<Unique ID>",
+            "provider_type": "<Provider Name>",
+            "data": {
+              "<Metadata Field>": <Value>,
+              ...
+            }
+          }
+       
+       .. list-table::
+          :header-rows: 1
+          :widths: 10 20
+
+          * - Field Name
+            - Description
+
+          * - ``id``
+            - A provider-generated string that uniquely identifies this
+              identity
+
+          * - ``provider_type``
+            - The type of authentication provider associated with this
+              identity.
+
+          * - ``data``
+            - Additional metadata from the authentication provider that
+              describes the user. The exact field names and values will
+              vary depending on which authentication providers the user
+              has logged in with. For a provider-specific breakdown of
+              user identity data, see :ref:`User Metadata
+              <user-metadata>`.

--- a/source/index.txt
+++ b/source/index.txt
@@ -45,6 +45,7 @@ MongoDB Realm
    :caption: Users & Authentication
 
    Users & Authentication </authentication>
+   User Objects </authentication/user-objects>
    Authentication Providers </authentication/providers>
    Anonymous Authentication </authentication/anonymous>
    Email/Password Authentication </authentication/email-password>


### PR DESCRIPTION
- Ports Users page
- Moves User Objects to its own page
- Identities and Sessions moved to Authentication & Users overview page
- User Metadata moved to Providers page
- Added summary sections
- Also trying out changing "System users" to singular "THE System user"

## Staged
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker/users/authentication
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker/users/authentication/user-objects
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker/users/authentication/providers

## JIRA
https://jira.mongodb.org/browse/DOCSP-8768