### PR TITLE
(DOCSP-12119): Realm %%prevRoot example is wrongly described

### DIFF
--- a/source/services/expression-variables.txt
+++ b/source/services/expression-variables.txt
@@ -249,7 +249,7 @@ expressions:
       {
         "%or": [
           { "%%prevRoot": { "%exists": %%true } },
-          { "%%root.name": "new" }
+          { "%%root.status": "new" }
         ]
       }
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
- (DOCSP-12119): Realm %%prevRoot example is wrongly described

