### PR TITLE
(DOCSP-10796): Remove 'language specific' type verbiage in client guides

### DIFF
--- a/source/android/objects.txt
+++ b/source/android/objects.txt
@@ -18,7 +18,7 @@ Overview
 {+service+} applications model data as objects composed of field-value pairs
 that each contain one or more primitive data types or other {+service-short+}
 objects. :term:`{+service-short+} objects <Realm object>` are essentially the same
-as regular objects in most programming languages, but they also include
+as regular objects, but they also include
 additional features like
 :ref:`real-time updating data views <android-live-object>` and reactive
 :ref:`change event handlers <android-client-notifications>`.
@@ -156,15 +156,7 @@ You can configure the following constraints for a given property:
        - String
        - Date
        - Data
-       
-       .. admonition:: Language-Specific Syntax
-          :class: important
-          
-          {+client-database+} supports language-specific data types for
-          each SDK by internally mapping them to one of the
-          core supported types. Check the client guide for
-          your platform to see the full list of supported
-          data types in your preferred language.
+       - ObjectId
 
    * - Optional
      - Optional properties may contain a null value or be entirely
@@ -191,7 +183,7 @@ Summary
 -------
 
 - {+service-short+} objects are of a **type** defined as you would any other
-  class in the given programming language.
+  class.
 
 - {+service-short+} objects are **live**: they always reflect the latest version
   on disk and update automatically when the underlying object changes.

--- a/source/dotnet/objects.txt
+++ b/source/dotnet/objects.txt
@@ -18,7 +18,7 @@ Overview
 {+service+} applications model data as objects composed of field-value pairs
 that each contain one or more primitive data types or other {+service-short+}
 objects. :term:`{+service-short+} objects <Realm object>` are essentially the same
-as regular objects in most programming languages, but they also include
+as regular objects, but they also include
 additional features like
 :ref:`real-time updating data views <dotnet-live-object>` and reactive
 :ref:`change event handlers <dotnet-client-notifications>`.
@@ -151,15 +151,7 @@ You can configure the following constraints for a given property:
        - String
        - Date
        - Data
-       
-       .. admonition:: Language-Specific Syntax
-          :class: important
-          
-          {+client-database+} supports language-specific data types for
-          each SDK by internally mapping them to one of the
-          core supported types. Check the client guide for
-          your platform to see the full list of supported
-          data types in your preferred language.
+       - ObjectId
 
    * - Optional
      - Optional properties may contain a null value or be entirely
@@ -186,7 +178,7 @@ Summary
 -------
 
 - {+service-short+} objects are of a **type** defined as you would any other
-  class in the given programming language.
+  class.
 
 - {+service-short+} objects are **live**: they always reflect the latest version
   on disk and update automatically when the underlying object changes.

