### PR TITLE
Stitch -> Realm, Hide Stitch SDK code

### DIFF
--- a/source/authentication/apple.txt
+++ b/source/authentication/apple.txt
@@ -60,9 +60,9 @@ Configure Apple ID Authentication
 
 .. include:: /includes/steps/apple-auth-configure.rst
 
-.. _setup-apple-auth-client:
+.. .. _setup-apple-auth-client:
 
-Set Up Your Client Application
-------------------------------
+.. Set Up Your Client Application
+.. ------------------------------
 
-.. include:: /includes/steps/apple-auth-setup-client.rst
+.. .. include:: /includes/steps/apple-auth-setup-client.rst

--- a/source/graphql/authenticate.txt
+++ b/source/graphql/authenticate.txt
@@ -31,7 +31,7 @@ access token <refresh-client-api-access-token>` after it expires.
    .. code-block:: shell
       :emphasize-lines: 2
    
-      curl --location --request POST 'https://stitch.mongodb.com/api/client/v2.0/app/<yourappid-abcde>/graphql' \
+      curl --location --request POST 'https://realm.mongodb.com/api/client/v2.0/app/<yourappid-abcde>/graphql' \
         --header 'Authorization: Bearer <Access Token>' \
         --header 'Content-Type: application/json' \
         --data-raw '{"query":"query AllMovies {\n  movies {\n    title\n    year\n  }\n}"}'

--- a/source/graphql/expose-data.txt
+++ b/source/graphql/expose-data.txt
@@ -202,7 +202,7 @@ Relationship definitions have the following form:
         }
       }
    
-   With this relationship defined, Stitch can fluidly return a customer
+   With this relationship defined, Realm can fluidly return a customer
    and all of their accounts in the same GraphQL query.
    
    .. code-block:: text

--- a/source/hosting/includes/metadata-config-json.rst
+++ b/source/hosting/includes/metadata-config-json.rst
@@ -46,7 +46,8 @@
           * - ``name``
             - The name of the metadata attribute. This should be one of
               the :doc:`file metadata attributes
-              </hosting/file-metadata-attributes>` that Stitch supports.
+              </hosting/file-metadata-attributes>` that {+service-short+}
+              supports.
 
           * - ``value``
             - The value of the metadata attribute.


### PR DESCRIPTION
- Removes the **Set Up Your Client Application** procedure from [Apple ID Authentication](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/stitch/authentication/apple.html) that used old Stitch code

- Switch Stitch -> Realm in a GraphQL examples & hosting reference docs