### PR TITLE
11085 - add info on background refresh

### DIFF
--- a/source/ios/sync-data.txt
+++ b/source/ios/sync-data.txt
@@ -71,8 +71,9 @@ Sync Data
 
 The syntax to :ref:`read <ios-realm-database-reads>`, :ref:`write
 <ios-realm-database-writes>`, and :ref:`watch for changes <ios-client-notifications>` on a
-synced {+realm+} is identical to the syntax for non-synced {+realms+}. While you work with
-local data, a background thread efficiently integrates, uploads, and downloads changesets.
+synced {+realm+} is identical to the syntax for non-synced {+realms+}. While you 
+work with local data, a background thread efficiently integrates, uploads, and 
+downloads changesets.
 
 .. admonition:: When Using Sync, Avoid Writes on the Main Thread
    :class: important
@@ -107,9 +108,22 @@ changes, then writes a new ``Task`` to the {+realm+}:
 
 .. seealso:: :ref:`Threading <ios-client-threading>`
 
+
+Background Data Sync
+~~~~~~~~~~~~~~~~~~~~
+If you want your app to update data in the background, while the app is minimized, 
+iOS requires you to implement `Background App Refresh  
+<https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background/updating_your_app_with_background_app_refresh>`_. 
+Enabling Background App Refresh minimizes the time it takes for the user to see 
+the most recent data; without Background App Refresh, {+realm+} updates the 
+data when the user launches the app, potentially resulting in a noticeable lag.
+
+
 Summary
 -------
 
-- Open a synced {+realm+} with the configuration object generated when you pass a :term:`partition value` to the user object's ``configuration`` method.
-- Compared to using a non-synced {+realm+}, there is no special syntax for reading from, writing to, or watching objects on a synced {+realm+}.
+- Open a synced {+realm+} with the configuration object generated when you pass 
+  a :term:`partition value` to the user object's ``configuration`` method.
+- Compared to using a non-synced {+realm+}, there is no special syntax for 
+  reading from, writing to, or watching objects on a synced {+realm+}.
 - You should avoid writing to a synced {+realm+} on the main thread.

--- a/source/ios/sync-data.txt
+++ b/source/ios/sync-data.txt
@@ -111,13 +111,12 @@ changes, then writes a new ``Task`` to the {+realm+}:
 
 Background Data Sync
 ~~~~~~~~~~~~~~~~~~~~
-If you want your app to update data in the background, while the app is minimized, 
+If you want your app to update data in the background (while the app is minimized), 
 iOS requires you to implement `Background App Refresh  
 <https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background/updating_your_app_with_background_app_refresh>`_. 
 Enabling Background App Refresh minimizes the time it takes for the user to see 
 the most recent data; without Background App Refresh, {+realm+} updates the 
 data when the user launches the app, potentially resulting in a noticeable lag.
-
 
 Summary
 -------


### PR DESCRIPTION
### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-11085

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/11085/ios/sync-data.html#background-data-sync
