### PR TITLE
(DOCSP-10281,10282): Code Deploy supports branch & directory

### DIFF
--- a/source/deploy.txt
+++ b/source/deploy.txt
@@ -76,8 +76,8 @@ particular development workflow.
 
           - You want to use a code-first approach to app development.
           - You want to use Git to version control your app.
-          - You want to automatically deploy changes based on the
-            ``master`` branch of a :github:`GitHub <>` repository.
+          - You want to automatically deploy changes when you push to
+            :github:`GitHub <>`.
 
        .. admonition:: Deployment Pattern
           :class: reference-block
@@ -91,8 +91,7 @@ particular development workflow.
              of the repository to specify your updated application.
 
           3. When you've made all the changes that you want to, commit
-             them and push to the  GitHub. Automatically deploy the most
-             recent version of a specific branch.
+             them and push the changes to GitHub.
 
    * - {+cli-bin+}
      - .. admonition:: Use This Method If

--- a/source/deploy/deploy-automatically-with-github.txt
+++ b/source/deploy/deploy-automatically-with-github.txt
@@ -13,16 +13,10 @@ Deploy Automatically with GitHub
 Overview
 --------
 
-You can deploy changes to your application by directly
-modifying the underlying :ref:`configuration files
-<config-files>` in an :ref:`application directory
-<app-directory>` that you host on :github:`GitHub <>`. Realm
-uses Git to version control your application and can
-automatically deploy new versions based on the latest commit
-in a GitHub repository that you specify. You can clone the
-GitHub repository to your computer and then use standard Git
-commands to pull down the latest versions and push new
-versions. This guide assumes that you are using the Git CLI.
+You can configure a Realm app to automatically deploy whenever you push updated
+:ref:`configuration files <config-files>` to a :github:`GitHub <>` repository.
+You can clone the GitHub repository to your computer and then use standard Git
+commands to pull down the latest versions and deploy new changes.
 
 Prerequisites
 -------------

--- a/source/includes/steps-github-deploy.yaml
+++ b/source/includes/steps-github-deploy.yaml
@@ -69,24 +69,25 @@ content: |
      
      git clone https://github.com/<organization>/<repo>.git
   
-  The repository needs to contain an :ref:`application directory
-  <app-directory>` with configuration files that define your
-  application. You can create the application directory manually or
-  :doc:`export the application directory </deploy/export-realm-app>`
-  using the ``--for-source-control`` option for an existing app.
+  The configured branch and directory must contain an :ref:`application
+  directory <app-directory>` with configuration files that define your
+  application. You can create the application directory manually or :doc:`export
+  the application directory </deploy/export-realm-app>` of an existing app (using the
+  ``--for-source-control`` option).
   
-  .. important::
+  .. admonition:: Export For Source Control
+     :class: important
 
-     {+app+}s deployed via GitHub *must not* specify
-     the ``name``, ``app_id``, ``location``, or ``deployment_model``
-     fields in the ``realm.json`` file. Applications deployed via
-     GitHub must also omit the ``config.clusterName`` field of the
-     ``config.json`` of any Atlas clusters connected to the application.
-     Application configurations exported with the
-     ``--for-source-control`` flag omit these fields automatically.
+     {+app+}s deployed via GitHub *must not* specify the ``name``, ``app_id``,
+     ``location``, or ``deployment_model`` fields in the ``realm.json`` file.
+     Applications deployed via GitHub must also omit the ``config.clusterName``
+     field of the ``config.json`` of any Atlas clusters connected to the
+     application.
+     
+     Application configurations exported with the ``--for-source-control`` flag
+     omit these fields automatically.
   
-  Add the application directory to the repository
-  and then commit the changes:
+  Add the application directory to the repository and then commit the changes:
 
   .. code-block:: shell
      
@@ -94,22 +95,21 @@ content: |
      git commit -m "Adds {+service-short+} Application Directory"
   
   Once you have committed the latest version of the application to the
