### PR TITLE
(DOCSP-11084): Realm CLI documentation references realm.json instead of config.json

### DIFF
--- a/source/hosting/use-a-custom-domain-name.txt
+++ b/source/hosting/use-a-custom-domain-name.txt
@@ -24,7 +24,7 @@ following form:
 You can configure a custom domain name for your application's hosted
 content from the {+ui+} or by :doc:`importing
 </deploy/deploy-cli>` an application configuration
-directory that specifies the domain in its ``realm.json`` configuration
+directory that specifies the domain in its ``config.json`` configuration
 file. Select the tab below that corresponds to the method you want to
 use.
 

--- a/source/includes/appschema-configuration.rst
+++ b/source/includes/appschema-configuration.rst
@@ -4,17 +4,17 @@
       :copyable: False
 
       yourRealmApp/
-      └── realm.json
+      └── config.json
 
 Application-level configuration information is defined in a single
-document named ``realm.json`` stored in your application's root
+document named ``config.json`` stored in your application's root
 directory.
 
 Configuration
 ~~~~~~~~~~~~~
 
 .. code-block:: javascript
-   :caption: ``realm.json``
+   :caption: ``config.json``
 
    {
      "app_id": "",

--- a/source/includes/options-realm-cli.yaml
+++ b/source/includes/options-realm-cli.yaml
@@ -17,8 +17,8 @@ inherit:
   name: app-id
 post: |
   If not specified, {+cli-bin+} will attempt to use the value of
-  ``app_id`` defined in :ref:`realm.json <appschema-realm-config>`. If
-  ``realm.json`` does not have an ``app_id`` value, {+cli-bin+}
+  ``app_id`` defined in :ref:`config.json <appschema-realm-config>`. If
+  ``config.json`` does not have an ``app_id`` value, {+cli-bin+}
   prompts you to create a new application.
   
   .. admonition:: New Application App IDs
@@ -71,11 +71,11 @@ description: |
   | **Optional.**
 
   The path to the directory containing files you wish to import.
-  The directory must contain, at minimum, a valid :ref:`realm.json
+  The directory must contain, at minimum, a valid :ref:`config.json
   <appschema-realm-config>` file.
 
   If the ``path`` argument is omitted, {+cli-bin+} will search for a
-  ``realm.json`` file in the current application directory.
+  ``config.json`` file in the current application directory.
 ---
 program: realm-cli import
 name: strategy
@@ -131,7 +131,7 @@ description: |
   If enabled, {+cli-bin+} exports the application configuration
   without any fields that conflict with deployment via GitHub source
   control, including fields like ``name``, ``app_id``, ``location``,
-  and ``deployment_model`` in the ``realm.json`` file as well as the
+  and ``deployment_model`` in the ``config.json`` file as well as the
   ``config.clusterName`` field in the ``config.json`` of any Atlas
   clusters linked to the application.
 ---

--- a/source/includes/realm-application-file-schema.rst
+++ b/source/includes/realm-application-file-schema.rst
@@ -1,7 +1,7 @@
 .. code-block:: none
 
    yourRealmApp/
-   ├── realm.json
+   ├── config.json
    ├── secrets.json
    ├── auth_providers/
    │   └── <provider name>.json

--- a/source/includes/steps-apple-auth-configure.yaml
+++ b/source/includes/steps-apple-auth-configure.yaml
@@ -304,7 +304,7 @@ content: |
        
          .. code-block:: shell
        
-            git add realm.json
+            git add ./auth_providers/oauth2-apple.json
             git commit -m "Configure and Enable Apple ID Authentication"
             git push origin master
 ...

--- a/source/includes/steps-cli-create.yaml
+++ b/source/includes/steps-cli-create.yaml
@@ -3,19 +3,19 @@ ref: create-app-directory
 content: |
   Create a new directory for your application and navigate into it.
 
-  Add a :ref:`realm.json <appschema-realm-config>` file to the root
+  Add a :ref:`config.json <appschema-realm-config>` file to the root
   level of the directory. The file should contain an empty JSON object.
 
   .. code-block:: shell
 
-     echo \{\} > realm.json
+     echo \{\} > config.json
 
   .. note::
 
      Upon successfully creating a new {+app+}, {+cli-bin+}
-     will immediately update ``realm.json`` to reflect the new app.
+     will immediately update ``config.json`` to reflect the new app.
 
-     This overwrites any existing values in ``realm.json``.
+     This overwrites any existing values in ``config.json``.
 ---
 title: Initialize Application Entities
 ref: initialize-app-entities
@@ -89,7 +89,7 @@ title: Verify Application Creation
 ref: verify-app-creation
 content: |
   You can confirm that your new {+app+} was successfully imported by
-  checking ``realm.json``. If the creation was successful, the
+  checking ``config.json``. If the creation was successful, the
   ``app_id`` and ``name`` fields will have updated values that reflect
   the new application.
 

--- a/source/includes/steps-define-custom-user-data-import-export.yaml
+++ b/source/includes/steps-define-custom-user-data-import-export.yaml
@@ -26,10 +26,10 @@ content: |
 
   To configure your application to read user data from this collection,
   specify a configuration document in the ``custom_user_data_config``
-  field of ``realm.json``:
+  field of ``config.json``:
 
   .. code-block:: json
-     :caption: realm.json
+     :caption: config.json
 
      {
        ...,
@@ -89,7 +89,7 @@ content: |
 
   .. code-block:: shell
 
-     git add realm.json
+     git add config.json
      git commit -m "Configure and Enable Custom User Data"
      git push origin master
 

--- a/source/includes/steps-deploy-cli.yaml
+++ b/source/includes/steps-deploy-cli.yaml
@@ -3,7 +3,7 @@ ref: prepare-application-directory
 content: |
   :doc:`Export </deploy/export-realm-app>` your application to a local
   application directory. Alternatively, create a new application
-  directory that contains a :ref:`realm.json <appschema-realm-config>`
+  directory that contains a :ref:`config.json <appschema-realm-config>`
   file with your application's ``app_id``.
 
   .. code-block:: json

--- a/source/includes/steps-enable-hosting-import-export.yaml
+++ b/source/includes/steps-enable-hosting-import-export.yaml
@@ -18,7 +18,7 @@ content: |
 title: Enable Hosting in the Application Configuration
 ref: enable-hosting-in-the-application-configuration
 content: |
-  In :ref:`realm.json <appschema-realm-config>`, set the value of
+  In :ref:`config.json <appschema-realm-config>`, set the value of
   ``hosting.enabled`` to ``true`` then save the file.
 
   .. code-block:: json
@@ -29,7 +29,7 @@ content: |
 title: Import the Updated Application Configuration
 ref: import-the-updated-application-configuration
 content: |
-  Once you have enabled hosting in ``realm.json``, you can import the
+  Once you have enabled hosting in ``config.json``, you can import the
   directory into your application.
   Navigate to the root of the application directory and run the
   following command:

--- a/source/includes/steps-github-deploy.yaml
+++ b/source/includes/steps-github-deploy.yaml
@@ -79,7 +79,7 @@ content: |
      :class: important
 
      {+app+}s deployed via GitHub *must not* specify the ``name``, ``app_id``,
-     ``location``, or ``deployment_model`` fields in the ``realm.json`` file.
+     ``location``, or ``deployment_model`` fields in the ``config.json`` file.
      Applications deployed via GitHub must also omit the ``config.clusterName``
      field of the ``config.json`` of any Atlas clusters connected to the
      application.

--- a/source/includes/steps-host-a-single-page-application-code-deploy.yaml
+++ b/source/includes/steps-host-a-single-page-application-code-deploy.yaml
@@ -38,14 +38,14 @@ content: |
 title: Configure Realm to Serve Your Application
 ref: configure-realm-to-serve-your-application
 content: |
-  In :ref:`realm.json <appschema-realm-config>`, set the value of
+  In :ref:`config.json <appschema-realm-config>`, set the value of
   ``hosting.default_response_code`` to ``200`` and set the value of
   ``hosting.default_error_path`` to the :ref:`resource path
   <hosting-resource-path>` of your SPA's root HTML file. Make sure to
   save the file when you're done.
 
   .. code-block:: json
-     :caption: ``realm.json``
+     :caption: ``config.json``
   
      "hosting": {
        "enabled": true,

--- a/source/includes/steps-use-a-custom-404-page-import-export.yaml
+++ b/source/includes/steps-use-a-custom-404-page-import-export.yaml
@@ -37,7 +37,7 @@ content: |
 title: Specify the 404 Page in the Application Configuration
 ref: specify-the-404-page-in-the-application-configuration
 content: |
-  In :ref:`realm.json <appschema-realm-config>`, set the value of
+  In :ref:`config.json <appschema-realm-config>`, set the value of
   ``hosting.default_error_path`` to the :ref:`resource path
   <hosting-resource-path>` of the HTML file then save the configuration
   file.
@@ -52,7 +52,7 @@ content: |
 title: Import the Updated Application Directory
 ref: import-the-updated-application-directory
 content: |
-  Once you have specified the custom 404 page path in ``realm.json``,
+  Once you have specified the custom 404 page path in ``config.json``,
   you can import the directory into your application. If you added the
   custom HTML file to ``/hosting``, make sure to use the
   ``--include-hosting`` flag.

--- a/source/includes/steps-use-a-custom-domain-name-import-export.yaml
+++ b/source/includes/steps-use-a-custom-domain-name-import-export.yaml
@@ -24,7 +24,7 @@ content: |
 title: Specify the Custom Domain
 ref: specify-the-custom-domain
 content: |
-  In :ref:`realm.json <appschema-realm-config>`, set the value of
+  In :ref:`config.json <appschema-realm-config>`, set the value of
   ``hosting.custom_domain`` to your custom domain name then save the
   file.
 


### PR DESCRIPTION
## Jira

- (DOCSP-11084): Realm CLI documentation references realm.json instead of config.json

## Staged Changes

- [staged](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/realm.json/index.html)