### PR TITLE
(DOCSP-11521): Add admonition about 4.4 required for sync

### DIFF
--- a/source/includes/mongodb-4.4-required-for-sync-admonition.rst
+++ b/source/includes/mongodb-4.4-required-for-sync-admonition.rst
@@ -1,0 +1,6 @@
+.. admonition:: MongoDB Version 4.4 Required
+   :class: note
+
+   In order to use {+sync+}, your Atlas cluster must use MongoDB version 4.4.
+   When setting up your cluster, select :guilabel:`MongoDB 4.4` from the
+   dropdown menu under :guilabel:`Additional Settings`.

--- a/source/mongodb/link-a-cluster.txt
+++ b/source/mongodb/link-a-cluster.txt
@@ -26,11 +26,7 @@ through the {+ui+} or with an :doc:`import/export
 </deploy/deploy-cli>` configuration directory.
 Select the tab below that corresponds to the method you want to use.
 
-.. admonition:: Version 4.4 Required
-   :class: note
-
-   In order to use {+sync+}, your Atlas cluster must use MongoDB version
-   4.4.
+.. include:: /includes/mongodb-4.4-required-for-sync-admonition.rst
 
 Procedure
 ---------

--- a/source/procedures/create-realm-app.txt
+++ b/source/procedures/create-realm-app.txt
@@ -87,11 +87,7 @@ C. Add a Realm App
    create a :ref:`MongoDB service <mongodb-service>` linked to this
    cluster.
 
-   .. admonition:: Version 4.4 Required
-      :class: note
-
-      In order to use {+sync+}, your Atlas cluster must use MongoDB version
-      4.4.
+   .. include:: /includes/mongodb-4.4-required-for-sync-admonition.rst
 
 #. Enter a name for the service that {+service+} will create in the
    :guilabel:`Realm Service Name` field.

--- a/source/sync.txt
+++ b/source/sync.txt
@@ -24,6 +24,8 @@ Enable Sync
 
 You can enable {+sync-short+} on any {+app+} you have :ref:`created <create-a-realm-app>`.
 
+.. include:: /includes/mongodb-4.4-required-for-sync-admonition.rst
+
 .. note::
 
    {+service-short+} syncs all data from collections with a defined

--- a/source/sync/overview.txt
+++ b/source/sync/overview.txt
@@ -23,6 +23,8 @@ business logic of your app.
 To understand how best to use {+sync+}, it's important to understand the problem
 {+sync-short+} aims to address.
 
+.. include:: /includes/mongodb-4.4-required-for-sync-admonition.rst
+
 .. _the-connectivity-problem:
 
 The Connectivity Problem

--- a/source/tutorial/realm-app.txt
+++ b/source/tutorial/realm-app.txt
@@ -14,12 +14,7 @@ Before you get started, you'll need a `{+atlas+}
 cluster. For details on how to create an account and set up a free
 ``M0`` cluster, see :atlas:`Get Started with Atlas </getting-started>`.
 
-.. admonition:: Version 4.4 Required
-   :class: note
-
-   In order to use {+sync+}, your Atlas cluster must use MongoDB version 4.4.
-   When setting up your cluster, select :guilabel:`MongoDB 4.4` from the
-   dropdown menu under :guilabel:`Additional Settings`.
+.. include:: /includes/mongodb-4.4-required-for-sync-admonition.rst
 
 A. Create a MongoDB Realm App
 -----------------------------


### PR DESCRIPTION
- Moves existing admonition to shared snippet
- Adds snippet on Get Started with Sync and Sync Overview pages

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/4.4/mongodb/link-a-cluster.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/4.4/tutorial/realm-app.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/4.4/sync/overview.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/4.4/sync.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/bush/4.4/procedures/create-realm-app.html#c-add-a-realm-app

## Jira
https://jira.mongodb.org/browse/DOCSP-11521

