### PR TITLE
(DOCSP-11507): Add character limit to Realm secret values

### DIFF
--- a/source/includes/steps-define-a-secret-realm-ui.yaml
+++ b/source/includes/steps-define-a-secret-realm-ui.yaml
@@ -15,7 +15,7 @@ content: |
   Enter a unique :guilabel:`Secret Name`. This name is used
   to refer to the Secret from authentication providers,
   service configurations, and :ref:`Values <app-value>`.
-  
+
   .. admonition:: Secret Name Restrictions
      :class: note
      
@@ -34,6 +34,11 @@ content: |
 
   .. cssclass:: bordered-figure
   .. figure:: /images/secret-value-realm-ui.png
+
+  .. admonition:: Secret Value Length Restrictions
+     :class: note
+     
+     Secret values may not exceed 500 characters in length.
 ---
 title: Save the Secret
 ref: save-the-secret
@@ -43,4 +48,3 @@ content: |
   :guilabel:`Save`. Once saved, you can immediately reference the Secret
   by name in :doc:`service </services>` configurations and secret
   Values.
-...

--- a/source/values-and-secrets.txt
+++ b/source/values-and-secrets.txt
@@ -67,6 +67,8 @@ need to access the Secret from a Function or
 Rule, you can link the Secret to a
 :ref:`Value <app-value>`.
 
+A Secret value has a maximum character length of 500 characters.
+
 Related Content
 ---------------
 


### PR DESCRIPTION
## Jira
https://jira.mongodb.org/browse/DOCSP-11507

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/secret-max-length/values-and-secrets.html

Note: the CSS has changed. Platform is investigating.
