### PR TITLE
improved installation and quickstart instructions

### DIFF
--- a/source/android/quick-start.txt
+++ b/source/android/quick-start.txt
@@ -53,11 +53,25 @@ access your {+app+} using your {+app+} ID. You can find your {+app+} ID in the
 
 .. code-block:: kotlin
 
-
    val appID = "<your app ID>" // replace this with your App ID
    Realm.init(this) // context, typically an Activity
    val app: App = App(AppConfiguration.Builder(appID)
                       .build())
+
+.. admonition:: Android Studio Errors?
+   :class: note
+
+   If Android Studio does not recognize the ``Realm``, ``App``, or
+   ``AppConfiguration`` types, there could be a problem with the
+   your Gradle build configuration. To fix the issue, try:
+
+   - Cleaning your project with ``Build > Clean Project``
+
+   - Rebuilding your project based on your updated ``build.gradle`` file
+     with ``Build > Rebuild Project``
+
+   - Revisiting the :ref:`Install the Android SDK <android-install>`
+     guide to make sure that you installed the dependencies correctly.
 
 Define Your Object Model
 ------------------------
@@ -129,8 +143,8 @@ Open a Realm
 Once you have :ref:`enabled {+sync+} <enable-sync>` and authenticated a user, you can open
 a synced :ref:`{+realm+} <android-realms>`. Use the ``SyncConfiguration``
 to control the specifics of how your application synchronizes data with
-{+backend+}, including the partition, which determines which data is
-synchronized, whether to wait for an initial batch of data to sync, and
+{+backend+}, including the :ref:`partition <partitioning>`,
+ whether to wait for an initial batch of data to sync, and
 more.
 
 .. code-block:: kotlin

--- a/source/android/quick-start.txt
+++ b/source/android/quick-start.txt
@@ -144,7 +144,7 @@ Once you have :ref:`enabled {+sync+} <enable-sync>` and authenticated a user, yo
 a synced :ref:`{+realm+} <android-realms>`. Use the ``SyncConfiguration``
 to control the specifics of how your application synchronizes data with
 {+backend+}, including the :ref:`partition <partitioning>`,
- whether to wait for an initial batch of data to sync, and
+whether to wait for an initial batch of data to sync, and
 more.
 
 .. code-block:: kotlin

--- a/source/includes/steps-install-android.yaml
+++ b/source/includes/steps-install-android.yaml
@@ -64,7 +64,7 @@ content: |
       :alt: Location of the application-level build.gradle file.
 
    If your application uses the Kotlin programming language, you need to
-   apply the ``kotlin-kapt`` extension:
+   apply the ``kotlin-kapt`` plugin:
 
    .. code-block:: groovy
 

--- a/source/includes/steps-install-android.yaml
+++ b/source/includes/steps-install-android.yaml
@@ -1,5 +1,5 @@
-title: Update the Project-Level ``build.gradle`` File
-ref: update-project-level-gradle
+title: Add the Realm Dependency to the Project-Level ``build.gradle`` File
+ref: add-realm-dependency-project-level-gradle
 content: |
 
    Create or open your project in Android Studio. Select the
@@ -13,18 +13,17 @@ content: |
    .. image:: /images/project-level-build-gradle.png
       :alt: Location of the project-level build.gradle file.
 
-   Paste the {+service-short+} classpath into the dependencies block:
+   Paste the {+service-short+} classpath into the
+   ``buildscript.dependencies`` block:
 
-   .. code-block:: text
+   .. code-block:: groovy
     
-      classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.4"
+      classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.5"
 
    When done, your project-level ``build.gradle`` should look something like this:
 
-   .. code-block:: text
-      :emphasize-lines: 14
-
-      // Top-level build file where you can add configuration options common to all sub-projects/modules.
+   .. code-block:: groovy
+      :emphasize-lines: 9
 
       buildscript {
           repositories {
@@ -34,7 +33,7 @@ content: |
           }
           dependencies {
               classpath 'com.android.tools.build:gradle:3.5.1'
-              classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.4"
+              classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.5"
           }
       }
 
@@ -54,7 +53,7 @@ content: |
 
 ---
 title: Add Realm to the Application-Level ``build.gradle`` File
-ref: update-app-level-gradle
+ref: add-realm-to-app-level-gradle
 content: |
 
    Expand the ``app`` folder on the "Project" view in the
@@ -64,59 +63,113 @@ content: |
    .. image:: /images/application-level-build-gradle.png
       :alt: Location of the application-level build.gradle file.
 
-   Paste the realm-android plugin line near the top of the file:
+   If your application uses the Kotlin programming language, you need to
+   apply the ``kotlin-kapt`` extension:
 
-   .. code-block:: text
+   .. code-block:: groovy
+
+      apply plugin: 'kotlin-kapt'
+
+   Apply the ``realm-android`` plugin near the top of your application
+   level ``build.gradle`` file:
+
+   .. code-block:: groovy
 
       apply plugin: 'realm-android'
 
-   When done, your application-level ``build.gradle`` file should look something like this:
+   .. admonition:: Application Order Matters
+      :class: note
 
-   .. code-block:: text
-      :emphasize-lines: 2
+      Application order matters for android plugins. Because the
+      ``realm-android`` plugin depends upon the ``kotlin-kapt``
+      plugin for applications written in Kotlin,
+      you must apply the ``realm-android`` plugin *after* the ``kotlin-kapt``
+      plugin if your application uses the Kotlin programming language.
 