--- a/source/node/include/property-schema.rst
+++ b/source/node/include/property-schema.rst
@@ -1,0 +1,88 @@
+A **property schema** is a field-level configuration that defines and
+constrains a specific property in an object schema. Every object schema
+must include a property schema for each property in the object. At
+minimum, a property schema defines a property's data type and indicates
+whether or not the property is required.
+
+You can configure the following constraints for a given property:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+   
+   * - Parameter
+     - Description
+
+   * - Type
+     - Every property in a {+service-short+} object has a strongly defined data
+       type. A property's type can be a primitive data type or an object
+       type defined in the same {+realm+}. The type also specifies whether
+       the property contains a single value or a list of values.
+       
+       {+client-database+} supports the following primitive data types:
+
+       - ``bool`` for boolean values
+       - ``int``, ``float``, and ``double``, which map to JavaScript ``number`` values
+       - ``string``
+       - ``date``, which maps to :mdn:`Date <Web/JavaScript/Reference/Global_Objects/Date>`
+       - ``data``, which maps to :mdn:`ArrayBuffer <Web/JavaScript/Reference/Global_Objects/ArrayBuffer>`
+       - ``objectId``, which maps to :manual:`ObjectId </reference/method/ObjectId/>`
+
+   * - Optional
+     - Optional properties may contain a null value or be entirely
+       omitted from an object. By default, all properties are required
+       unless explicitly marked as optional. To mark a property as
+       optional, append a question mark (``?``) to its name.
+
+       .. example::
+      
+          The following schema defines an optional string property, ``breed``:
+
+          .. literalinclude:: /examples/Schemas/DogSchema.js
+             :language: javascript
+             :emphasize-lines: 6
+
+   * - Default
+     - If a client application creates a new object that does not have a
+       value for a defined property, the object uses the default value
+       instead.
+
+       You can specify a default value on a property by using the
+       object-form property specification. For example, the following
+       schema defines a Car with a default value of 0 for its ``miles``
+       property:
+
+       .. code-block:: javascript
+          :emphasize-lines: 6
+          
+          const CarSchema = {
+            name: 'Car',
+            properties: {
+              make:  'string',
+              model: 'string',
+              miles: {type: 'int', default: 0},
+            }
+          };
+
+   * - Indexed
+     - A property index significantly increases the speed of certain
+       read operations at the cost of additional overhead for write
+       operations. Indexes are particularly useful for equality
+       comparison, such as querying for an object based on the value of
+       a property.
+
+       To enable an index on a given property, set ``indexed`` to
+       ``true`` in the long-form property specification. The following
+       example defined a BookSchema with an index on the ``name``
+       property:
+
+       .. code-block:: javascript
+          :emphasize-lines: 4
+
+          const BookSchema = {
+          name: 'Book',
+            properties: {
+              name: { type: 'string', indexed: true },
+              price: 'float'
+            }
+          };

--- a/source/node/objects.txt
+++ b/source/node/objects.txt
@@ -15,13 +15,13 @@ Realm Objects
 Overview
 --------
 
-{+service+} applications model data as objects composed of field-value pairs
-that each contain one or more primitive data types or other {+service-short+}
-objects. :term:`{+service-short+} objects <Realm object>` are essentially the same
-as regular objects in most programming languages, but they also include
-additional features like
-:ref:`real-time updating data views <node-live-object>` and reactive
-:ref:`change event handlers <node-client-notifications>`.
+{+service+} applications model data as objects composed of field-value
+pairs that each contain one or more primitive data types or other
+{+service-short+} objects. :term:`{+service-short+} objects <Realm
+object>` are essentially the same as regular objects, but they also
+include additional features like :ref:`real-time updating data views
+<node-live-object>` and reactive :ref:`change event handlers
+<node-client-notifications>`.
 
 Every {+service-short+} object has an *object type* that refers to the object's
 class. Objects of the same type share an :ref:`object schema
@@ -121,72 +121,12 @@ to a {+realm+}.
 Property Schema
 ~~~~~~~~~~~~~~~
 
-A **property schema** is a field-level configuration that defines and
-constrains a specific property in an object schema. Every object schema
-must include a property schema for each property in the object. At
-minimum, a property schema defines a property's data type and indicates
-whether or not the property is required.
-
-You can configure the following constraints for a given property:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 80
-   
-   * - Parameter
-     - Description
-
-   * - Type
-     - Every property in a {+service-short+} object has a strongly defined data
-       type. A property's type can be a primitive data type or an object
-       type defined in the same {+realm+}. The type also specifies whether
-       the property contains a single value or a list of values.
-       
-       {+client-database+} supports the following primitive data types:
-
-       - Boolean
-       - Integer
-       - Float
-       - Double
-       - String
-       - Date
-       - Data
-       
-       .. admonition:: Language-Specific Syntax
-          :class: important
-          
-          {+client-database+} supports language-specific data types for
-          each SDK by internally mapping them to one of the
-          core supported types. Check the client guide for
-          your platform to see the full list of supported
-          data types in your preferred language.
-
-   * - Optional
-     - Optional properties may contain a null value or be entirely
-       omitted from an object. By default, all properties are required
-       unless explicitly marked as optional.
-
-   * - Default
-     - If a client application creates a new object that does not have a
-       value for a defined property, the object uses the default value
-       instead.
-       
-       Objects that are missing a required field without a defined
-       default value will fail validation when you attempt to create
-       them and will not persist to the {+realm+}.
-
-   * - Indexed
-     - A property index significantly increases the speed of certain
-       read operations at the cost of additional overhead for write
-       operations. Indexes are particularly useful for equality
-       comparison, such as querying for an object based on the value of
-       a property.
+.. include:: /node/include/property-schema.rst
 
 Summary
 -------
 
-- {+service-short+} objects are of a **type** defined as you would any other
-  class in the given programming language.
+- {+service-short+} objects are of a **type** defined by a schema.
 
 - {+service-short+} objects are **live**: they always reflect the latest version
   on disk and update automatically when the underlying object changes.

--- a/source/react-native/objects.txt
+++ b/source/react-native/objects.txt
@@ -15,13 +15,13 @@ Realm Objects
 Overview
 --------
 
-{+service+} applications model data as objects composed of field-value pairs
-that each contain one or more primitive data types or other {+service-short+}
-objects. :term:`{+service-short+} objects <Realm object>` are essentially the same
-as regular objects in most programming languages, but they also include
-additional features like
-:ref:`real-time updating data views <react-native-live-object>` and reactive
-:ref:`change event handlers <react-native-client-notifications>`.
+{+service+} applications model data as objects composed of field-value
+pairs that each contain one or more primitive data types or other
+{+service-short+} objects. :term:`{+service-short+} objects <Realm
+object>` are essentially the same as regular objects, but they also
+include additional features like :ref:`real-time updating data views
+<react-native-live-object>` and reactive :ref:`change event handlers
+<react-native-client-notifications>`.
 
 Every {+service-short+} object has an *object type* that refers to the object's
 class. Objects of the same type share an :ref:`object schema
