### PR TITLE
(DOCSP-11754): Add encrypt a realm page

### DIFF
--- a/source/android.txt
+++ b/source/android.txt
@@ -55,6 +55,9 @@ threads in an application, see :ref:`Threading
 For information about how to react to changes in {+realm+} data, see
 :ref:`Notifications <android-client-notifications>`.
 
+For additional security, you can also :ref:`encrypt a {+realm+}
+<android-encrypt-a-realm>`.
+
 Work with MongoDB Realm
 -----------------------
 
@@ -101,6 +104,7 @@ To learn how to handle schema updates in your client application, see
    Reads </android/reads>
    Writes </android/writes>
    Query Engine </android/query-engine>
+   Encrypt a Realm </android/encrypt>
 
 .. toctree::
    :titlesonly:

--- a/source/android/encrypt.txt
+++ b/source/android/encrypt.txt
@@ -1,0 +1,72 @@
+.. _android-encrypt-a-realm:
+
+===============
+Encrypt a Realm
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+You can the encrypt the {+realm+} database file on disk with AES-256 +
+SHA-2 by supplying a 64-byte encryption key when :ref:`opening a
+{+realm+} <android-open-a-realm>`.
+
+Realm transparently encrypts and decrypts data with standard
+:wikipedia:`AES-256 encryption <Advanced_Encryption_Standard>` using the
+first 256 bits of the given 512-bit encryption key. {+service-short+}
+uses the other 256 bits of the 512-bit encryption key to validate
+integrity using a :wikipedia:`hash-based message authentication code
+(HMAC) <HMAC>`.
+
+Considerations
+--------------
+
+Storing & Reusing Keys
+~~~~~~~~~~~~~~~~~~~~~~
+
+You must pass the same encryption key when opening the encrypted
+{+realm+} again. Apps should store the encryption key in the
+:android-dev:`Android KeyStore <training/articles/keystore.html>` so
+that other apps cannot read the key.
+
+Performance Impact
+~~~~~~~~~~~~~~~~~~
+
+Typically, reads and writes on encrypted {+realm+}s can be up to 10%
+slower than unencrypted {+realm+}s.
+
+Encryption and Realm Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can encrypt a :ref:`synced realm <android-sync-data>`. {+service+} only
+encrypts the data on the device and stores the data unencrypted in your
+{+atlas+} :term:`data source`.
+
+Example
+-------
+
+The following code demonstrates how to generate an encryption key and
+open an encrypted {+realm+}:
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
+
+      .. literalinclude:: /examples/Encrypt/encrypt.kt
+         :language: kotlin
+
+   .. tab::
+      :tabid: java
+
+      .. literalinclude:: /examples/Encrypt/encrypt.java
+         :language: java
+

--- a/source/examples/Encrypt/StoreInKeychain.swift
+++ b/source/examples/Encrypt/StoreInKeychain.swift
@@ -1,0 +1,61 @@
+// Retrieve the existing encryption key for the app if it exists or create a new one
+func getKey() -> Data {
+    // Identifier for our keychain entry - should be unique for your application
+    let keychainIdentifier = "io.Realm.EncryptionExampleKey"
+    let keychainIdentifierData = keychainIdentifier.data(using: String.Encoding.utf8, allowLossyConversion: false)!
+
+    // First check in the keychain for an existing key
+    var query: [NSString: AnyObject] = [
+        kSecClass: kSecClassKey,
+        kSecAttrApplicationTag: keychainIdentifierData as AnyObject,
+        kSecAttrKeySizeInBits: 512 as AnyObject,
+        kSecReturnData: true as AnyObject
+    ]
+
+    // To avoid Swift optimization bug, should use withUnsafeMutablePointer() function to retrieve the keychain item
+    // See also: http://stackoverflow.com/questions/24145838/querying-ios-keychain-using-swift/27721328#27721328
+    var dataTypeRef: AnyObject?
+    var status = withUnsafeMutablePointer(to: &dataTypeRef) { SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0)) }
+    if status == errSecSuccess {
+        return dataTypeRef as! Data
+    }
+
+    // No pre-existing key from this application, so generate a new one
+    // Generate a random encryption key
+    var key = Data(count: 64)
+    _ = key.withUnsafeMutableBytes({ (pointer: UnsafeMutableRawBufferPointer) in
+        let result = SecRandomCopyBytes(kSecRandomDefault, 64, pointer.baseAddress!)
+        assert(result == 0, "Failed to get random bytes")
+    })
+
+    // Store the key in the keychain
+    query = [
+        kSecClass: kSecClassKey,
+        kSecAttrApplicationTag: keychainIdentifierData as AnyObject,
+        kSecAttrKeySizeInBits: 512 as AnyObject,
+        kSecValueData: key as AnyObject
+    ]
+
+    status = SecItemAdd(query as CFDictionary, nil)
+    assert(status == errSecSuccess, "Failed to insert the new key in the keychain")
+
+    return key
+}
+
+// ...
+// Use the getKey() function to get the stored encryption key or create a new one
+let config = Realm.Configuration(encryptionKey: getKey())
+
+do {
+    // Open the realm with the configuration
+    let realm = try Realm(configuration: config)
+    
+    // Use the realm as normal
+    let dogs = realm.objects(Dog.self).filter("name contains 'Fido'");
+
+    // ...
+
+} catch let error as NSError {
+    // If the encryption key is wrong, `error` will say that it's an invalid database
+    fatalError("Error opening realm: \(error)")
+}

--- a/source/examples/Encrypt/encrypt.java
+++ b/source/examples/Encrypt/encrypt.java
@@ -1,0 +1,7 @@
+byte[] key = new byte[64];
+new SecureRandom().nextBytes(key);
+RealmConfiguration config = new RealmConfiguration.Builder()
+        .encryptionKey(key)
+        .build();
+
+Realm realm = Realm.getInstance(config);

--- a/source/examples/Encrypt/encrypt.java
+++ b/source/examples/Encrypt/encrypt.java
@@ -1,7 +1,13 @@
+// Generate a key
+// IMPORTANT! This is a silly way to generate a key. It is also never stored.
+// For proper key handling please consult:
+// * https://developer.android.com/training/articles/keystore.html
+// * http://nelenkov.blogspot.dk/2012/05/storing-application-secrets-in-androids.html
 byte[] key = new byte[64];
 new SecureRandom().nextBytes(key);
 RealmConfiguration config = new RealmConfiguration.Builder()
         .encryptionKey(key)
         .build();
 
+// Open the encrypted realm
 Realm realm = Realm.getInstance(config);

--- a/source/examples/Encrypt/encrypt.js
+++ b/source/examples/Encrypt/encrypt.js
@@ -1,0 +1,7 @@
+const key = new Int8Array(64); // pupulate with a secure key
+Realm.open({ schema: [DogSchema], encryptionKey: key }).then((realm) => {
+  // Use the Realm as normal
+  const dogs = realm.objects("Dog");
+
+  // ...
+});

--- a/source/examples/Encrypt/encrypt.js
+++ b/source/examples/Encrypt/encrypt.js
@@ -1,6 +1,10 @@
-const key = new Int8Array(64); // pupulate with a secure key
+// Retrieve key from secure location or create one...
+const key = new Int8Array(64); // Populate with a secure key
+// ... store key ...
+
+// Use key to open realm
 Realm.open({ schema: [DogSchema], encryptionKey: key }).then((realm) => {
-  // Use the Realm as normal
+  // Use the realm as normal
   const dogs = realm.objects("Dog");
 
   // ...

--- a/source/examples/Encrypt/encrypt.kt
+++ b/source/examples/Encrypt/encrypt.kt
@@ -1,7 +1,13 @@
+// Generate a key
+// IMPORTANT! This is a silly way to generate a key. It is also never stored.
+// For proper key handling please consult:
+// * https://developer.android.com/training/articles/keystore.html
+// * http://nelenkov.blogspot.dk/2012/05/storing-application-secrets-in-androids.html
 val key = ByteArray(64)
 SecureRandom().nextBytes(key)
 val config = RealmConfiguration.Builder()
     .encryptionKey(key)
     .build()
 
+// Open the encrypted realm
 val realm = Realm.getInstance(config)

--- a/source/examples/Encrypt/encrypt.kt
+++ b/source/examples/Encrypt/encrypt.kt
@@ -1,0 +1,7 @@
+val key = ByteArray(64)
+SecureRandom().nextBytes(key)
+val config = RealmConfiguration.Builder()
+    .encryptionKey(key)
+    .build()
+
+val realm = Realm.getInstance(config)

--- a/source/examples/Encrypt/encrypt.m
+++ b/source/examples/Encrypt/encrypt.m
@@ -1,0 +1,17 @@
+// Generate a random encryption key
+NSMutableData *key = [NSMutableData dataWithLength:64];
+(void)SecRandomCopyBytes(kSecRandomDefault, key.length, (uint8_t *)key.mutableBytes);
+
+// Open the encrypted Realm file
+RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+config.encryptionKey = key;
+NSError *error = nil;
+RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:&error];
+if (!realm) {
+    // If the encryption key is wrong, `error` will say that it's an invalid database
+    NSLog(@"Error opening realm: %@", error);
+}
+
+// Use the Realm as normal
+RLMResults<Dog *> *dogs = [Dog objectsInRealm:realm where:@"name contains 'Fido'"];
+// ...

--- a/source/examples/Encrypt/encrypt.swift
+++ b/source/examples/Encrypt/encrypt.swift
@@ -1,0 +1,19 @@
+// Generate a random encryption key
+var key = Data(count: 64)
+_ = key.withUnsafeMutableBytes { bytes in
+    SecRandomCopyBytes(kSecRandomDefault, 64, bytes)
+}
+
+// Open the encrypted Realm file
+let config = Realm.Configuration(encryptionKey: key)
+
+do {
+    let realm = try Realm(configuration: config)
+    // Use the Realm as normal
+    let dogs = realm.objects(Dog.self).filter("name contains 'Fido'")
+    // ...
+
+} catch let error as NSError {
+    // If the encryption key is wrong, `error` will say that it's an invalid database
+    fatalError("Error opening realm: \(error)")
+}

--- a/source/ios.txt
+++ b/source/ios.txt
@@ -80,6 +80,9 @@ For information about how to react to changes in {+realm+} data, see
 For advice on how to safely interact with {+client-database+} across threads in an
 application, see :ref:`Threading <ios-client-threading>`.
 
+For additional security, you can also :ref:`encrypt a {+realm+}
+<encrypt-a-realm>`.
+
 .. toctree::
    :titlesonly:
    :caption: Work with Realm Database
@@ -90,6 +93,7 @@ application, see :ref:`Threading <ios-client-threading>`.
    Query Engine </ios/query-engine>
    Notifications </ios/notifications>
    Threading </ios/threading>
+   Encrypt a Realm </ios/encrypt>
 
 
 Work with MongoDB Realm

--- a/source/ios.txt
+++ b/source/ios.txt
@@ -81,7 +81,7 @@ For advice on how to safely interact with {+client-database+} across threads in 
 application, see :ref:`Threading <ios-client-threading>`.
 
 For additional security, you can also :ref:`encrypt a {+realm+}
