### PR TITLE
(DOCSP-11856): Android quick-start install beta 6

### DIFF
--- a/source/includes/steps-install-android.yaml
+++ b/source/includes/steps-install-android.yaml
@@ -18,7 +18,7 @@ content: |
 
    .. code-block:: groovy
     
-      classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.5"
+      classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.6"
 
    When done, your project-level ``build.gradle`` should look something like this:
 
@@ -33,7 +33,7 @@ content: |
           }
           dependencies {
               classpath "com.android.tools.build:gradle:3.5.1"
-              classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.5"
+              classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.6"
           }
       }
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-11856

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/DOCSP-11856/android/install.html#add-the-realm-dependency-to-the-project-level-build-gradle-file
