### PR TITLE
(DOCSP-8811): Added 'empty object' needed for resume trigger api

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -327,6 +327,13 @@ paths:
       tags: ["triggers"]
       operationId: "adminResumeTrigger"
       summary: "Resume a suspended trigger."
+      requestBody:
+        description: "An empty object."
+        required: true
+        content:
+          application/json:
+            schema:
+              properties: {}
       responses:
         "204":
           description: "Successfully resumed the trigger."


### PR DESCRIPTION
JIRA:
-----
* https://jira.mongodb.org/browse/DOCSP-8811

Stage:
------
* https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-8811-resume-triggers/admin/api/v3.html#put-/groups/{groupid}/apps/{appid}/triggers/{triggerid}/resume