### PR TITLE
(DOCSP-8928): Port: Flush the CDN Cache

### DIFF
--- a/source/hosting/flush-the-cdn-cache.txt
+++ b/source/hosting/flush-the-cdn-cache.txt
@@ -13,27 +13,29 @@ Flush the CDN Cache
 Overview
 --------
 
-Realm serves hosted files through a :wikipedia:`CDN
-<Content_delivery_network>` in order to minimize the latency between
-receiving a request for a resource and returning the requested resource.
+Realm serves hosted files through a :wikipedia:`Content Delivery Network
+(CDN) <Content_delivery_network>` in order to minimize the latency
+between receiving a request for a resource and returning the requested
+resource.
+
 When a client requests a resource that's hosted in Realm, the CDN server
-that processes the request checks for a cached copy of the file that it
-can return instead of requesting a new copy of the file from Realm.
+that processes the request checks for a cached copy of the file. If the
+server finds a valid cached copy of the resource, it returns it to the
+client. Otherwise, it forwards the request to Realm and caches the
+returned file before returning it to the client.
 
 The CDN caching process decreases the latency for end users when they
-request a resource, but it can also prevent them from receiving the most
-up-to-date version of a resource if the file has changed since the CDN
-server cached it. You can invalidate all cached files to force the CDN
-servers to fetch new copies from Realm.
+request a resource but may cause users to receieve an out-of-date
+version of a resource if the file has changed since the CDN server
+cached it. You can *flush* the CDN cache in order to make it drop all
+cached files and start serving the latest version of each file.
 
-To flush the CDN cache for all hosted files, select the tab below that
-corresponds to the interface you want to use and follow the procedure.
-
-.. note::
-
-   You can configure the caching behavior for an individual file by
-   adding a a :ref:`Cache-Control <metadata-cache-control>` attribute to
-   the file.
+.. admonition:: Automatic Cache Invalidation
+   :class: note
+   
+   The CDN automatically refreshes cached files periodically. You can
+   configure the caching behavior for an individual file by adding a a
+   :ref:`Cache-Control <metadata-cache-control>` attribute to the file.
 
 Procedure
 ---------

--- a/source/hosting/flush-the-cdn-cache.txt
+++ b/source/hosting/flush-the-cdn-cache.txt
@@ -1,0 +1,51 @@
+===================
+Flush the CDN Cache
+===================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+Realm serves hosted files through a :wikipedia:`CDN
+<Content_delivery_network>` in order to minimize the latency between
+receiving a request for a resource and returning the requested resource.
+When a client requests a resource that's hosted in Realm, the CDN server
+that processes the request checks for a cached copy of the file that it
+can return instead of requesting a new copy of the file from Realm.
+
+The CDN caching process decreases the latency for end users when they
+request a resource, but it can also prevent them from receiving the most
+up-to-date version of a resource if the file has changed since the CDN
+server cached it. You can invalidate all cached files to force the CDN
+servers to fetch new copies from Realm.
+
+To flush the CDN cache for all hosted files, select the tab below that
+corresponds to the interface you want to use and follow the procedure.
+
+.. note::
+
+   You can configure the caching behavior for an individual file by
+   adding a a :ref:`Cache-Control <metadata-cache-control>` attribute to
+   the file.
+
+Procedure
+---------
+
+.. tabs-stitch-interfaces::
+
+   .. tab::
+      :tabid: stitch-ui
+       
+       .. include:: /includes/steps/flush-the-cdn-cache-realm-ui.rst
+     
+   .. tab::
+      :tabid: import-export
+       
+       .. include:: /includes/steps/flush-the-cdn-cache-import-export.rst

--- a/source/includes/steps-flush-the-cdn-cache-import-export.yaml
+++ b/source/includes/steps-flush-the-cdn-cache-import-export.yaml
@@ -1,0 +1,28 @@
+title: Export Your Realm Application
+ref: export-your-application
+content: |
+  To flush the CDN cache with :doc:`realm-cli
+  </deploy/realm-cli-reference>` you need to export an
+  :ref:`application directory <application-directory>` for your
+  application.
+
+  You can :doc:`export </deploy/export-realm-app>` your
+  application from the :guilabel:`Export` tab of the
+  :guilabel:`Settings` page in the Realm UI, or by running the
+  following command from an authenticated instance of :doc:`realm-cli
+  </deploy/realm-cli-reference>`:
+
+  .. code-block:: shell
+
+     realm-cli export --app-id=<App ID>
+---
+title: Import the Application Directory
+ref: import-the-application-directory
+content: |
+  To purge the CDN cache, simply include the ``--reset-cdn-cache`` flag
+  when you import the application directory:
+
+  .. code-block:: shell
+
+     realm-cli import --reset-cdn-cache
+...

--- a/source/includes/steps-flush-the-cdn-cache-realm-ui.yaml
+++ b/source/includes/steps-flush-the-cdn-cache-realm-ui.yaml
@@ -1,0 +1,29 @@
+title: Navigate to the Hosted File Tree
+ref: navigate-to-the-hosting-file-tree
+content: |
+  Click :guilabel:`Hosting` in the left-hand navigation.
+---
+title: Select the Purge Cache Action
+ref: select-the-purge-cache-action
+content: |
+  You can purge the cache for all hosted files from the
+  :guilabel:`Files` tab.
+
+  1. Click the :guilabel:`Actions` button above the list of files.
+
+  2. Click :guilabel:`Purge Cache`.
+
+  3. In the :guilabel:`Purge Cache` modal, click :guilabel:`Confirm`.
+---
+title: Select the Attribute Type and Value
+ref: select-the-attribute-type-and-value
+content: |
+  The new metadata attribute will not have a type or value when you
+  first add it.
+
+  1. Select the attribute type from new attribute's left-hand dropdown
+
+  2. Enter a value for the attribute in the right-hand input box.
+
+  3. Click :guilabel:`Save`.
+...

--- a/source/index.txt
+++ b/source/index.txt
@@ -83,6 +83,7 @@ MongoDB Realm
    
    Host a Single-Page Application </hosting/host-a-single-page-application>
    Use a Custom Domain Name </hosting/use-a-custom-domain-name>
+   Flush the CDN Cache </hosting/flush-the-cdn-cache>
    Configure File Metadata </hosting/configure-file-metadata>
    File Metadata Attributes </hosting/file-metadata-attributes>
 


### PR DESCRIPTION
## Jira

- [(DOCSP-8928): Port: Flush the CDN Cache](https://jira.mongodb.org/browse/DOCSP-8928)

## Staged Changes

- [Flush the CDN Cache](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker/hosting-cache/hosting/flush-the-cdn-cache)