### PR TITLE
(DOCSP-12327): Show how to get App Object ID on Access Logs with the Admin API page

### DIFF
--- a/source/admin/api/v3.txt
+++ b/source/admin/api/v3.txt
@@ -75,10 +75,11 @@ Project & Application IDs
 {+service-short+} APIs frequently require two parameters: your |atlas|
 *Project/Group ID*, and your {+service-short+} *Application ID*.
 
-.. _realm-api-application-id:
 
 Project ID
 ~~~~~~~~~~
+
+.. _realm-api-application-id:
 
 To find your Project ID, go to your |atlas| administration console,
 click :guilabel:`Settings` in the left-hand navigation bar, and look

--- a/source/admin/api/v3.txt
+++ b/source/admin/api/v3.txt
@@ -75,6 +75,8 @@ Project & Application IDs
 {+service-short+} APIs frequently require two parameters: your |atlas|
 *Project/Group ID*, and your {+service-short+} *Application ID*.
 
+.. _realm-api-application-id:
+
 Project ID
 ~~~~~~~~~~
 

--- a/source/logs/api.txt
+++ b/source/logs/api.txt
@@ -43,6 +43,27 @@ The examples in this section use the following helper functions in a
        ? "?" + params.map(([a, b]) => `${a}=${b}`).join("&")
        : ""
    }
+   
+Application ID
+-------------- 
+   
+In order to request your application's log entries, you'll need the application's 
+object ID. You can find your application ID in the URL when you are accessing 
+your {+service-short+} app through :ref:`cloud.mongodb.com <https://cloud.mongodb.com>`.
+You can also get the :ref:`application ID via curl <realm-api-application-id>`. 
+
+.. example:: 
+  When you access your {+service-short+} app, you should have a URL of the 
+  following format:
+  
+  .. code-block:: shell
+    
+    https://realm.mongodb.com/groups/<Atlas Organization ID>/apps/<Realm App ID>/dashboard
+    
+  You will use the {+service-short+} App ID in the URL to call the logging 
+  endpoints.
+
+  
 
 Get Recent Logs
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12327

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/lisbethlazala/app-object-id-logs/logs/api.html
