### PR TITLE
(DOCSP-9796): Clarify where relationship definition goes on GraphQL page

### DIFF
--- a/source/graphql/expose-data.txt
+++ b/source/graphql/expose-data.txt
@@ -87,7 +87,6 @@ children from the same ``people`` collection:
      }
    }
 
-
 Realm evaluates which foreign documents are related to a given local
 document based on a foreign key value. For each relationship, the local
 document contains either a single foreign key value or an array of
@@ -95,17 +94,47 @@ foreign key values in a specific field. A document is related to any
 documents in the foreign collection where the value of the foreign key
 field matches a foreign key included in the local field.
 
-Relationship definitions have the following form:
-
-.. code-block:: json
+.. tabs-realm-admin-interfaces::
+   
+   .. tab::
+      :tabid: ui
       
-   {
-     "<Local Field Name>": {
-       "ref": "#/realm/<Cluster>/<Database>/<Collection>",
-       "foreign_key": "<Foreign Key Field Name>",
-       "is_list": <Boolean>
-     }
-   }
+      To define a relationship in the Realm UI, navigate to the :guilabel:`Rules` page
+      for the local collection, click the :guilabel:`Relationships` tab, and enter a
+      relationship definition.
+      
+      Relationship definitions have the following form:
+      
+      .. code-block:: json
+         
+         {
+           "<Local Field Name>": {
+             "ref": "#/realm/<Cluster>/<Database>/<Collection>",
+             "foreign_key": "<Foreign Key Field Name>",
+             "is_list": <Boolean>
+           }
+         }
+   
+   .. tab::
+      :tabid: cli
+      
+      To define a relationship for a local collection using Realm CLI or another
+      code deploy method, add a relationship definition to the ``relationships``
+      field of the collection's rules configuration file.
+      
+      .. code-block:: json
+         :caption: ``/services/mongodb-atlas/rules/<db>.<collection>.json``
+         
+         {
+           ...,
+           relationships: {
+             "<Local Field Name>": {
+               "ref": "#/realm/<Cluster>/<Database>/<Collection>",
+               "foreign_key": "<Foreign Key Field Name>",
+               "is_list": <Boolean>
+             }
+           }
+         }
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
## Jira

- (DOCSP-9796): Clarify where relationship definition goes on GraphQL page

## Staged

- [Expose Data in a Collection > 3. Define Relationships to Other Collections](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/graphql-relationships/graphql/expose-data.html#define-relationships-to-other-collections)