### PR TITLE
(DOCSP-12267): Remove direct embedded object query examples

### DIFF
--- a/source/android/embedded-objects.txt
+++ b/source/android/embedded-objects.txt
@@ -152,6 +152,7 @@ Use dot notation to filter or sort a :ref:`collection
 <android-client-collections>` of objects based on an embedded object
 property value:
 
+.. include:: /includes/directly-query-embedded-objects-note.rst
 
 .. tabs-realm-languages::
    
@@ -166,8 +167,3 @@ property value:
 
       .. literalinclude:: /examples/EmbeddedObjects/QueryEmbeddedObjects.java
          :language: java
-
-Query an Embedded Object Type Directly
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-It is not possible to query embedded objects directly.

--- a/source/includes/directly-query-embedded-objects-note.rst
+++ b/source/includes/directly-query-embedded-objects-note.rst
@@ -1,0 +1,4 @@
+.. note::
+
+   It is not possible to query embedded objects directly. Instead,
+   access embedded objects through a query for the parent object type.

--- a/source/ios/embedded-objects.txt
+++ b/source/ios/embedded-objects.txt
@@ -151,6 +151,7 @@ Use dot notation to filter or sort a :ref:`collection
 <ios-client-collections>` of objects based on an embedded object
 property value:
 
+.. include:: /includes/directly-query-embedded-objects-note.rst
 
 .. tabs-realm-languages::
    
@@ -165,8 +166,3 @@ property value:
 
       .. literalinclude:: /examples/EmbeddedObjects/QueryEmbeddedObjects.m
          :language: objective-c
-
-Query an Embedded Object Type Directly
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-It is not possible to query embedded objects directly.

--- a/source/node/embedded-objects.txt
+++ b/source/node/embedded-objects.txt
@@ -170,16 +170,3 @@ of objects based on an embedded object property value:
    const nycContacts = realm.objects("Contact")
      .filtered("address.city = 'New York City'")
      .sorted("address.street");
-
-Query an Embedded Object Type Directly
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Embedded object types are reusable across different parent object types and you
-may want to access a collection of all instances of an embedded object type
-regardless of their parent object type. In this case, you can access a
-collection of embedded objects of the same type as if they were regular Realm
-Objects:
-
-.. code-block:: javascript
-
-   const nycAddresses = realm.objects("Address").filtered("city = 'New York City'");

--- a/source/node/embedded-objects.txt
+++ b/source/node/embedded-objects.txt
@@ -165,6 +165,8 @@ Query a Collection on Embedded Object Properties
 Use dot-notation to filter or sort a :ref:`collection <node-client-collections>`
 of objects based on an embedded object property value:
 
+.. include:: /includes/directly-query-embedded-objects-note.rst
+
 .. code-block:: javascript
 
    const nycContacts = realm.objects("Contact")

--- a/source/react-native/embedded-objects.txt
+++ b/source/react-native/embedded-objects.txt
@@ -170,16 +170,3 @@ of objects based on an embedded object property value:
    const nycContacts = realm.objects("Contact")
      .filtered("address.city = 'New York City'")
      .sorted("address.street");
-
-Query an Embedded Object Type Directly
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Embedded object types are reusable across different parent object types and you
-may want to access a collection of all instances of an embedded object type
-regardless of their parent object type. In this case, you can access a
-collection of embedded objects of the same type as if they were regular Realm
-Objects:
-
-.. code-block:: javascript
-
-   const nycAddresses = realm.objects("Address").filtered("city = 'New York City'");

--- a/source/react-native/embedded-objects.txt
+++ b/source/react-native/embedded-objects.txt
@@ -165,6 +165,8 @@ Query a Collection on Embedded Object Properties
 Use dot-notation to filter or sort a :ref:`collection <react-native-client-collections>`
 of objects based on an embedded object property value:
 
+.. include:: /includes/directly-query-embedded-objects-note.rst
+
 .. code-block:: javascript
 
    const nycContacts = realm.objects("Contact")


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12267

### Docs staging link (requires sign-in on MongoDB Corp SSO):
At bottom of page -- removed "query directly" section from node/react-native, added a note to all pages.
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12267/node/embedded-objects.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12267/react-native/embedded-objects.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12267/android/embedded-objects.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12267/ios/embedded-objects.html