### PR TITLE
(DOCSP-12596) JS Initialize Realm App

### DIFF
--- a/source/android/init-realmclient.txt
+++ b/source/android/init-realmclient.txt
@@ -9,7 +9,7 @@ Initialize the Realm App Client
 Overview
 --------
 
-The {+service-short+} {+app+} client is the interface to the {+backend+}
+The {+app+} client is the interface to the {+backend+}
 backend. It provides access to the :ref:`authentication functionality
 <android-authenticate>`, :ref:`functions <android-call-a-function>`, and
 :ref:`sync management <android-sync-data>`.
@@ -21,8 +21,9 @@ backend. It provides access to the :ref:`authentication functionality
 Access the App Client
 ---------------------
 
-Pass the {+app+} ID for your {+app+}, which you can find in the {+ui+}.
-
+Pass the {+app+} ID for your {+app+}, which you can :ref:`find in the Realm
+  UI <find-your-app-id>`.
+  
 .. tabs-realm-languages::
 
       .. tab::

--- a/source/ios/init-realmclient.txt
+++ b/source/ios/init-realmclient.txt
@@ -9,7 +9,7 @@ Initialize the Realm App Client
 Overview
 --------
 
-The {+service-short+} {+app+} client is the interface to the {+backend+}
+The {+app+} client is the interface to the {+backend+}
 backend. It provides access to the :ref:`authentication functionality
 <ios-authenticate>`, :ref:`functions <ios-call-a-function>`, and
 :ref:`sync management <ios-sync-data>`.
@@ -19,12 +19,12 @@ backend. It provides access to the :ref:`authentication functionality
 Access the App Client
 ---------------------
 
-Pass the {+app+} ID for your {+app+}, which you can find in the {+ui+}.
+Pass the {+app+} ID for your {+app+}, which you can :ref:`find in the Realm
+  UI <find-your-app-id>`.
 
 .. code-block:: swift
 
-   let app = App(id: "my-realm-app-id")
-
+   let app = App(id: "<Your App ID>") // replace this with your App ID
 
 .. _ios-app-client-configuration:
 

--- a/source/node.txt
+++ b/source/node.txt
@@ -120,6 +120,7 @@ To learn how to query for data in MongoDB with the Node.js SDK, see
    :caption: Work with MongoDB Realm
    :hidden:
 
+   Initialize the App Client </node/init-realmclient>
    Authenticate a User </node/authenticate>
    Manage Email/Password Users </node/manage-email-password-users>
    Create & Manage User API Keys </node/create-manage-api-keys>

--- a/source/node/init-realmclient.txt
+++ b/source/node/init-realmclient.txt
@@ -86,7 +86,7 @@ To retrieve an instance of the App Client from anywhere in your application, cal
 
          .. code-block:: typescript
 
-            const app = Realm.App.getApp("<Your App ID>"); // replace this with your App ID
+            const app: Realm.App =  Realm.App.getApp("<Your App ID>"); // replace this with your App ID
 
       .. tab::
          :tabid: javascript

--- a/source/node/init-realmclient.txt
+++ b/source/node/init-realmclient.txt
@@ -56,7 +56,7 @@ of ``Realm.App``.
             const config = {
               id,
             };
-            const app = new Realm.App(config);
+            const app: Realm.App = new Realm.App(config);
 
       .. tab::
          :tabid: javascript

--- a/source/node/init-realmclient.txt
+++ b/source/node/init-realmclient.txt
@@ -1,0 +1,92 @@
+.. _node-init-appclient:
+
+===============================
+Initialize the Realm App Client
+===============================
+
+.. default-domain:: mongodb
+
+Overview
+--------
+
+The {+app+} client is the interface to the {+backend+}
+backend. It provides access to the :ref:`authentication functionality
+<ios-authenticate>`, :ref:`functions <ios-call-a-function>`, and
+:ref:`sync management <ios-sync-data>`.
+
+
+.. _node-access-the-app-client:
+
+Access the App Client
+---------------------
+
+Pass the {+service+} App ID for your {+app+}, which you can :ref:`find in the Realm UI <find-your-app-id>`.
+
+.. tabs-realm-languages::
+
+      .. tab::
+         :tabid: typescript
+
+         .. code-block:: typescript
+
+            const id = "<Your App ID>"; // replace this with your App ID
+
+      .. tab::
+         :tabid: javascript
+
+         .. code-block:: javascript
+
+            const id = "<Your App ID>"; // replace this with your App ID
+
+Configuration
+-------------
+
+To set up your {+app+} client, pass a configuration object to an instance
+of ``Realm.App``.
+
+.. tabs-realm-languages::
+
+      .. tab::
+         :tabid: typescript
+
+         .. code-block:: typescript
+
+            const config = {
+              id,
+            };
+            const app = new Realm.App(config);
+
+      .. tab::
+         :tabid: javascript
+
+         .. code-block:: javascript
+
+            const config = {
+              id,
+            };
+            const app = new Realm.App(config);
+
+.. note:: 
+    
+   ``id`` is a required field of the application configuration object. To see the full list of fields for the configuration object that ``Realm.App`` accepts as a parameter, view the :js-sdk:`App Configuration Type Definitions <Realm.App.html#~AppConfiguration>`.
+
+To retrieve an instance of the App Client from anywhere in your application, call :js-sdk:`Realm.App.getApp() <Realm.App.html#getApp>` and pass in your ``App ID``. 
+
+.. tabs-realm-languages::
+
+      .. tab::
+         :tabid: typescript
+
+         .. code-block:: typescript
+
+            const app = Realm.App.getApp("<Your App ID>"); // replace this with your App ID
+
+      .. tab::
+         :tabid: javascript
+
+         .. code-block:: javascript
+
+            const app = Realm.App.getApp("<Your App ID>"); // replace this with your App ID
+
+
+  

