### PR TITLE
(DOCSP-9795) - add custom_data info

### DIFF
--- a/source/services/expression-variables.txt
+++ b/source/services/expression-variables.txt
@@ -139,6 +139,20 @@ user that initiated a request or action.
        ``"server"`` for :doc:`API key </authentication/api-key>` users
        and ``"normal"`` for all other users.
 
+   * - .. json-expansion:: %%user.custom_data
+     - Document
+     - The user's custom data. The exact contents will vary depending on
+       the :doc:`custom user data </users/define-custom-user-data/>`
+       available.
+
+       .. example::
+
+          .. code-block:: json
+
+             "custom_data": {
+               "primaryLanguage": "English",
+             }
+
    * - .. json-expansion:: %%user.data
      - Document
      - The user's metadata. The exact contents will vary depending on

--- a/source/services/expression-variables.txt
+++ b/source/services/expression-variables.txt
@@ -141,7 +141,7 @@ user that initiated a request or action.
 
    * - .. json-expansion:: %%user.custom_data
      - Document
-     - The user's custom data. The exact contents will vary depending on
+     - The user's custom data. The exact contents vary depending on
        the :doc:`custom user data </users/define-custom-user-data/>`
        available.
 


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker/DOCSP-9795/)
I can't direct link to it for some reason, it's on the Expression variables page.

This is the other 1/2 of [9795](https://jira.mongodb.org/browse/DOCSP-9795)