### PR TITLE
(DOCSP-8952): Utility Packages

### DIFF
--- a/source/functions/json-and-bson.txt
+++ b/source/functions/json-and-bson.txt
@@ -58,8 +58,8 @@ objects.
       .. code-block:: javascript
 
          const jsonString = `{
-           someField: "someValue",
-           anotherField: 42
+           answer: 42,
+           submittedAt: "2020-03-02T16:50:24.475Z"
          }`;
          const object = JSON.parse(jsonString);
 
@@ -89,8 +89,8 @@ objects.
       .. code-block:: javascript
 
          const object = {
-           someField: "someValue",
-           anotherField: 42
+           answer: 42,
+           submittedAt: new Date("2020-03-02T16:46:47.977Z")
          };
          const jsonString = JSON.stringify(object);
 
@@ -137,8 +137,14 @@ preserves additional type information.
       .. code-block:: javascript
 
          const ejsonString = `{
-           someField: "someValue",
-           anotherField: 42
+           answer: {
+             "$numberLong": "42"
+           },
+           submittedAt: {
+             "$date": {
+               "$numberLong": "1583167607977"
+             }
+           }
          }`;
          const object = EJSON.stringify(ejsonString);
 
@@ -170,8 +176,8 @@ preserves additional type information.
       .. code-block:: javascript
 
          const object = {
-           someField: "someValue",
-           anotherField: 42
+           answer: 42,
+           submittedAt: new Date("2020-03-02T16:46:47.977Z")
          };
          const ejsonString = EJSON.stringify(object);
 
@@ -198,8 +204,8 @@ types and encodings.
    :class: note
 
    MongoDB stores all documents in BSON format, so you'll use the
-   ``BSON`` package most commonly when you read and write data to a
-   MongoDB collection.
+   ``BSON`` package most commonly when you run :ref:`CRUD & Aggregation
+   operations <crud-aggregation-operations>`.
 
 .. _bson-objectid:
 

--- a/source/functions/json-and-bson.txt
+++ b/source/functions/json-and-bson.txt
@@ -13,7 +13,30 @@ JSON & BSON
 Overview
 --------
 
-TODO
+Stitch :doc:`functions </functions>` include built-in global modules
+that allow you to process and convert between data formats. Each format
+supports various different data types and encodings.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+   
+   * - Module
+     - Description
+   
+   * - :ref:`JSON <json>`
+     - Includes methods that convert between string and object
+       representations of :wikipedia:`JSON <JSON>` data.
+   
+   * - :ref:`EJSON <ejson>`
+     - Includes methods that convert between string and object
+       representations of :manual:`Extended JSON
+       </reference/mongodb-extended-json>` data.
+   
+   * - :ref:`BSON <bson>`
+     - Includes methods that create :wikipedia:`Binary JSON <BSON>`
+       objects and convert between various BSON data types and
+       encodings.
 
 .. _json:
 
@@ -230,8 +253,7 @@ identifier.
 
       * - ``id``
         - string
-        - Optional. A 12-byte :manual:`ObjectId
-          </reference/method/ObjectId>` string.
+        - Optional. A 12-byte string or a string of 24 hex characters.
 
    :returns:
       
@@ -313,8 +335,8 @@ The ``BSON.Binary`` type represents a binary-encoded data string.
 
       * - ``hexString``
         - string
-        - A string of hexadecimal characters (0-9 and A-F). The encoding
-          must be byte aligned.
+        - A :wikipedia:`byte aligned <Data_structure_alignment>` string
+          of hexadecimal characters (0-9 and A-F).
 
       * - ``subType``
         - integer
@@ -549,7 +571,7 @@ number.
    exactly, e.g. financial data. For these cases, use
    :ref:`BSON.Decimal128 <bson-decimal128>` instead.
 
-.. method:: BSON.Double(double);
+.. method:: BSON.Double(double)
 
    Constructs a ``BSON.Double`` object from a 64-bit decimal value.
 

