### PR TITLE
Fix Encrypt unit test

### DIFF
--- a/examples/dotnet/Examples/EncryptionExamples.cs
+++ b/examples/dotnet/Examples/EncryptionExamples.cs
@@ -28,6 +28,8 @@ namespace UnitTests
             // Open or create a realm with the encryption key.
             var realm = Realm.GetInstance(config);
             // :code-block-end:
+            realm.Dispose();
+            Realm.DeleteRealm(config);
         }
     }
 }


### PR DESCRIPTION
- Oops! Encrypted ur realm and lost the key causing subsequent tests to fail.
- Deletes realm when done.
- You may need to `rm -rf ~/*.realm*`
