### PR TITLE
Syntax fixed for IOS Tutorial

### DIFF
--- a/source/includes/steps-tutorial-ios-swift.yaml
+++ b/source/includes/steps-tutorial-ios-swift.yaml
@@ -593,7 +593,7 @@ content: |
 
      import RealmSwift
 
-  To begin, declare some member variables at the top of the
+  Next, declare some member variables at the top of the
   new class:
 
   .. code-block:: swift

--- a/source/includes/steps-tutorial-ios-swift.yaml
+++ b/source/includes/steps-tutorial-ios-swift.yaml
@@ -417,7 +417,7 @@ content: |
                  let partitionValue = "My Project"
 
                  // Open a realm.
-                 let projectRealm = try! Realm(configuration: user.configuration(partitionValue: partitionValue))
+                 let projectRealm = try! Realm(configuration: user!.configuration(partitionValue: partitionValue))
 
                  self!.navigationController!.pushViewController(TasksViewController(projectRealm: projectRealm), animated: true);
              }

--- a/source/includes/steps-tutorial-ios-swift.yaml
+++ b/source/includes/steps-tutorial-ios-swift.yaml
@@ -583,6 +583,16 @@ content: |
      :width: 300px
      :lightbox:
 
+
+  With the TasksViewController file open, the first thing
+  to add at the top of the file is the import statement for
+  RealmSwift, so that our view controller can use
+  {+service-short+}:
+
+  .. code-block:: swift
+
+     import RealmSwift
+
   To begin, declare some member variables at the top of the
   new class:
 


### PR DESCRIPTION
Stage:
-------
* https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/Moe-IOS-Swift-Tutorial-Fixes/tutorial/ios-swift.html

Changes:
---------
* Added missing "import RealmSwift" to TaskViewController (if you don't import RealmSwift, you will see the error: "Use of undeclared type 'Realm'" as seen in the screenshot below
<img width="1009" alt="missing-realm-import-taskviewcontroller" src="https://user-images.githubusercontent.com/52428905/88379454-fe051a80-cd70-11ea-8dff-046552e5b6be.png">
* Fixed syntax: `user.configuration(partitionValue: partitionValue) should be `user!.configuration(partitionValue: partitionValue)`
<img width="615" alt="user!" src="https://user-images.githubusercontent.com/52428905/88571819-35dbbe80-d00c-11ea-94fc-d4f4ff71ea10.png">