-<encrypt-a-realm>`.
+<ios-encrypt-a-realm>`.
 
 .. toctree::
    :titlesonly:

--- a/source/ios/encrypt.txt
+++ b/source/ios/encrypt.txt
@@ -42,11 +42,11 @@ You can encrypt a :ref:`synced realm <ios-sync-data>`. {+service+} only
 encrypts the data on the device and stores the data unencrypted in your
 {+atlas+} :term:`data source`.
 
-Procedure
----------
+Example
+-------
 
-The following code demonstrates how to open a {+realm+} with a generated
-encryption key.
+The following code demonstrates how to generate an encryption key and
+open an encrypted {+realm+}:
 
 .. tabs-realm-languages::
    

--- a/source/ios/encrypt.txt
+++ b/source/ios/encrypt.txt
@@ -1,0 +1,70 @@
+.. _ios-encrypt-a-realm:
+
+===============
+Encrypt a Realm
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+You can the encrypt the {+realm+} database file on disk with AES-256 +
+SHA-2 by supplying a 64-byte encryption key when :ref:`opening a
+{+realm+} <ios-open-a-realm>`.
+
+Realm transparently encrypts and decrypts data with standard
+:wikipedia:`AES-256 encryption <Advanced_Encryption_Standard>` using the
+first 256 bits of the given 512-bit encryption key. {+service-short+}
+uses the other 256 bits of the 512-bit encryption key to validate
+integrity using a :wikipedia:`hash-based message authentication code
+(HMAC) <HMAC>`.
+
+Considerations
+--------------
+
+Performance Impact
+~~~~~~~~~~~~~~~~~~
+
+Typically, reads and writes on encrypted {+realm+}s can be up to 10%
+slower than unencrypted {+realm+}s.
+
+Encryption and Realm Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can encrypt a :ref:`synced realm <ios-sync-data>`. {+service+} only
+encrypts the data on the device and stores the data unencrypted in your
+{+atlas+} :term:`data source`.
+
+Procedure
+---------
+
+The following code demonstrates how to open a {+realm+} with a generated
+encryption key.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      .. literalinclude:: /examples/Encrypt/encrypt.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      .. literalinclude:: /examples/Encrypt/encrypt.m
+         :language: objective-c
+
+You must pass the same encryption key when opening the {+realm+} again.
+Apps should store the encryption key in the Keychain. The following
+Swift example demonstrates how to do this:
+
+.. literalinclude:: /examples/Encrypt/StoreInKeychain.swift
+   :language: swift

