### PR TITLE
(DOCSP-12151): Cascading deletes callout for embedded objects

### DIFF
--- a/source/android/embedded-objects.txt
+++ b/source/android/embedded-objects.txt
@@ -29,6 +29,14 @@ exist as an independent Realm object. Realm automatically deletes
 embedded objects if their parent object is deleted or when overwritten
 by a new embedded object instance.
 
+.. note:: Realm Uses Cascading Deletes for Embedded Objects
+
+   When you delete a Realm object, Realm automatically deletes any
+   embedded objects referenced by that object. Any objects that your
+   application must persist after the deletion of their parent object
+   should use :ref:`relationships <android-client-relationships>`
+   instead.
+
 Embedded Object Data Models
 ---------------------------
 

--- a/source/android/embedded-objects.txt
+++ b/source/android/embedded-objects.txt
@@ -29,7 +29,8 @@ exist as an independent Realm object. Realm automatically deletes
 embedded objects if their parent object is deleted or when overwritten
 by a new embedded object instance.
 
-.. note:: Realm Uses Cascading Deletes for Embedded Objects
+.. admonition:: Realm Uses Cascading Deletes for Embedded Objects
+   :class: note
 
    When you delete a Realm object, Realm automatically deletes any
    embedded objects referenced by that object. Any objects that your

--- a/source/ios/embedded-objects.txt
+++ b/source/ios/embedded-objects.txt
@@ -29,6 +29,14 @@ exist as an independent Realm object. Realm automatically deletes
 embedded objects if their parent object is deleted or when overwritten
 by a new embedded object instance.
 
+.. note:: Realm Uses Cascading Deletes for Embedded Objects
+
+   When you delete a Realm object, Realm automatically deletes any
+   embedded objects referenced by that object. Any objects that your
+   application must persist after the deletion of their parent object
+   should use :ref:`relationships <ios-client-relationships>`
+   instead.
+
 Embedded Object Data Models
 ---------------------------
 

--- a/source/ios/embedded-objects.txt
+++ b/source/ios/embedded-objects.txt
@@ -29,7 +29,8 @@ exist as an independent Realm object. Realm automatically deletes
 embedded objects if their parent object is deleted or when overwritten
 by a new embedded object instance.
 
-.. note:: Realm Uses Cascading Deletes for Embedded Objects
+.. admonition:: Realm Uses Cascading Deletes for Embedded Objects
+   :class: note
 
    When you delete a Realm object, Realm automatically deletes any
    embedded objects referenced by that object. Any objects that your

--- a/source/node/embedded-objects.txt
+++ b/source/node/embedded-objects.txt
@@ -27,7 +27,8 @@ inherits the lifecycle of its parent object and cannot exist as an independent
 Realm object. Realm automatically deletes embedded objects if their parent
 object is deleted or if they are overwritten by a new embedded object.
 
-.. note:: Realm Uses Cascading Deletes for Embedded Objects
+.. admonition:: Realm Uses Cascading Deletes for Embedded Objects
+   :class: note
 
    When you delete a Realm object, Realm automatically deletes any
    embedded objects referenced by that object. Any objects that your

--- a/source/node/embedded-objects.txt
+++ b/source/node/embedded-objects.txt
@@ -27,6 +27,14 @@ inherits the lifecycle of its parent object and cannot exist as an independent
 Realm object. Realm automatically deletes embedded objects if their parent
 object is deleted or if they are overwritten by a new embedded object.
 
+.. note:: Realm Uses Cascading Deletes for Embedded Objects
+
+   When you delete a Realm object, Realm automatically deletes any
+   embedded objects referenced by that object. Any objects that your
+   application must persist after the deletion of their parent object
+   should use :ref:`relationships <node-client-relationships>`
+   instead.
+
 Embedded Object Data Models
 ---------------------------
 

--- a/source/react-native/embedded-objects.txt
+++ b/source/react-native/embedded-objects.txt
@@ -27,6 +27,14 @@ inherits the lifecycle of its parent object and cannot exist as an independent
 Realm object. Realm automatically deletes embedded objects if their parent
 object is deleted or if they are overwritten by a new embedded object.
 
+.. note:: Realm Uses Cascading Deletes for Embedded Objects
+
+   When you delete a Realm object, Realm automatically deletes any
+   embedded objects referenced by that object. Any objects that your
+   application must persist after the deletion of their parent object
+   should use :ref:`relationships <react-native-client-relationships>`
+   instead.
+
 Embedded Object Data Models
 ---------------------------
 

--- a/source/react-native/embedded-objects.txt
+++ b/source/react-native/embedded-objects.txt
@@ -27,7 +27,8 @@ inherits the lifecycle of its parent object and cannot exist as an independent
 Realm object. Realm automatically deletes embedded objects if their parent
 object is deleted or if they are overwritten by a new embedded object.
 
-.. note:: Realm Uses Cascading Deletes for Embedded Objects
+.. admonition:: Realm Uses Cascading Deletes for Embedded Objects
+   :class: note
 
    When you delete a Realm object, Realm automatically deletes any
    embedded objects referenced by that object. Any objects that your


### PR DESCRIPTION
## Pull Request Info
Regrettably, I couldn't single-source this content because I wanted to link to the relationships doc for each SDK.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12151

### Docs staging link (requires sign-in on MongoDB Corp SSO):
React Native: https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12151/react-native/embedded-objects.html
Android: https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12151/android/embedded-objects.html
iOS: https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12151/ios/embedded-objects.html
Node: https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12151/node/embedded-objects.html
