### PR TITLE
(DOCSP-12694): Add "tip" to look at SDKs and Schemas page in the Realm UI to connect client models sections

### DIFF
--- a/source/includes/steps-tutorial-android-kotlin.yaml
+++ b/source/includes/steps-tutorial-android-kotlin.yaml
@@ -248,6 +248,11 @@ content: |
   projects in the ``User`` object. Tasktracker stores each ``User``
   object in a special :ref:`{+realm+} <partitioning>` with a value of
   the following format: ``user=<user-id>``.
+  
+  .. note::
+
+    To learn more about how {+service-short+} Object models are used in Android applications, 
+    check out the :doc:`Android SDK client guide</android/objects>`. 
 
   To access the user's list of projects, we need to open a connection to
   that {+realm+} and access the ``User`` object. To get started, open

--- a/source/includes/steps-tutorial-android-kotlin.yaml
+++ b/source/includes/steps-tutorial-android-kotlin.yaml
@@ -252,7 +252,7 @@ content: |
   .. note::
 
     To learn more about how {+service-short+} Object models are used in Android applications, 
-    check out the :doc:`Android SDK client guide</android/objects>`. 
+    see :doc:`Realm Objects</android/objects>` in our Android client guide. 
 
   To access the user's list of projects, we need to open a connection to
   that {+realm+} and access the ``User`` object. To get started, open

--- a/source/includes/steps-tutorial-android-kotlin.yaml
+++ b/source/includes/steps-tutorial-android-kotlin.yaml
@@ -252,7 +252,7 @@ content: |
   .. note::
 
     To learn more about how {+service-short+} Object models are used in Android applications, 
-    see :doc:`Realm Objects</android/objects>` in our Android client guide. 
+    see :doc:`Realm Objects </android/objects>` in our Android client guide. 
 
   To access the user's list of projects, we need to open a connection to
   that {+realm+} and access the ``User`` object. To get started, open

--- a/source/includes/steps-tutorial-ios-swift.yaml
+++ b/source/includes/steps-tutorial-ios-swift.yaml
@@ -111,6 +111,12 @@ content: |
   .. literalinclude:: /tutorial/generated/code/final/Models.codeblock.task-model.swift
      :language: swift
 
+
+  .. note::
+
+      To learn more about how {+service-short+} Object models are used in iOS applications, 
+      check out the :doc:`iOS SDK client guide</ios/objects>`. 
+
 ---
 title: Enable Authentication
 ref: enable-authentication

--- a/source/includes/steps-tutorial-ios-swift.yaml
+++ b/source/includes/steps-tutorial-ios-swift.yaml
@@ -100,6 +100,11 @@ content: |
   .. literalinclude:: /tutorial/generated/code/final/Models.codeblock.user-model.swift
      :language: swift
 
+  .. note::
+
+      To learn more about how {+service-short+} Object models are used in iOS applications, 
+      see :doc:`Realm Objects</ios/objects>` in our iOS client guide. 
+
   Next, implement the Project embedded object that represents a Project that a
   User is a member of:
 
@@ -110,12 +115,6 @@ content: |
 
   .. literalinclude:: /tutorial/generated/code/final/Models.codeblock.task-model.swift
      :language: swift
-
-
-  .. note::
-
-      To learn more about how {+service-short+} Object models are used in iOS applications, 
-      check out the :doc:`iOS SDK client guide</ios/objects>`. 
 
 ---
 title: Enable Authentication

--- a/source/includes/steps-tutorial-react-native.yaml
+++ b/source/includes/steps-tutorial-react-native.yaml
@@ -171,6 +171,11 @@ content: |
   member of. We have set up our app so that the custom user data object exists
   in a specific realm, where at most one user object exists.
 
+  .. note::
+
+    To learn more about how {+service-short+} Object models are used in React Native applications, 
+    check out the :doc:`React Native SDK client guide</react-native/objects>`. 
+
   Open the realm for that user with the partition key value following the
   pattern ``user=<USER_ID>``.
 

--- a/source/includes/steps-tutorial-react-native.yaml
+++ b/source/includes/steps-tutorial-react-native.yaml
@@ -174,7 +174,7 @@ content: |
   .. note::
 
     To learn more about how {+service-short+} Object models are used in React Native applications, 
