### PR TITLE
(DOCSP-11531): Document different ways to implement sync permissions

### DIFF
--- a/source/includes/steps-define-sync-rules-api.yaml
+++ b/source/includes/steps-define-sync-rules-api.yaml
@@ -96,8 +96,7 @@ content: |
   to the user that opened the realm, and :json-expansion:`%%partition`, which
   resolves to the partition key value for the realm. You can also use operators,
   including :json-operator:`%function`, to handle more complex cases. For
-  examples of permission expressions that apply to different use cases, see
-  :ref:`Sync Permission Strategies <sync-permission-strategies>`.
+  examples, see :ref:`Define Sync Permissions <define-sync-permissions>`.
 
   Once you've determined how to decide a user's read and write permissions for a
   given partition, define the corresponding JSON expressions in the

--- a/source/includes/steps-define-sync-rules-api.yaml
+++ b/source/includes/steps-define-sync-rules-api.yaml
@@ -95,7 +95,9 @@ content: |
   Sync rule expressions have access to :json-expansion:`%%user`, which resolves
   to the user that opened the realm, and :json-expansion:`%%partition`, which
   resolves to the partition key value for the realm. You can also use operators,
-  including :json-operator:`%function`, to handle more complex cases.
+  including :json-operator:`%function`, to handle more complex cases. For
+  examples of permission expressions that apply to different use cases, see
+  :ref:`Sync Permission Strategies <sync-permission-strategies>`.
 
   Once you've determined how to decide a user's read and write permissions for a
   given partition, define the corresponding JSON expressions in the

--- a/source/includes/steps-define-sync-rules-cli.yaml
+++ b/source/includes/steps-define-sync-rules-cli.yaml
@@ -85,8 +85,7 @@ content: |
   to the user that opened the realm, and :json-expansion:`%%partition`, which
   resolves to the partition key value for the realm. You can also use operators,
   including :json-operator:`%function`, to handle more complex cases. For
-  examples of permission expressions that apply to different use cases, see
-  :ref:`Sync Permission Strategies <sync-permission-strategies>`.
+  examples, see :ref:`Define Sync Permissions <define-sync-permissions>`.
 
   Once you've determined how to decide a user's read and write permissions for a
   given partition, define the corresponding JSON expressions in the

--- a/source/includes/steps-define-sync-rules-cli.yaml
+++ b/source/includes/steps-define-sync-rules-cli.yaml
@@ -84,7 +84,9 @@ content: |
   Sync rule expressions have access to :json-expansion:`%%user`, which resolves
   to the user that opened the realm, and :json-expansion:`%%partition`, which
   resolves to the partition key value for the realm. You can also use operators,
-  including :json-operator:`%function`, to handle more complex cases.
+  including :json-operator:`%function`, to handle more complex cases. For
+  examples of permission expressions that apply to different use cases, see
+  :ref:`Sync Permission Strategies <sync-permission-strategies>`.
 
   Once you've determined how to decide a user's read and write permissions for a
   given partition, define the corresponding JSON expressions in the

--- a/source/includes/steps-define-sync-rules-ui.yaml
+++ b/source/includes/steps-define-sync-rules-ui.yaml
@@ -60,7 +60,9 @@ content: |
   Sync rule expressions have access to :json-expansion:`%%user`, which resolves
   to the user that opened the realm, and :json-expansion:`%%partition`, which
   resolves to the partition key value for the realm. You can also use operators,
-  including :json-operator:`%function`, to handle more complex cases.
+  including :json-operator:`%function`, to handle more complex cases. For
+  examples of permission expressions that apply to different use cases, see
+  :ref:`Sync Permission Strategies <sync-permission-strategies>`.
 
   Once you've determined how to decide a user's read and write permissions for a
   given partition, define the corresponding JSON expressions in the

--- a/source/includes/steps-define-sync-rules-ui.yaml
+++ b/source/includes/steps-define-sync-rules-ui.yaml
@@ -61,8 +61,7 @@ content: |
   to the user that opened the realm, and :json-expansion:`%%partition`, which
   resolves to the partition key value for the realm. You can also use operators,
   including :json-operator:`%function`, to handle more complex cases. For
