### PR TITLE
(DOCSP-10805): Clean up Application Management toctree

### DIFF
--- a/source/deploy.txt
+++ b/source/deploy.txt
@@ -12,6 +12,16 @@ Application Deployment
    :depth: 2
    :local:
 
+.. toctree::
+   :titlesonly:
+   :caption: Deployment Methods
+   :hidden:
+   
+   Deploy from the Realm UI </deploy/deploy-ui>
+   Deploy Automatically with GitHub </deploy/deploy-automatically-with-github>
+   Deploy with the Realm CLI </deploy/deploy-cli>
+   Export an Existing Realm Application </deploy/export-realm-app>
+
 Overview
 --------
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -56,6 +56,7 @@ MongoDB Realm App </procedures/create-realm-app>` to get started.
    :hidden:
 
    Create a MongoDB Realm App </procedures/create-realm-app>
+   Create a Realm App with Realm CLI </deploy/create-with-cli>
 
 Cloud Features
 --------------
@@ -120,6 +121,7 @@ Features include:
    JSON & BSON </functions/json-and-bson>
    Upload External Dependencies </functions/upload-external-dependencies>
    Import External Dependencies </functions/import-external-dependencies>
+   Function Context Reference </functions/context>
 
 .. toctree::
    :titlesonly:
@@ -129,6 +131,7 @@ Features include:
    Triggers Overview </triggers>
    Trigger Snippets </triggers/trigger-snippets>
    Send Trigger Events to AWS EventBridge </triggers/eventbridge>
+   CRON Expressions </triggers/cron-expressions>
 
 .. toctree::
    :titlesonly:
@@ -177,19 +180,25 @@ Features include:
 
 .. toctree::
    :titlesonly:
-   :caption: Application Management
+   :caption: Application Deployment
    :hidden:
 
-   Application Deployment  </deploy>
-   Deploy from the Realm UI </deploy/deploy-ui>
-   Deploy Automatically with GitHub </deploy/deploy-automatically-with-github>
-   Deploy with the Realm CLI </deploy/deploy-cli>
-   Create a Realm App with Realm CLI </deploy/create-with-cli>
-   Export an Existing Realm Application </deploy/export-realm-app>
-   Application Configuration Files </deploy/application-configuration-files>
-   Deployment Models & Regions </admin/deployment-models-and-regions>
-   MongoDB Cloud Users </admin/users-and-groups>
-   Logs </logs>
+   Deployment Overview </deploy>
+
+.. toctree::
+   :titlesonly:
+   :caption: Logs
+   :hidden:
+
+   Logs Overview </logs>
+   Access Logs with the Admin API </logs/api>
+   Authentication Logs </logs/authentication>
+   Change Stream Logs </logs/changestream>
+   Function Logs </logs/function>
+   Service Logs </logs/service>
+   Trigger Logs </logs/trigger>
+   Schema Logs </logs/schema>
+   Sync Logs </logs/sync>
 
 Clients
 -------
@@ -249,12 +258,12 @@ no cost. To see how billing works in {+service+}, see :doc:`Billing
 The reference section contains all additional detailed information:
 
 - :doc:`Glossary </get-started/glossary>`
-- :doc:`Function Context Reference </functions/context>`
 - :doc:`Realm Administration API </admin/api/v3>`
 - :doc:`Realm CLI Reference </deploy/realm-cli-reference>`
-- :doc:`CRON Expressions </triggers/cron-expressions>`
 - :doc:`Expression Variables </services/expression-variables>`
 - :doc:`JSON Expressions </services/json-expressions>`
+- :doc:`Application Configuration Files </deploy/application-configuration-files>`
+- :doc:`MongoDB Cloud Users </admin/users-and-groups>`
 
 .. toctree::
    :titlesonly:
@@ -262,13 +271,14 @@ The reference section contains all additional detailed information:
    :hidden:
 
    Glossary </get-started/glossary>
-   Function Context Reference </functions/context>
+   Billing </billing>
+   Deployment Models & Regions </admin/deployment-models-and-regions>
    Realm Administration API </admin/api/v3>
    Realm CLI Reference </deploy/realm-cli-reference>
-   CRON Expressions </triggers/cron-expressions>
    Expression Variables </services/expression-variables>
    JSON Expressions </services/json-expressions>
-   Billing </billing>
+   Application Configuration Files </deploy/application-configuration-files>
+   MongoDB Cloud Users </admin/users-and-groups>
 
 Stitch Documentation (Legacy)
 -----------------------------

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -147,19 +147,6 @@ each log to extract and externally store your log history.
 Reference Documentation
 -----------------------
 
-.. toctree::
-   :titlesonly:
-   :caption: Logs
-
-   Access Logs with the Admin API </logs/api>
-   Authentication Logs </logs/authentication>
-   Change Stream Logs </logs/changestream>
-   Function Logs </logs/function>
-   Service Logs </logs/service>
-   Trigger Logs </logs/trigger>
-   Schema Logs </logs/schema>
-   Sync Logs </logs/sync>
-
 .. list-table::
    :header-rows: 1
    :widths: 20 50


### PR DESCRIPTION
**Jira:** [(DOCSP-10805): Clean up Application Management toctree](https://jira.mongodb.org/browse/DOCSP-10805)

- Adds **Logs** as a top level section
- Moves some pages between reference/deployment and various cloud sections
- Application Management -> Application Deployment

[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/cleanup/index.html)