### PR TITLE
Unified `realm-cli login` Syntax

### DIFF
--- a/source/deploy/realm-cli-reference.txt
+++ b/source/deploy/realm-cli-reference.txt
@@ -87,7 +87,7 @@ with a :atlas:`MongoDB Atlas programmatic API Key
 
 .. code-block:: shell
 
-   realm-cli login --api-key=<my api key> --private-api-key=<my private api key>
+   realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 
 .. include:: /includes/option/option-realm-cli-login-api-key.rst
 .. include:: /includes/option/option-realm-cli-login-private-api-key.rst

--- a/source/includes/steps-cli-create.yaml
+++ b/source/includes/steps-cli-create.yaml
@@ -42,7 +42,7 @@ content: |
 
   .. code-block:: shell
 
-     realm-cli login --api-key=my-api-key --private-api-key=my-private-api-key
+     realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 ---
 title: Run the Import Command
 ref: run-import-command

--- a/source/includes/steps-cli-export.yaml
+++ b/source/includes/steps-cli-export.yaml
@@ -9,7 +9,7 @@ pre: |
 
   .. code-block:: shell
 
-     realm-cli login --api-key=my-api-key --private-api-key=my-private-api-key
+     realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 
 ---
 title: Run the Export Command

--- a/source/includes/steps-define-a-function-import-export.yaml
+++ b/source/includes/steps-define-a-function-import-export.yaml
@@ -218,7 +218,7 @@ content: |
 
      .. code-block:: shell
 
-        realm-cli login --api-key="<MongoDB Cloud API Key>" --private-api-key="<My Private API Key>"
+        realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 
   #. Import the directory:
 

--- a/source/includes/steps-define-a-service-rule-cli.yaml
+++ b/source/includes/steps-define-a-service-rule-cli.yaml
@@ -108,7 +108,7 @@ content: |
 
      .. code-block:: shell
 
-        realm-cli login --username="<MongoDB Cloud Username>" --api-key="<MongoDB Cloud API Key>"
+        realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 
   4. Import the directory:
 
@@ -117,4 +117,3 @@ content: |
         realm-cli import
 
   Now that you have imported the rule, it takes effect immediately.
-...

--- a/source/includes/steps-define-a-value-import-export.yaml
+++ b/source/includes/steps-define-a-value-import-export.yaml
@@ -72,7 +72,7 @@ content: |
 
   .. code-block:: shell
 
-     realm-cli login --username="<MongoDB Cloud Username>" --api-key="<MongoDB Cloud API Key>"
+     realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 
   Once you're logged in, import the directory:
 

--- a/source/includes/steps-define-roles-and-permissions-cli.yaml
+++ b/source/includes/steps-define-roles-and-permissions-cli.yaml
@@ -163,7 +163,7 @@ content: |
 
   .. code-block:: shell
 
-     realm-cli login --api-key=<my api key> --private-api-key=<my private api key>
+     realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 
   Once you're logged in, import the directory:
 
@@ -173,4 +173,3 @@ content: |
 
   Once the import completes, Realm will immediately begin using the
   roles you defined for all incoming queries on the collection.
-...

--- a/source/includes/steps-deploy-cli.yaml
+++ b/source/includes/steps-deploy-cli.yaml
@@ -28,7 +28,7 @@ content: |
 
   .. code-block:: shell
 
-     realm-cli login --api-key=<my api key> --private-api-key=<my private api key>
+     realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 ---
 title: Run the Import Command
 ref: run-import-command

--- a/source/includes/steps-enforce-a-document-schema-import-export.yaml
+++ b/source/includes/steps-enforce-a-document-schema-import-export.yaml
@@ -124,7 +124,7 @@ content: |
 
   .. code-block:: shell
 
-     realm-cli login --api-key=<my api key> --private-api-key=<my private api key>
+     realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 
   After logging in, import the directory:
 

--- a/source/includes/steps-filter-incoming-queries-import-export.yaml
+++ b/source/includes/steps-filter-incoming-queries-import-export.yaml
@@ -68,7 +68,7 @@ content: |
 
   .. code-block:: shell
 
-     realm-cli login --api-key=<my api key> --private-api-key=<my private api key>
+     realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 
   After logging in, import the directory:
 

--- a/source/includes/steps-link-a-cluster-import-export.yaml
+++ b/source/includes/steps-link-a-cluster-import-export.yaml
@@ -77,7 +77,7 @@ content: |
 
      .. code-block:: shell
 
-        realm-cli login --api-key=<my api key> --private-api-key=<my private api key>
+        realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
 
   #. Import the directory:
 


### PR DESCRIPTION
Changes in this PR:
--------------------
* Unified `realm-cli login` code snippets (sometimes the current snippets were using the old Username method and sometimes the current snippets did not have `<>` brackets)
* Unified `realm-cli login` code snippets to the following:
```
realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
```



JIRA:
-----
* None