-  examples of permission expressions that apply to different use cases, see
-  :ref:`Sync Permission Strategies <sync-permission-strategies>`.
+  examples, see :ref:`Define Sync Permissions <define-sync-permissions>`.
 
   Once you've determined how to decide a user's read and write permissions for a
   given partition, define the corresponding JSON expressions in the

--- a/source/sync.txt
+++ b/source/sync.txt
@@ -56,4 +56,4 @@ Summary
    :titlesonly:
    :caption: Reference
 
-   Sync Permissions </sync/permissions>
+   Define Sync Permissions </sync/permissions>

--- a/source/sync.txt
+++ b/source/sync.txt
@@ -51,3 +51,9 @@ Summary
    Configure Your Data Model </sync/configure-your-data-model>
    Define Sync Rules  </sync/rules>
    Enable Development Mode  </sync/enable-development-mode>
+
+.. toctree::
+   :titlesonly:
+   :caption: Reference
+
+   Sync Permissions </sync/permissions>

--- a/source/sync/permissions.txt
+++ b/source/sync/permissions.txt
@@ -131,7 +131,7 @@ explicitly specifying their ID values.
        specified user ID values has the given access permissions for data in any
        partition.
 
-Permissions Based On User Data
+Permissions Based on User Data
 ------------------------------
 
 You can define permissions that apply to users based on specific data defined in

--- a/source/sync/permissions.txt
+++ b/source/sync/permissions.txt
@@ -1,8 +1,8 @@
-.. _sync-permission-strategies:
+.. _define-sync-permissions:
 
-==========================
-Sync Permission Strategies
-==========================
+=======================
+Define Sync Permissions
+=======================
 
 .. default-domain:: mongodb
 
@@ -21,8 +21,8 @@ determines the user's permissions for the underlying partition based on
 :ref:`Sync rules <sync-rules>` that you define.
 
 You can structure your read and write permission expressions as a set of
-:ref:`permission strategies <sync-permission-strategies>` that apply to the
-different :ref:`partition strategies <partition-strategies>` in your data model.
+permission strategies that apply to the different :ref:`partition strategies
+<partition-strategies>` in your data model.
 
 The following strategies outline common approaches that you might take to define
 sync read and write permissions for your app.
@@ -46,15 +46,15 @@ boolean value.
           
           true
      
-     - The read or write permission expression ``true`` means that all users
-       have the given access permissions for all partitions.
+     - The expression ``true`` means that all users have the given access
+       permissions for all partitions.
 
    * - .. code-block:: json
           
           false
      
-     - The read/write permission expression ``false`` means that no users
-       have the given access permissions for any partitions.
+     - The expression ``false`` means that no users have the given access
+       permissions for any partitions.
 
    * - .. code-block:: json
           
@@ -80,21 +80,21 @@ partitions by explicitly specifying their partition values.
      
           { "%%partition": "PUBLIC" }
      
-     - This read/write permission expression means that all users have the given
-       access permissions for data with a partition value of ``"Public"``.
+     - This expression means that all users have the given access permissions
+       for data with a partition value of ``"Public"``.
 
    * - .. code-block:: json
      
           {
-            "%%partition": 
+            "%%partition": [
               "PUBLIC (NA)",
               "PUBLIC (EMEA)",
               "PUBLIC (APAC)"
             ]
           }
      
-     - This read/write permission expression means that all users have the given
-       access permissions for data with any of the specified partition values.
+     - This expression means that all users have the given access permissions
+       for data with any of the specified partition values.
 
 Permissions for Specific Users
 ------------------------------
@@ -113,7 +113,7 @@ explicitly specifying their ID values.
           
           { "%%user.id": "5f4863e4d49bd2191ff1e623" }
      
-     - This read/write permission expression means that the user with id
+     - This expression means that the user with id
        ``"5f4863e4d49bd2191ff1e623"`` has the given access permissions for data
        in any partition.
 
@@ -127,9 +127,8 @@ explicitly specifying their ID values.
             ]
           }
      
-     - This read/write permission expression means that any user with one of the
-       specified user ID values has the given access permissions for data in any
-       partition.
+     - This expression means that any user with one of the specified user ID
+       values has the given access permissions for data in any partition.
 
 Permissions Based on User Data
 ------------------------------