-  repository, push it to the ``master`` branch of your repository on
-  GitHub:
+  repository, push it to your GitHub repository:
 
   .. code-block:: shell
      
-     git push origin master
+     git push origin <branch name>
 ---
 title: Enable Automatic Deployment
 ref: enable-automatic-deployment
 content: |
-  After you have specified a repository to deploy and initialized it
-  with the latest version of your app, you need to enable automatic
-  deployment to begin deploying it. On the :guilabel:`Configuration` tab
-  of the :guilabel:`Deploy` page, click :guilabel:`Enable Automatic
-  Deployment`. In the modal that appears, click :guilabel:`Enable
-  Automatic Deployment` to confirm your selection.
+  After you have specified a repository to deploy and initialized it with the
+  latest version of your app, you need to enable automatic deployment to begin
+  deploying it. On the :guilabel:`Configuration` tab of the :guilabel:`Deploy`
+  page, click :guilabel:`Enable Automatic Deployment`. In the modal that
+  appears, click :guilabel:`Enable Automatic Deployment` to confirm your
+  selection.
   
   .. cssclass:: bordered-figure
   .. figure:: /images/enable-automatic-deployment.png
@@ -118,39 +118,38 @@ content: |
 title: Make Changes to Your Application
 ref: make-changes-to-your-application
 content: |
-  A deployment contains one or more changes that you have
-  made to your application since the previous deployment.
-  Make any additions, modifications, or deletions to the
-  repository that you want to include in your deployment.
+  A deployment contains one or more changes that you have made to your
+  application since the previous deployment. Make any additions, modifications,
+  or deletions to the repository that you want to include in your deployment.
 
   Refer to the :doc:`Application Configuration Files
-  </deploy/application-configuration-files>` reference page and
-  individual component reference pages for details on the structure and
-  schema of your application directory.
+  </deploy/application-configuration-files>` reference page and individual
+  component reference pages for details on the structure and schema of your
+  application directory.
 ---
 title: Commit and Push Your Changes
 ref: commit-and-push-your-changes
 content: |
-  Once you have updated your application configuration, you
-  can deploy the updates as a new version of your {+app+}
-  by pushing them to the GitHub repo that you specified. If
-  Automatic GitHub Deployment is enabled, {+service-short+} immediately
-  deploys the latest commit from the ``master`` branch.
+  Once you have updated your application configuration, you can deploy the
+  updates as a new version of your {+app+} by pushing them to the GitHub repo
+  that you specified. If Automatic GitHub Deployment is enabled,
+  {+service-short+} immediately deploys the latest commit for the configured
+  branch and directory.
   
-  When you are ready to deploy, commit all of the files that
-  you want to include and then push them to GitHub:
+  When you are ready to deploy, commit all of the files that you want to include
+  and then push them to GitHub:
 
   .. code-block:: sh
   
      git add -A
      git commit -m "<commit message>"
-     git push origin master
+     git push origin <branch name>
   
-  Once you successfully push your changes to ``master`` in the GitHub
-  repo, {+service-short+} immediately deploys a new version of your application
-  that matches the state of the latest commit. Client applications will
-  automatically use the newest version, so make sure that you also
-  update your client code to use the new version if necessary.
+  Once you successfully push your changes to GitHub, {+service-short+}
+  immediately deploys a new version of your application that matches the state
+  of the latest commit. Client applications will automatically use the newest
+  version, so make sure that you also update your client code to use the new
+  version if necessary.
 
   .. admonition:: Deployment History
      :class: note


### PR DESCRIPTION
## Jira

- [(DOCSP-10281): Ability to point Code Deployment to a Directory](https://jira.mongodb.org/browse/DOCSP-10281)
- [(DOCSP-10282): Support Branch Selection for Code Deployment](https://jira.mongodb.org/browse/DOCSP-10282)

## Staged Changes

- [Deployment Overview](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/deploy/deploy.html)
- [Deploy Automatically with GitHub](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/deploy/deploy/deploy-automatically-with-github.html)