### PR TITLE
(DOCSP-8291): Identify common Node API version for functions modules

### DIFF
--- a/source/functions.txt
+++ b/source/functions.txt
@@ -75,11 +75,11 @@ Constraints
   - New Math, Number, String, Array, and Object APIs (e.g. ``Array.prototype.includes``)
 
 - A function may open a maximum of 5 sockets using the :nodejs:`net
-  <api/net.html>` built-in module.
+  <docs/v10.18.1/api/net.html>` built-in module.
 
-- Realm does not support some built-in Node modules. For a full list of
-  unsupported modules, see :ref:`Built-In Module Support
-  <builtin-module-support>`.
+- {+service-short+} supports a subset of built-in Node modules. For a 
+  full list of supported and unsupported modules, see
+  :ref:`Built-In Module Support <builtin-module-support>`.
 
 Concepts
 --------

--- a/source/functions/upload-external-dependencies.txt
+++ b/source/functions/upload-external-dependencies.txt
@@ -36,47 +36,54 @@ the {+ui+} under the :guilabel:`Dependencies` tab.
 Built-In Module Support
 -----------------------
 
-.. list-table::
-   :header-rows: 1
-   :widths: 50 50
+You can use the following built-in modules in your {+service-short+}
+functions:
 
-   * - Supported
-     - Unsupported
+.. note::
+   
+   The supported modules are compatible with :nodejs:`Node API version
+   10.18.1 <docs/v10.18.1/api/>`. Avoid using APIs in these modules
+   introduced after or deprecated since Node 10.18.1.
 
-   * - .. hlist::
-          :columns: 2
-          
-          - ``assert``
-          - ``buffer``
-          - ``crypto``
-          - ``events``
-          - ``fs``
-          - ``http``
-          - ``https``
-          - ``net``
-          - ``os``
-          - ``path``
-          - ``querystring``
-          - ``stream``
-          - ``string_decoder``
-          - ``timers``
-          - ``tls``
-          - ``tty``
-          - ``url``
-          - ``util``
-          - ``zlib``
-     - .. hlist::
-          :columns: 1
-          
-          - ``child_process``
-          - ``cluster``
-          - ``dgram``
-          - ``dns``
-          - ``domain``
-          - ``punycode``
-          - ``readline``
-          - ``v8``
-          - ``vm``
+.. hlist::
+   :columns: 3
+   
+   - :nodejs:`assert <docs/v10.18.1/api/assert.html>`
+   - :nodejs:`buffer <docs/v10.18.1/api/buffer.html>`
+   - :nodejs:`crypto <docs/v10.18.1/api/crypto.html>`
+   - :nodejs:`events <docs/v10.18.1/api/events.html>`
+   - :nodejs:`fs <docs/v10.18.1/api/fs.html>`
+   - :nodejs:`http <docs/v10.18.1/api/http.html>`
+   - :nodejs:`https <docs/v10.18.1/api/https.html>`
+   - :nodejs:`net <docs/v10.18.1/api/net.html>`
+   - :nodejs:`os <docs/v10.18.1/api/os.html>`
+   - :nodejs:`path <docs/v10.18.1/api/path.html>`
+   - process (supports :nodejs:`nextTick <docs/latest-v10.x/api/process.html#process_process_nexttick_callback_args>` only)
+   - :nodejs:`querystring <docs/v10.18.1/api/querystring.html>`
+   - :nodejs:`stream <docs/v10.18.1/api/stream.html>`
+   - :nodejs:`string_decoder <docs/v10.18.1/api/string_decoder.html>`
+   - :nodejs:`timers <docs/v10.18.1/api/timers.html>`
+   - :nodejs:`tls <docs/v10.18.1/api/tls.html>`
+   - :nodejs:`tty <docs/v10.18.1/api/tty.html>`
+   - :nodejs:`url <docs/v10.18.1/api/url.html>`
+   - :nodejs:`util <docs/v10.18.1/api/util.html>`
+   - :nodejs:`zlib <docs/v10.18.1/api/zlib.html>`
+
+{+service-short+} functions **do not** support the following built-in
+modules:
+
+.. hlist::
+   :columns: 1
+   
+   - ``child_process``
+   - ``cluster``
+   - ``dgram``
+   - ``dns``
+   - ``domain``
+   - ``punycode``
+   - ``readline``
+   - ``v8``
+   - ``vm``
 
 Procedure
 ---------


### PR DESCRIPTION
## Pull Request Info
This adds an admonition specifying the Node API version and adds links to the corresponding Node API docs.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-8291

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/node-version/functions/upload-external-dependencies.html#built-in-module-support
