### PR TITLE
removing logout call from full quickstart because it triggers a race condition

### DIFF
--- a/source/android/code-samples/quick-start.java
+++ b/source/android/code-samples/quick-start.java
@@ -91,13 +91,7 @@ public class MainActivity extends AppCompatActivity {
                         innerYetAnotherTask.deleteFromRealm();
                 });
 
-                user.logOutAsync( result -> {
-                    if (result.isSuccess()) {
-                        Log.v("QUICKSTART", "Successfully logged out.");
-                    } else {
-                        Log.e("QUICKSTART", "Failed to log out. Error: " + result.getError().toString());
-                    }
-                });
+                realm.close();
             } else {
                 Log.e("QUICKSTART", it.getError().toString());
             }

--- a/source/android/code-samples/quick-start.kt
+++ b/source/android/code-samples/quick-start.kt
@@ -92,13 +92,7 @@ class MainActivity : AppCompatActivity() {
                     innerYetAnotherTask.deleteFromRealm()
                 }
 
-                user.logOutAsync {
-                    if (it.isSuccess) {
-                        Log.v("QUICKSTART", "Successfully logged out.")
-                    } else {
-                        Log.e("QUICKSTART", "Failed to log out. Error: ${it.error}")
-                    }
-                }
+                realm.close()
             } else {
                 Log.e("QUICKSTART", "Failed to log in. Error: ${it.error}")
             }


### PR DESCRIPTION

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/androidQuickStartRaceCoondition/android/quick-start.html