-      apply plugin: 'com.android.application'
-      apply plugin: 'realm-android'
+   And enable sync:
 
-      android {
-          compileSdkVersion 28
-          defaultConfig {
-              applicationId "com.mongodb.exampleapplication"
-              minSdkVersion 16
-              targetSdkVersion 28
-              versionCode 1
-              versionName "1.0"
-              testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-          }
-          buildTypes {
-               def appId = "<your app ID here>"  // Replace with proper Application ID
-               debug {
-                  buildConfigField "String", "MONGODB_REALM_APP_ID", "\"${appId}\""
-               }
-               release {
-                  buildConfigField "String", "MONGODB_REALM_APP_ID", "\"${appId}\""
-                  minifyEnabled false
-                  signingConfig signingConfigs.debug
-               }
-          }
-          compileOptions {
-              sourceCompatibility 1.8
-              targetCompatibility 1.8
-          }
-      }
+   .. code-block:: groovy
 
       realm {
-          syncEnabled = true
+         syncEnabled = true
       }
 
-      dependencies {
-          implementation fileTree(dir: 'libs', include: ['*.jar'])
-          implementation 'androidx.appcompat:appcompat:1.0.2'
-          implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-          testImplementation 'junit:junit:4.12'
-          androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-          androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
-      }
+   When done, your application-level ``build.gradle`` file should look
+   something like this:
+
+   .. tabs-realm-languages::
+
+      .. tab::
+         :tabid: java
+
+         .. code-block:: groovy
+            :emphasize-lines: 2, 19-21
+
+            apply plugin: 'com.android.application'
+            apply plugin: 'realm-android'
+
+            android {
+               compileSdkVersion 29
+               buildToolsVersion "29.0.2"
+
+               defaultConfig {
+                  applicationId "com.mongodb.realmsnippets"
+                  minSdkVersion 21
+                  targetSdkVersion 29
+               }
+               compileOptions {
+                  sourceCompatibility 1.8
+                  targetCompatibility 1.8
+               }
+            }
+
+            realm {
+               syncEnabled = true
+            }
+
+            dependencies {
+               implementation fileTree(dir: 'libs', include: ['*.jar'])
+               implementation 'androidx.appcompat:appcompat:1.1.0'
+            }
+      
+      .. tab::
+         :tabid: kotlin
+
+         .. code-block:: groovy
+            :emphasize-lines: 4, 5, 22-24
+
+            apply plugin: 'com.android.application'
+            apply plugin: 'kotlin-android'
+            apply plugin: 'kotlin-android-extensions'
+            apply plugin: 'kotlin-kapt'
+            apply plugin: 'realm-android'
+
+            android {
+               compileSdkVersion 29
+               buildToolsVersion "29.0.2"
+
+               defaultConfig {
+                  applicationId "com.mongodb.realmsnippets"
+                  minSdkVersion 21
+                  targetSdkVersion 29
+               }
+               compileOptions {
+                  sourceCompatibility 1.8
+                  targetCompatibility 1.8
+               }
+            }
+
+            realm {
+               syncEnabled = true
+            }
+
+            dependencies {
+               implementation fileTree(dir: 'libs', include: ['*.jar'])
+               implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+               implementation 'androidx.appcompat:appcompat:1.1.0'
+               implementation 'androidx.core:core-ktx:1.2.0'
+            }
+
 ---
 title: Sync Project with Gradle Files
 ref: sync-gradle-dependencies

--- a/source/includes/steps-tutorial-android-kotlin.yaml
+++ b/source/includes/steps-tutorial-android-kotlin.yaml
@@ -93,9 +93,7 @@ content: |
   into your **project** ``build.gradle`` file:
 
   .. code-block:: groovy
-     :emphasize-lines: 8-10, 15, 23-25
-
-     // Top-level build file where you can add configuration options common to all sub-projects/modules.
+     :emphasize-lines: 6-8, 13, 21-23
 
      buildscript {
         ext.kotlin_version = '1.3.72'
@@ -109,7 +107,7 @@ content: |
         dependencies {
             classpath 'com.android.tools.build:gradle:4.0.0'
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-            classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.4"
+            classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.5"
         }
      }
 
@@ -171,7 +169,7 @@ content: |
   code to instantiate a connection:
 
   .. code-block:: groovy
-     :emphasize-lines: 2-9
+     :emphasize-lines: 2, 4, 7
 
      buildTypes {
         def appId = "<your app ID here>"  // Replace with proper Application ID
@@ -191,7 +189,7 @@ content: |
   When done, your **app** ``build.gradle`` file should look something like this:
 
   .. code-block:: groovy
-     :emphasize-lines: 4-5, 21-37, 39-41, 47, 50-51
+     :emphasize-lines: 4-5, 21-36, 39-41, 47, 50, 51
 
      apply plugin: 'com.android.application'
      apply plugin: 'kotlin-android'


### PR DESCRIPTION
Description:

- split the app-level gradle build file into java/kotlin examples since there are significant differences
- updated the tutorial and installation pages to use Android beta 5
- condensed a confusing aside/runon sentence into a link to the partitioning doc
- various QOL improvements with highlighted lines in examples, some of which were broken
- callouts in the android quickstart for users who *may* have *accidentally* skipped parts or all of the installation page

Staging:

https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/InstallationAndQuickStartImprovements/android/quick-start.html

https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/InstallationAndQuickStartImprovements/android/install.html