### PR TITLE
(DOCSP-9610) - removes incorrect object key `profile`

### DIFF
--- a/source/includes/define-custom-user-data-example.rst
+++ b/source/includes/define-custom-user-data-example.rst
@@ -14,7 +14,7 @@
           
             const app = Stitch.defaultAppClient;
             const user = app.auth.user;
-            const speaksEnglish = user.profile.customData.primaryLanguage === "English";
+            const speaksEnglish = user.customData.primaryLanguage === "English";
       
       .. tab::
          :tabid: android


### PR DESCRIPTION
Continuation of [this](https://jira.mongodb.org/browse/DOCSP-9610)