### PR TITLE
(DOCSP-11855): Update Android Tutorial to Beta 6

### DIFF
--- a/source/includes/steps-tutorial-android-kotlin.yaml
+++ b/source/includes/steps-tutorial-android-kotlin.yaml
@@ -106,7 +106,7 @@ content: |
         dependencies {
             classpath 'com.android.tools.build:gradle:4.0.0'
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-            classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.5"
+            classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.6"
         }
      }
 


### PR DESCRIPTION
## Pull Request Info
tutorial repo update: https://github.com/mongodb-university/realm-tutorial/pull/64

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-11855

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/DOCSP-11855/tutorial/android-kotlin.html#install-realm-as-a-gradle-plugin
