### PR TITLE
Move Users & Authentication TOC to authentication.txt

### DIFF
--- a/source/authentication.txt
+++ b/source/authentication.txt
@@ -71,20 +71,6 @@ provider allows you to define custom logic in a :term:`{+service-short+} Functio
    authentication providers, see :doc:`Authentication Providers
    </authentication/providers>`.
 
-.. toctree::
-   :titlesonly:
-   :caption: Authentication Providers
-   :maxdepth: 2
-
-   Anonymous Authentication </authentication/anonymous>
-   Email/Password Authentication </authentication/email-password>
-   Custom JWT Authentication </authentication/custom-jwt>
-   Custom Function Authentication </authentication/custom-function>
-   API Key Authentication </authentication/api-key>
-   Facebook Authentication </authentication/facebook>
-   Google Authentication </authentication/google>
-   Apple ID Authentication  </authentication/apple>
-
 .. _user-accounts:
 
 User Accounts
@@ -268,3 +254,34 @@ Summary
 
 - {+backend+} handles the access tokens and refresh tokens that comprise
   a **user session** automatically.
+
+
+.. toctree::
+   :titlesonly:
+   :caption: User Management
+   :maxdepth: 2
+   :hidden:
+
+   User Objects </authentication/user-objects>
+   Create a User </users/create>
+   Find and View a User </users/find-and-view>
+   Define Custom User Data </users/define-custom-user-data>
+   Work with Multiple Users  </users/work-with-multiple-users>
+   Link a New Identity to a User </authentication/linking>
+   Delete or Prevent Users From Accessing a Realm Application </users/delete-or-revoke>
+
+.. toctree::
+   :titlesonly:
+   :caption: Authentication Providers
+   :maxdepth: 2
+   :hidden:
+
+   Authentication Providers </authentication/providers>
+   Anonymous Authentication </authentication/anonymous>
+   Email/Password Authentication </authentication/email-password>
+   Custom JWT Authentication </authentication/custom-jwt>
+   Custom Function Authentication </authentication/custom-function>
+   API Key Authentication </authentication/api-key>
+   Facebook Authentication </authentication/facebook>
+   Google Authentication </authentication/google>
+   Apple ID Authentication  </authentication/apple>

--- a/source/index.txt
+++ b/source/index.txt
@@ -41,14 +41,6 @@ the internal beta Slack channel, ``#realm-sync-private-beta``.
    :hidden:
 
    Users & Authentication </authentication>
-   User Objects </authentication/user-objects>
-   Authentication Providers </authentication/providers>
-   Create a User </users/create>
-   Find and View a User </users/find-and-view>
-   Define Custom User Data </users/define-custom-user-data>
-   Work with Multiple Users  </users/work-with-multiple-users>
-   Link a New Identity to a User </authentication/linking>
-   Delete or Prevent Users From Accessing a Realm Application </users/delete-or-revoke>
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
This fixes the sidebar so that Auth Providers overview and providers section are together.

## JIRA
https://jira.mongodb.org/browse/DOCSP-10340

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/auth-providers-toc/authentication.html