### PR TITLE
Rearrange TOC for Alpha release

### DIFF
--- a/source/android.txt
+++ b/source/android.txt
@@ -7,3 +7,4 @@ Android
    :caption: Get Started
 
    Install Realm for Android </get-started/install-android>
+   Call a Function </functions/call-a-function>

--- a/source/client-sdk-key-concepts.txt
+++ b/source/client-sdk-key-concepts.txt
@@ -1,0 +1,20 @@
+=======================
+Client SDK Key Concepts
+=======================
+
+.. toctree::
+   :titlesonly:
+   :caption: Client SDK Key Concepts
+   :hidden:
+
+   Realms  </data-model/realms>
+   Objects  </data-model/objects>
+   Relationships  </data-model/relationships>
+   Reads  </crud/reads>
+   Writes  </crud/writes>
+   Query Engine  </crud/query-engine>
+   Collections  </crud/collections>
+   Notifications  </crud/notifications>
+   Threading  </data-model/threading>
+   Migrations  </data-model/migrations>
+   Auxiliary Files  </data-model/auxiliary-files>

--- a/source/index.txt
+++ b/source/index.txt
@@ -5,6 +5,7 @@ MongoDB Realm
 .. toctree::
    :titlesonly:
    :caption: Introduction
+   :hidden:
 
    Introduction for Mobile Developers </get-started/introduction-mobile>
    Introduction for Backend Developers  </get-started/introduction-backend>
@@ -12,12 +13,14 @@ MongoDB Realm
 .. toctree::
    :titlesonly:
    :caption: MongoDB Realm
+   :hidden:
 
    MongoDB Realm </mongodb-realm>
 
 .. toctree::
    :titlesonly:
    :caption: Client SDK Key Concepts
+   :hidden:
 
    Realms  </data-model/realms>
    Objects  </data-model/objects>
@@ -34,30 +37,35 @@ MongoDB Realm
 .. toctree::
    :titlesonly:
    :caption: Android SDK
+   :hidden:
 
    Android Client SDK </android>
 
 .. toctree::
    :titlesonly:
    :caption: iOS SDK
+   :hidden:
 
    iOS Client SDK </ios>
 
 .. toctree::
    :titlesonly:
    :caption: React Native SDK
+   :hidden:
 
    React Native Client SDK </react-native>
 
 .. toctree::
    :titlesonly:
    :caption: Web SDK
+   :hidden:
 
    Web Client SDK </web>
 
 .. toctree::
    :titlesonly:
    :caption: Reference
+   :hidden:
 
    Glossary </get-started/glossary>
    Function Context Reference </functions/context>

--- a/source/index.txt
+++ b/source/index.txt
@@ -13,7 +13,7 @@ ticket
 <https://jira.mongodb.org/secure/CreateIssueDetails!init.jspa?pid=10380&issuetype=4&components=Realm&labels=alpha-docs&priority=3>`__.
 
 Additionally, you can ask questions and make suggestions on
-the internal beta Slack channel.
+the internal beta Slack channel, ``#realm-internal-beta``.
 
 .. toctree::
    :titlesonly:

--- a/source/index.txt
+++ b/source/index.txt
@@ -12,6 +12,8 @@ If you find problems with the content, please file a `DOCSP
 ticket
 <https://jira.mongodb.org/secure/CreateIssueDetails!init.jspa?pid=14181&issuetype=4&components=Realm&labels=alpha-docs&priority=3>`__.
 
+If you find a bug in MongoDB Realm, please file a `REALMC ticket <https://jira.mongodb.org/secure/CreateIssueDetails!init.jspa?pid=14287&issuetype=1&priority=3>`__.
+
 Additionally, you can ask questions and make suggestions on
 the internal beta Slack channel, ``#realm-internal-beta``.
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -6,7 +6,6 @@ MongoDB Realm
    :titlesonly:
    :caption: Introduction
 
-   What is Realm?  </get-started/what-is-realm>
    Introduction for Mobile Developers </get-started/introduction-mobile>
    Introduction for Backend Developers  </get-started/introduction-backend>
 
@@ -15,6 +14,22 @@ MongoDB Realm
    :caption: MongoDB Realm
 
    MongoDB Realm </mongodb-realm>
+
+.. toctree::
+   :titlesonly:
+   :caption: Client SDK Key Concepts
+
+   Realms  </data-model/realms>
+   Objects  </data-model/objects>
+   Relationships  </data-model/relationships>
+   Reads  </crud/reads>
+   Writes  </crud/writes>
+   Query Engine  </crud/query-engine>
+   Collections  </crud/collections>
+   Notifications  </crud/notifications>
+   Threading  </data-model/threading>
+   Migrations  </data-model/migrations>
+   Auxiliary Files  </data-model/auxiliary-files>
 
 .. toctree::
    :titlesonly:

--- a/source/index.txt
+++ b/source/index.txt
@@ -2,6 +2,19 @@
 MongoDB Realm
 =============
 
