### PR TITLE
(DOCSP-12508): Update extlinks to match Snooty definitions

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -99,7 +99,7 @@ extlinks = {
     'admin-api-endpoint': ('https://docs.mongodb.com/realm/admin/api/v3/#%s', ''), # sphinx_openapi doesn't support endpoint refs, so we have to use an extlink instead
     'manual': ('http://docs.mongodb.org/manual%s', ''),
     'atlas': ('https://docs.atlas.mongodb.com%s',''),
-    'datalake': ('https://docs.mongodb.com/datalake/%s',''),
+    'adl': ('https://docs.mongodb.com/datalake/%s',''),
     'facebook': ('https://developers.facebook.com/%s', ''),
     'mms-docs': ('https://docs.cloud.mongodb.com%s', ''),
     'mms-home': ('https://cloud.mongodb.com%s', ''),

--- a/conf.py
+++ b/conf.py
@@ -99,7 +99,7 @@ extlinks = {
     'admin-api-endpoint': ('https://docs.mongodb.com/realm/admin/api/v3/#%s', ''), # sphinx_openapi doesn't support endpoint refs, so we have to use an extlink instead
     'manual': ('http://docs.mongodb.org/manual%s', ''),
     'atlas': ('https://docs.atlas.mongodb.com%s',''),
-    'adl': ('https://docs.mongodb.com/datalake/%s',''),
+    'adl': ('https://docs.mongodb.com/datalake%s',''),
     'facebook': ('https://developers.facebook.com/%s', ''),
     'mms-docs': ('https://docs.cloud.mongodb.com%s', ''),
     'mms-home': ('https://cloud.mongodb.com%s', ''),

--- a/conf.py
+++ b/conf.py
@@ -119,7 +119,7 @@ extlinks = {
     'aws-iam': ('https://docs.aws.amazon.com/IAM/latest/%s', ''),
     'aws-reference': ('https://docs.aws.amazon.com/general/latest/%s', ''),
     'codesandbox': ('https://codesandbox.io/%s', ''),
-    'gcp': ('https://cloud.google.com/%s', ''),
+    'gcp': ('https://cloud.google.com%s', ''),
     'github': ('https://github.com/%s', ''),
     'github-dev': ('https://developer.github.com/%s', ''),
     'google': ('https://developers.google.com/%s', ''),

--- a/conf.py
+++ b/conf.py
@@ -136,7 +136,7 @@ extlinks = {
     'fcm': ('https://firebase.google.com/docs/%s', ''),
     'typescript': ('https://www.typescriptlang.org/%s', ''),
     'node-driver': ('https://mongodb.github.io/node-mongodb-native/3.6/api/%s', ''),
-    'ietf': ('https://tools.ietf.org/html/%s', ''),
+    'rfc': ('https://tools.ietf.org/html/%s', ''),
 }
 
 intersphinx_mapping = {}

--- a/conf.py
+++ b/conf.py
@@ -110,8 +110,7 @@ extlinks = {
     'objc-sdk': ('https://docs.mongodb.com/realm-sdks/objc/10.0.0-beta.5/%s', ''),
     'js-sdk': ('https://docs.mongodb.com/realm-sdks/js/latest/%s', ''),
     # True External Links
-    'android': ('https://developer.android.com/reference/%s', ''),
-    'android-dev': ('https://developer.android.com/%s', ''),
+    'android': ('https://developer.android.com/%s', ''),
     'apollo': ('https://www.apollographql.com/%s', ''),
     'apple': ('https://developer.apple.com/%s', ''),
     'aws-docs': ('https://docs.aws.amazon.com/%s', ''),

--- a/source/android/encrypt.txt
+++ b/source/android/encrypt.txt
@@ -34,7 +34,7 @@ Storing & Reusing Keys
 
 You must pass the same encryption key when opening the encrypted
 {+realm+} again. Apps should store the encryption key in the
-:android-dev:`Android KeyStore <training/articles/keystore.html>` so
+:android:`Android KeyStore <training/articles/keystore.html>` so
 that other apps cannot read the key.
 
 Performance Impact
@@ -69,4 +69,3 @@ open an encrypted {+realm+}:
 
       .. literalinclude:: /examples/Encrypt/encrypt.java
          :language: java
-

--- a/source/android/mongodb.txt
+++ b/source/android/mongodb.txt
@@ -218,7 +218,7 @@ These code snippets demonstrate how to read data stored in a MongoDB
 collection from a mobile application. Read operations use :manual:`query filters
 </core/document/#document-query-filter>` to specify which documents to
 return from the database. Read operations return a
-:android:`Task <com/google/android/play/core/tasks/Task>` that resolves to
+:android:`Task <reference/com/google/android/play/core/tasks/Task>` that resolves to
 either a single matched document (in the case of ``findOne()``), a ``long``
 numeric value (in the case of ``count()``) or an iterator that allows you to
 traverse the collection of matched documents (in the case of ``find()``).
@@ -435,7 +435,7 @@ collection from a mobile application. Update operations use query filters
 to specify which documents to update and :manual:`update operators
 </reference/operator/update>` to describe how to mutate documents that
 match the query. Update operations return a :android:`Task
-<com/google/android/play/core/tasks/Task>` that resolves to an object
+<reference/com/google/android/play/core/tasks/Task>` that resolves to an object
 that contains the results of the execution of the operation.
 
 .. _android-mongodb-updateOne:
@@ -691,7 +691,7 @@ Delete Documents
 These code snippets demonstrate how to delete documents that
 are stored in a MongoDB collection from a mobile application.
 Delete operations use a query filter to specify which documents to delete
-and return a :android:`Task <com/google/android/play/core/tasks/Task>`
+and return a :android:`Task <reference/com/google/android/play/core/tasks/Task>`
 that resolves to an object that contains the results of the execution
 of the operation.
 
@@ -860,7 +860,7 @@ you to filter and shape documents as well as collect summary data about
 groups of related documents.
 
 Aggregation operations accept a list of aggregation stages as input, and
-return a :android:`Task <com/google/android/play/core/tasks/Task>` that
+return a :android:`Task <reference/com/google/android/play/core/tasks/Task>` that
 resolves to a collection of documents processed by the pipeline.
 
 .. _android-mongodb-aggregate:

--- a/source/authentication/google.txt
+++ b/source/authentication/google.txt
@@ -194,7 +194,7 @@ Set Up a Project in the Google API Console
        content: ""
 
 The Google authentication provider requires a :gcp:`project in the Google
-API Console<>` to manage authentication and user permissions. The
+API Console </>` to manage authentication and user permissions. The
 following steps walk through creating the project, generating OAuth
 credentials, and configuring the provider to connect with the project.
 

--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -137,7 +137,7 @@ Glossary
       A design pattern in which a central loop waits
       for signals from a UI or other source before updating underlying
       data structures. On iOS, known as a :apple:`run loop
-      <documentation/foundation/runloop>`. On Android, known as a :android-dev:`Looper
+      <documentation/foundation/runloop>`. On Android, known as a :android:`Looper
       <reference/android/os/Looper>`. Also known as the **main loop** or
       **main event loop** on some platforms.
 

--- a/source/graphql/types-and-resolvers.txt
+++ b/source/graphql/types-and-resolvers.txt
@@ -72,7 +72,7 @@ The following scalar types are supported:
 - ``Int``: A signed 32‐bit integer
 - ``Long``: A signed 64‐bit integer
 - ``Float``: A signed double-precision floating-point value
-- ``DateTime``: An :ietf:`RFC 3339 <rfc3339>` UTC DateTime (e.g. "2020-09-01T15:38:14.918Z")
+- ``DateTime``: An :rfc:`RFC 3339 <rfc3339>` UTC DateTime (e.g. "2020-09-01T15:38:14.918Z")
 
 .. _graphql-document-types:
 

--- a/source/includes/extracts-mongodb-action.yaml
+++ b/source/includes/extracts-mongodb-action.yaml
@@ -1536,7 +1536,7 @@ content: |
          | ``result.first()``
 
        - Return a :android:`Task
-         <com/google/android/play/core/tasks/Task>` that resolves to the
+         <reference/com/google/android/play/core/tasks/Task>` that resolves to the
          first document from the query result set.
 
          See :java-sdk:`MongoIterable.first() <io/realm/mongodb/mongo/iterable/MongoIterable.html#first-->`
@@ -1546,7 +1546,7 @@ content: |
          | ``result.iterator()``
 
        - Return a :android:`Task
-         <com/google/android/play/core/tasks/Task>` that resolves to a
+         <reference/com/google/android/play/core/tasks/Task>` that resolves to a
          :java-sdk:`MongoCursor <io/realm/mongodb/mongo/iterable/MongoCursor.html>` object. You can
          use this :term:`cursor` to iterate through each document in the
          query result set with the
@@ -1571,8 +1571,8 @@ content: |
          | ``result.first()``
 
        - Return a :android:`Task
-         <com/google/android/play/core/tasks/Task>` that resolves to the
-         first document from the query result set.
+         <reference/com/google/android/play/core/tasks/Task>` that resolves to
+         the first document from the query result set.
 
          See :java-sdk:`MongoIterable.first() <io/realm/mongodb/mongo/iterable/MongoIterable.html#first-->`
 
@@ -1581,7 +1581,7 @@ content: |
          | ``result.iterator()``
 
        - Return a :android:`Task
-         <com/google/android/play/core/tasks/Task>` that resolves to a
+         <reference/com/google/android/play/core/tasks/Task>` that resolves to a
          :java-sdk:`MongoCursor <io/realm/mongodb/mongo/iterable/MongoCursor.html>` object. You can
          use this :term:`cursor` to iterate through each document in the
          query result set with the

--- a/source/includes/steps-auth-google-project-setup.yaml
+++ b/source/includes/steps-auth-google-project-setup.yaml
@@ -2,7 +2,7 @@ title: Create a Project in the Google API Console
 ref: auth-create-gcp-project
 content: |
   Follow Google's :gcp:`official guide
-  <resource-manager/docs/creating-managing-projects>` to create a new
+  </resource-manager/docs/creating-managing-projects>` to create a new
   GCP project.
 ---
 title: Generate OAuth Client Credentials

--- a/source/mongodb/link-a-data-source.txt
+++ b/source/mongodb/link-a-data-source.txt
@@ -62,7 +62,7 @@ For the most part, you can interact with a linked Data Lake just as
 you would with a linked Atlas cluster. However, there are some
 caveats to keep in mind when working with a Data Lake:
 
-- Data Lakes :datalake:`do not support write operations <supported-unsupported/mql-support>`.
+- Data Lakes :adl:`do not support write operations <supported-unsupported/mql-support>`.
 - You can only access a linked Data Lake from a :ref:`system function <system-functions>`.
 - You cannot connect to the Data Lake via the wire protocol.
 - You cannot define :ref:`roles and permissions <define-roles-and-permissions>` for a linked Data Lake.

--- a/source/mongodb/link-a-data-source.txt
+++ b/source/mongodb/link-a-data-source.txt
@@ -62,7 +62,7 @@ For the most part, you can interact with a linked Data Lake just as
 you would with a linked Atlas cluster. However, there are some
 caveats to keep in mind when working with a Data Lake:
 
-- Data Lakes :adl:`do not support write operations <supported-unsupported/mql-support>`.
+- Data Lakes :adl:`do not support write operations </supported-unsupported/mql-support>`.
 - You can only access a linked Data Lake from a :ref:`system function <system-functions>`.
 - You cannot connect to the Data Lake via the wire protocol.
 - You cannot define :ref:`roles and permissions <define-roles-and-permissions>` for a linked Data Lake.


### PR DESCRIPTION
This is a sibling PR that preps the Realm docs to match the updated Snooty config in https://github.com/mongodb/snooty-parser/pull/226

## Pull Request Info

Some definitions for extlink roles in snooty ([rstspec.toml](https://github.com/mongodb/snooty-parser/blob/master/snooty/rstspec.toml) don't quite match our legacy definitions. Rather than renaming these in the centralized repo, this PR updates our local `conf.py` and all references to match.

### Issue JIRA link:

- (DOCSP-12508): Centralize extlink definitions

### Docs staging link (requires sign-in on MongoDB Corp SSO):

(probably need to use the diff view for this PR but staged if you want to sanity check)

- [Realm Docs](https://docs-mongodbcom-staging.corp.mongodb.com/realm/nlarew/snooty/index.html)
