### PR TITLE
kotlin java parity, init Realm as include file

### DIFF
--- a/source/android/call-a-function.txt
+++ b/source/android/call-a-function.txt
@@ -40,61 +40,63 @@ of the app.
 
 .. tabs-realm-languages::
 
-      .. tab::
-         :tabid: java
+   .. tab::
+      :tabid: java
 
-         .. code-block:: java
+      .. code-block:: java
+         :emphasize-lines: 11-19
 
-            Realm.init(this);
-            String appID = "<your App ID>"; // replace this with your App ID
-            Realm.init(this); // context, typically an Application or Activity
-            App app = new App(new AppConfiguration.Builder(appID).build());
+         Realm.init(this);
+         String appID = "<your App ID>"; // replace this with your App ID
+         Realm.init(this); // context, typically an Application or Activity
+         App app = new App(new AppConfiguration.Builder(appID).build());
 
-            Credentials credentials = Credentials.anonymous();
-            app.loginAsync(credentials, it -> {
-               if (it.isSuccess()) {
-                  user = app.currentUser();
-                  assert user != null;
-                  Functions functionsManager = app.getFunctions(user);
-                  List<Integer> args = Arrays.asList(1, 2);
-                  functionsManager.callFunctionAsync("sum", args, Integer.class, result -> {
-                     if (result.isSuccess()) {
-                        Log.v(TAG, "Sum value: " + result.get());
+         Credentials credentials = Credentials.anonymous();
+         app.loginAsync(credentials, it -> {
+            if (it.isSuccess()) {
+               user = app.currentUser();
+               assert user != null;
+               Functions functionsManager = app.getFunctions(user);
+               List<Integer> args = Arrays.asList(1, 2);
+               functionsManager.callFunctionAsync("sum", args, Integer.class, result -> {
+                  if (result.isSuccess()) {
+                     Log.v(TAG, "Sum value: " + result.get());
+                  } else {
+                     Log.e("EXAMPLE", "failed to call sum function with: " + result.getError());
+                  }
+               });
+            } else {
+               Log.e("EXAMPLE", "Error logging into the Realm app. Make sure that anonymous authentication is enabled. Error: " + it.getError());
+            }
+         });
+
+   .. tab::
+      :tabid: kotlin
+
+      .. code-block:: kotlin
+         :emphasize-lines: 10-20
+
+         Realm.init(this)
+         val appID = "<your App ID>" // replace this with your App ID
+         val app: App = App(AppConfiguration.Builder(appID).build())
+
+         val anonymousCredentials: Credentials = Credentials.anonymous()
+         app.loginAsync(anonymousCredentials) {
+            if (it.isSuccess) {
+               val user: User? = app.currentUser()
+
+               val functionsManager: Functions = app.getFunctions(user)
+               val args: List<Int> = listOf(1, 2)
+               functionsManager.callFunctionAsync("sum", args, Integer::class.java) { result ->
+                  run {
+                     if (result.isSuccess) {
+                         Log.v(TAG, "Sum value: ${result.get()}")
                      } else {
-                        Log.e("EXAMPLE", "failed to call sum function with: " + result.getError());
-                     }
-                  });
-               } else {
-                  Log.e("EXAMPLE", "Error logging into the Realm app. Make sure that anonymous authentication is enabled. Error: " + it.getError());
-               }
-            });
-
-      .. tab::
-         :tabid: kotlin
-
-         .. code-block:: kotlin
-
-            Realm.init(this)
-            val appID = "<your App ID>" // replace this with your App ID
-            val app: App = App(AppConfiguration.Builder(appID).build())
-
-            val anonymousCredentials: Credentials = Credentials.anonymous()
-            app.loginAsync(anonymousCredentials) {
-               if (it.isSuccess) {
-                  val user: User? = app.currentUser()
-
-                  val functionsManager: Functions = app.getFunctions(user)
-                  val args: List<Int> = listOf(1, 2)
-                  functionsManager.callFunctionAsync("sum", args, Integer::class.java) { result ->
-                     run {
-                        if (result.isSuccess) {
-                            Log.v(TAG, "Sum value: ${result.get()}")
-                        } else {
-                            Log.e("EXAMPLE", "failed to call sum function with: " + result.error)
-                        }
+                         Log.e("EXAMPLE", "failed to call sum function with: " + result.error)
                      }
                   }
-               } else {
-                  Log.e("EXAMPLE", "Error logging into the Realm app. Make sure that anonymous authentication is enabled. Error: " + it.error)
                }
+            } else {
+               Log.e("EXAMPLE", "Error logging into the Realm app. Make sure that anonymous authentication is enabled. Error: " + it.error)
             }
+         }

--- a/source/android/call-a-function.txt
+++ b/source/android/call-a-function.txt
@@ -37,27 +37,64 @@ Call from a Client Application
 To execute a function from the Android SDK, use the ``functions`` method
 of the app.
 
-.. code-block:: kotlin
-   :emphasize-lines: 9-17
 
-   Realm.init(this)
-   val appID = "<your app ID>"
-   val app: App = App(AppConfiguration.Builder(appID)
-                .build())
+.. tabs-realm-languages::
 
-   val anonymousCredentials: Credentials = Credentials.anonymous()
-   app.loginAsync(anonymousCredentials) {
-      if (it.isSuccess) {
-         val user: User? = app.currentUser()
+      .. tab::
+         :tabid: java
 
-         val functionsManager: Functions = app.getFunctions(user)
-         val args: ArrayList<Int> = ArrayList<Int>()
-         args.add(1)
-         args.add(2)
-         functionsManager.callFunctionAsync("sum", args, Integer::class.java) {
-               result -> Log.v(TAG, "Sum value: ${result.get()}")
-         }
-      } else {
-            Log.e(TAG, it.error.toString())
-      }
-   }
+         .. code-block:: java
+
+            Realm.init(this);
+            String appID = "<your App ID>"; // replace this with your App ID
+            Realm.init(this); // context, typically an Application or Activity
+            App app = new App(new AppConfiguration.Builder(appID).build());
+
+            Credentials credentials = Credentials.anonymous();
+            app.loginAsync(credentials, it -> {
+               if (it.isSuccess()) {
+                  user = app.currentUser();
+                  assert user != null;
+                  Functions functionsManager = app.getFunctions(user);
+                  List<Integer> args = Arrays.asList(1, 2);
+                  functionsManager.callFunctionAsync("sum", args, Integer.class, result -> {
+                     if (result.isSuccess()) {
+                        Log.v(TAG, "Sum value: " + result.get());
+                     } else {
+                        Log.e("EXAMPLE", "failed to call sum function with: " + result.getError());
+                     }
+                  });
+               } else {
+                  Log.e("EXAMPLE", "Error logging into the Realm app. Make sure that anonymous authentication is enabled. Error: " + it.getError());
+               }
+            });
+
+      .. tab::
+         :tabid: kotlin
+
+         .. code-block:: kotlin
+
+            Realm.init(this)
+            val appID = "<your App ID>" // replace this with your App ID
+            val app: App = App(AppConfiguration.Builder(appID).build())
+
+            val anonymousCredentials: Credentials = Credentials.anonymous()
+            app.loginAsync(anonymousCredentials) {
+               if (it.isSuccess) {
+                  val user: User? = app.currentUser()
+
+                  val functionsManager: Functions = app.getFunctions(user)
+                  val args: List<Int> = listOf(1, 2)
+                  functionsManager.callFunctionAsync("sum", args, Integer::class.java) { result ->
+                     run {
+                        if (result.isSuccess) {
+                            Log.v(TAG, "Sum value: ${result.get()}")
+                        } else {
+                            Log.e("EXAMPLE", "failed to call sum function with: " + result.error)
+                        }
+                     }
+                  }
+               } else {
+                  Log.e("EXAMPLE", "Error logging into the Realm app. Make sure that anonymous authentication is enabled. Error: " + it.error)
+               }
+            }

--- a/source/android/init-realmclient.txt
+++ b/source/android/init-realmclient.txt
@@ -31,7 +31,7 @@ Pass the {+app+} ID for your {+app+}, which you can find in the {+ui+}.
          .. code-block:: java
 
             String appID = "<your App ID>"; // replace this with your App ID
-            Realm.init(this); // context, typically an Application or Activity
+            Realm.init(this); // `this` is a Context, typically an Application or Activity
             App app = new App(new AppConfiguration.Builder(appID).build());
 
       .. tab::
@@ -40,7 +40,7 @@ Pass the {+app+} ID for your {+app+}, which you can find in the {+ui+}.
          .. code-block:: kotlin
 
             val appID : String = "<your App ID>" // replace this with your App ID
-            Realm.init(this) // context, typically an Application or Activity
+            Realm.init(this) // `this` is a Context, typically an Application or Activity
             val app: App = App(AppConfiguration.Builder(appID).build())
 
 .. important:: Initialize the App before Creating an Instance
@@ -67,7 +67,7 @@ Builder to control details of your ``App``:
          .. code-block:: java
 
             String appID = "<your App ID>"; // replace this with your App ID
-            Realm.init(this); // context, typically an Application or Activity
+            Realm.init(this); // `this` is a Context, typically an Application or Activity
             App app = new App(new AppConfiguration.Builder(appID)
                               .appName("My App")
                               .requestTimeout(30, TimeUnit.SECONDS)
@@ -79,7 +79,7 @@ Builder to control details of your ``App``:
          .. code-block:: kotlin
 
             val appID = "<your App ID>" // replace this with your App ID
-            Realm.init(this) // context, typically an Application or Activity
+            Realm.init(this) // `this` is a Context, typically an Application or Activity
             val app: App = App(AppConfiguration.Builder(appID)
                                .appName("My App")
                                .requestTimeout(30, TimeUnit.SECONDS)

--- a/source/android/init-realmclient.txt
+++ b/source/android/init-realmclient.txt
@@ -14,6 +14,8 @@ backend. It provides access to the :ref:`authentication functionality
 <android-authenticate>`, :ref:`functions <android-call-a-function>`, and
 :ref:`sync management <android-sync-data>`.
 
+.. include:: /includes/android-initialize-realm.rst
+
 .. _android-access-the-app-client:
 
 Access the App Client
@@ -21,11 +23,30 @@ Access the App Client
 
 Pass the {+app+} ID for your {+app+}, which you can find in the {+ui+}.
 
-.. code-block:: kotlin
+.. tabs-realm-languages::
 
-   val appID = "<your app ID>" // replace this with your App ID
-   Realm.init(this) // context, typically an Activity
-   val app: App = App(AppConfiguration.Builder(appID).build())
+      .. tab::
+         :tabid: java
+
+         .. code-block:: java
+
+            String appID = "<your App ID>"; // replace this with your App ID
+            Realm.init(this); // context, typically an Application or Activity
+            App app = new App(new AppConfiguration.Builder(appID).build());
+
+      .. tab::
+         :tabid: kotlin
+
+         .. code-block:: kotlin
+
+            val appID : String = "<your App ID>" // replace this with your App ID
+            Realm.init(this) // context, typically an Application or Activity
+            val app: App = App(AppConfiguration.Builder(appID).build())
+
+.. important:: Initialize the App before Creating an Instance
+
+   You must initialize your {+service-short+} app connection with
+   ``Realm.init()`` before creating any instance of an ``App``.
 
 
 .. _android-app-client-configuration:
@@ -38,15 +59,32 @@ such as custom timeouts for connections, codecs used for MongoDB Data Access,
 and keys for local encryption, you can use the ``AppConfiguration``
 Builder to control details of your ``App``:
 
-.. code-block:: kotlin
+.. tabs-realm-languages::
 
-   val appID = "<your app ID>" // replace this with your App ID
-   Realm.init(this) // context, typically an Activity
-   val app: App = App(AppConfiguration.Builder(appID)
-         .appName("My App")
-         .requestTimeout(30, TimeUnit.SECONDS)
-         .build())
-         
+      .. tab::
+         :tabid: java
+
+         .. code-block:: java
+
+            String appID = "<your App ID>"; // replace this with your App ID
+            Realm.init(this); // context, typically an Application or Activity
+            App app = new App(new AppConfiguration.Builder(appID)
+                              .appName("My App")
+                              .requestTimeout(30, TimeUnit.SECONDS)
+                              .build());
+
+      .. tab::
+         :tabid: kotlin
+
+         .. code-block:: kotlin
+
+            val appID = "<your App ID>" // replace this with your App ID
+            Realm.init(this) // context, typically an Application or Activity
+            val app: App = App(AppConfiguration.Builder(appID)
+                               .appName("My App")
+                               .requestTimeout(30, TimeUnit.SECONDS)
+                               .build())
+
 .. note:: 
     
    For most use cases, you only need your application's App ID to connect

--- a/source/android/quick-start.txt
+++ b/source/android/quick-start.txt
@@ -56,61 +56,7 @@ statement:
 
 .. _android-quick-start-init-app:
 
-Initialize Realm
-----------------
-
-Before you can use {+service-short+} in your {+app+}, you must
-initialize the {+service-short+} library. Your application should
-initialize {+service-short+} just once each time the application runs.
-
-To initialize the {+service-short+} library, provide an Android
-``context`` to the ``Realm.init()`` static function. You can provide
-an Activity, Fragment, or Application ``context`` for initialization with no
-difference in behavior. You can initialize the {+service-short+} library
-in the ``onCreate()`` method of an `application subclass
-<https://developer.android.com/reference/android/app/Application>`__ to
-ensure that you only initialize {+service-short+} once each time the
-application runs.
-
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: java
-   
-      .. code-block:: java
-
-         Realm.init(this); // context, usually an Activity or Application
-   
-   .. tab::
-      :tabid: kotlin
-
-      .. code-block:: kotlin
-   
-         Realm.init(this) // context, usually an Activity or Application
-
-.. admonition:: Register Your Application Subclass in the Android Manifest
-   :class: note
-
-   If you create your own ``Application`` subclass, you must add it to your
-   application's ``AndroidManifest.xml`` to execute your custom
-   application code. Setting the ``android.name`` property of your
-   manifest's application definition instantiates your ``Application``
-   subclass before any other class when the process for your application
-   is created.
-   
-   .. code-block:: xml
-      :emphasize-lines: 6
-
-      <?xml version="1.0" encoding="utf-8"?>
-      <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-         package="com.mongodb.example">
-
-         <application
-            android:name=".MyApplicationSubclass"
-            ...
-         />
-      </manifest>
-
+.. include:: /includes/android-initialize-realm.rst
 
 Initialize the App
 ------------------

--- a/source/includes/android-initialize-realm.rst
+++ b/source/includes/android-initialize-realm.rst
@@ -1,0 +1,54 @@
+Initialize Realm
+----------------
+
+Before you can use {+service-short+} in your {+app+}, you must
+initialize the {+service-short+} library. Your application should
+initialize {+service-short+} just once each time the application runs.
+
+To initialize the {+service-short+} library, provide an Android
+``context`` to the ``Realm.init()`` static function. You can provide
+an Activity, Fragment, or Application ``context`` for initialization with no
+difference in behavior. You can initialize the {+service-short+} library
+in the ``onCreate()`` method of an `application subclass
+<https://developer.android.com/reference/android/app/Application>`__ to
+ensure that you only initialize {+service-short+} once each time the
+application runs.
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: java
+   
+      .. code-block:: java
+
+         Realm.init(this); // context, usually an Activity or Application
+   
+   .. tab::
+      :tabid: kotlin
+
+      .. code-block:: kotlin
+   
+         Realm.init(this) // context, usually an Activity or Application
+
+.. admonition:: Register Your Application Subclass in the Android Manifest
+   :class: note
+
+   If you create your own ``Application`` subclass, you must add it to your
+   application's ``AndroidManifest.xml`` to execute your custom
+   application code. Setting the ``android.name`` property of your
+   manifest's application definition instantiates your ``Application``
+   subclass before any other class when the process for your application
+   is created.
+   
+   .. code-block:: xml
+      :emphasize-lines: 6
+
+      <?xml version="1.0" encoding="utf-8"?>
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+         package="com.mongodb.example">
+
+         <application
+            android:name=".MyApplicationSubclass"
+            ...
+         />
+      </manifest>

--- a/source/includes/android-initialize-realm.rst
+++ b/source/includes/android-initialize-realm.rst
@@ -1,7 +1,7 @@
 Initialize Realm
 ----------------
 
-Before you can use {+service-short+} in your {+app+}, you must
+Before you can use {+service-short+} in your app, you must
 initialize the {+service-short+} library. Your application should
 initialize {+service-short+} just once each time the application runs.
 
@@ -21,14 +21,14 @@ application runs.
    
       .. code-block:: java
 
-         Realm.init(this); // context, usually an Activity or Application
+         Realm.init(this); // `this` is a Context, typically an Application or Activity
    
    .. tab::
       :tabid: kotlin
 
       .. code-block:: kotlin
    
-         Realm.init(this) // context, usually an Activity or Application
+         Realm.init(this) // `this` is a Context, typically an Application or Activity
 
 .. admonition:: Register Your Application Subclass in the Android Manifest
    :class: note


### PR DESCRIPTION
### Staging links:

Quick start: https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/moartabs/android/quick-start.html
- same content, refactored "Initialize Realm" into an includes file

Initialize the Realm Client: https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/moartabs/android/init-realmclient.html
- Added "Initialize Realm" section that was already written for quick start, which contains details about where and why you need to run ``Realm.init()``
- Java/Kotlin tabbed examples where previously we only had Kotlin examples

Call a Function: https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/moartabs/android/call-a-function.html
- Java/Kotlin tabbed examples where previously we only had Kotlin examples