--- a/source/ios/encrypt.txt
+++ b/source/ios/encrypt.txt
@@ -29,6 +29,13 @@ integrity using a :wikipedia:`hash-based message authentication code
 Considerations
 --------------
 
+Storing & Reusing Keys
+~~~~~~~~~~~~~~~~~~~~~~
+
+You must pass the same encryption key when opening the {+realm+} again.
+Apps should store the encryption key in the Keychain so that other apps
+cannot read the key.
+
 Performance Impact
 ~~~~~~~~~~~~~~~~~~
 
@@ -62,9 +69,8 @@ open an encrypted {+realm+}:
       .. literalinclude:: /examples/Encrypt/encrypt.m
          :language: objective-c
 
-You must pass the same encryption key when opening the {+realm+} again.
-Apps should store the encryption key in the Keychain. The following
-Swift example demonstrates how to do this:
+The following Swift example demonstrates how to store and retrieve a
+generated key from the Keychain:
 
 .. literalinclude:: /examples/Encrypt/StoreInKeychain.swift
    :language: swift

--- a/source/node.txt
+++ b/source/node.txt
@@ -60,6 +60,9 @@ To learn how to query for data in local {+realms+}, see
 For information about how to react to changes in {+realm+} data, see
 :ref:`Notifications <node-client-notifications>`.
 
+For additional security, you can also :ref:`encrypt a {+realm+}
+<node-encrypt-a-realm>`.
+
 Work with MongoDB Realm
 -----------------------
 
@@ -96,7 +99,6 @@ MongoDB Data Access <node-mongodb-data-access>`.
    Collections </node/collections>
    Notifications </node/notifications>
    Realms </node/realms>