--- a/source/functions/json-and-bson.txt
+++ b/source/functions/json-and-bson.txt
@@ -1,0 +1,607 @@
+===========
+JSON & BSON
+===========
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+TODO
+
+.. _json:
+
+JSON (JavaScript Object Notation)
+---------------------------------
+
+:wikipedia:`JSON <JSON>` is a standard data format that stores groups of
+key-value pairs and supports basic JavaScript types. For details on
+syntax and supported types, refer to the `JSON specification
+<https://www.json.org/>`_.
+
+Realm exposes the standard :mdn:`JSON
+<Web/JavaScript/Reference/Global_Objects/JSON>` module in the global
+scope of every :doc:`function </functions>`. The module includes methods
+that convert between string and object representations of standard JSON
+objects.
+
+.. method:: JSON.parse(jsonString)
+
+   Parses the provided JSON string and converts it to a JavaScript
+   object.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``jsonString``
+        - :mdn:`string <Web/JavaScript/Reference/Global_Objects/String>`
+        - A serialized string representation of a standard JSON object.
+
+   :returns:
+
+      A standard JavaScript object generated from the provided JSON
+      string.
+   
+   .. example::
+      
+      .. code-block:: javascript
+
+         const jsonString = `{
+           someField: "someValue",
+           anotherField: 42
+         }`;
+         const object = JSON.parse(jsonString);
+
+.. method:: JSON.stringify(object)
+
+   Serializes the provided JavaScript object to a JSON string.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``object``
+        - :mdn:`object <Web/JavaScript/Reference/Global_Objects/Object>`
+        - A standard :mdn:`JavaScript Object
+          <Web/JavaScript/Reference/Global_Objects/Object>`.
+
+   :returns:
+
+      A string representation of the provided JavaScript object.
+   
+   .. example::
+      
+      .. code-block:: javascript
+
+         const object = {
+           someField: "someValue",
+           anotherField: 42
+         };
+         const jsonString = JSON.stringify(object);
+
+.. _ejson:
+.. _extended-json:
+
+EJSON (Extended JSON)
+---------------------
+
+:manual:`Extended JSON </reference/mongodb-extended-json>` is a superset
+of standard JSON that adds additional support for types that are
+available in :ref:`BSON <bson>` but not included in the `JSON
+specification <https://www.json.org/>`_.
+
+Realm exposes the ``EJSON`` module in the global scope of every
+:doc:`function </functions>`. This module is similar to the standard
+:mdn:`JSON <Web/JavaScript/Reference/Global_Objects/JSON>` module but
+preserves additional type information.
+
+.. method:: EJSON.parse(ejsonString)
+
+   Parses the provided :manual:`EJSON
+   </reference/mongodb-extended-json/>` string and converts it to a
+   JavaScript object.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ejsonString
+        - string
+        - A serialized string representation of an Extended JSON object.
+
+   :returns:
+
+      A Javascript object representation of the provided EJSON string.
+   
+   .. example::
+      
+      .. code-block:: javascript
+
+         const ejsonString = `{
+           someField: "someValue",
+           anotherField: 42
+         }`;
+         const object = EJSON.stringify(ejsonString);
+
+.. method:: EJSON.stringify(object)
+
+   Serializes the provided JavaScript object to an :manual:`EJSON
+   </reference/mongodb-extended-json/>` string.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``object``
+        - document
+        - An :manual:`EJSON
+          </reference/mongodb-extended-json/>` object. The object may
+          contain BSON types.
+
+   :returns:
+
+      A string representation of the provided EJSON object.
+   
+   .. example::
+      
+      .. code-block:: javascript
+
+         const object = {
+           someField: "someValue",
+           anotherField: 42
+         };
+         const ejsonString = EJSON.stringify(object);
+
+.. _bson:
+.. _binary-json:
+
+BSON (Binary JSON)
+------------------
+
+:wikipedia:`BSON <BSON>` is a data format that encodes binary
+representations of :manual:`extended JSON
+</reference/mongodb-extended-json>` objects. BSON includes additional
+data types beyond those in the JSON standard and provides a unified
+interface for converting data to and from binary representations. For
+more information, refer to the `BSON specification
+<http://bsonspec.org/>`__.
+
+Realm exposes the ``BSON`` module in the global scope of every
+:doc:`function </functions>`. This module provides methods that allow
+you to create BSON objects and convert them to and from various data
+types and encodings.
+
+.. admonition:: MongoDB Documents are BSON
+   :class: note
+
+   MongoDB stores all documents in BSON format, so you'll use the
+   ``BSON`` package most commonly when you read and write data to a
+   MongoDB collection.
+
+.. _bson-objectid:
+
+BSON.ObjectId
+~~~~~~~~~~~~~
+
+The ``BSON.ObjectId`` type represents a 12-byte MongoDB ``ObjectId``
+identifier.
+
+.. method:: BSON.ObjectId(id)
+   
+   Constructs a ``BSON.ObjectId`` object that encodes an
+   :manual:`ObjectId </reference/method/ObjectId>`
+   
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``id``
+        - string
+        - Optional. A 12-byte :manual:`ObjectId
+          </reference/method/ObjectId>` string.
+
+   :returns:
+      
+      A ``BSON.ObjectId`` object that encodes the specified
+      :manual:`ObjectId </reference/method/ObjectId>` string or a
+      generated ``ObjectId`` string if none was specified.
+   
+   .. example::
+      
+      .. code-block:: javascript
+
+         const objectId = new BSON.ObjectId("5e58667d902d38559c802b13");
+         const generatedObjectId = new BSON.ObjectId();
+
+.. _bson-regexp:
+
+BSON.BSONRegExp
+~~~~~~~~~~~~~~~
+
+The ``BSON.BSONRegExp`` type represents a :mdn:`regular expression
+<Web/JavaScript/Guide/Regular_Expressions>`. You can use a
+``BSON.BSONRegExp`` object with the ``$regex`` query operator to
+:ref:`perform a regular expression query <query-operators-regex>` on a
+MongoDB collection.
+
+.. method:: BSON.BSONRegExp(pattern, flags)
+   
+   Constructs a ``BSON.BSONRegExp`` object from a regular expression
+   string. You can optionally specify configuration flags.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``pattern``
+        - string
+        - A :mdn:`regular expression
+          <Web/JavaScript/Guide/Regular_Expressions>` pattern.
+
+      * - ``flags``
+        - string
+        - Optional. One or more :mdn:`regular expression flags
+          <Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags_2>`.
+
+   :returns:
+
+      A ``BSON.BSONRegExp`` object that encodes the provided regular
+      expression pattern and flags.
+
+   .. example::
+      
+      .. code-block:: javascript
+      
+         const regex = BSON.BSONRegExp("the great", "ig");
+
+.. _bson-binary:
+
+BSON.Binary
+~~~~~~~~~~~
+
+The ``BSON.Binary`` type represents a binary-encoded data string.
+
+.. method:: BSON.Binary.fromHex(hexString, subType)
+
+   Constructs a ``BSON.Binary`` object from data represented as a
+   hexadecimal string.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``hexString``
+        - string
+        - A string of hexadecimal characters (0-9 and A-F). The encoding
+          must be byte aligned.
+
+      * - ``subType``
+        - integer
+        - Optional. The type of data encoded in the hexadecimal string.
+          The value must be in the range 0-255 where ``0``, the default
+          value, represents a generic binary. For a full list of
+          supported subtypes, refer to the `BSON specification
+          <http://bsonspec.org/spec.html>`__.
+
+   :returns:
+
+      A ``BSON.Binary`` object that encodes the provided hexadecimal
+      string.
+
+   .. example::
+      
+      .. code-block:: javascript
+      
+         const binary = BSON.Binary.fromHex("54657374206d65737361676520706c656173652069676e6f7265=");
+
+.. method:: BSON.Binary.toHex()
+
+   Converts the ``BSON.Binary`` object into a hexadecimal string.
+
+   :returns:
+
+      A hexadecimal string representation of the provided
+      ``BSON.Binary`` object.
+
+   .. example::
+      
+      .. code-block:: javascript
+      
+         const binary = BSON.Binary.fromHex("54657374206d65737361676520706c656173652069676e6f7265=");
+         const hexString = binary.toHex();
+
+.. method:: BSON.Binary.fromBase64(base64String, subType)
+
+   Constructs a ``BSON.Binary`` object from data represented as a base64
+   string.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``base64String``
+        - string
+        - A string of base64 encoded characters.
+
+      * - ``subType``
+        - integer
+        - Optional. The type of data encoded in the hexadecimal string.
+          The value must be in the range 0-255 where ``0``, the default
+          value, represents a generic binary. For a full list of
+          supported subtypes, refer to the `BSON specification
+          <http://bsonspec.org/spec.html>`__.
+
+   :returns:
+
+      A ``BSON.Binary`` object that encodes the provided base64 string.
+
+   .. example::
+      
+      .. code-block:: javascript
+      
+         const binary = BSON.Binary.fromBase64("VGVzdCBtZXNzYWdlIHBsZWFzZSBpZ25vcmU=");
+
+.. method:: BSON.Binary.toBase64()
+
+   Converts the ``BSON.Binary`` object into a base64 string.
+
+   :returns:
+
+      A base64 string representation of the ``BSON.Binary`` object.
+
+   .. example::
+      
+      .. code-block:: javascript
+      
+         const binary = BSON.Binary.fromBase64("VGVzdCBtZXNzYWdlIHBsZWFzZSBpZ25vcmU=");
+         const base64String = binary.toBase64();
+
+.. method:: BSON.Binary.text()
+
+   Converts the ``BSON.Binary`` object into a UTF-8 string.
+
+   :returns:
+
+      A UTF-8 string representation of the provided ``BSON.Binary``
+      object.
+
+   .. example::
+      
+      .. code-block:: javascript
+      
+         const binary = BSON.Binary.fromBase64("VGVzdCBtZXNzYWdlIHBsZWFzZSBpZ25vcmU=");
+         const decodedString = binary.text();
+
+
+
+
+
+.. _bson-maxkey:
+
+BSON.MaxKey
+~~~~~~~~~~~
+
+The ``BSON.MaxKey`` type represents a value that compares higher than
+all other BSON values.
+
+.. example::
+   
+   .. code-block:: javascript
+      
+      await collection.findOne({ date: { $lt: BSON.MaxKey } });
+
+.. _bson-minkey:
+
+BSON.MinKey
+~~~~~~~~~~~
+
+The ``BSON.MinKey`` type represents a value that compares lower than all
+other BSON values.
+
+.. example::
+   
+   .. code-block:: javascript
+      
+      await collection.findOne({ date: { $gt: BSON.MinKey } });
+
+.. _bson-int32:
+
+BSON.Int32
+~~~~~~~~~~
+
+The ``BSON.Int32`` type represents a 32-bit signed integer.
+
+.. method:: BSON.Int32(integer)
+
+   Constructs a ``BSON.Int32`` object from a 32-bit number.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``low32``
+        - number
+        - A 32-bit number.
+
+   :returns:
+
+      A ``BSON.Int32`` object that encodes the specified integer.
+      Returns ``0`` if no arguments are supplied.
+
+   .. example::
+      
+      .. code-block:: javascript
+      
+         const int32 = BSON.Int32(42);
+
+.. _bson-long:
+
+BSON.Long
+~~~~~~~~~
+
+The ``BSON.Long`` type represents a 64-bit signed integer.
+
+.. method:: BSON.Long(low32, high32)
+
+   Constructs a ``BSON.Long`` object from two 32-bit integers that
+   represent the low 32 bits and the high 32 bits in the 64-bit ``Long``
+   integer.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``low32``
+        - integer
+        
+        - Optional. The long integer's 32 low bits. These bits represent
+          the least significant digits of the number.
+
+      * - ``high32``
+        - integer
+        - Optional. The long integer's 32 high bits. These bits
+          represent the most significant digits of the number.
+
+   :returns:
+
+      A ``BSON.Long`` object that encodes the specified integer.
+      Returns ``0`` if no arguments are supplied.
+
+      ``BSON.Long`` encodes using the following formula:
+
+      .. code-block:: javascript
+         :copyable: false
+
+         (high32 * (2**32)) + low32
+
+   .. example::
+      
+      .. code-block:: javascript
+      
+         const long = BSON.Long(600206158, 342);
+
+.. _bson-double:
+
+BSON.Double
+~~~~~~~~~~~
+
+The ``BSON.Double`` type represents a 64-bit (8-byte) floating point
+number.
+
+.. admonition:: Use Decimal128 for Money
+   :class: important
+
+   ``BSON.Double`` is subject to floating point rounding errors, so it
+   is not recommended for use cases where decimal values must round
+   exactly, e.g. financial data. For these cases, use
+   :ref:`BSON.Decimal128 <bson-decimal128>` instead.
+
+.. method:: BSON.Double(double);
+
+   Constructs a ``BSON.Double`` object from a 64-bit decimal value.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``double``
+        - number
+        - A 64-bit decimal value.
+
+   :returns:
+
+      A ``BSON.Double`` object that encodes the specified double.
+      Returns ``0`` if no argument is supplied.
+
+   .. example::
+      
+      .. code-block:: javascript
+      
+         const double = BSON.Double(1234.5678);
+
+.. _bson-decimal128:
+
+BSON.Decimal128
+~~~~~~~~~~~~~~~
+
+The ``BSON.Decimal128`` type represents a 128-bit (16-byte) floating
+point number. This type is intended for use cases where decimal values
+must round exactly, e.g. financial data.
+
+.. method:: BSON.Decimal128.fromString(decimalString)
+
+   Constructs a ``BSON.Decimal128`` from a string representation of a
+   decimal number.
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``decimalString``
+        - string
+        - A string representing a decimal number, e.g. ``"1234.5678910123456"``.
+
+   :returns:
+
+      A ``BSON.Decimal128`` that encodes the provided decimal value.
+
+   .. example::
+      
+      .. code-block:: javascript
+         
+         const double = BSON.Decimal128.fromString("1234.5678910123456");

