### PR TITLE
Update android SDK links in sidebar

### DIFF
--- a/source/android.txt
+++ b/source/android.txt
@@ -140,4 +140,4 @@ Reference
 
    Auxiliary Files </android/auxiliary-files>
    Java Reference Manual (Javadoc) <https://docs.mongodb.com/realm-sdks/java/10.0.0-BETA.6>
-   Kotlin Extensions Reference Manual <https://docs.mongodb.com/realm-sdks/java/10.0.0-BETA.6>
+   Kotlin Extensions Reference Manual <https://docs.mongodb.com/realm-sdks/kotlin/10.0.0-BETA.6>

--- a/source/android.txt
+++ b/source/android.txt
@@ -139,4 +139,5 @@ Reference
    :caption: Reference
 
    Auxiliary Files </android/auxiliary-files>
-   SDK Reference Manual <https://docs.mongodb.com/realm-sdks/android/>
+   Java Reference Manual (Javadoc) <https://docs.mongodb.com/realm-sdks/java/10.0.0-BETA.6>
+   Kotlin Extensions Reference Manual <https://docs.mongodb.com/realm-sdks/java/10.0.0-BETA.6>


### PR DESCRIPTION
## Pull Request Info
The conf.py links had already been updated to the new format, but not the sidebar links.

### Issue JIRA link:
N/A

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/update-sidebar-links/android.html