-   Open and Close a Realm </node/open-a-realm>
    Objects </node/objects>
    Embedded Objects </node/embedded-objects>
    Relationships </node/relationships>
@@ -106,9 +108,11 @@ MongoDB Data Access <node-mongodb-data-access>`.
    :caption: Work with Realm Database
    :hidden:
 
+   Open and Close a Realm </node/open-a-realm>
    Reads </node/reads>
    Writes </node/writes>
    Query Engine </node/query-engine>
+   Encrypt a Realm </node/encrypt>
 
 .. toctree::
    :titlesonly:

--- a/source/node/encrypt.txt
+++ b/source/node/encrypt.txt
@@ -1,0 +1,64 @@
+.. _node-encrypt-a-realm:
+
+===============
+Encrypt a Realm
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+You can the encrypt the {+realm+} database file on disk with AES-256 +
+SHA-2 by supplying a 64-byte encryption key when :ref:`opening a
+{+realm+} <node-open-a-realm>`.
+
+Realm transparently encrypts and decrypts data with standard
+:wikipedia:`AES-256 encryption <Advanced_Encryption_Standard>` using the
+first 256 bits of the given 512-bit encryption key. {+service-short+}
+uses the other 256 bits of the 512-bit encryption key to validate
+integrity using a :wikipedia:`hash-based message authentication code
+(HMAC) <HMAC>`.
+
+Considerations
+--------------
+
+Storing & Reusing Keys
+~~~~~~~~~~~~~~~~~~~~~~
+
+You must pass the same encryption key when opening the encrypted
+{+realm+} again. Apps should store the encryption key securely.
+
+Performance Impact
+~~~~~~~~~~~~~~~~~~
+
+Typically, reads and writes on encrypted {+realm+}s can be up to 10%
+slower than unencrypted {+realm+}s.
+
+Encryption and Realm Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can encrypt a :ref:`synced realm <node-sync-data>`. {+service+} only
+encrypts the data on the device and stores the data unencrypted in your
+{+atlas+} :term:`data source`.
+
+Example
+-------
+
+The following code demonstrates how to generate an encryption key and
+open an encrypted {+realm+}:
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: javascript
+
+      .. literalinclude:: /examples/Encrypt/encrypt.js
+         :language: javascript
+

--- a/source/react-native.txt
+++ b/source/react-native.txt
@@ -65,6 +65,9 @@ To learn how to query for data in local {+realms+}, see
 For information about how to react to changes in {+realm+} data, see
 :ref:`Notifications <react-native-client-notifications>`.
 
+For additional security, you can also :ref:`encrypt a {+realm+}
+<react-native-encrypt-a-realm>`.
+
 Work with MongoDB Realm
 -----------------------
 
@@ -101,7 +104,6 @@ MongoDB Data Access <react-native-mongodb-data-access>`.
    Collections </react-native/collections>
    Notifications </react-native/notifications>
    Realms </react-native/realms>