+Welcome to the ``Realm Internal Beta`` documentation set.
+This documentation is still under active development, and
+lacks many code examples. We also expect the table of
+contents order (left hand navigation) to change both in
+structure and in aesthetic quality.
+
+If you find problems with the content, please file a `DOCSP
+ticket
+<https://jira.mongodb.org/secure/CreateIssueDetails!init.jspa?pid=10380&issuetype=4&components=Realm&labels=alpha-docs&priority=3>`__.
+
+Additionally, you can ask questions and make suggestions on
+the internal beta Slack channel.
+
 .. toctree::
    :titlesonly:
    :caption: Introduction

--- a/source/index.txt
+++ b/source/index.txt
@@ -10,7 +10,7 @@ structure and in aesthetic quality.
 
 If you find problems with the content, please file a `DOCSP
 ticket
-<https://jira.mongodb.org/secure/CreateIssueDetails!init.jspa?pid=10380&issuetype=4&components=Realm&labels=alpha-docs&priority=3>`__.
+<https://jira.mongodb.org/secure/CreateIssueDetails!init.jspa?pid=14181&issuetype=4&components=Realm&labels=alpha-docs&priority=3>`__.
 
 Additionally, you can ask questions and make suggestions on
 the internal beta Slack channel, ``#realm-internal-beta``.

--- a/source/index.txt
+++ b/source/index.txt
@@ -22,17 +22,7 @@ MongoDB Realm
    :caption: Client SDK Key Concepts
    :hidden:
 
-   Realms  </data-model/realms>
-   Objects  </data-model/objects>
-   Relationships  </data-model/relationships>
-   Reads  </crud/reads>
-   Writes  </crud/writes>
-   Query Engine  </crud/query-engine>
-   Collections  </crud/collections>
-   Notifications  </crud/notifications>
-   Threading  </data-model/threading>
-   Migrations  </data-model/migrations>
-   Auxiliary Files  </data-model/auxiliary-files>
+   Client SDK Key Concepts </client-sdk-key-concepts>
 
 .. toctree::
    :titlesonly:

--- a/source/index.txt
+++ b/source/index.txt
@@ -2,7 +2,7 @@
 MongoDB Realm
 =============
 
-Welcome to the ``Realm Internal Beta`` documentation set.
+Welcome to the **MongoDB Realm Internal Beta** documentation set.
 This documentation is still under active development, and
 lacks many code examples. We also expect the table of
 contents order (left hand navigation) to change both in

--- a/source/ios.txt
+++ b/source/ios.txt
@@ -14,34 +14,3 @@ iOS
    :caption: Functions
 
    Call a Function </functions/call-a-function>
-
-.. toctree::
-   :titlesonly:
-   :caption: Services
-
-   AWS S3 Service Snippets </services/snippets/s3>
-   GitHub Service Snippets </services/snippets/github>
-   Call a Service Action </services/call-a-service-action>
-
-.. toctree::
-   :titlesonly:
-   :caption: Data Model
-
-   Realms  </data-model/realms>
-   Objects  </data-model/objects>
-   Relationships  </data-model/relationships>
-   Migrations  </data-model/migrations>
-   Threading  </data-model/threading>
-   Auxiliary Files  </data-model/auxiliary-files>
-
-.. toctree::
-   :titlesonly:
-   :caption: Read & Write
-
-   Reads  </crud/reads>
-   Query Engine  </crud/query-engine>
-   Collections  </crud/collections>
-   Writes  </crud/writes>
-   Notifications  </crud/notifications>
-   Read & Write Data  </by-example/read-and-write>
-   Observe Changes  </by-example/observe-changes>

--- a/source/mongodb-realm.txt
+++ b/source/mongodb-realm.txt
@@ -10,11 +10,18 @@ MongoDB Realm
 
 .. toctree::
    :titlesonly:
-   :caption: Sync
+   :caption: Application Management
 
-   Sync Overview  </sync/sync-overview>
-   Define Sync Rules  </sync/rules>
-   Partition Atlas Data into Realms </sync/partitioning>
+   Application Deployment  </deploy>
+   Deploy from the Realm UI </deploy/deploy-ui>
+   Deploy Automatically with GitHub </deploy/deploy-automatically-with-github>
+   Deploy with the Realm CLI </deploy/deploy-cli>
+   Create a Realm App with Realm CLI </deploy/create-with-cli>
+   Export an Existing Realm Application </deploy/export-realm-app>
+   Application Configuration Files </deploy/application-configuration-files>
+   Deployment Models & Regions </admin/deployment-models-and-regions>
+   MongoDB Cloud Users </admin/users-and-groups>
+   Logs </logs>
 
 .. toctree::
    :titlesonly:
@@ -23,42 +30,13 @@ MongoDB Realm
 
    Users & Authentication </authentication>
    User Objects </authentication/user-objects>
+   Authentication Providers </authentication/providers>
    Create a User </users/create>
    Find and View a User </users/find-and-view>
