### PR TITLE
(DOCSP-9838,9847,9846): Quick Wins

### DIFF
--- a/source/authentication/email-password.txt
+++ b/source/authentication/email-password.txt
@@ -78,8 +78,24 @@ Configuration
 
       .. cssclass:: wide-container
       .. code-block:: none
+         :caption: ``/auth_providers/local-userpass.json``
 
-         TBD
+         {
+           "name": "local-userpass",
+           "type": "local-userpass",
+           "config": {
+             "autoConfirm": <boolean>,
+             "emailConfirmationUrl": <string>,
+             "confirmEmailSubject": <string>,
+             "runConfirmationFunction": <boolean>,
+             "confirmationFunctionName": <string>,
+             "resetPasswordUrl": <string>,
+             "resetPasswordSubject": <string>,
+             "runResetFunction": <boolean>,
+             "resetFunctionName": <string>,
+           },
+           "disabled": <boolean>
+         }
 
 .. _email-password-authentication-confirmation:
 

--- a/source/functions/json-and-bson.txt
+++ b/source/functions/json-and-bson.txt
@@ -389,6 +389,13 @@ The ``BSON.Binary`` type represents a binary-encoded data string.
       * - ``base64String``
         - string
         - A string of base64 encoded characters.
+          
+          .. admonition:: String Padding
+             :class: note
+             
+             The base64-encoded string must include either one or two equals
+             signs (``=``), referred to as "padding", at the end of the string.
+             ``BSON.Binary.fromBase64()`` does not support unpadded strings.
 
       * - ``subType``
         - integer

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -2382,6 +2382,38 @@ components:
                 | If true, indicates that ``UPDATE`` change events should include the most current
                   :manual:`majority-committed </reference/read-concern-majority/>` version of the
                   modified document in the ``fullDocument`` field.
+            schedule:
+              type: string
+              description: |
+                | **Only Available for Scheduled Triggers**
+                | A :doc:`cron expression </triggers/cron-expressions>` that defines the trigger schedule.
+        event_processors:
+          type: object
+          description: |
+            | An object where each field name is an event processor ID and each
+              value is an object that configures its corresponding event
+              processor.
+
+              The following event processors are supported:
+
+              - ``AWS_EVENTBRIDGE``
+              
+              .. example
+                 
+                 The following object configures a trigger to :doc:`send events to AWS
+                 Eventbridge </triggers/eventbridge>`.
+
+                 .. code-block:: json
+                    
+                    "event_processors": {
+                      "AWS_EVENTBRIDGE": {
+                        "type": "AWS_EVENTBRIDGE",
+                        "config": {
+                          "account_id": "012345678901",
+                          "region": "us-east-1"
+                        }
+                      }
+                    }
     MetadataAttribute:
       type: object
       properties:


### PR DESCRIPTION
_**Port of: https://github.com/10gen/baas-docs/pull/475**_

## Jira

- [(DOCSP-9838): Missing Configuration File Options for Email/Password Auth](https://jira.mongodb.org/browse/DOCSP-9838)
- [(DOCSP-9847): BSON.Binary.fromBase64() does not support unpadded strings](https://jira.mongodb.org/browse/DOCSP-9847)
- [(DOCSP-9846): Document AWS EventBridge Triggers in Admin API](https://jira.mongodb.org/browse/DOCSP-9846)

## Staged Changes

- [Email/Password Authentication](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/fixes/authentication/email-password.html#configuration)
- [BSON.Binary.fromBase64()](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/fixes/functions/json-and-bson.html#BSON.Binary.fromBase64)
- [Create a Trigger (Admin API)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/fixes/admin/api/v3.html#post-/groups/{groupid}/apps/{appid}/triggers)