### PR TITLE
(DOCSP-8947): Port - Upload External Dependencies

### DIFF
--- a/source/functions/upload-external-dependencies.txt
+++ b/source/functions/upload-external-dependencies.txt
@@ -1,0 +1,45 @@
+============================
+Upload External Dependencies
+============================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+You can upload npm modules into your Realm application and use the
+uploaded :ref:`external dependencies <external-dependencies>` in your
+Functions. This allows your application to depend upon external
+libraries for code reuse.
+
+To use external dependencies, upload an archive of an npm
+``node_modules`` folder via the Realm UI. Once uploaded, any Realm
+Function can import and use any dependencies listed on the dependencies
+page of the Realm UI.
+
+.. admonition:: External Dependency Size Constraints
+   :class: important
+
+   Uploaded zip files are subject to a ``10MB`` size cap.
+
+Procedure
+---------
+
+.. include:: /includes/steps/upload-external-dependencies.rst
+
+
+Summary
+-------
+- External Dependencies can be uploaded through the Realm UI 
+- Uploaded Dependencies can be used in Realm Functions
+
+Next Steps
+----------
+
+- You have installed and archived your external dependencies locally, uploaded them to Realm, and deployed your application. Now you can :doc:`import external dependencies </functions/import-external-dependencies>` in a Realm Function.

--- a/source/includes/steps-upload-external-dependencies.yaml
+++ b/source/includes/steps-upload-external-dependencies.yaml
@@ -1,0 +1,88 @@
+title: Locally Install External Dependencies
+ref: locally-install-external-dependencies
+content: |
+  To upload external dependencies, you first need a local
+  ``node_modules`` folder containing at least one Node.js package. You
+  can use the following code snippet to install a dependency locally
+  you would like to upload:
+
+  .. code-block:: shell
+
+     npm install <package name>
+
+  If the ``node_modules`` folder does not already exist, this command
+  automatically creates it.
+
+  .. admonition:: Alternative Methods of Installation
+     :class: note
+     You can also configure a ``package.json`` and run the
+     ``npm install`` command to install all packages (and their
+     dependencies) listed in your ``package.json``.
+
+     To learn more about npm and ``node_modules``, consult the
+     `npm documentation <https://docs.npmjs.com/cli/install>`_ .
+
+---
+title: Create a Dependency Archive
+ref: create-a-dependency-archive
+content: |
+  Now that you've downloaded all of your npm modules, you need to
+  package them up in an archive so you can upload them to Realm. Create
+  an archive containing the ``node_modules`` folder:
+
+  .. code-block:: shell
+     tar -czf node_modules.tar.gz node_modules/
+
+  .. admonition:: Supported Archive Formats
+     :class: note
+     Realm supports ``.tar``, ``.tar.gz``, and ``.zip`` archive
+     formats.
+
+---
+title: Upload the Dependency Archive
+ref: upload-the-dependency-archive
+content: |
+  Once you've created an archive containing your dependencies, you can upload your
+  dependency archive using the Realm UI or Realm CLI:
+
+  .. tabs-realm-interfaces::
+     
+     .. tab::
+        :tabid: realm-ui
+
+        #. Select :guilabel:`Functions` from the left-side navigation.
+        #. Select the :guilabel:`Dependencies` tab.
+      
+        #. Click the :guilabel:`Upload` button.
+      
+        #. In the file picker, select the ``node_modules.tar.gz`` archive you
+           just created and click Open. Realm automatically uploads the
+           archive file, which may take several minutes depending on the
+           speed of your internet connection and the size of your dependency
+           archive.
+      
+        #. Whether the operation succeeded or failed, Realm displays a banner
+           indicating the success or failure of the operation. If successful,
+           the :guilabel:`Dependencies` tab displays a list of the
+           dependencies that you included in your dependency archive. If
+           drafts are enabled, you will also need to click
+           :guilabel:`Review & Deploy` to apply these changes. If drafts are
+           disabled, the change will take effect within 5 to 60 seconds
+           depending on the size of your dependency archive.
+     
+     .. tab::
+        :tabid: import-export
+        
+        #. Add the ``node_modules`` archive to your ``/functions``
+           directory:
+           
+           .. code-block:: shell
+              
+              mv node_modules.tar.gz ./myapp/functions
+        
+        #. Import your application with the :option:`--include-dependencies
+           <realm-cli import --include-dependencies>` option:
+           
+           .. code-block:: shell
+              
+              realm-cli import --include-dependencies

--- a/source/index.txt
+++ b/source/index.txt
@@ -72,6 +72,7 @@ MongoDB Realm
    Define a Function </functions/define-a-function>
    Call a Function </functions/call-a-function>
    Access Function Context </functions/access-function-context>
+   Upload External Dependencies </functions/upload-external-dependencies>
    Import External Dependencies </functions/import-external-dependencies>
 
 .. toctree::


### PR DESCRIPTION
Jira:
----
* https://jira.mongodb.org/browse/DOCSP-8947

Original/Adjacent Stitch Doc:
-----------------------------
* https://docs.mongodb.com/stitch/functions/upload-external-dependencies/

Stage:
------
* https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-8947-Port-Upload-External-Dependencies/functions/upload-external-dependencies.html