@@ -149,7 +148,7 @@ authentication provider.
      
           { "%%user.custom_data.readPartitions" : "%%partition" }
      
-     - This permission expression means that a user has read access to a
+     - This expression means that a user has read access to a
        partition if the partition value is listed in the ``readPartitions``
        field of their custom user data.
 
@@ -157,7 +156,7 @@ authentication provider.
      
           { "%%user.data.writePartitions" : "%%partition" }
      
-     - This permission expression means that a user has write access to a
+     - This expression means that a user has write access to a
        partition if the partition value is listed in the
        ``data.writePartitions`` field of their user object.
 
@@ -182,21 +181,24 @@ cannot express solely in JSON expressions.
             "%%true": {
               "%function": {
                 "name": "canReadPartition",
-                "arguments": ["%%partition", "%%user"]
+                "arguments": ["%%partition"]
               }
             }
           }
        
        .. code-block:: javascript
           
-          exports = async function canReadPartition(partitionValue, user) {
+          // canReadPartition
+          exports = async (partition) => {
             const cluster = context.services.get("mongodb-atlas");
-            const permissions = cluster.db("myApp").collection("permissions");
-            const { canRead } = await permissions.findOne({ partitionValue });
-            return partitionPermissions.canRead.includes(user.id);
+            const permissions = cluster
+              .db("myApp")
+              .collection("permissions");
+            const { canRead } = await permissions.findOne({ partition });
+            return canRead.includes(context.user.id);
           }
      
-     - This permission expression calls the ``canReadPartition`` function and
+     - This expression calls the ``canReadPartition`` function and
        passes in the partition value and user object. The function looks up the
        user's permissions for the partition from a MongoDB collection and then
        returns a boolean that indicates if the user can read data in the

--- a/source/sync/permissions.txt
+++ b/source/sync/permissions.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 Sync permissions determine a given user's read and write access to a specific
-partition. When a user opens a synced realm instance, Realm dynamically
+partition. When a user opens a synced {+realm+} instance, {+service-short+} dynamically
 determines the user's permissions for the underlying partition based on
 :ref:`Sync rules <sync-rules>` that you define.
 

--- a/source/sync/permissions.txt
+++ b/source/sync/permissions.txt
@@ -199,7 +199,7 @@ cannot express solely in JSON expressions.
           }
      
      - This expression calls the ``canReadPartition`` function and
-       passes in the partition value and user object. The function looks up the
-       user's permissions for the partition from a MongoDB collection and then
-       returns a boolean that indicates if the user can read data in the
-       requested partition.
+       passes in the partition value as its first and only argument. The
+       function looks up the user's permissions for the partition from a MongoDB
+       collection and then returns a boolean that indicates if the user can read
+       data in the requested partition.

