### PR TITLE
Updating realm path mentions to instead point to partitions & rules

### DIFF
--- a/source/data-model/realms.txt
+++ b/source/data-model/realms.txt
@@ -161,7 +161,7 @@ granted by the owner or a user with manage permissions on the {+realm+}.
 
    * - ``mayManage``
      - If ``true``, the user has read and write access to all objects in
-       the {+realm+} and can set permissions on the Realm for other users.
+       the {+realm+} and can set permissions on the {+realm+} for other users.
        
        Manage access requires write access, so the ``mayManage``
        permission also sets ``mayWrite`` and ``mayRead`` to ``true`` for
@@ -169,67 +169,16 @@ granted by the owner or a user with manage permissions on the {+realm+}.
 
 .. _realm-path:
 
-Realm Path
-~~~~~~~~~~
+Realms are Partitions of Atlas Data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A {+realm+}'s **path** is a string that serves as the {+realm+}'s unique ID. The
-path can also optionally include the ID of a specific {+realm+} user that
-owns and manages the {+realm+}. A {+realm+} path determines the default read,
-write, and manage permissions for its associated {+realm+}. There are two
-types of {+realm+} path - *public* and *private* - based on whether or not a
-path includes a user ID.
+Each {+realm+} corresponds to a subset of the data in your
+:term:`{+instance+}'s <{+instance+}>`
+:term:`synced {+atlas+} cluster <synced cluster>`. You can customize the
+partitioning of data using your application's :ref:`partition key <partition-key>`.
 
-The following table describes the default permissions and syntax for
-each type of {+realm+} path:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 80
-
-   * - Realm Path Type
-     - Description
-
-   * - Public
-     - A {+realm+} that does not specify an owner is a **public {+realm+}**. By
-       default in a public {+realm+}, non-admin users have read-only
-       privileges and admin users have read-write-manage privileges.
-       
-       Public {+realm+} paths begin with a slash (``/``) followed by any
-       string that is not a {+service-short+} user's ID or a tilde (``~``), such as
-       the following example:
-       
-       .. code-block:: text
-          :copyable: False
-          
-          /someGlobalRealm
-
-   * - Private
-     - A {+realm+} that specifies an owner is a **private Realm**. By
-       default in a private {+realm+}, the owner has read-write-manage
-       privileges, all other non-admin users have no read or write
-       privileges, and admin users have read-write-manage permissions.
-       
-       Private {+realm+} paths begin with a slash (``/``) followed by a
-       specific {+service-short+} user's ID, another slash, and then a string, such
-       as the following example:
-       
-       .. code-block:: text
-          :copyable: False
-          
-          /user-id/someUserRealm
-       
-       .. admonition:: Use a Tilde to Represent the Current User
-          :class: note
-       
-          You can represent the current user's ID by specifying a tilde
-          (``~``) in place of the user id. This shorthand removes the
-          need to manually interpolate the current user's ID when you
-          refer to a private Realm.
-          
-          .. code-block:: text
-             :copyable: False
-             
-             /~/someUserRealm
+You can customize permissions for these partitions of data using
+:ref:`{+rules+} <sync-rules>`.
 
 Summary
 -------

--- a/source/sync/rules.txt
+++ b/source/sync/rules.txt
@@ -15,17 +15,17 @@ Define Sync Rules
 Overview
 --------
 
-In order to control who can :term:`sync <{+sync+}>`, read, and write data,
-:term:`{+service+}` allows you to configure **sync
+In order to control who can :term:`{+sync-short+} <{+sync+}>`, read, and write data,
+:term:`{+service+}` allows you to configure **{+sync-short+}
 rules**. Sync rules enforce two essential data access
 principles:
 
-- Users can only sync and read a :term:`{+realm+}` that they are allowed to see.
-- Users can only sync and make changes to a {+realm+} that they are allowed to write to.
+- Users can only {+sync-short+} and read a :term:`{+realm+}` that they are allowed to see.
+- Users can only {+sync-short+} and make changes to a {+realm+} that they are allowed to write to.
 
-Rules are bundled into :ref:`sync roles <sync-roles>`, which
+Rules are bundled into :ref:`{+sync-short+} roles <sync-roles>`, which
 are then associated with a :ref:`user <user-objects>` to
-determine whether that user can sync, read, or write a given
+determine whether that user can {+sync-short+}, read, or write a given
 {+realm+}. You can edit roles in the MongoDB :term:`{+ui+}`
 or import them using the :term:`{+cli+}`.
 
@@ -35,9 +35,9 @@ Rules and Realms
 ----------------
 
 Rules apply to entire :ref:`{+realms+} <{+realms+}>`. That is, you
-can either sync an entire {+realm+} or none of it. This level
+can either {+sync-short+} an entire {+realm+} or none of it. This level
 of access control strikes a balance between suitability for
-most applications and scalability of sync.
+most applications and scalability of {+sync-short+}.
 
 .. example::
 
@@ -60,19 +60,19 @@ most applications and scalability of sync.
 Users and Sync Roles
 --------------------
 
-A :term:`sync role` is a set of {+realm+}-level permissions
+A :term:`{+sync-short+} role` is a set of {+realm+}-level permissions
 that {+backend+} evaluates when determining whether a user may
-sync a given {+realm+}. You select a property of the
+{+sync-short+} a given {+realm+}. You select a property of the
 :ref:`user object <user-objects>` that {+backend+} uses to
-determine whether that user may sync the {+realm+}.
+determine whether that user may {+sync-short+} the {+realm+}.
 
 There are two initial roles:
 
-- :guilabel:`Read-only`: the user may sync the {+realm+} and read the data.
-- :guilabel:`Read/Write`: the user may sync the {+realm+}, read the data, and modify the data.
+- :guilabel:`Read-only`: the user may {+sync-short+} the {+realm+} and read the data.
+- :guilabel:`Read/Write`: the user may {+sync-short+} the {+realm+}, read the data, and modify the data.
 
 You may define custom roles with a rules :ref:`expression
-<expressions>`. In a sync rules expression, access the
+<expressions>`. In a {+sync-short+} rules expression, access the
 partition key value with the ``%%partition``
 :ref:`expression expansion <expansions>`.
 
@@ -142,6 +142,6 @@ Summary
 -------
 
 - **Sync rules** allow you to control who can read and write on which :term:`{+realm+}`.
-- **Roles** are collections of permissions that {+realm+} evaluates to determine whether a user may sync a {+realm+}.
+- **Roles** are collections of permissions that {+realm+} evaluates to determine whether a user may {+sync-short+} a {+realm+}.
 - You can define rules in the {+ui+} or by importing them with :term:`{+cli+}`.
 


### PR DESCRIPTION
Stage: https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/sync-update/data-model/realms.html#realms-are-partitions-of-atlas-data