### PR TITLE
(DOCSP-11835): Clarify Partition Key handling on Client-side vs. Server-side

### DIFF
--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -438,3 +438,7 @@ Glossary
    relationship
      A relationship is an object property that references another object rather
      than a scalar or embedded object.
+     
+   null partition
+      A null partition is the default :term:`{+service-short+}` on the client 
+      device.

--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -440,5 +440,5 @@ Glossary
      than a scalar or embedded object.
      
    null partition
-      A null partition is the default :term:`{+service-short+}` on the client 
+      A null partition is the default :term:`{+realm+}` on the client 
       device.

--- a/source/includes/steps-define-sync-rules-api.yaml
+++ b/source/includes/steps-define-sync-rules-api.yaml
@@ -57,6 +57,17 @@ content: |
      curl https://realm.mongodb.com/api/admin/v3.0/groups/{GROUP_ID}/apps/{APP_ID}/sync/data?service_id=<MongoDB Service ID> \
        -X GET \
        -h 'Authorization: Bearer <Valid Access Token>'
+       
+  .. note::
+    
+    The partition key can either be required or optional. If the partition key 
+    field is optional, then all MongoDB documents that either exclude the 
+    partition key or have a null value for the partition key will be sent to the 
+    :term:`null partition`. If the partition key field is required, {+sync+} 
+    ignores any MongoDB documents that lack a valid value for the partition 
+    key. We recommend a required partition key unless you want to sync
+    pre-existing data with invalid or missing partition values from a
+    MongoDB collection.
 
   Once you have decided which field to use, update ``config.sync.partition``
   with the partition key field name in the ``key`` field and the partition key

--- a/source/includes/steps-define-sync-rules-cli.yaml
+++ b/source/includes/steps-define-sync-rules-cli.yaml
@@ -48,6 +48,17 @@ content: |
   so it's particularly important to consider your data model and access
   patterns. For more information on partition keys and how to choose one, see
   :ref:`Partition Atlas Data into Realms <partitioning>`.
+  
+  .. note::
+    
+    The partition key can either be required or optional. If the partition key 
+    field is optional, then all MongoDB documents that either exclude the 
+    partition key or have a null value for the partition key will be sent to the 
+    :term:`null partition`. If the partition key field is required, {+sync+} 
+    ignores any MongoDB documents that lack a valid value for the partition 
+    key. We recommend a required partition key unless you want to sync
+    pre-existing data with invalid or missing partition values from a
+    MongoDB collection.
 
   Once you have decided which field to use, update ``config.sync.partition``
   with the partition key field name in the ``key`` field and the partition key

--- a/source/includes/steps-define-sync-rules-ui.yaml
+++ b/source/includes/steps-define-sync-rules-ui.yaml
@@ -35,12 +35,13 @@ content: |
   .. note::
     
     The partition key can either be required or optional. If the partition key 
-    field is optional, then all documents that either exclude the partition 
-    key or have a null value for the partition key will be sent to the 
+    field is optional, then all MongoDB documents that either exclude the 
+    partition key or have a null value for the partition key will be sent to the 
     :term:`null partition`. If the partition key field is required, {+sync+} 
-    will ignore any documents that lack a valid value for 
-    the partition key. We recommend a required partition key unless your 
-    application specifically needs access to unpartitioned documents. 
+    ignores any MongoDB documents that lack a valid value for the partition 
+    key. We recommend a required partition key unless you want to sync
+    pre-existing data with invalid or missing partition values from a
+    MongoDB collection.
 
   Once you have decided which field to use, select it from the :guilabel:`Choose
   A Partition Key` dropdown menu.

--- a/source/includes/steps-define-sync-rules-ui.yaml
+++ b/source/includes/steps-define-sync-rules-ui.yaml
@@ -27,9 +27,10 @@ title: Choose a Partition Key
 ref: choose-a-partition-key
 content: |
   The sync :term:`partition key` is a field in every synced document that maps
-  each document to a client-side realm. If the partition key field is optional, 
-  then all documents that either don't contain the partition key or have a null 
-  value for the partition key will be sent to the null partition by default. 
+  each document to a client-side realm. Partition key fields should be made 
+  required through the {+Realm+} UI. If the partition key field is optional, 
+  then all documents that either exclude the partition key or have a null 
+  value for the partition key will be sent to the null partition. 
   Sync rules apply at the partition level, so it's particularly important to 
   consider your data model and access patterns. For more information on 
   partition keys and how to choose one, see

--- a/source/includes/steps-define-sync-rules-ui.yaml
+++ b/source/includes/steps-define-sync-rules-ui.yaml
@@ -27,9 +27,12 @@ title: Choose a Partition Key
 ref: choose-a-partition-key
 content: |
   The sync :term:`partition key` is a field in every synced document that maps