--- a/source/react-native.txt
+++ b/source/react-native.txt
@@ -124,6 +124,7 @@ MongoDB Data Access <react-native-mongodb-data-access>`.
    :caption: Work with MongoDB Realm
    :hidden:
 
+   Initialize the Realm App Client </react-native/init-realmclient>
    Authenticate a User </react-native/authenticate>
    Manage Email/Password Users </react-native/manage-email-password-users>
    Create & Manage User API Keys </node/create-manage-api-keys>

--- a/source/react-native/init-realmclient.txt
+++ b/source/react-native/init-realmclient.txt
@@ -87,7 +87,7 @@ To retrieve an instance of the App Client from anywhere in your application, cal
 
          .. code-block:: typescript
 
-            const app = Realm.App.getApp("<Your App ID>"); // replace this with your App ID
+            const app: Realm.App =  Realm.App.getApp("<Your App ID>"); // replace this with your App ID
 
       .. tab::
          :tabid: javascript

--- a/source/react-native/init-realmclient.txt
+++ b/source/react-native/init-realmclient.txt
@@ -1,4 +1,4 @@
-.. _node-init-appclient:
+.. _react-native-init-appclient:
 
 ===============================
 Initialize the Realm App Client
@@ -15,7 +15,7 @@ backend. It provides access to the :ref:`authentication functionality
 :ref:`sync management <ios-sync-data>`.
 
 
-.. _node-access-the-app-client:
+.. _react-native-access-the-app-client:
 
 Access the App Client
 ---------------------
@@ -38,7 +38,7 @@ Pass the {+service+} App ID for your {+app+}, which you can :ref:`find in the Re
 
             const id = "<Your App ID>"; // replace this with your App ID
 
-.. _node-app-client-configuration:
+.. _react-native-client-configurations:
 
 Configuration
 -------------
@@ -71,8 +71,9 @@ of ``Realm.App``.
 .. note:: 
     
    ``id`` is a required field of the application configuration object. To see the full list of fields for the configuration object that ``Realm.App`` accepts as a parameter, view the :js-sdk:`App Configuration Type Definitions <Realm.App.html#~AppConfiguration>`.
+   
 
-.. _node-app-retrieve-client:
+.. _react-native-app-retrieve-client:
 
 Retrieve an Instance of the App Client
 --------------------------------------

--- a/source/web.txt
+++ b/source/web.txt
@@ -36,6 +36,7 @@ TypeScript applications.
    :caption: Work with MongoDB Realm
    :hidden:
 
+   Initialize the Realm App Client </web/init-realmclient>
    Authenticate a User </web/authenticate>
    Manage Email/Password Users </web/manage-email-password-users>
    Create & Manage User API Keys </node/create-manage-api-keys>

--- a/source/web/init-realmclient.txt
+++ b/source/web/init-realmclient.txt
@@ -1,4 +1,4 @@
-.. _react-native-init-appclient:
+.. _web-init-appclient:
 
 ===============================
 Initialize the Realm App Client
@@ -15,7 +15,7 @@ backend. It provides access to the :ref:`authentication functionality
 :ref:`sync management <ios-sync-data>`.
 
 
-.. _react-native-access-the-app-client:
+.. _web-access-the-app-client:
 
 Access the App Client
 ---------------------
@@ -38,7 +38,7 @@ Pass the {+service+} App ID for your {+app+}, which you can :ref:`find in the Re
 
             const id = "<Your App ID>"; // replace this with your App ID
 
-.. _react-native-client-configurations:
+.. _web-client-configurations:
 
 Configuration
 -------------
@@ -73,7 +73,7 @@ of ``Realm.App``.
    ``id`` is a required field of the application configuration object. To see the full list of fields for the configuration object that ``Realm.App`` accepts as a parameter, view the :js-sdk:`App Configuration Type Definitions <Realm.App.html#~AppConfiguration>`.
    
 
-.. _react-native-app-retrieve-client:
+.. _web-app-retrieve-client:
 
 Retrieve an Instance of the App Client
 --------------------------------------

--- a/source/web/init-realmclient.txt
+++ b/source/web/init-realmclient.txt
@@ -87,14 +87,14 @@ To retrieve an instance of the App Client from anywhere in your application, cal
 
          .. code-block:: typescript
 
-            const app = Realm.App.getApp("<Your App ID>"); // replace this with your App ID
+            const app: Realm.App =  Realm.getApp("<Your App ID>"); // replace this with your App ID
 
       .. tab::
          :tabid: javascript
 
          .. code-block:: javascript
 
-            const app = Realm.App.getApp("<Your App ID>"); // replace this with your App ID
+            const app = Realm.getApp("<Your App ID>"); // replace this with your App ID
 
 
   


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12596

### Docs staging link (requires sign-in on MongoDB Corp SSO):
* Node: https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-12596-JS-Initialize-Realm-App/node/init-realmclient.html
* React Native: https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-12596-JS-Initialize-Realm-App/react-native/init-realmclient.html
* Web: https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-12596-JS-Initialize-Realm-App/web/init-realmclient.html


Note: 
* The method "Realm.App.getApp()" is not documented in this PR for the "realm-web" SDK. There is a merged PR on the package w/ this API method, so that method will not be made available until the next release. I have created a JIRA ticket for this documentation: https://jira.mongodb.org/browse/DOCSP-12708