-   Authentication Providers </authentication/providers>
    Define Custom User Data </users/define-custom-user-data>
    Work with Multiple Users  </users/work-with-multiple-users>
    Link a New Identity to a User </authentication/linking>
    Delete or Prevent Users From Accessing a Realm Application </users/delete-or-revoke>
-
-.. toctree::
-   :titlesonly:
-   :caption: Functions
-
-   Functions Overview </functions>
-   Define a Function </functions/define-a-function>
-   Access Function Context </functions/access-function-context>
-   Utility Packages </functions/utilities>
-   JSON & BSON </functions/json-and-bson>
-   Upload External Dependencies </functions/upload-external-dependencies>
-   Import External Dependencies </functions/import-external-dependencies>
-
-.. toctree::
-   :titlesonly:
-   :caption: Values & Secrets
-
-   Values & Secrets  </values-and-secrets>
-   Define a Value  </values-and-secrets/define-a-value>
-   Define a Secret  </values-and-secrets/define-a-secret>
-   Access a Value </values-and-secrets/access-a-value>
-
-.. toctree::
-   :titlesonly:
-   :caption: Triggers
-
-   Triggers Overview </triggers>
-   Trigger Snippets </triggers/trigger-snippets>
-   Send Trigger Events to AWS EventBridge </triggers/eventbridge>
 
 .. toctree::
    :titlesonly:
@@ -88,6 +66,34 @@ MongoDB Realm
 
 .. toctree::
    :titlesonly:
+   :caption: Sync
+
+   Sync Overview  </sync/sync-overview>
+   Define Sync Rules  </sync/rules>
+   Partition Atlas Data into Realms </sync/partitioning>
+
+.. toctree::
+   :titlesonly:
+   :caption: Functions
+
+   Functions Overview </functions>
+   Define a Function </functions/define-a-function>
+   Access Function Context </functions/access-function-context>
+   Utility Packages </functions/utilities>
+   JSON & BSON </functions/json-and-bson>
+   Upload External Dependencies </functions/upload-external-dependencies>
+   Import External Dependencies </functions/import-external-dependencies>
+
+.. toctree::
+   :titlesonly:
+   :caption: Triggers
+
+   Triggers Overview </triggers>
+   Trigger Snippets </triggers/trigger-snippets>
+   Send Trigger Events to AWS EventBridge </triggers/eventbridge>
+
+.. toctree::
+   :titlesonly:
    :caption: Services
 
    Services Overview </services>
@@ -99,6 +105,9 @@ MongoDB Realm
    Webhook Requests & Responses </services/webhook-requests-and-responses>
    Send Mobile Push Notifications </services/send-mobile-push-notifications>
    Push Notifications </services/push-notifications>
+   AWS S3 Service Snippets </services/snippets/s3>
+   GitHub Service Snippets </services/snippets/github>
+   Call a Service Action </services/call-a-service-action>
 
 .. toctree::
    :titlesonly:
@@ -116,15 +125,9 @@ MongoDB Realm
 
 .. toctree::
    :titlesonly:
-   :caption: Application Management
+   :caption: Values & Secrets
 
-   Application Deployment  </deploy>
-   Deploy from the Realm UI </deploy/deploy-ui>
-   Deploy Automatically with GitHub </deploy/deploy-automatically-with-github>
-   Deploy with the Realm CLI </deploy/deploy-cli>
-   Create a Realm App with Realm CLI </deploy/create-with-cli>
-   Export an Existing Realm Application </deploy/export-realm-app>
-   Application Configuration Files </deploy/application-configuration-files>
-   Deployment Models & Regions </admin/deployment-models-and-regions>
-   MongoDB Cloud Users </admin/users-and-groups>
-   Logs </logs>
+   Values & Secrets  </values-and-secrets>
+   Define a Value  </values-and-secrets/define-a-value>
+   Define a Secret  </values-and-secrets/define-a-secret>
+   Access a Value </values-and-secrets/access-a-value>

--- a/source/web.txt
+++ b/source/web.txt
@@ -4,14 +4,6 @@ Web
 
 .. toctree::
    :titlesonly:
-   :caption: Get Started
-
-   Install Realm for Node.js </get-started/install-node>
-   Install Realm for .NET </get-started/install-dotnet>
-   Install Realm for React Native </get-started/install-react-native>
-
-.. toctree::
-   :titlesonly:
    :caption: GraphQL API
 
    Authenticate GraphQL Requests </graphql/authenticate>
@@ -34,3 +26,4 @@ Web
    Run Aggregation Pipelines </mongodb/run-aggregation-pipelines>
    Connect Over the Wire Protocol </mongodb/connect-over-the-wire-protocol>
    CRUD Snippets </mongodb/crud-snippets>
+   


### PR DESCRIPTION
- Adds "key concepts" section
- Rearranges MongoDB Realm section in a way that makes sense from a user journey perspective
(comments welcome)

Oldgen stage:
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/alpha-toc/index.html

Nextgen stage:
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/alpha-toc/