@@ -121,72 +121,12 @@ to a {+realm+}.
 Property Schema
 ~~~~~~~~~~~~~~~
 
-A **property schema** is a field-level configuration that defines and
-constrains a specific property in an object schema. Every object schema
-must include a property schema for each property in the object. At
-minimum, a property schema defines a property's data type and indicates
-whether or not the property is required.
-
-You can configure the following constraints for a given property:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 80
-   
-   * - Parameter
-     - Description
-
-   * - Type
-     - Every property in a {+service-short+} object has a strongly defined data
-       type. A property's type can be a primitive data type or an object
-       type defined in the same {+realm+}. The type also specifies whether
-       the property contains a single value or a list of values.
-       
-       {+client-database+} supports the following primitive data types:
-
-       - Boolean
-       - Integer
-       - Float
-       - Double
-       - String
-       - Date
-       - Data
-       
-       .. admonition:: Language-Specific Syntax
-          :class: important
-          
-          {+client-database+} supports language-specific data types for
-          each SDK by internally mapping them to one of the
-          core supported types. Check the client guide for
-          your platform to see the full list of supported
-          data types in your preferred language.
-
-   * - Optional
-     - Optional properties may contain a null value or be entirely
-       omitted from an object. By default, all properties are required
-       unless explicitly marked as optional.
-
-   * - Default
-     - If a client application creates a new object that does not have a
-       value for a defined property, the object uses the default value
-       instead.
-       
-       Objects that are missing a required field without a defined
-       default value will fail validation when you attempt to create
-       them and will not persist to the {+realm+}.
-
-   * - Indexed
-     - A property index significantly increases the speed of certain
-       read operations at the cost of additional overhead for write
-       operations. Indexes are particularly useful for equality
-       comparison, such as querying for an object based on the value of
-       a property.
+.. include:: /node/include/property-schema.rst
 
 Summary
 -------
 
-- {+service-short+} objects are of a **type** defined as you would any other
-  class in the given programming language.
+- {+service-short+} objects are of a **type** defined by a schema.
 
 - {+service-short+} objects are **live**: they always reflect the latest version
   on disk and update automatically when the underlying object changes.


### PR DESCRIPTION
- Update Node + RN guides with proper syntax for defining properties
- Remove various instances of "given programming language", "client-specific...", etc.
- Add 'ObjectId' to supported types

## JIRA
https://jira.mongodb.org/browse/DOCSP-10796

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/language-specific/node/objects.html
