### PR TITLE
(DOCSP-10023): IoT SDK installation instructions

### DIFF
--- a/source/includes/steps-install-node-iot.yaml
+++ b/source/includes/steps-install-node-iot.yaml
@@ -35,7 +35,7 @@ content: |
 
    .. code-block:: bash
 
-      npm install --save realm@beta
+      npm install --save realm@10.0.0-beta.6
 
 ---
 title: Enable TypeScript (optional)
@@ -50,4 +50,3 @@ content: |
    <https://github.com/Microsoft/TypeScript-Node-Starter#typescript--node>`__.
    {+service-short+} supports TypeScript natively and integrates easily
    into a TypeScript project.
-

--- a/source/includes/steps-install-node-iot.yaml
+++ b/source/includes/steps-install-node-iot.yaml
@@ -1,0 +1,53 @@
+title: Install a C++ Compiler
+ref: iot-install-c++-compiler
+content: |
+
+   The Realm IoT SDK is not distributed as a binary, so you must build
+   it from source. To do this, you'll need a working C++ compiler. To
+   install such a compiler on your IoT device, run the following command:
+
+   .. code-block:: bash
+
+      sudo apt install build-essential g++ libssl-dev
+
+---
+title: Create a Node.js Project
+ref: create-a-node-project
+content: |
+
+   Create your Node.js project by creating a new directory
+   for your project and running ``npm init`` in that
+   directory. In the example below, replace ``MyRealmApp``
+   with your desired project name. Answer all of the prompts
+   to fill out the details of your project.
+
+   .. code-block:: bash
+
+      mkdir MyRealmApp && cd MyRealmApp && npm init
+
+---
+title: Install Realm with NPM
+ref: install-realm-with-npm
+content: |
+
+   In your Node.js project directory, use the following command
+   to add {+service-short+} to your project:
+
+   .. code-block:: bash
+
+      npm install --save realm@beta
+
+---
+title: Enable TypeScript (optional)
+ref: enable-typescript
+content: |
+
+   TypeScript is a superset of JavaScript that adds static
+   type checking and other features intended to make
+   application-scale development more robust. If you'd like
+   to use TypeScript, follow the TypeScript team's official
+   `Node Starter guide
+   <https://github.com/Microsoft/TypeScript-Node-Starter#typescript--node>`__.
+   {+service-short+} supports TypeScript natively and integrates easily
+   into a TypeScript project.
+

--- a/source/node/install.txt
+++ b/source/node/install.txt
@@ -51,6 +51,16 @@ Follow these steps to create a Node.js project and add the
 
 .. include:: /includes/steps/install-node.rst
 
+
+IoT Installation
+----------------
+
+To create a Node.js project and add the {+service+} Node.js SDK on an
+Internet of Things (IoT) platform such as the Raspberry Pi 2, 3, or 4
+running Raspberry Pi OS (formerly Raspbian), follow the steps below:
+
+.. include:: /includes/steps/install-node-iot.rst
+
 Import Realm
 ------------
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-10023

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/DOCSP-10023iot/node/install.html#iot-installation

We could also look into creating a separate tab for the IoT SDK, but since it doesn't deviate anywhere else I'm not sure if it's necessary. Open to the idea though if you think this layout is confusing or just too long though.