### PR TITLE
(DOCSP-12343): Specify $function operator support

### DIFF
--- a/source/mongodb/crud-and-aggregation-apis.txt
+++ b/source/mongodb/crud-and-aggregation-apis.txt
@@ -499,7 +499,7 @@ Query Option Availability
    :header-rows: 1
    :widths: 25 10 10
 
-   * - Modifier
+   * - Option
      - User Context
      - System Context
 
@@ -520,6 +520,9 @@ Query Option Availability
 Aggregation
 -----------
 
+Aggregation Pipeline Stage Availability
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 {+service+} does not support the following :manual:`aggregation pipeline
 stages </reference/operator/aggregation-pipeline/>` when you :doc:`run
 an aggregation pipeline </mongodb/run-aggregation-pipelines>` in the
@@ -527,15 +530,12 @@ context of an :ref:`application user <user-accounts>`. All aggregation
 pipeline stages are available to the system user except ``$indexStats``
 and ``$currentOp``.
 
-Aggregation Pipeline Stage Availability
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 .. cssclass:: config-table
 .. list-table::
    :header-rows: 1
    :widths: 25 10 10
 
-   * - Modifier
+   * - Stage
      - User Context
      - System Context
 
@@ -587,6 +587,29 @@ Aggregation Pipeline Stage Availability
 
    * - :manual:`$unionWith </reference/operator/aggregation/unionWith/>`
      - Yes
+     - Yes
+
+Aggregation Pipeline Operator Availability
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+{+service+} supports all :manual:`aggregation pipeline operators
+</reference/operator/aggregation/>` when you :doc:`run an aggregation pipeline
+</mongodb/run-aggregation-pipelines>` in the :ref:`system user
+<system-functions>` context. {+service-short+} supports all pipeline operators
+in an :ref:`application user <user-accounts>` context with the following
+exceptions:
+
+.. cssclass:: config-table
+.. list-table::
+   :header-rows: 1
+   :widths: 25 10 10
+
+   * - Operator
+     - User Context
+     - System Context
+
+   * - :manual:`$function </reference/operator/aggregation/function/>`
+     - No
      - Yes
 
 .. _mongodb-crud-and-aggregation-apis-database-commands:

--- a/source/mongodb/supported-aggregation-stages.rst
+++ b/source/mongodb/supported-aggregation-stages.rst
@@ -2,8 +2,7 @@
    :class: note
 
    {+service+} supports nearly all MongoDB aggregation pipeline stages and
-   operators, but some stages must be executed within a
-   :ref:`system function <system-functions>`. See
-   :ref:`Aggregation Framework Limitations
-   <mongodb-crud-and-aggregation-apis-aggregation>` for more
+   operators, but some stages and operators must be executed within a
+   :ref:`system function <system-functions>`. See :ref:`Aggregation Framework
+   Limitations <mongodb-crud-and-aggregation-apis-aggregation>` for more
    information.


### PR DESCRIPTION
- Adds section to crud-and-aggregation-apis for aggregation operator support exceptions

## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12343

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/function-agg-op/mongodb/crud-and-aggregation-apis.html#aggregation-pipeline-operator-availability
