### PR TITLE
(DOCSP-9836): add version note and transaction mention for graphql

### DIFF
--- a/source/graphql.txt
+++ b/source/graphql.txt
@@ -15,6 +15,11 @@ GraphQL API (Beta)
 Overview
 --------
 
+.. admonition:: Version Requirement
+   :class: note
+
+   GraphQL requires MongoDB version 4.0 or greater.
+
 The Realm :graphql:`GraphQL <>` API (Beta Release) allows client
 applications to access data stored in a linked MongoDB cluster using any
 standard GraphQL client. Realm automatically creates GraphQL types for
@@ -135,7 +140,8 @@ Mutations
 A GraphQL **mutation** is a write operation that creates, modifies, or
 deletes one or more documents. Realm automatically generates mutation
 types for documents in each collection that has a defined :doc:`schema
-</mongodb/enforce-a-document-schema>`.
+</mongodb/enforce-a-document-schema>`. Realm uses transactions to ensure
+safe writes via mutations.
 
 For more information and examples, including a list of all automatically
 generated mutation types, see :ref:`Mutation Resolvers


### PR DESCRIPTION
- [x] Realm portion of [JIRA](https://jira.mongodb.org/browse/DOCSP-9836)
- [x] Adds a version note and transaction mention to GraphQL into.
- [x] [Stitch PR](https://github.com/10gen/baas-docs/pull/470)

[Version requirement note](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-9836/graphql)
[Transaction mention in mutations into paragraph](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-9836/graphql#mutations)
