### PR TITLE
(DOCSP-10822): Add bidirectional links between quick starts and tutorials

### DIFF
--- a/source/android/quick-start.txt
+++ b/source/android/quick-start.txt
@@ -22,6 +22,16 @@ integrated into your app. Before you begin, ensure you have:
 - :ref:`Enabled {+sync+} <enable-sync>`
 - :ref:`Installed the Android SDK <android-install>`
 
+.. admonition:: Check Out the Tutorial
+   :class: note
+   
+   This page contains only the essential information that you need to set up a
+   MongoDB Realm application. If you prefer to follow a guided tutorial that
+   shows you step-by-step how to set up a working app, check out the
+   :ref:`Android Tutorial <android-kotlin-tutorial>` where you'll build a mobile
+   app that connects to the :ref:`Task Tracker backend
+   <tutorial-task-tracker-create-realm-app>`.
+
 Import Realm
 ------------
 

--- a/source/ios/quick-start.txt
+++ b/source/ios/quick-start.txt
@@ -22,6 +22,15 @@ integrated into your app. Before you begin, ensure you have:
 - :ref:`Enabled {+sync+} <enable-sync>`
 - :ref:`Installed the iOS SDK <ios-install>`
 
+.. admonition:: Check Out the Tutorial
+   :class: note
+   
+   This page contains only the essential information that you need to set up a
+   MongoDB Realm application. If you prefer to follow a guided tutorial that
+   shows you step-by-step how to set up a working app, check out the :ref:`iOS
+   Tutorial <ios-swift-tutorial>` where you'll build a mobile app that connects
+   to the :ref:`Task Tracker backend <tutorial-task-tracker-create-realm-app>`.
+
 Import Realm
 ------------
 

--- a/source/react-native/quick-start.txt
+++ b/source/react-native/quick-start.txt
@@ -22,6 +22,16 @@ integrated into your app. Before you begin, ensure you have:
 - :ref:`Enabled {+sync+} <enable-sync>`
 - :ref:`Installed the Node SDK <react-native-install>` to use with your Realm Native app.
 
+.. admonition:: Check Out the Tutorial
+   :class: note
+   
+   This page contains only the essential information that you need to set up a
+   MongoDB Realm application. If you prefer to follow a guided tutorial that
+   shows you step-by-step how to set up a working app, check out the :ref:`React
+   Native Tutorial <react-native-tutorial>` where you'll build a mobile app that
+   connects to the :ref:`Task Tracker backend
+   <tutorial-task-tracker-create-realm-app>`.
+
 .. _react-native-quick-start-import:
 
 Import Realm

--- a/source/tutorial/android-kotlin.txt
+++ b/source/tutorial/android-kotlin.txt
@@ -24,15 +24,22 @@ tracker app that allows users to:
 
 This tutorial should take around 30 minutes.
 
-.. note::
+.. admonition:: Check Out the Quick Start
+   :class: note
    
-   Want to get started right away with the complete source
-   code? Check out our :github:`repo
-   <mongodb-university/realm-tutorial>` with
-   ready-to-compile source code, then follow the instructions
-   in README.md to get started. Don't forget to update the
-   application ``build.gradle`` file with your {+app+} ID, which you
-   can find in the {+ui+}.
+   If you prefer to explore on your own rather than follow a guided tutorial,
+   check out the :ref:`Android Quick Start <android-client-quick-start>`. It
+   includes copyable code examples and the essential information that you need
+   to set up a MongoDB Realm application.
+
+.. admonition:: Download the Complete Source Code
+   :class: note
+   
+   We host this tutorial application's :github:`complete and ready-to-compile
+   source code <mongodb-university/realm-tutorial/tree/main/kotlin-android>` on
+   GitHub. Just follow the instructions in ``README.md`` to get started. Don't
+   forget to update the ``build.gradle`` file with your App ID, which you can
+   find in the {+ui+}.
 
 Prerequisites
 -------------

--- a/source/tutorial/ios-swift.txt
+++ b/source/tutorial/ios-swift.txt
@@ -24,15 +24,22 @@ tracker app that allows users to:
 
 This tutorial should take around 30 minutes.
 
-.. note::
+.. admonition:: Check Out the Quick Start
+   :class: note
    
-   Want to get started right away with the complete source
-   code? Check out our :github:`repo
-   <mongodb-university/realm-tutorial>` with
-   ready-to-compile source code, then follow the instructions
-   in README.md to get started. Don't forget to update the
-   AppDelegate.swift file with your {+app+} ID, which you
-   can find in the {+ui+}.
+   If you prefer to explore on your own rather than follow a guided tutorial,
+   check out the :ref:`iOS Quick Start <ios-client-quick-start>`. It includes
+   copyable code examples and the essential information that you need to set up
+   a MongoDB Realm application.
+
+.. admonition:: Download the Complete Source Code
+   :class: note
+   
+   We host this tutorial application's :github:`complete and ready-to-compile
+   source code <mongodb-university/realm-tutorial/tree/main/swift-ios>` on GitHub.
+   Just follow the instructions in ``README.md`` to get started. Don't forget to
+   update the ``AppDelegate.swift`` file with your App ID, which you can find in
+   the {+ui+}.
 
 Prerequisites
 -------------
@@ -48,4 +55,3 @@ Procedure
 ---------
 
 .. include:: /includes/steps/tutorial-ios-swift.rst
-

--- a/source/tutorial/react-native.txt
+++ b/source/tutorial/react-native.txt
@@ -24,33 +24,49 @@ application that allows users to:
 
 This tutorial should take around 30 minutes.
 
-.. note::
+.. admonition:: Check Out the Quick Start
+   :class: note
    
-   Want to get started right away with the complete source code? Check out our
-   :github:`repo <mongodb-university/realm-tutorial/tree/master/rn>` with ready-to-compile
-   source code, then follow the instructions in README.md to get started. Don't forget to
-   update the getRealmApp.js file with your {+app+} ID, which you can find in the {+ui+}.
+   If you prefer to explore on your own rather than follow a guided tutorial,
+   check out the :ref:`React Native Quick Start
+   <react-native-client-quick-start>`. It includes copyable code examples and
+   the essential information that you need to set up a MongoDB Realm
+   application.
 
-
-.. note::
+.. admonition:: Download the Complete Source Code
+   :class: note
    
-   This tutorial does not implement user registration through the Client
-   SDK. If you're interested in learning more about user registration
-   with {+service+}, see the :doc:`Manage Email/Password Users
-   </react-native/manage-email-password-users>` doc.
+   We host this tutorial application's :github:`complete and ready-to-compile
+   source code <mongodb-university/realm-tutorial/tree/main/rn>` on GitHub.
+   Just follow the instructions in ``README.md`` to get started. Don't forget to
+   update the ``getRealmApp.js`` file with your App ID, which you can find in
+   the {+ui+}.
 
 Prerequisites
 -------------
 
-Ensure you have the following:
+Ensure that you have the following:
 
-- `nodejs <https://nodejs.org/dist/latest-v10.x/>`_ version 8.3.0 (and later versions of 8.x), Node.js 10.x, or Node.js 12.x
-- If you wish to run on iOS: `Xcode <https://developer.apple.com/xcode/>`__ version 11.0 or higher, which requires macOS 10.14.4 or higher.
-- If you wish to run on Android: `Android Studio <https://developer.android.com/studio>`_.
+- `nodejs <https://nodejs.org/dist/latest-v10.x/>`_ version 8.3.0 (and later
+  versions of 8.x), Node.js 10.x, or Node.js 12.x
+
+- If you wish to run on iOS: `Xcode <https://developer.apple.com/xcode/>`__
+  version 11.0 or higher, which requires macOS 10.14.4 or higher.
+
+- If you wish to run on Android: `Android Studio
+  <https://developer.android.com/studio>`_.
+
 - :ref:`Set up the backend <tutorial-task-tracker-create-realm-app>`.
 
 Procedure
 ---------
