### PR TITLE
added warning to log out documentation about local realm access

### DIFF
--- a/source/android/authenticate.txt
+++ b/source/android/authenticate.txt
@@ -579,6 +579,8 @@ methods. This:
 Because logging out halts synchronization, you should only log out after
 all local Realm updates have uploaded to the server.
 
+.. include:: /includes/log-out-queries-in-progress.rst
+
 .. tabs-realm-languages::
 
    .. tab::

--- a/source/android/authenticate.txt
+++ b/source/android/authenticate.txt
@@ -568,13 +568,13 @@ Log Out
 
 You can log out any user, regardless of the authentication provider used
 to log in, using the ``user.logOut()`` or ``user.logOutAsync()``
-methods. This:
+methods. Both methods:
 
-- deletes locally stored user credentials from the device
+- delete locally stored user credentials from the device
 
-- immediately halts any synchronization to and from the user's {+realm+}s
+- immediately halt any synchronization to and from the user's {+realm+}s
 
-- marks the user's {+realm+}s for deletion the next time the app restarts
+- mark the user's {+realm+}s for deletion the next time the app restarts
 
 Because logging out halts synchronization, you should only log out after
 all local Realm updates have uploaded to the server.

--- a/source/includes/log-out-queries-in-progress.rst
+++ b/source/includes/log-out-queries-in-progress.rst
@@ -1,0 +1,7 @@
+.. warning::
+
+   You can only access {+realm+}s accessed with a given user object
+   while that user is logged in. As a result, logging out a user while
+   operations are still executing can cause errors, prevent reads from
+   returning valid results, and prevent data from writing to local
+   {+realm+}s.

--- a/source/includes/log-out-queries-in-progress.rst
+++ b/source/includes/log-out-queries-in-progress.rst
@@ -1,7 +1,7 @@
 .. warning::
 
-   Realms accessed with a given user object only remain valid
-   while that user is logged in. As a result, any operation that has not
-   yet completed before the initiating user logs out cannot complete
-   successfully and will likely result in an error. Any data in a write
-   operation that fails in this way will be lost.
+   If a user logs out, you can no longer read or write data in any
+   synced {+realm+}s that the user opened. As a result, any operation
+   that has not yet completed before the initiating user logs out cannot
+   complete successfully and will likely result in an error. Any data in
+   a write operation that fails in this way will be lost.

--- a/source/includes/log-out-queries-in-progress.rst
+++ b/source/includes/log-out-queries-in-progress.rst
@@ -1,6 +1,6 @@
 .. warning::
 
-   If a user logs out, you can no longer read or write data in any
+   When a user logs out, you can no longer read or write data in any
    synced {+realm+}s that the user opened. As a result, any operation
    that has not yet completed before the initiating user logs out cannot
    complete successfully and will likely result in an error. Any data in

--- a/source/includes/log-out-queries-in-progress.rst
+++ b/source/includes/log-out-queries-in-progress.rst
@@ -1,7 +1,7 @@
 .. warning::
 
-   You can only access {+realm+}s accessed with a given user object
-   while that user is logged in. As a result, logging out a user while
-   operations are still executing can cause errors, prevent reads from
-   returning valid results, and prevent data from writing to local
-   {+realm+}s.
+   Realms accessed with a given user object only remain valid
+   while that user is logged in. As a result, any operation that has not
+   yet completed before the initiating user logs out cannot complete
+   successfully and will likely result in an error. Any data in a write
+   operation that fails in this way will be lost.

--- a/source/ios/authenticate.txt
+++ b/source/ios/authenticate.txt
@@ -258,6 +258,8 @@ Log Out
 
 Once logged in, you can log out:
 
+.. include:: /includes/log-out-queries-in-progress.rst
+
 .. code-block:: swift
 
    app.currentUser()?.logOut(completion: { (error) in

--- a/source/node/authenticate.txt
+++ b/source/node/authenticate.txt
@@ -497,6 +497,8 @@ Log Out
 
 To log any user out, call the ``User.logOut()`` on their user instance.
 
+.. include:: /includes/log-out-queries-in-progress.rst
+
 .. tabs-realm-languages::
    
    .. tab::

--- a/source/react-native/authenticate.txt
+++ b/source/react-native/authenticate.txt
@@ -683,6 +683,8 @@ Log Out
 
 To log any user out, call the ``User.logOut()`` on their user instance.
 
+.. include:: /includes/log-out-queries-in-progress.rst
+
 .. tabs-realm-languages::
    
    .. tab::

--- a/source/react-native/authenticate.txt
+++ b/source/react-native/authenticate.txt
@@ -681,7 +681,7 @@ the user's ID token to finish logging the user in to your app.
 Log Out
 -------
 
-To log any user out, call the ``User.logOut()`` on their user instance.
+To log any user out, call ``User.logOut()`` on their user instance.
 
 .. include:: /includes/log-out-queries-in-progress.rst
 

--- a/source/react-native/authenticate.txt
+++ b/source/react-native/authenticate.txt
@@ -672,16 +672,13 @@ the user's ID token to finish logging the user in to your app.
          };
          export default Login;
 
-
-
-
-
 .. _react-native-logout:
 
 Log Out
 -------
 
-To log any user out, call ``User.logOut()`` on their user instance.
+You can log out any user, regardless of the authentication provider used
+to log in, using the ``User.logOut()`` method:
 
 .. include:: /includes/log-out-queries-in-progress.rst
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/RJAVA-669

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/master/android/authenticate.html#log-out
https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/master/ios/authenticate.html#log-out
https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/master/node/authenticate.html#log-out
https://docs-mongodbcom-staging.corp.mongodb.com/realm/pegasus/master/react-native/authenticate.html#log-out
