### PR TITLE
(DOCSP-10848): Add link to legacy Stitch docs on left-hand nav

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -269,3 +269,21 @@ The reference section contains all additional detailed information:
    Expression Variables </services/expression-variables>
    JSON Expressions </services/json-expressions>
    Billing </billing>
+
+Stitch Documentation (Legacy)
+-----------------------------
+
+You can find the deprecated MongoDB Stitch documentation at
+http://stitch-docs-old.s3-website-us-east-1.amazonaws.com/.
+
+.. toctree::
+   :titlesonly:
+   :caption: Stitch (Legacy)
+   :hidden:
+
+   (Legacy) Stitch Documentation <http://stitch-docs-old.s3-website-us-east-1.amazonaws.com/>
+   (Legacy) Stitch JavaScript Browser SDK <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/js/4/index.html>
+   (Legacy) Stitch Java/Android SDK <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/java/4/overview-summary.html>
+   (Legacy) Stitch Swift/iOS SDK <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/swift/6/>
+   (Legacy) Stitch React Native SDK <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/js-react-native/4/index.html>
+   (Legacy) Stitch JavaScript Server SDK <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/js-server/4/index.html>


### PR DESCRIPTION
- Tooling does not support having an uncategorized item (?) so I made a collection of items including the old SDK docs.
- Including repeated use of "Legacy" and "Stitch" to avoid having someone accidentally think this is the current SDK.

## JIRA
https://jira.mongodb.org/browse/DOCSP-10848

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/stitch-legacy/index.html

## Screenshot
![image](https://user-images.githubusercontent.com/20050130/84840039-7d822a00-b00c-11ea-85f9-0b2548f96c08.png)

