### PR TITLE
(DOCSP-11307): type check for sync client guides

### DIFF
--- a/source/android/objects.txt
+++ b/source/android/objects.txt
@@ -151,7 +151,6 @@ You can configure the following constraints for a given property:
 
        - Boolean
        - Integer
-       - Float
        - Double
        - String
        - Date

--- a/source/ios/objects.txt
+++ b/source/ios/objects.txt
@@ -106,7 +106,7 @@ Objective-C.
 
       - Boolean ``Bool``
       - Integral types ``Int``, ``Int8``, ``Int16``, ``Int32``, ``Int64``
-      - Floating-point types ``Float``, ``Double``
+      - ``Double``
       - ``String``
       - ``Date``
       - ``Data``
@@ -136,14 +136,12 @@ Objective-C.
       - ``RLMList``
 
       Additionally, you can represent optional number types with
-      ``NSNumber`` tagged with ``RLMInt``, ``RLMFloat``, ``RLMDouble``,
+      ``NSNumber`` tagged with ``RLMInt``, ``RLMDouble``,
       or ``RLMBool``:
 
       .. code-block:: objective-c
 
          @property NSNumber<RLMInt> *age;
-
-      Avoid ``CGFloat`` properties, as the type is not platform independent.
 
 .. _ios-primary-key:
 

--- a/source/node/include/property-schema.rst
+++ b/source/node/include/property-schema.rst
@@ -22,7 +22,7 @@ You can configure the following constraints for a given property:
        {+client-database+} supports the following primitive data types:
 
        - ``bool`` for boolean values
-       - ``int``, ``float``, and ``double``, which map to JavaScript ``number`` values
+       - ``int``, and ``double``, which map to JavaScript ``number`` values
        - ``string``
        - ``date``, which maps to :mdn:`Date <Web/JavaScript/Reference/Global_Objects/Date>`
        - ``data``, which maps to :mdn:`ArrayBuffer <Web/JavaScript/Reference/Global_Objects/ArrayBuffer>`
@@ -83,6 +83,6 @@ You can configure the following constraints for a given property:
           name: 'Book',
             properties: {
               name: { type: 'string', indexed: true },
-              price: 'float'
+              price: 'int'
             }
           };

--- a/source/node/include/property-schema.rst
+++ b/source/node/include/property-schema.rst
@@ -22,7 +22,7 @@ You can configure the following constraints for a given property:
        {+client-database+} supports the following primitive data types:
 
        - ``bool`` for boolean values
-       - ``int``, and ``double``, which map to JavaScript ``number`` values
+       - ``int`` and ``double``, which map to JavaScript ``number`` values
        - ``string``
        - ``date``, which maps to :mdn:`Date <Web/JavaScript/Reference/Global_Objects/Date>`
        - ``data``, which maps to :mdn:`ArrayBuffer <Web/JavaScript/Reference/Global_Objects/ArrayBuffer>`


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-11307

### Docs staging link (requires sign-in on MongoDB Corp SSO):
- android: https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-11307-type-check-for-sync-client-guides/android/objects.html
- ios: https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-11307-type-check-for-sync-client-guides/ios/objects.html
- node: https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-11307-type-check-for-sync-client-guides/node/objects.html

doc w/ summary of types allowed/not allowed:
https://docs.google.com/document/d/1vSPniERWWe-CLh8vcAb9YMjKBozI9rXlzfzPFxXBi2k/edit?usp=sharing