-    check out the :doc:`React Native SDK client guide</react-native/objects>`. 
+    see :doc:`Realm Objects</react-native/objects>` in our React Native client guide. 
 
   Open the realm for that user with the partition key value following the
   pattern ``user=<USER_ID>``.

--- a/source/includes/steps-tutorial-react-native.yaml
+++ b/source/includes/steps-tutorial-react-native.yaml
@@ -174,7 +174,7 @@ content: |
   .. note::
 
     To learn more about how {+service-short+} Object models are used in React Native applications, 
-    see :doc:`Realm Objects</react-native/objects>` in our React Native client guide. 
+    see :doc:`Realm Objects </react-native/objects>` in our React Native client guide. 
 
   Open the realm for that user with the partition key value following the
   pattern ``user=<USER_ID>``.

--- a/source/tutorial/nodejs-cli.txt
+++ b/source/tutorial/nodejs-cli.txt
@@ -279,7 +279,7 @@ In ``projects.js``:
    .. note::
 
       To learn more about how {+service-short+} Object models are used in Node.js applications, 
-      check out the :doc:`Node.JS SDK client guide </node/objects>`. 
+      see :doc:`Realm Objects </node/objects>` in our Node.js client guide. 
 
 F. Use Realm Functions
 ----------------------

--- a/source/tutorial/nodejs-cli.txt
+++ b/source/tutorial/nodejs-cli.txt
@@ -276,6 +276,11 @@ In ``projects.js``:
    .. literalinclude:: /tutorial/generated/code/final/projects.codeblock.getProjects.js
       :language: javascript
 
+   .. note::
+
+      To learn more about how {+service-short+} Object models are used in Node.js applications, 
+      check out the :doc:`Node.JS SDK client guide </node/objects>`. 
+
 F. Use Realm Functions
 ----------------------
 

--- a/source/tutorial/web-graphql.txt
+++ b/source/tutorial/web-graphql.txt
@@ -257,9 +257,14 @@ connect to your app's GraphQL API.
 F. Implement the Projects List
 ------------------------------
 
-As defined by our data model, ``projects`` are an :term:`embedded object`of the ``users`` object.
+As defined by our data model, ``projects`` are an :term:`embedded object` of the ``users`` object.
 Therefore, if we want to retrieve a list of projects, we'll have to access the :ref:`user custom 
 data object </users/enable-custom-user-data>`. 
+
+.. note::
+
+   To learn more about how {+service-short+} Object models are used in Node.js applications, 
+   see :doc:`Realm Objects </node/objects>` in our Node.js client guide. 
 
 In the file ``/graphql/useProjects.js``, we need to implement the retrieval of the 
 current user's projects. We'll need to add the following code:

--- a/source/tutorial/web-graphql.txt
+++ b/source/tutorial/web-graphql.txt
@@ -257,7 +257,7 @@ connect to your app's GraphQL API.
 F. Implement the Projects List
 ------------------------------
 
-As defined by our data model, ``projects`` are an embedded object of the ``users`` object.
+As defined by our data model, ``projects`` are an :term:`embedded object`of the ``users`` object.
 Therefore, if we want to retrieve a list of projects, we'll have to access the :ref:`user custom 
 data object </users/enable-custom-user-data>`. 
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12694

### Docs staging link (requires sign-in on MongoDB Corp SSO):
iOS Swift tutorial: https://docs-mongodbcom-staging.corp.mongodb.com/realm/lisbethlazala/add-sdk-tip-to-tutorials/tutorial/ios-swift.html#define-the-object-models
Android: https://docs-mongodbcom-staging.corp.mongodb.com/realm/lisbethlazala/add-sdk-tip-to-tutorials/tutorial/android-kotlin.html#implement-the-projects-list
React Native: https://docs-mongodbcom-staging.corp.mongodb.com/realm/lisbethlazala/add-sdk-tip-to-tutorials/tutorial/android-kotlin.html#implement-the-projects-list
Node.js: https://docs-mongodbcom-staging.corp.mongodb.com/realm/lisbethlazala/add-sdk-tip-to-tutorials/tutorial/nodejs-cli.html#e-implement-the-crud-methods
Web: https://docs-mongodbcom-staging.corp.mongodb.com/realm/lisbethlazala/add-sdk-tip-to-tutorials/tutorial/web-graphql.html#f-implement-the-projects-list
