### PR TITLE
(DOCSP-12247): Update iOS objects text to include String and Int types on _id

### DIFF
--- a/source/ios/objects.txt
+++ b/source/ios/objects.txt
@@ -32,7 +32,7 @@ classes that derive from {+service-short+}'s ``Object`` class.
 .. note::
 
    If you are using :term:`{+sync+}`, the :ref:`primary key <ios-primary-key>` of an
-   object *must* be an ``ObjectId`` called ``_id``.
+   object *must* be an ``ObjectId``, ``String``, or ``Int`` called ``_id``.
 
 .. example::
 


### PR DESCRIPTION
## Pull Request Info
- Raised in #realm-users
- Typo fix

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12247

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/object-id-fix/ios/objects.html
