### PR TITLE
(DOCS-13793): [Realm] Remove MongoDB 4.4 beta references

### DIFF
--- a/source/tutorial/realm-app.txt
+++ b/source/tutorial/realm-app.txt
@@ -17,9 +17,9 @@ cluster. For details on how to create an account and set up a free
 .. admonition:: Version 4.4 Required
    :class: note
 
-   In order to use {+sync+}, your Atlas cluster must use MongoDB version
-   4.4. When setting up your cluster, select :guilabel:`MongoDB 4.4 -
-   Beta` from the dropdown menu under :guilabel:`Additional Settings`.
+   In order to use {+sync+}, your Atlas cluster must use MongoDB version 4.4.
+   When setting up your cluster, select :guilabel:`MongoDB 4.4` from the
+   dropdown menu under :guilabel:`Additional Settings`.
 
 A. Create a MongoDB Realm App
 -----------------------------


### PR DESCRIPTION
Relatively small impact to the realm docs. We only mentioned the 4.4 beta in one spot.