### PR TITLE
(DOCSP-8042): Access Custom User Data from a Client SDK

### DIFF
--- a/source/includes/define-custom-user-data-example.rst
+++ b/source/includes/define-custom-user-data-example.rst
@@ -1,10 +1,40 @@
 .. example::
    
-   You can access custom user data from a ``StitchUser`` object in
+   You can access custom user data in the client SDKs as well as
    :doc:`functions </functions>` and :doc:`rule expressions
    </services/json-expressions>`.
 
    .. tabs-stitch-sdks::
+      
+      .. tab::
+         :tabid: javascript
+         
+         .. code-block:: javascript
+            :emphasize-lines: 3
+          
+            const app = Stitch.defaultAppClient;
+            const user = app.auth.user;
+            const speaksEnglish = user.profile.customData.primaryLanguage === "English";
+      
+      .. tab::
+         :tabid: android
+         
+         .. code-block:: java
+            :emphasize-lines: 3
+          
+            StitchAppClient app = Stitch.getDefaultAppClient();
+            StitchUser user = client.getAuth().getUser();
+            Boolean speaksEnglish = user.getCustomData().primaryLanguage == "English";
+      
+      .. tab::
+         :tabid: ios
+         
+         .. code-block:: swift
+            :emphasize-lines: 3
+          
+            let app: StitchAppClient = Stitch.defaultAppClient
+            let user: StitchUser = app.auth.currentUser
+            let speaksEnglish: Bool = user.customData.primaryLanguage == "English"
       
       .. tab::
          :tabid: json-expressions
@@ -12,7 +42,7 @@
          .. code-block:: json
           
             {
-              "%%user.custom_data.favoriteColor": "blue"
+              "%%user.custom_data.primaryLanguage": "English"
             }
       
       .. tab::
@@ -21,4 +51,4 @@
          .. code-block:: javascript
             
             const user = context.user;
-            const likesBlue = user.custom_data.favoriteColor === "blue";
+            const speaksEnglish = user.custom_data.primaryLanguage === "English";

--- a/source/includes/steps-define-custom-user-data-import-export.yaml
+++ b/source/includes/steps-define-custom-user-data-import-export.yaml
@@ -100,7 +100,4 @@ content: |
   document matches, Realm exposes the data in the document in the
   ``custom_data`` field of that user's :ref:`user object
   <user-objects>`.
-
-  .. include:: /includes/configure-custom-user-data-example.rst
-
 ...

--- a/source/includes/steps-define-custom-user-data-realm-ui.yaml
+++ b/source/includes/steps-define-custom-user-data-realm-ui.yaml
@@ -71,7 +71,4 @@ content: |
   document matches, Realm exposes the data in the document in the
   ``custom_data`` field of that user's :ref:`user object
   <user-objects>`.
-
-  .. include:: /includes/configure-custom-user-data-example.rst
-
 ...

--- a/source/users/define-custom-user-data.txt
+++ b/source/users/define-custom-user-data.txt
@@ -34,6 +34,8 @@ custom data. You can also use :doc:`authentication triggers
 documents, such as storing the time of their most recent login in the
 ``lastLogin`` field.
 
+.. include:: /includes/define-custom-user-data-example.rst
+
 .. admonition:: Store One Document Per User
    :class: important
 


### PR DESCRIPTION
_**This is a duplicate/port of https://github.com/10gen/baas-docs/pull/443**_

## Jira

- [(DOCSP-8042): Access Custom User Data from a Client SDK](https://jira.mongodb.org/browse/DOCSP-8042)

## Staged Changes

- [Configure Custom User Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker/auth-custom-data/users/define-custom-user-data)