### PR TITLE
Cleanup of android beta 8 changes based on eng suggestions

### DIFF
--- a/source/android/auxiliary-files.txt
+++ b/source/android/auxiliary-files.txt
@@ -58,36 +58,6 @@ closed. Deleting any of a {+realm+}'s files while the {+realm+} is
 open might corrupt the {+realm+} or disrupt :doc:`Sync
 </sync>`.
 
-.. _android-client-reset:
-
-Client Reset Scenario
-~~~~~~~~~~~~~~~~~~~~~
-
-When using :doc:`{+sync+} </sync>`, a **client
-reset** is a serious error recovery task that your client
-app must perform in the following situation:
-
-- The given synced {+realm+} on the server was restored from a backup.
-  For example, due to a {+service-short+} server crash.
-
-- The client app made changes to that {+realm+} since the backup was made,
-  but did not sync those changes back to the server before the server
-  was restored.
-
-In other words, the client app must carry out a client reset
-on a given synced {+realm+} if the server is restored to a
-version older than the version on the client.
-
-To perform a client reset, follow these steps:
-
-1. Create a backup of the local {+realm+} file.
-
-#. Delete the local {+realm+} file.
-
-#. The next time the app connects to the server and opens that {+realm+},
-   the app downloads a fresh copy of the {+realm+} file. The local changes
-   made since the backup on the server are not reflected in the new file.
-
 .. _android-client-realm-studio:
 
 Realm Studio

--- a/source/android/client-reset.txt
+++ b/source/android/client-reset.txt
@@ -1,4 +1,5 @@
 .. _android-client-resets:
+.. _android-client-reset:
 
 =============
 Client Resets
@@ -15,26 +16,41 @@ Client Resets
 Overview
 --------
 
-When a {+realm+} becomes too far out of sync with the data stored in
-MongoDB Atlas, the client must perform a **client reset**. A client
-reset erases all local data and syncs down a new copy of the data stored
-in MongoDB Atlas. Performing a client reset loses all local changes made
-since the client last successfully synced. Your app might require
-a client reset if a large number of changes has occurred in a {+realm+}
-since the last time your client synced successfully. Realms with many
-active writers can cause client resets, as well as clients that do not
-sync for long periods of time (weeks or months).
+When using :doc:`{+sync+} </sync>`, a **client
+reset** is a serious error recovery task that your client
+app must perform in the following situation:
+
+- The given synced {+realm+} on the server was restored from a backup.
+  For example, due to a {+service-short+} server crash.
+
+- The client app made changes to that {+realm+} since the backup was made,
+  but did not sync those changes back to the server before the server
+  was restored.
+
+In other words, the client app must carry out a client reset
+on a given synced {+realm+} if the server is restored to a
+version older than the version on the client.
+
+A client reset erases all local data and downloads a new copy of the
+data stored in MongoDB Atlas. Performing a client reset loses all local
+changes made since the client last successfully synced.
 
 Example
 -------
 
-By default, the SDK performs client resets automatically. However, for
-certain use cases, you might want to customize client reset behavior.
-For instance, you might want to make a backup copy of local data so that
-you can manually recover changes. To override the default client reset
-behavior, create an instance of a ``SyncSession.ClientResetHandler`` that
-overrides the default ``onClientReset()`` behavior. Pass this object to
-your ``AppConfiguration.Builder`` using the ``defaultClientResetHandler()``
+By default, the SDK performs client resets automatically on startup when
+instructed to do so by the server. When a client
+reset occurs, the SDK creates a backup of local data. By default,
+the SDK makes no effort to recover lost local changes from this backup.
+If you override the client reset handler, you can access this backup
+copy through the ``RealmConfiguration`` stored in the
+``ClientResetRequiredError`` to manually transfer data from the
+backup copy to the newly created {+realm+}.
+
+To override the default client reset behavior, create an instance of a
+``SyncSession.ClientResetHandler`` that overrides the default
+``onClientReset()`` behavior. Pass this object to your
+``AppConfiguration.Builder`` using the ``defaultClientResetHandler()``
 builder method:
 
 .. tabs-realm-languages::

