### PR TITLE
(DOCSP-10905): Empty body no longer required for trigger resume API

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -327,13 +327,6 @@ paths:
       tags: ["triggers"]
       operationId: "adminResumeTrigger"
       summary: "Resume a suspended trigger."
-      requestBody:
-        description: "An empty object."
-        required: true
-        content:
-          application/json:
-            schema:
-              properties: {}
       responses:
         "204":
           description: "Successfully resumed the trigger."


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-10905

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/DOCSP-10905/admin/api/v3.html#put-/groups/{groupid}/apps/{appid}/triggers/{triggerid}/resume