### PR TITLE
Remove client configuration section from Android

### DIFF
--- a/source/android/init-realmclient.txt
+++ b/source/android/init-realmclient.txt
@@ -26,23 +26,3 @@ Pass the {+app+} ID for your {+app+}, which you can find in the {+ui+}.
    val appID = "<your app ID>" // replace this with your App ID
    Realm.init(this) // context, typically an Activity
    val app: App = App(AppConfiguration.Builder(appID).build())
-
-
-.. _android-app-client-configuration:
-
-Configuration
--------------
-
-You can use the ``AppConfiguration`` Builder to control details of
-your ``App``:
-
-.. code-block:: kotlin
-
-   val appID = "<your app ID>" // replace this with your App ID
-   Realm.init(this) // context, typically an Activity
-   val app: App = App(AppConfiguration.Builder(appID)
-         .baseUrl("https://realm.mongodb.com")
-         .appName("My App")
-         .appVersion("3.14.159")
-         .requestTimeout(30, TimeUnit.SECONDS)
-         .build())


### PR DESCRIPTION
Content could confuse some users who just need to follow the basic initialization example.

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/nathan-contino-experiencing-confusion/android/init-realmclient.html