### PR TITLE
(DOCSP-10039) - adds missing header info

### DIFF
--- a/source/includes/steps-admin-api-deploy-a-draft.yaml
+++ b/source/includes/steps-admin-api-deploy-a-draft.yaml
@@ -4,23 +4,24 @@ content: |
   A draft represents a group of application changes that you can deploy
   or discard as a single unit. To create a draft, send a ``POST``
   request to the drafts endpoint:
-  
+
   .. code-block:: shell
-   
+
      curl --request POST \
+       --header 'Content-Type: application/json' \
        --header 'Authorization: Bearer <access_token>' \
        'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts'
-  
+
   .. admonition:: One Draft Per User
      :class: important
-     
+
      Each user can only create a single draft at a time, either through
      the UI or the Admin API. If you already have an existing draft, you
      can discard the changes associated with it by sending a ``DELETE``
      request to the draft's endpoint:
 
      .. code-block:: shell
-        
+
         curl --request DELETE \
           --header 'Authorization: Bearer <access_token>' \
           'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}'
@@ -40,8 +41,9 @@ content: |
   draft's deployment endpoint:
 
   .. code-block:: shell
-     
+
      curl --request POST \
+       --header 'Content-Type: application/json' \
        --header 'Authorization: Bearer <access_token>' \
        'https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps/{appId}/drafts/{draftId}/deployment'
 ...


### PR DESCRIPTION
Based on [JIRA](https://jira.mongodb.org/browse/DOCSP-10039) it looks like Stitch/Realm now enforces a content-type for this route.