### PR TITLE
(DOCSP-13758) React Native Tutorial Fixes for Beta.9 + Typo in Docs

### DIFF
--- a/source/includes/steps-tutorial-react-native.yaml
+++ b/source/includes/steps-tutorial-react-native.yaml
@@ -423,7 +423,7 @@ ref: define-the-object-model-schemas
 content: |
 
   Now that we can log in with a user account, let's start working with data.
-  First, we must define the data model. Create a file called ``schemas.json``
+  First, we must define the data model. Create a file called ``schemas.js``
   and paste the following data model code in:
 
   .. code-block:: js

--- a/source/includes/steps-tutorial-react-native.yaml
+++ b/source/includes/steps-tutorial-react-native.yaml
@@ -21,7 +21,7 @@ content: |
 
   .. code-block:: sh
 
-     npm install realm@v10.0.0-beta.6
+     npm install realm@v10.0.0-beta.9
 
   In this tutorial, we'll also use the `React Native Elements
   <https://react-native-elements.github.io/react-native-elements/>`__ library
@@ -208,7 +208,7 @@ content: |
        // authentication provider to register the user.
        const registerUser = async (email, password) => {
          console.log(`Registering as ${email}...`);
-         await app.auth.emailPassword.registerEmail(email, password);
+         await app.emailPasswordAuth.registerUser(email, password);
        };
 
        return (


### PR DESCRIPTION
Jira:
-----
* https://jira.mongodb.org/browse/DOCS-13758

Stage:
-------
* https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-13758-RN-LogInView-Syntax-Fix/tutorial/react-native.html

Changes Related to Jira Ticket:
-------------------------------
* Fixed Step 8 name of file from `schemas.json` to `schemas.js`


Changes **Not** Made Related to Jira Ticket and Why:
-------------------------------------------------------
* Did not alter step 6 to include `export default LogInView` because the function is already exported in it's declaration as `export function LogInView() {` and this works fine (the reporter of this ticket may have forgotten to export the function and assumed it was a fault in the docs)


Changes Made Outside of the Scope of This Ticket:
----------------------------------------------------
* Upgrade `package.json` to have Realm use `beta.9` of SDK because it is the latest version
* Update old register user syntax to adhere to beta.9 sdk  

edit:
- created JIRA Ticket for beta.9 syntax fixes: https://jira.mongodb.org/browse/DOCS-13795