### PR TITLE
Clarify note about Node.js/RN incompatibility

### DIFF
--- a/source/node.txt
+++ b/source/node.txt
@@ -12,10 +12,11 @@ TypeScript applications.
 
 .. note::
 
-   The Node.js SDK does not support JavaScript or TypeScript applications
-   written for web browsers or React Native mobile apps. For those use cases,
-   you should consider the :ref:`Web SDK <web-intro>` and the :ref:`React Native
-   SDK <react-native-intro>`.
+   The Node.js SDK does not support JavaScript or TypeScript
+   applications written for web browsers. For that use case, you should
+   consider the :ref:`Web SDK <web-intro>`. For development on React
+   Native, refer to the :ref:`React Native SDK <react-native-intro>`
+   documentation.
 
 Installation
 ------------

--- a/source/node.txt
+++ b/source/node.txt
@@ -14,7 +14,7 @@ TypeScript applications.
 
    The Node.js SDK does not support JavaScript or TypeScript
    applications written for web browsers. For that use case, you should
-   consider the :ref:`Web SDK <web-intro>`. For development on React
+   consider the :ref:`Web SDK <web-intro>`. For development in React
    Native, refer to the :ref:`React Native SDK <react-native-intro>`
    documentation.
 

--- a/source/react-native.txt
+++ b/source/react-native.txt
@@ -16,10 +16,11 @@ applications.
 
 .. note::
 
-   The React Native SDK does not support JavaScript or TypeScript applications
-   written for web browsers or the Node.js environment. For those use cases, you
-   should consider the :ref:`Web SDK <web-intro>` and the :ref:`Node.js SDK
-   <node-intro>`.
+   The React Native SDK does not support JavaScript or TypeScript
+   applications written for web browsers. For that use case, you should
+   consider the :ref:`Web SDK <web-intro>`. For development on Node.js
+   without React, refer to the :ref:`Node.js SDK <node-intro>`
+   documentation.
 
 Installation
 ------------


### PR DESCRIPTION
- The Node.js and RN SDKs are the same. However, the documentation is different
in case we want more RN-specific code examples. This commit clarifies the note
that previously implied the two SDKs were not the same.

https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/rn-text-update/node.html