### PR TITLE
Update Install pages to latest version

### DIFF
--- a/source/android/install.txt
+++ b/source/android/install.txt
@@ -28,7 +28,7 @@ meets the following prerequisites:
 
 - `Android Studio <https://developer.android.com/studio/index.html>`__ version 1.5.1 or higher.
 - JDK version 7.0 or higher.
-- Android API Level 9 or higher (Android 2.3 and above).
+- Android API Level 16 or higher (Android 4.1 and above).
 
 Installation
 ------------

--- a/source/includes/steps-install-android.yaml
+++ b/source/includes/steps-install-android.yaml
@@ -17,7 +17,7 @@ content: |
 
    .. code-block:: text
     
-      classpath "io.realm:realm-gradle-plugin:6.0.1"
+      classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.2"
 
    When done, your project-level ``build.gradle`` should look something like this:
 
@@ -37,7 +37,7 @@ content: |
               
               // NOTE: Do not place your application dependencies here; they belong
               // in the individual module build.gradle files
-              classpath "io.realm:realm-gradle-plugin:6.0.1"
+              classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.2"
           }
       }
 
@@ -85,7 +85,7 @@ content: |
           compileSdkVersion 28
           defaultConfig {
               applicationId "com.mongodb.exampleapplication"
-              minSdkVersion 15
+              minSdkVersion 16
               targetSdkVersion 28
               versionCode 1
               versionName "1.0"

--- a/source/includes/steps-install-cocoapods.yaml
+++ b/source/includes/steps-install-cocoapods.yaml
@@ -30,7 +30,7 @@ content: |
          Add the line ``use_frameworks!`` if it is not
          already there.
          
-         Add the line ``pod 'RealmSwift', '=10.0.0-alpha.4'`` to your main and test
+         Add the line ``pod 'RealmSwift', '=10.0.0-alpha.6'`` to your main and test
          targets.
 
          When done, your Podfile should look something like this:
@@ -45,8 +45,7 @@ content: |
               use_frameworks!
 
               # Pods for MyRealmProject
-              pod 'RealmSwift', '=10.0.0-alpha.4'
-
+              pod 'RealmSwift', '=10.0.0-alpha.6'
 
             end
 

--- a/source/includes/steps-install-node.yaml
+++ b/source/includes/steps-install-node.yaml
@@ -22,7 +22,7 @@ content: |
 
    .. code-block:: bash
 
-      npm install --save realm
+      npm install --save realm@10.0.0-beta.4
 
 ---
 title: Enable TypeScript (optional)

--- a/source/includes/steps-install-react-native-pre-v60.yaml
+++ b/source/includes/steps-install-react-native-pre-v60.yaml
@@ -26,7 +26,7 @@ content: |
 
    .. code-block:: bash
 
-      npm install --save realm
+      npm install --save realm@10.0.0-beta.4
 
 ---
 title: Link the Realm Native Module

--- a/source/includes/steps-install-react-native-v60-plus.yaml
+++ b/source/includes/steps-install-react-native-v60-plus.yaml
@@ -26,7 +26,7 @@ content: |
 
    .. code-block:: bash
 
-      npm install --save realm
+      npm install --save realm@10.0.0-beta.4
 
 ---
 title: Resolve CocoaPods Dependencies

--- a/source/ios/install.txt
+++ b/source/ios/install.txt
@@ -30,7 +30,6 @@ meets the following prerequisites:
 - `Xcode <https://developer.apple.com/xcode/>`__ version 10.0 or higher.
 - Target of iOS 12.0 or higher, macOS 10.9 or higher, or any version of tvOS or watchOS.
 - If you are installing with `CocoaPods <https://guides.cocoapods.org/using/getting-started.html>`__, you need CocoaPods 1.6.0 or later.
-- If you are installing with `Carthage <https://github.com/Carthage/Carthage#installing-carthage>`__, you need Carthage 0.33 or later.
 
 Installation
 ------------
@@ -38,26 +37,7 @@ Installation
 Follow these steps to add the {+service+} Apple platform SDK to
 your project.
 
-.. note::
-   Not sure which dependency manager to use? We recommend
-   CocoaPods.
-
-.. tabs::
-
-   .. tab:: CocoaPods
-      :tabid: cocoapods
-
-      .. include:: /includes/steps/install-cocoapods.rst
-
-   .. tab:: Carthage
-      :tabid: carthage
-
-      .. include:: /includes/steps/install-carthage.rst
-
-   .. tab:: Dynamic Framework
-      :tabid: dynamic-framework
-
-      .. include:: /includes/steps/install-dynamic-framework.rst
+.. include:: /includes/steps/install-cocoapods.rst
 
 Import Realm
 ------------


### PR DESCRIPTION
- Updates install pages to latest version
- Hides carthage & dynamic framework install tabs on iOS. Can be re-added later.

https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/install/android/install.html