--- a/source/functions/utilities.txt
+++ b/source/functions/utilities.txt
@@ -1,0 +1,776 @@
+================
+Utility Packages
+================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. _function-utils-jwt:
+
+JSON Web Tokens (``utils.jwt``)
+-------------------------------
+
+The ``utils.jwt`` package provides methods for working with
+:jwt-io:`JSON Web Tokens <introduction>`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40
+   
+   * - Method
+     - Description
+   
+   * - :method:`utils.jwt.encode()`
+     - Generates an encoded JSON Web Token string for a given
+       ``payload``, ``signingMethod``, and ``secret``.
+   
+   * - :method:`utils.jwt.decode()`
+     - Decodes the ``payload`` of a JSON Web Token string.
+
+.. method:: utils.jwt.encode()
+
+   Generates an encoded JSON Web Token string for the ``payload`` based
+   on the specified ``signingMethod`` and ``secret``.
+
+   .. code-block:: javascript
+      
+      utils.jwt.encode(signingMethod, payload, secret, customHeaderFields)
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 15 10 75
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``signingMethod``
+        - String
+        - The cryptographic algorithm to use when encoding the JWT.
+          Stitch supports the following JWT signing methods:
+          
+          .. list-table::
+             :class: config-table
+             :widths: 30 70
+             :header-rows: 1
+             
+             * - Signing Method
+               - Description
+
+             * - ``"HS256"``
+               - HMAC using SHA-256
+             * - ``"HS384"``
+               - HMAC using SHA-384
+             * - ``"HS512"``
+               - HMAC using SHA-512
+             
+             * - ``"RS256"``
+               - RSASSA-PKCS1-v1_5 using SHA-256
+             * - ``"RS384"``
+               - RSASSA-PKCS1-v1_5 using SHA-384
+             * - ``"RS512"``
+               - RSASSA-PKCS1-v1_5 using SHA-512
+             
+             * - ``"ES256"``
+               - ECDSA using P-256 and SHA-256
+             * - ``"ES384"``
+               - ECDSA using P-384 and SHA-384
+             * - ``"ES512"``
+               - ECDSA using P-512 and SHA-512
+             
+             * - ``"PS256"``
+               - RSASSA-PSS using SHA-256 and MGF1 with SHA-256
+             * - ``"PS384"``
+               - RSASSA-PSS using SHA-384 and MGF1 with SHA-384
+             * - ``"PS512"``
+               - RSASSA-PSS using SHA-512 and MGF1 with SHA-512
+
+      * - ``payload``
+        - Object
+        
+        - A JSON object that specifies the token's claims and any
+          additional related data.
+
+      * - ``secret``
+        - String
+        - A secret string that Stitch uses to sign the token. The value
+          of the string depends on the signing method that you use:
+          
+          .. list-table::
+             :header-rows: 1
+             :widths: 30 70
+
+             * - Signing Methods
+               - Description
+
+             * - | ``"HS256"``
+                 | ``"HS384"``
+                 | ``"HS512"``
+               - A random string.
+             * - | ``"RS256"``
+                 | ``"RS384"``
+                 | ``"RS512"``
+               - An RSA-SHA private key in PKCS#8 format.
+             * - | ``"PS256"``
+                 | ``"PS384"``
+                 | ``"PS512"``
+               - An RSA-PSS private key in PKCS#8 format.
+             * - | ``"ES256"``
+                 | ``"ES384"``
+                 | ``"ES512"``
+               - An :wikipedia:`ECDSA
+                 <Elliptic_Curve_Digital_Signature_Algorithm>`  private
+                 key in PKCS#8 format.
+
+      * - ``customHeaderFields``
+        - Object
+        
+        - A JSON object that specifies additional fields to include in
+          the JWT's `JOSE header
+          <https://tools.ietf.org/html/rfc7515#section-4>`__.
+   
+   :returns:
+       A JSON Web Token string encoded for the provided ``payload``.
+
+   .. example::
+      
+      Consider the following JWT claims object:
+      
+      .. code-block:: json
+         
+         {
+           "sub": "1234567890",
+           "name": "Joe Example",
+           "iat": 1565721223187
+         }
+      
+      We can encode the claims object as a JWT string by calling
+      ``utils.jwt.encode()``. The following function encodes the JWT
+      using the ``HS512`` signing method and the secret
+      ``"SuperSecret"``:
+
+      .. code-block:: javascript
+         
+         exports = function() {
+           const signingMethod = "HS512";
+           const payload = {
+             "sub": "1234567890",
+             "name": "Joe Example",
+             "iat": 1565721223187
+           };
+           const secret = "SuperSecret";
+           return utils.jwt.encode(signingMethod, payload, secret);
+         }
+      
+      The function returns the following JWT string:
+
+      .. code-block:: none
+         
+         eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvZSBTY2htb2UiLCJpYXQiOjE1NjU3MjEyMjMxODd9.-QL15ldu2BYuJokNWT6YRiwZQIiIpvq6Kyv-C6qslNdNiUVxo8zqLJZ1iEkNf2yZKMIrQuMCtIC1tzd2H31AxA
+
+.. method:: utils.jwt.decode()
+
+   Decodes the ``payload`` of the provided JSON Web Token string. The
+   value of ``key`` must correspond to the secret value that was used to
+   encode the JWT string.
+
+   .. code-block:: javascript
+      
+      utils.jwt.decode(jwtString, key, returnHeader)
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 15 15 70
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``jwtString``
+        - String
+        - A JSON Web Token string that encodes a set of claims signed
+          with a secret value.
+
+      * - ``key``
+        - String
+        - A string that Stitch uses to verify the token signature. The
+          value of the string depends on the signing method that you use:
+          
+          .. list-table::
+             :header-rows: 1
+
+             * - Signing Methods
+               - Description
+
+             * - | ``"HS256"``
+                 | ``"HS384"``
+                 | ``"HS512"``
+               - The random string that was used to sign the token.
+             * - | ``"RS256"``
+                 | ``"RS384"``
+                 | ``"RS512"``
+               - The RSA-SHA public key that corresponds to the private
+                 key that was used to sign the token.
+             * - | ``"PS256"``
+                 | ``"PS384"``
+                 | ``"PS512"``
+               - The RSA-PSS public key that corresponds to the private
+                 key that was used to sign the token.
+             * - | ``"ES256"``
+                 | ``"ES384"``
+                 | ``"ES512"``
+               - The :wikipedia:`ECDSA
+                 <Elliptic_Curve_Digital_Signature_Algorithm>` public
+                 key that corresponds to the private key that was used
+                 to sign the token.
+
+      * - ``returnHeader``
+        - Boolean
+        
+        - If ``true``, return the JWT's `JOSE header
+          <https://tools.ietf.org/html/rfc7515#section-4>`__ in addition
+          to the decoded payload.
+   
+   :returns:
+       If ``returnHeader`` is ``false``, returns the decoded EJSON
+       payload.
+
+       If ``returnHeader`` is ``true``, returns an object that contains
+       the `JOSE header
+       <https://tools.ietf.org/html/rfc7515#section-4>`__ in the
+       ``header`` field and the decoded EJSON payload in the ``payload``
+       field.
+
+       .. code-block:: json
+          
+          {
+            "header": {
+              "<JOSE Header Field>": <JOSE Header Value>,
+              ...
+            },
+            "payload": {
+              "<JWT Claim Field>": <JWT Claim Value>,
+              ...
+            }
+          }
+
+   .. example::
+      
+      Consider the following signed JWT string:
+      
+      .. code-block:: none
+         
+         eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvZSBTY2htb2UiLCJpYXQiOjE1NjU3MjEyMjMxODd9.-QL15ldu2BYuJokNWT6YRiwZQIiIpvq6Kyv-C6qslNdNiUVxo8zqLJZ1iEkNf2yZKMIrQuMCtIC1tzd2H31AxA
+
+      The JWT was signed using the ``HS512`` signing method with the
+      secret value ``"SuperSecret"``. We can decode the JWT's claims
+      object ``utils.jwt.decode()``. The following function decodes the
+      JWT string:
+
+      .. code-block:: javascript
+         
+         exports = function(jwtString) {
+           const signingMethod = "HS512";
+           const key = "SuperSecret";
+           return utils.jwt.decode(jwtString, key);
+         }
+      
+      The function returns the following EJSON representation of the JWT
+      payload:
+
+      .. code-block:: json
+         
+         {
+           "sub": "1234567890",
+           "name": "Joe Example",
+           "iat": { "$numberDouble": 1565721223187 }
+         }
+
+.. _function-utils-crypto:
+
+Cryptography (``utils.crypto``)
+-------------------------------
+
+The ``utils.crypto`` package provides methods for working with
+cryptographic algorithms.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40
+   
+   * - Method
+     - Description
+   
+   * - :method:`utils.crypto.encrypt()`
+     - Generates an encrypted text string from a given text string using
+       a specific encryption method and key.
+   
+   * - :method:`utils.crypto.decrypt()`
+     - Decrypts a provided text string using a specific encryption
+       method and key.
+   
+   * - :method:`utils.crypto.sign()`
+     - Generates a cryptographically unique signature for a given
+       message using a private key.
+   
+   * - :method:`utils.crypto.verify()`
+     - Verifies that a signature is valid for a given message and public
+       key.
+   
+   * - :method:`utils.crypto.hmac()`
+     - Generates an :wikipedia:`HMAC <HMAC>` signature from a given
+       input and secret.
+   
+   * - :method:`utils.crypto.hash()`
+     - Generates a hash value for a given input and hash function.
+
+.. method:: utils.crypto.encrypt()
+
+   Generates an encrypted text string from the provided text using the
+   specified encryption method and key.
+
+   .. code-block:: javascript
+      
+      utils.crypto.encrypt(encryptionType, message, key)
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``encryptionType``
+        - String
+        - The type of encryption with which to encrypt the message. The
+          following encryption types are supported:
+
+          - :wikipedia:`AES Encryption <Advanced_Encryption_Standard>` (``"aes"``)
+
+      * - ``message``
+        - String
+        - The text string that you want to encrypt.
+
+      * - ``key``
+        - String
+        
+        - A cryptographic key used to encrypt the text. The key
+          you should use depends on the encryption method:
+
+          .. list-table::
+             :header-rows: 1
+             :widths: 30 70
+
+             * - Encryption Type
+               - Encryption Key
+
+             * - AES
+               - A 16-byte, 24-byte, or 32-byte random string
+
+   :returns:
+
+      A :ref:`BSON Binary <bson-binary>` object that contains the text
+      string encrypted with the specified encryption type and key.
+
+   .. example::
+      
+      Assume that we have defined a :doc:`Value </values>` named
+      ``aesEncryptionKey`` that contains the following 32-byte AES
+      encryption key:
+
+      .. code-block:: javascript
+         
+         "603082712271C525E087BD999A4E0738"
+      
+      We can encrypt a message with this key using the following Stitch
+      function:
+
+      .. code-block:: javascript
+         :emphasize-lines: 3
+         
+         exports = function(message) {
+           const key = context.values.get("aesEncryptionKey");
+           const encryptedMessage = utils.crypto.encrypt("aes", message, key);
+           return encryptedMessage.toBase64();
+         }
+      
+      If we use the function to encrypt the message ``"MongoDB is
+      great!"``, it returns the following encrypted base64 string:
+
+      .. code-block:: javascript
+         
+         "WPBuIvJ6Bity43Uh822dW8QlVYVJaFUiDeUjlTiJXzptUuTYIKPlXekBQAJb"
+
+.. method:: utils.crypto.decrypt()
+
+   Decrypts the provided text string using the specified encryption type
+   and key. If both the encryption type and key are the same as those
+   used to encrypt, this returns the original, unencrypted text.
+
+   .. code-block:: javascript
+      
+      utils.crypto.decrypt(encryptionType, encryptedMessage, key)
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+      
+      * - Parameter
+        - Type
+        - Description
+      
+      * - ``encryptionType``
+        - String
+        - The type of encryption that was used to encrypt the provided
+          text. The following encryption types are supported:
+          
+          - :wikipedia:`AES Encryption <Advanced_Encryption_Standard>` (``"aes"``)
+      
+      * - ``encryptedMessage``
+        - :ref:`BSON.Binary <bson-binary>`
+        - A BSON Binary that encodes the encrypted text string that
+          you want to decrypt.
+      
+      * - ``key``
+        - String
+        - A cryptographic key used to decrypt the text. The key
+          you should use depends on the encryption type:
+          
+          .. list-table::
+             :header-rows: 1
+             :widths: 30 70
+             
+             * - Encryption Type
+               - Encryption Key
+             
+             * - AES
+               - A 16-byte, 24-byte, or 32-byte random string
+
+   :returns:
+       
+       A :ref:`BSON Binary <bson-binary>` object that contains the
+       decrypted message.
+       
+       If the provided encrypted message was encrypted with the
+       specified method and key, then the decrypted message is identical
+       to the original message.
+
+   .. example::
+      
+      Assume that we have defined a :doc:`Value </values>` named
+      ``aesEncryptionKey`` that contains the following 32-byte AES
+      encryption key:
+      
+      .. code-block:: none
+         
+         "603082712271C525E087BD999A4E0738"
+      
+      We can decrypt a message that was encrypted with this key using
+      the following Stitch function:
+      
+      .. code-block:: javascript
+         :emphasize-lines: 7
+         
+         exports = function(encryptedMessage) {
+           // The encrypted message must be a BSON.Binary
+           if(typeof encryptedMessage === "string") {
+             encryptedMessage = BSON.Binary.fromBase64(encryptedMessage)
+           }
+           const key = context.values.get("aesEncryptionKey");
+           const decryptedMessage = utils.crypto.decrypt("aes", encryptedMessage, key);
+           return decryptedMessage.text();
+         }
+      
+      If we use the function to decrypt the encrypted message, it
+      returns the original, unencrypted string:
+
+      .. code-block:: javascript
+         
+         "MongoDB is great!"
+
+.. method:: utils.crypto.sign()
+   
+   Generates a cryptographically unique signature for a message using a
+   private key. The signature can be verified with the corresponding
+   public key to ensure that the signer has access to the private key
+   and that the message content has not been altered since it was
+   signed.
+
+   .. code-block:: javascript
+      
+      utils.crypto.sign(encryptionType, message, privateKey, signatureScheme)
+   
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+      
+      * - Parameter
+        - Type
+        - Description
+      
+      * - ``encryptionType``
+        - String
+        - The type of encryption that was used to generate the
+          private/public key pair. The following encryption types are
+          supported:
+          
+          - :wikipedia:`RSA Encryption <RSA_algorithm>` (``"rsa"``)
+      
+      * - ``message``
+        - String
+        - The text string that you want to sign.
+      
+      * - ``privateKey``
+        - String
+        - A private key generated with the specified encryption type.
+
+          .. admonition:: Key Format
+             :class: reference-block
+             
+             Not all RSA keys use the same format. Stitch can only sign
+             messages with a private key that conforms to the standard
+             :wikipedia:`PKCS#1 <PKCS_1>` format. Private keys in this
+             format have the header ``-----BEGIN RSA PRIVATE KEY-----``.
+
+             .. include:: /includes/shell-generate-an-rsa-key-pair.rst
+      
+      * - ``signatureScheme``
+        - String
+        - Optional. Default: ``"pss"``
+          
+          The :wikipedia:`padding scheme <Padding_(cryptography)>` that
+          the signature should use. Stitch supports signing messages
+          with the following schemes:
+
+          - :wikipedia:`Probabilistic signature scheme <Probabilistic_signature_scheme>` (``"pss"``)
+          - :wikipedia:`PKCS1v1.5 <PKCS_1>` (``"pkcs1v15"``)
+
+   :returns:
+       
+       A :ref:`BSON.Binary <bson-binary>` :wikipedia:`cryptographic
+       signature <Digital_signature>` for the message signed using the
+       specified private key.
+
+   .. example::
+      
+      Assume that we have defined a :doc:`Value </values>` named
+      ``rsaPrivateKey`` that contains the following RSA private key:
+
+      .. code-block:: none
+         
+         -----BEGIN RSA PRIVATE KEY-----
+         MIICXAIBAAKBgQDVsEjse2qO4v3p8RM/q8Rqzloc1lee34yoYuKZ2cemuUu8Jpc7
+         KFO1+aJpXdbSPZNhGLdANn8f2oMIZ1R9hgEJRn/Qm/YyC4RPTGg55nzHqSlziNZJ
+         JAyEUyU7kx5+Kb6ktgojhk8ocZRkorM8FEylkrKzgSrfay0PcWHPsKlmeQIDAQAB
+         AoGAHlVK1L7kLmpMbuP4voYMeLjYE9XdVEEZf2GiFwLSE3mkJY44033y/Bb2lgxr
+         DScOf675fFUAEK59ATlhxfu6s6rgx+g9qQQ+mL74YZWPqiZHBPjyMRaBalDVC4QF
+         YJ+DopFcB8hY2ElXnbK70ALmVYNjw3RdmC97h0YfOsQcWW0CQQD18aeuPNicVnse
+         Ku22vvhvQYlabaQh4xdkEIxz1TthZj48f61wZwEMipYqOAc5XEtDlNnxgeipv0yF
+         RHstUjwXAkEA3m0Br/U/vC9evuXppWbONana08KLgfELyd3Uw9jG7VKJZTBH5mS8
+         7CB68aEF8egrJpo8Ss8BkWrvCxYDb4Y77wJAUlbOMZozVtvpKidrIFR9Lho91uWA
+         Hsw9h4W20AzibXBig7SnJ0uE4WMAdS/+0yhgFkceVCmO8E2YW8Gaj4jJjwJASxtg
+         AHy+ItuUEL4uIW4Pn8tVW0BMP3qX0niXyfI/ag/+2S5uePv3V3y4RzNqgH83Yved
+         +FziWKpVQdcTHeuj/QJBAJl1G3WFruk0llIoKKbKljaEiCm1WCTcuEPbdOtkJYvO
+         9ZYQg/fji70FERkq2KHtY7aLhCHzy0d4n9xgE/pjV+I=
+         -----END RSA PRIVATE KEY-----
+      
+      We can sign a message with this key using the following Stitch
+      function:
+
+      .. code-block:: javascript
+         :emphasize-lines: 3
+         
+         exports = function(message) {
+           const rsaPrivateKey = context.values.get("rsaPrivateKey");
+           const signature = utils.crypto.sign("rsa", message, rsaPrivateKey, "pss");
+           return signature;
+         }
+      
+      If we use the function to sign the message ``"MongoDB is
+      great!"``, it returns a :ref:`BSON.Binary <bson-binary>` signature
+      that evaluates to the following base64 string:
+
+      .. code-block:: none
+         
+         "SpfXcJwPbypArt+XuYQyuZqU52YCAY/sZj2kiuin2b6/RzyM4Ek3n3spOtqZJqxn1tfQavxIX4V+prbs74/pOaQkCLekl9Hoa1xOzSKcGoRd8U+n1+UBY3d3cyODGMpyr8Tim2HZAeLPE/D3Q36/K+jpgjvrJFXsJoAy5/PV7iEGV1fkzogmZtXWDcUUBBTTNPY4qZTzjNhL4RAFOc7Mfci+ojE/lLsNaumUVU1/Eky4vasmyjqunm+ULCcRmgWtGDMGHaQV4OXC2LMUe9GOqd3Q9ghCe0Vlhn25oTh8cXoGpd1Fr8wolNa//9dUqSM+QYDpZJXGLShX/Oa8mPwJZKDKHtqrS+2vE6S4dDWR7zKDza+DeovOeCih71QyuSYMXSz+WWGgfLzv/syhmUXP/mjqgLmJU6Kwg5htajDoylpzLC0BLGT4zDZEwBrq/AjwRs/EPjYdFgGCt1WCbbVlDyXvvH1ekDrzACzumhiMSZNNa+ZH3JmMJxTCQWDfiTeAfkauaaZHKIj2q2/QE7vuAhNcVPJ2YgpXnvnQHJpEZBc/Y3Q6JLxom6+cGC4P//9d++r2cwzXIkqD+wSGZVSVtpm5CLtWMRSK5FX2dv16bM+LE8ozoRvtMUDTrQ8SSSDGxyuYbvN9b2fYYPcWpCMchqOBXV6eZGoMldaHX3Qy5h8="
+
+.. method:: utils.crypto.verify()
+   
+   Checks that the provided signature is valid for the specified message
+   and public key.
+   
+   If the signature is valid, it guarantees that the signer has access
+   to the corresponding private key and that the message content has not
+   been altered since it was signed.
+
+   .. code-block:: javascript
+      
+      utils.crypto.verify(encryptionType, message, publicKey, signature, signatureScheme)
+   
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+      
+      * - Parameter
+        - Type
+        - Description
+      
+      * - ``encryptionType``
+        - String
+        - The type of encryption that was used to generate the
+          private/public key pair. The following encryption types are
+          supported:
+          
+          - :wikipedia:`RSA Encryption <RSA_algorithm>` (``"rsa"``)
+      
+      * - ``message``
+        - String
+        - The text string for which you want to verify the signature. If
+          the signature is valid, this is the exact message that was
+          signed.
+      
+      * - ``publicKey``
+        - String
+        
+        - The public key for which you want to verify the signature. If
+          the signature is valid, this is the corresponding public key
+          of the private key that was used to sign the message.
+
+          .. admonition:: Key Format
+             :class: reference-block
+             
+             Not all RSA keys use the same format. Stitch can only
+             verify signatures with RSA keys that conform to the
+             standard :wikipedia:`PKCS#1 <PKCS_1>` format. Public keys
+             in this format have the header ``-----BEGIN RSA PUBLIC
+             KEY-----``.
+
+             .. include:: /includes/shell-generate-an-rsa-key-pair.rst
+          
+      * - ``signature``
+        - :ref:`BSON.Binary <bson-binary>`
+        - The signature that you want to verify.
+      
+      * - ``signatureScheme``
+        - String
+        - Optional. Default: ``"pss"``
+          
+          The :wikipedia:`padding scheme <Padding_(cryptography)>` that
+          the signature uses. Stitch supports verifying signatures that
+          use the following schemes:
+
+          - :wikipedia:`Probabilistic signature scheme <Probabilistic_signature_scheme>` (``"pss"``)
+          - :wikipedia:`PKCS1v1.5 <PKCS_1>` (``"pkcs1v15"``)
+          
+   :returns:
+       
+      A boolean that, if ``true``, indicates whether or not the
+      signature is valid for the provided message and public key.
+
+   .. example::
+      
+      We received a message with a signature in :ref:`BSON.Binary
+      <bson-binary>` format and want to verify that the message was
+      signed with the private key that corresponds to the sender's RSA
+      public key:
+
+      .. code-block:: none
+         
+         -----BEGIN RSA PUBLIC KEY-----
+         MIGJAoGBANWwSOx7ao7i/enxEz+rxGrOWhzWV57fjKhi4pnZx6a5S7wmlzsoU7X5
+         omld1tI9k2EYt0A2fx/agwhnVH2GAQlGf9Cb9jILhE9MaDnmfMepKXOI1kkkDIRT
+         JTuTHn4pvqS2CiOGTyhxlGSiszwUTKWSsrOBKt9rLQ9xYc+wqWZ5AgMBAAE=
+         -----END RSA PUBLIC KEY-----
+
+      We can use the following Stitch function to verify the RSA
+      signature:
+      
+      .. code-block:: javascript
+         :emphasize-lines: 2
+         
+         exports = function(message, rsaPublicKey, signature) {
+           const isValid = utils.crypto.verify("rsa", message, rsaPublicKey, signature, "pss");
+           return isValid; // true if the signature matches, else false
+         }
+
+.. method:: utils.crypto.hmac()
+
+   Generates an :wikipedia:`HMAC <HMAC>` signature from the provided
+   input and secret. This is useful when communicating with third-party
+   HTTP services that require signed requests.
+
+   .. code-block:: javascript
+      
+      utils.crypto.hmac(input, secret, hash_function, output_format)
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``input``
+        - string
+        - The input for which you would like to generate a signature.
+
+      * - ``secret``
+        - string
+        - The secret key to use when generating the signature.
+
+      * - ``hash_function``
+        - string
+        - The name of the hashing function to use when generating the
+          signature. The following functions are supported: ``"sha1"``,
+          ``"sha256"``, ``"sha512"``.
+
+      * - ``output_format``
+        - string
+        - The format of the generated signature. Can be either
+          ``"hex"`` for a hex string, or ``"base64"`` for a Base64
+          string.
+
+   :returns:
+
+      The signature of the input, in the format specified by
+      ``output_format``.
+
+.. method:: utils.crypto.hash()
+
+   Generates a hash value for the provided input using the specified
+   hash function.
+
+   .. code-block:: javascript
+      
+      utils.crypto.hash(hash_function, input)
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Parameter
+        - Type
+        - Description
+
+      * - ``hash_function``
+        - string
+        - The name of the hashing function.
+          The following functions are supported: ``"sha1"``,
+          ``"sha256"``, ``"md5"``.
+
+      * - ``input``
+        - string or BSON.Binary
+        - Required.
+          The input for which you would like to generate a hash value.
+
+   :returns:
+
+      A hash value for the provided input generated by the specified
+      hashing function.

