### PR TITLE
(DOCSP-11250): Fix Wikipedia links

### DIFF
--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -167,14 +167,14 @@ Glossary
       A principle upon which :term:`{+service+}` is built. While traditional
       ORMs copy data from the database into native-language objects,
       :term:`{+service-short+} objects<{+service-short+} object>` read and write data using
-      :wikipedia:`memory mapping </Memory-mapped_file>` to read and
+      :wikipedia:`memory mapping <Memory-mapped_file>` to read and
       write data directly to and from the database via shallow object
       wrappers.
 
    ACID
       An acronym that expands to "Atomicity, Consistency, Isolation, and
       Durability". {+service+} is :term:`ACID-compliant <ACID compliance>`. See
-      :wikipedia:`the Wikipedia entry for ACID </ACID>` for more
+      :wikipedia:`the Wikipedia entry for ACID <ACID>` for more
       information.
 
    ACID compliance


### PR DESCRIPTION
- Searched for other broken wikipedia links and fixed any

## Jira
https://jira.mongodb.org/browse/DOCSP-11250

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/fix-wiki-link/get-started/glossary.html
