### PR TITLE
textdump fix

### DIFF
--- a/source/node/access-custom-user-data.txt
+++ b/source/node/access-custom-user-data.txt
@@ -41,12 +41,6 @@ The code examples in this page use the following :ref:`user object
      ]
    }
 
-
- and configure your :doc:`rules
-   </mongodb/configure-advanced-rules/>` to give users access to the
-   custom data collection.
-
-
 .. include:: /includes/use-custom-data-note.rst
 
 Write to Custom User Data with a RemoteMongoClient


### PR DESCRIPTION
## Pull Request Info
Old page contained garbage text (directly after first code sample):
https://docs.mongodb.com/realm/node/access-custom-user-data/
Doesn't seem to be tied in to any note, so I figured we should just delete it. If you can make sense of it, happy to turn into a note or paragraph.

### Docs staging link (requires sign-in on MongoDB Corp SSO):
DNE