-   Open and Close a Realm </react-native/open-a-realm>
    Objects </react-native/objects>
    Embedded Objects </react-native/embedded-objects>
    Relationships </react-native/relationships>
@@ -111,9 +113,11 @@ MongoDB Data Access <react-native-mongodb-data-access>`.
    :caption: Work with Realm Database
    :hidden:
 
+   Open and Close a Realm </react-native/open-a-realm>
    Reads </react-native/reads>
    Writes </react-native/writes>
    Query Engine </react-native/query-engine>
+   Encrypt a Realm </react-native/encrypt>
 
 .. toctree::
    :titlesonly:

--- a/source/react-native/encrypt.txt
+++ b/source/react-native/encrypt.txt
@@ -1,0 +1,64 @@
+.. _react-native-encrypt-a-realm:
+
+===============
+Encrypt a Realm
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+You can the encrypt the {+realm+} database file on disk with AES-256 +
+SHA-2 by supplying a 64-byte encryption key when :ref:`opening a
+{+realm+} <react-native-open-a-realm>`.
+
+Realm transparently encrypts and decrypts data with standard
+:wikipedia:`AES-256 encryption <Advanced_Encryption_Standard>` using the
+first 256 bits of the given 512-bit encryption key. {+service-short+}
+uses the other 256 bits of the 512-bit encryption key to validate
+integrity using a :wikipedia:`hash-based message authentication code
+(HMAC) <HMAC>`.
+
+Considerations
+--------------
+
+Storing & Reusing Keys
+~~~~~~~~~~~~~~~~~~~~~~
+
+You must pass the same encryption key when opening the encrypted
+{+realm+} again. Apps should store the encryption key securely.
+
+Performance Impact
+~~~~~~~~~~~~~~~~~~
+
+Typically, reads and writes on encrypted {+realm+}s can be up to 10%
+slower than unencrypted {+realm+}s.
+
+Encryption and Realm Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can encrypt a :ref:`synced realm <react-native-sync-data>`. {+service+} only
+encrypts the data on the device and stores the data unencrypted in your
+{+atlas+} :term:`data source`.
+
+Example
+-------
+
+The following code demonstrates how to generate an encryption key and
+open an encrypted {+realm+}:
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: javascript
+
+      .. literalinclude:: /examples/Encrypt/encrypt.js
+         :language: javascript
+


### PR DESCRIPTION
## Pull Request Info
Adds the encryption pages based on https://realm.io/docs/swift/latest/#encryption

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-11754

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/encryption/ios/encrypt.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/encryption/android/encrypt.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/encryption/node/encrypt.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/encryption/react-native/encrypt.html

