### PR TITLE
(DOCSP-9648): Array items should be an object schema

### DIFF
--- a/source/includes/steps-enforce-a-document-schema-realm-ui.yaml
+++ b/source/includes/steps-enforce-a-document-schema-realm-ui.yaml
@@ -110,11 +110,14 @@ content: |
               "bsonType": "array",
               "uniqueItems": true,
               "items": {
-                "rank": { "bsonType": "int" },
-                "name": { "bsonType": "string" },
-                "hexCode": {
-                  "bsonType": "string",
-                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+                "bsonType": "object",
+                "properties": {
+                  "rank": { "bsonType": "int" },
+                  "name": { "bsonType": "string" },
+                  "hexCode": {
+                    "bsonType": "string",
+                    "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+                  }
                 }
               }
             }


### PR DESCRIPTION
_**Port of https://github.com/10gen/baas-docs/pull/465**_