### PR TITLE
(DOCSP-9818): add missing fields

### DIFF
--- a/source/includes/steps-define-roles-and-permissions-cli.yaml
+++ b/source/includes/steps-define-roles-and-permissions-cli.yaml
@@ -40,10 +40,15 @@ content: |
   .. code-block:: json
 
      {
+       "database": "",
+       "collection": "",
        "roles": [],
        "filters": [],
        "schema": {}
      }
+
+  Set the ``database`` and ``collection`` values to the database and collection
+  the role applies to.
 
   .. note::
 


### PR DESCRIPTION
Adds missing fields to example definition file and instructs user what to set them to.