+
+.. note::
+   
+   This tutorial does not implement user registration through the Client SDK. If
+   you're interested in learning more about user registration with {+service+},
+   see the :doc:`Manage Email/Password Users
+   </react-native/manage-email-password-users>` doc.
 
 .. include:: /includes/steps/tutorial-react-native.rst
 

--- a/source/tutorial/web-graphql.txt
+++ b/source/tutorial/web-graphql.txt
@@ -36,6 +36,25 @@ The app is a task tracker that allows users to:
 - Add, view, and delete tasks.
 - Switch tasks between Open, In Progress, and Complete statuses
 
+This tutorial should take around 30 minutes.
+
+.. admonition:: Check Out the Quick Start
+   :class: note
+   
+   If you prefer to explore on your own rather than follow a guided tutorial,
+   check out the :ref:`Web Quick Start <web-quick-start>`. It includes copyable
+   code examples and the essential information that you need to set up a MongoDB
+   Realm application.
+
+.. admonition:: Download the Complete Source Code
+   :class: note
+   
+   We host this tutorial application's :github:`complete and ready-to-run
+   source code <mongodb-university/realm-tutorial/tree/main/web>` on GitHub.
+   Just follow the instructions in ``README.md`` to get started. Don't forget to
+   update the ``/src/realm/RealmApp.tsx`` file with your App ID, which you can
+   find in the {+ui+}.
+
 Prerequisites
 -------------
 
@@ -71,7 +90,7 @@ client application and install its dependencies:
    cd realm-tutorial/web
    npm install
 
-The ``master`` branch is a finished version of the app as it should look after
+The ``main`` branch is a finished version of the app as it should look after
 you complete this tutorial. To remove the Realm-specific source code that you'll
 define in this tutorial, check out the ``todo`` branch:
 

--- a/source/web/quickstart.txt
+++ b/source/web/quickstart.txt
@@ -19,6 +19,18 @@ This page shows you how to connect the Realm Web SDK to a MongoDB Realm
 application, authenticate a user, and work with data. Before you begin, you'll
 need to :ref:`create a {+app+} <create-a-realm-app>` for your web app to use.
 
+.. admonition:: Check Out the Tutorial
+   :class: note
+   
+   This page contains only the essential information that you need to set up a
+   MongoDB Realm application. If you prefer to follow a guided tutorial that
+   shows you step-by-step how to set up a working app, check out the :ref:`Web
+   Tutorial <tutorial-task-tracker-web>` where you'll build a React web app that
+   connects to the :ref:`Task Tracker backend
+   <tutorial-task-tracker-create-realm-app>` and uses the :doc:`GraphQL API
+   </graphql>`.
+   
+
 .. _web-quickstart-install:
 
 Install the Web SDK


### PR DESCRIPTION
## Jira

- [(DOCSP-10822): Add bidirectional links between quick starts and tutorials](https://jira.mongodb.org/browse/DOCSP-10822)

## Staged

### Tutorials

- [Web Tutorial](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/gs/tutorial/web-graphql.html)
- [iOS Tutorial](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/gs/tutorial/ios-swift.html)
- [Android Tutorial](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/gs/tutorial/android-kotlin.html)
- [React Native Tutorial](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/gs/tutorial/react-native.html)

### Quick Starts

- [Web Quick Start](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/gs/web/quickstart.html)
- [iOS Quick Start](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/gs/ios/quick-start.html)
- [Android Quick Start](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/gs/android/quick-start.html)
- [React Native Quick Start](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/gs/react-native/quick-start.html)