--- a/source/android/mongodb.txt
+++ b/source/android/mongodb.txt
@@ -945,6 +945,13 @@ Running this snippet produces output resembling the following:
 
 .. _android-mongodb-watch:
 
+Watch for Changes
+-----------------
+
+These code snippets demonstrate how to configure and run
+:manual:`watch </reference/method/db.collection.watch/>` operations on a
+collection.
+
 Watch for Changes in a Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/android/mongodb.txt
+++ b/source/android/mongodb.txt
@@ -950,11 +950,13 @@ Watch for Changes in a Collection
 
 You can open a stream of changes made to a collection by calling
 :java-sdk:`collection.watch()
-<io/realm/mongodb/mongo/MongoCollection.html#watch->` or
+<io/realm/mongodb/mongo/MongoCollection.html#watch-->` or
 :java-sdk:`collection.watchAsync()
-<io/realm/mongodb/mongo/MongoCollection.html#watchAsync->`. You can watch for
-changes to specific documents in a collection by providing a list of the
-object ids of the objects you would like to monitor.
+<io/realm/mongodb/mongo/MongoCollection.html#watchAsync-->`. You can
+watch for changes to specific documents in a collection by passing the
+object ids of the objects you would like to monitor as a
+`variable number of arguments
+<https://kotlinlang.org/docs/reference/functions.html#variable-number-of-arguments-varargs>`__.
 
 The following snippet watches for changes to any documents in the
 ``plants`` collection:
@@ -990,6 +992,7 @@ The following snippet watches for changes to any documents in the
                     .append("color", "green")
                     .append("type", "perennial")
                     .append("_partition", "Store 47")
+
          mongoCollection?.insertOne(plant)?.getAsync() {
             if (it.isSuccess) {
                 Log.v("EXAMPLE", "successfully inserted a document with id: ${it.get().insertedId}")
@@ -1051,16 +1054,21 @@ Running this snippet produces output resembling the following:
 Watch for Changes in a Collection with a Filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can open a stream of changes made to a collection by calling
-:java-sdk:`collection.watchWithFilter()
-<io/realm/mongodb/mongo/MongoCollection.html#watchWithFilter->` or
+You can open a stream of changes made to documents in a collection that
+fulfill certain criteria by calling :java-sdk:`collection.watchWithFilter()
+<io/realm/mongodb/mongo/MongoCollection.html#watchWithFilter-BsonDocument->` or
 :java-sdk:`collection.watchWithFilterAsync()
-<io/realm/mongodb/mongo/MongoCollection.html#watchWithFilterAsync->`. You can watch for
-changes to specific documents in a collection by providing the 
+<io/realm/mongodb/mongo/MongoCollection.html#watchWithFilterAsync-Document->`.
+Both methods accept a `Document` or `BsonDocument` parameter that is
+used as the query of a :manual:`$match operator
+</reference/operator/aggregation/match/>` to process each
+:ref:`database event <database-events>` that occurs while watching the
+collection.
 
-
-The following snippet watches for changes to any documents in the
-``plants`` collection:
+The following snippet watches for changes to documents in the
+``plants`` collection, but only triggers the provided callback for
+events corresponding to documents belonging to the partition named
+"Store 42":
 
 .. tabs-realm-languages::
    


### PR DESCRIPTION
## Pull Request Info
ENG [reviewed the beta 8 changes and had some suggestions](https://github.com/mongodb/docs-realm/pull/474). I noticed some random things that could be cleaned up. Notable changes:
- broken link fixes
- removed client reset description from the "auxiliary files" page (even I have only read it once) and merged it with the description on a the new client reset page
- improved text for the `watch` description
- new section for `watch` in the MongoDB page

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/androidbeta8/android/client-reset.html
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/androidbeta8/android/mongodb.html#watch-for-changes
