### PR TITLE
(DOCSP-11349): fix insertOne Example on mongodb/insert-documents

### DIFF
--- a/source/mongodb/insert-documents.txt
+++ b/source/mongodb/insert-documents.txt
@@ -34,7 +34,7 @@ You can insert a single document using the
 The following :ref:`function <functions>` snippet inserts a single item
 document into the ``items`` collection:
 
-.. include:: /mongodb/crud-snippets/findOne/functions.rst
+.. include:: /mongodb/crud-snippets/insertOne/functions.rst
 
 Insert One or More Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
jira:https://jira.mongodb.org/browse/DOCSP-11349
stage: https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-11349-Fix-MongoDB-InsertOne-Example/mongodb/insert-documents.html#insert-a-single-document