--- a/source/sync/permissions.txt
+++ b/source/sync/permissions.txt
@@ -1,0 +1,203 @@
+.. _sync-permission-strategies:
+
+==========================
+Sync Permission Strategies
+==========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+Sync permissions determine a given user's read and write access to a specific
+partition. When a user opens a synced realm instance, Realm dynamically
+determines the user's permissions for the underlying partition based on
+:ref:`Sync rules <sync-rules>` that you define.
+
+You can structure your read and write permission expressions as a set of
+:ref:`permission strategies <sync-permission-strategies>` that apply to the
+different :ref:`partition strategies <partition-strategies>` in your data model.
+
+The following strategies outline common approaches that you might take to define
+sync read and write permissions for your app.
+
+Global Permissions
+------------------
+
+You can define global permissions that apply to all users for all
+partitions. To define a global read or write permission, specify a boolean value
+or a :ref:`JSON expression <expressions>` that always evaluates to the same
+boolean value.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Example
+     - Description
+
+   * - .. code-block:: json
+          
+          true
+     
+     - The read or write permission expression ``true`` means that all users
+       have the given access permissions for all partitions.
+
+   * - .. code-block:: json
+          
+          false
+     
+     - The read/write permission expression ``false`` means that no users
+       have the given access permissions for any partitions.
+
+   * - .. code-block:: json
+          
+          { "%%true": true }
+     
+     - This expression always evaluates to ``true``, so it's effectively the
+       same as directly specifying ``true``.
+
+Permissions for Specific Partitions
+-----------------------------------
+
+You can define permissions that apply to a specific partition or a groups of
+partitions by explicitly specifying their partition values.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Example
+     - Description
+
+   * - .. code-block:: json
+     
+          { "%%partition": "PUBLIC" }
+     
+     - This read/write permission expression means that all users have the given
+       access permissions for data with a partition value of ``"Public"``.
+
+   * - .. code-block:: json
+     
+          {
+            "%%partition": 
+              "PUBLIC (NA)",
+              "PUBLIC (EMEA)",
+              "PUBLIC (APAC)"
+            ]
+          }
+     
+     - This read/write permission expression means that all users have the given
+       access permissions for data with any of the specified partition values.
+
+Permissions for Specific Users
+------------------------------
+
+You can define permissions that apply to a specific user or a group of users by
+explicitly specifying their ID values.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Example
+     - Description
+
+   * - .. code-block:: json
+          
+          { "%%user.id": "5f4863e4d49bd2191ff1e623" }
+     
+     - This read/write permission expression means that the user with id
+       ``"5f4863e4d49bd2191ff1e623"`` has the given access permissions for data
+       in any partition.
+
+   * - .. code-block:: json
+          
+          { 
+            "%%user.id": [
+               "5f4863e4d49bd2191ff1e623",
+               "5f48640dd49bd2191ff1e624",
+               "5f486417d49bd2191ff1e625"
+            ]
+          }
+     
+     - This read/write permission expression means that any user with one of the
+       specified user ID values has the given access permissions for data in any
+       partition.
+
+Permissions Based On User Data
+------------------------------
+
+You can define permissions that apply to users based on specific data defined in
+their custom data document, metadata fields, or other data from an
+authentication provider.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Example
+     - Description
+
+   * - .. code-block:: json
+     
+          { "%%user.custom_data.readPartitions" : "%%partition" }
+     
+     - This permission expression means that a user has read access to a
+       partition if the partition value is listed in the ``readPartitions``
+       field of their custom user data.
+
+   * - .. code-block:: json
+     
+          { "%%user.data.writePartitions" : "%%partition" }
+     
+     - This permission expression means that a user has write access to a
+       partition if the partition value is listed in the
+       ``data.writePartitions`` field of their user object.
+
+Function Rules
+--------------
+
+You can define complex dynamic permissions by evaluating a :ref:`function
+<functions>` that returns a boolean value. This is useful for permission schemes
+that require you to access external systems or other custom logic that you
+cannot express solely in JSON expressions.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Example
+     - Description
+   
+   * - .. code-block:: json
+          
+          {
+            "%%true": {
+              "%function": {
+                "name": "canReadPartition",
+                "arguments": ["%%partition", "%%user"]
+              }
+            }
+          }
+       
+       .. code-block:: javascript
+          
+          exports = async function canReadPartition(partitionValue, user) {
+            const cluster = context.services.get("mongodb-atlas");
+            const permissions = cluster.db("myApp").collection("permissions");
+            const { canRead } = await permissions.findOne({ partitionValue });
+            return partitionPermissions.canRead.includes(user.id);
+          }
+     
+     - This permission expression calls the ``canReadPartition`` function and
+       passes in the partition value and user object. The function looks up the
+       user's permissions for the partition from a MongoDB collection and then
+       returns a boolean that indicates if the use can read data in the
+       requested partition.

--- a/source/sync/permissions.txt
+++ b/source/sync/permissions.txt
@@ -199,5 +199,5 @@ cannot express solely in JSON expressions.
      - This permission expression calls the ``canReadPartition`` function and
        passes in the partition value and user object. The function looks up the
        user's permissions for the partition from a MongoDB collection and then
-       returns a boolean that indicates if the use can read data in the
+       returns a boolean that indicates if the user can read data in the
        requested partition.


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:

- (DOCSP-11531): Document different ways to implement sync permissions

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [Sync Permission Strategies](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/sync-permissions/sync/permissions.html)
- [Define Sync Rules](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/sync-permissions/sync/rules.html)
