### PR TITLE
Fix "Stitch UI" to be "Realm UI" in 'Enable Hosting'

### DIFF
--- a/source/hosting/enable-hosting.txt
+++ b/source/hosting/enable-hosting.txt
@@ -14,7 +14,7 @@ Overview
 --------
 
 You need to enable static hosting for your application before you can
-upload and access content. You can allow static hosting from the Stitch
+upload and access content. You can allow static hosting from the Realm
 UI or by :doc:`importing </deploy/deploy-changes-with-realm-cli>` an
 application directory that enables hosting in its configuration file.
 Select the tab below that corresponds to the method you want to use.


### PR DESCRIPTION
stage: https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/Fix-Accidental-Stitch-Word-Usage-For-Enable-Hosting/hosting/enable-hosting.html