-  each document to a client-side realm. Sync rules apply at the partition level,
-  so it's particularly important to consider your data model and access
-  patterns. For more information on partition keys and how to choose one, see
+  each document to a client-side realm. If the partition key field is optional, 
+  then all documents that either don't contain the partition key or have a null 
+  value for the partition key will be sent to the null partition by default. 
+  Sync rules apply at the partition level, so it's particularly important to 
+  consider your data model and access patterns. For more information on 
+  partition keys and how to choose one, see
   :ref:`Partition Atlas Data into Realms <partitioning>`.
 
   Once you have decided which field to use, select it from the :guilabel:`Choose

--- a/source/includes/steps-define-sync-rules-ui.yaml
+++ b/source/includes/steps-define-sync-rules-ui.yaml
@@ -27,14 +27,18 @@ title: Choose a Partition Key
 ref: choose-a-partition-key
 content: |
   The sync :term:`partition key` is a field in every synced document that maps
-  each document to a client-side realm. Partition key fields should be made 
-  required through the {+Realm+} UI. If the partition key field is optional, 
-  then all documents that either exclude the partition key or have a null 
-  value for the partition key will be sent to the null partition. 
-  Sync rules apply at the partition level, so it's particularly important to 
-  consider your data model and access patterns. For more information on 
-  partition keys and how to choose one, see
+  each document to a client-side realm. Sync rules apply at the partition 
+  level, so it's particularly important to consider your data model and access 
+  patterns. For more information on partition keys and how to choose one, see
   :ref:`Partition Atlas Data into Realms <partitioning>`.
+  
+  .. note::
+    
+    Partition key fields should be made required. If the partition key field is 
+    optional, then all documents that either exclude the partition key or have 
+    a null value for the partition key will be sent to the 
+    :term:`null partition`. If the partition key field is required, {+sync+} 
+    will ignore any documents that lack a valid value for the partition key. 
 
   Once you have decided which field to use, select it from the :guilabel:`Choose
   A Partition Key` dropdown menu.

--- a/source/includes/steps-define-sync-rules-ui.yaml
+++ b/source/includes/steps-define-sync-rules-ui.yaml
@@ -34,11 +34,13 @@ content: |
   
   .. note::
     
-    Partition key fields should be made required. If the partition key field is 
-    optional, then all documents that either exclude the partition key or have 
-    a null value for the partition key will be sent to the 
+    The partition key can either be required or optional. If the partition key 
+    field is optional, then all documents that either exclude the partition 
+    key or have a null value for the partition key will be sent to the 
     :term:`null partition`. If the partition key field is required, {+sync+} 
-    will ignore any documents that lack a valid value for the partition key. 
+    will ignore any documents that lack a valid value for 
+    the partition key. We recommend a required partition key unless your 
+    application specifically needs access to unpartitioned documents. 
 
   Once you have decided which field to use, select it from the :guilabel:`Choose
   A Partition Key` dropdown menu.

--- a/source/sync/partitioning.txt
+++ b/source/sync/partitioning.txt
@@ -84,7 +84,9 @@ choose partition keys:
   required. If the partition key field is designated as optional, all documents 
   that exclude the partition key or have a null value for the partition key 
   will be sent to the :term:`null partition`. If the partition key field is 
-  required, 
+  required, {+sync+} will ignore any documents that lack a valid value for 
+  the partition key. We recommend a required partition key unless your 
+  application specifically requires access to unpartitioned documents. 
 
 For more information about how to choose
 a partition key for your application, see :ref:`Partition Strategies

--- a/source/sync/partitioning.txt
+++ b/source/sync/partitioning.txt
@@ -80,10 +80,11 @@ choose partition keys:
   :ref:`supported types for partition keys
   <partition-limitations-types>`.
   
-- Partition key fields should be made required through the {+Realm+} UI. If 
-  the partition key field is designated as optional, all documents that 
-  exclude the partition key or have a null value for the partition key will be 
-  sent to the null partition. 
+- You can configure your app to treat partition keys as either optional or 
+  required. If the partition key field is designated as optional, all documents 
+  that exclude the partition key or have a null value for the partition key 
+  will be sent to the :term:`null partition`. If the partition key field is 
+  required, 
 
 For more information about how to choose
 a partition key for your application, see :ref:`Partition Strategies

--- a/source/sync/partitioning.txt
+++ b/source/sync/partitioning.txt
@@ -81,12 +81,13 @@ choose partition keys:
   <partition-limitations-types>`.
   
 - You can configure your app to treat partition keys as either optional or 
-  required. If the partition key field is designated as optional, all documents 
-  that exclude the partition key or have a null value for the partition key 
-  will be sent to the :term:`null partition`. If the partition key field is 
-  required, {+sync+} will ignore any documents that lack a valid value for 
-  the partition key. We recommend a required partition key unless your 
-  application specifically requires access to unpartitioned documents. 
+  required. If the partition key field is designated as optional, all MongoDB 
+  documents that exclude the partition key or have a null value for the 
+  partition key will be sent to the :term:`null partition`. If the partition 
+  key field is required, {+sync+} ignores any MongoDB documents that lack a 
+  valid value for the partition key. We recommend a required partition key 
+  unless you want to sync pre-existing MongoDB documents with invalid or 
+  missing partition values.
 
 For more information about how to choose
 a partition key for your application, see :ref:`Partition Strategies

--- a/source/sync/partitioning.txt
+++ b/source/sync/partitioning.txt
@@ -79,6 +79,10 @@ choose partition keys:
 - Partition keys must have a value of one of the
   :ref:`supported types for partition keys
   <partition-limitations-types>`.
+  
+- If the partition key field is designated as optional, all documents that 
+  don't contain the partition key or have a null value for the partition key 
+  will be sent to the null partition by default. 
 
 For more information about how to choose
 a partition key for your application, see :ref:`Partition Strategies

--- a/source/sync/partitioning.txt
+++ b/source/sync/partitioning.txt
@@ -80,9 +80,10 @@ choose partition keys:
   :ref:`supported types for partition keys
   <partition-limitations-types>`.
   
-- If the partition key field is designated as optional, all documents that 
-  don't contain the partition key or have a null value for the partition key 
-  will be sent to the null partition by default. 
+- Partition key fields should be made required through the {+Realm+} UI. If 
+  the partition key field is designated as optional, all documents that 
+  exclude the partition key or have a null value for the partition key will be 
+  sent to the null partition. 
 
 For more information about how to choose
 a partition key for your application, see :ref:`Partition Strategies


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-11835

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/lisbethlazala/clarify-partition-key-handling/sync/rules.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/lisbethlazala/clarify-partition-key-handling/sync/partitioning.html#choose-a-partition-key