--- a/source/functions/utilities.txt
+++ b/source/functions/utilities.txt
@@ -275,7 +275,6 @@ The ``utils.jwt`` package provides methods for working with
       .. code-block:: javascript
          
          exports = function(jwtString) {
-           const signingMethod = "HS512";
            const key = "SuperSecret";
            return utils.jwt.decode(jwtString, key);
          }

--- a/source/includes/shell-generate-an-rsa-key-pair.rst
+++ b/source/includes/shell-generate-an-rsa-key-pair.rst
@@ -1,0 +1,13 @@
+You can use the following shell script to generate a valid RSA
+private/public key pair and save each key to its own text file:
+
+.. code-block:: shell
+   
+   # Generate an RSA SSH key pair
+   # Save the key to a file called `rsa_key` when prompted
+   ssh-keygen -t rsa -m PEM -b 2048 -C "2048-bit RSA Key"
+   
+   # Private Key
+   cat rsa_key > rsa.private.txt
+   # Public Key
+   ssh-keygen -f rsa_key.pub -e -m pem > rsa.public.txt

--- a/source/index.txt
+++ b/source/index.txt
@@ -73,6 +73,8 @@ MongoDB Realm
    Access Function Context </functions/access-function-context>
    Upload External Dependencies </functions/upload-external-dependencies>
    Import External Dependencies </functions/import-external-dependencies>
+   JSON & BSON </functions/json-and-bson>
+   Utility Packages </functions/utilities>
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
- Removes docs for `console`
- Splits `JSON`, `EJSON`, and `BSON` into a new page
  - Adds brief context with links to additional resources for each format
  - Adds examples for all methods
- This leaves `utils.jwt` and `utils.crypto` on a separate page for easier deprecation

## Jira

- [(DOCSP-8952): Utility Packages](https://jira.mongodb.org/browse/DOCSP-8952)

## Staged Changes

- [Utility Packages](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nick/function-utils/functions/utilities.html)
- [JSON & BSON](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nick/function-utils/functions/json-and-bson.html)