### PR TITLE
Shouldn't refer to "legos"

### DIFF
--- a/source/mongodb/crud-snippets/deleteOne/functions.rst
+++ b/source/mongodb/crud-snippets/deleteOne/functions.rst
@@ -1,6 +1,6 @@
 .. code-block:: javascript
 
-   const query = { "name": "legos" };
+   const query = { "name": "lego" };
 
    itemsCollection.deleteOne(query)
      .then(result => console.log(`Deleted ${result.deletedCount} item.`))

--- a/source/mongodb/crud-snippets/findOneAndReplace/functions.rst
+++ b/source/mongodb/crud-snippets/findOneAndReplace/functions.rst
@@ -1,8 +1,8 @@
 .. code-block:: javascript
    :emphasize-lines: 12
 
-   // Find the document that describes "legos"
-   const query = { "name": "legos" };
+   // Find the document that describes "lego"
+   const query = { "name": "lego" };
    // Replace it with a new document
    const replacement = {
        "name": "blocks",

--- a/source/mongodb/crud-snippets/findOneAndUpdate/functions.rst
+++ b/source/mongodb/crud-snippets/findOneAndUpdate/functions.rst
@@ -1,8 +1,8 @@
 .. code-block:: javascript
    :emphasize-lines: 14
 
-   // Find the document that describes "legos"
-   const query = { "name": "legos" };
+   // Find the document that describes "lego"
+   const query = { "name": "lego" };
    // Set some fields in that document
    const update = {
      "$set": {

--- a/source/mongodb/crud-snippets/updateOneSetField/functions.rst
+++ b/source/mongodb/crud-snippets/updateOneSetField/functions.rst
@@ -1,6 +1,6 @@
 .. code-block:: javascript
 
-   const query = { "name": "legos" };
+   const query = { "name": "lego" };
    const update = {
      "$set": {
        "name": "blocks",

--- a/source/mongodb/delete-documents.txt
+++ b/source/mongodb/delete-documents.txt
@@ -33,7 +33,7 @@ You can delete a single document from a collection using the
 :method:`collection.deleteOne()` action.
 
 The following :ref:`function <functions>` snippet deletes one document
-in the ``items`` collection that has a ``name`` value of ``legos``:
+in the ``items`` collection that has a ``name`` value of ``lego``:
 
 .. include:: /mongodb/crud-snippets/deleteOne/functions.rst
 

--- a/source/mongodb/update-documents.txt
+++ b/source/mongodb/update-documents.txt
@@ -39,7 +39,7 @@ You can update a single document using the
 :method:`collection.updateOne()` action.
 
 The following :ref:`function <functions>` snippet updates the ``name``
-of a single document in the ``items`` collection from ``legos`` to
+of a single document in the ``items`` collection from ``lego`` to
 ``blocks`` and adds a ``price`` of ``20.99``:
 
 .. include:: /mongodb/crud-snippets/updateOneSetField/functions.rst


### PR DESCRIPTION
"legos" isn't the plural for "Lego"

## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-NNNN

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/NNNNNNN/java/docsworker-xlarge/NNNNNNNNNNN/
