### PR TITLE
(DOCSP-10777): Add note explaining there's no registration on RN Tutorial + (DOCSP-10821): Switch registerUser with proper method name "registerEmail" on Node/RN docs

### DIFF
--- a/source/node/manage-email-password-users.txt
+++ b/source/node/manage-email-password-users.txt
@@ -24,7 +24,7 @@ with the :doc:`Email/Password authentication provider
 Register a New User Account
 ---------------------------
 
-To register a new email/password user, call the ``registerUser()`` method with
+To register a new email/password user, call the ``registerEmail()`` method with
 the user's email address and desired password. The email address must not be
 associated with another email/password user and the password must be between 6
 and 128 characters.
@@ -36,14 +36,14 @@ and 128 characters.
 
       .. code-block:: javascript
          
-         await app.auth.emailPassword.registerUser(email, password);
+         await app.auth.emailPassword.registerEmail(email, password);
    
    .. tab::
       :tabid: typescript
 
       .. code-block:: typescript
          
-         await app.auth.emailPassword.registerUser(email, password);
+         await app.auth.emailPassword.registerEmail(email, password);
 
 .. admonition:: Confirm New Users
    :class: note

--- a/source/react-native/manage-email-password-users.txt
+++ b/source/react-native/manage-email-password-users.txt
@@ -24,7 +24,7 @@ associated with the :doc:`Email/Password authentication provider
 Register a New User Account
 ---------------------------
 
-To register a new email/password user, call the ``registerUser()`` method with
+To register a new email/password user, call the ``registerEmail()`` method with
 the user's email address and desired password. The email address must not be
 associated with another email/password user and the password must be between 6
 and 128 characters.
@@ -36,14 +36,14 @@ and 128 characters.
 
       .. code-block:: javascript
          
-         await app.auth.emailPassword.registerUser(email, password);
+         await app.auth.emailPassword.registerEmail(email, password);
    
    .. tab::
       :tabid: typescript
 
       .. code-block:: typescript
          
-         await app.auth.emailPassword.registerUser(email, password);
+         await app.auth.emailPassword.registerEmail(email, password);
 
 .. admonition:: Confirm New Users
    :class: note

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -36,7 +36,7 @@ This tutorial should take around 30 minutes.
    
    This tutorial does not implement user registration through the Client
    SDK. If you're interested in learning more about user registration
-   with {+backend+}, see the :doc:`Manage Email/Password Users
+   with {+service+}, see the :doc:`Manage Email/Password Users
    </react-native/manage-email-password-users>` doc.
 
 Prerequisites

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -31,6 +31,14 @@ This tutorial should take around 30 minutes.
    source code, then follow the instructions in README.md to get started. Don't forget to
    update the getRealmApp.js file with your {+app+} ID, which you can find in the {+ui+}.
 
+
+.. note::
+   
+   This tutorial does not implement user registration through the Client
+   SDK. If you're interested in learning more about user registration
+   with {+backend+}, see the :doc:`Manage Email/Password Users
+   </react-native/manage-email-password-users>` doc.
+
 Prerequisites
 -------------
 


### PR DESCRIPTION
Jira: 
----
* DOCSP-10777: https://jira.mongodb.org/browse/DOCSP-10777
* DOCSP-10821: https://jira.mongodb.org/browse/DOCSP-10821


Stage: 
-------
* Note on RN tutorial (For DOCSP-10777): https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-10777-RN-fix-registerEmail/tutorial/react-native.html
* Fixed Node Method for registration (For DOCSP-10821): https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-10777-RN-fix-registerEmail/node/manage-email-password-users.html
* Fixed RN Method for registration (For DOCSP-10821): https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-10777-RN-fix-registerEmail/react-native/manage-email-password-users.html