### PR TITLE
(DOCSP-12646): Update React Native to use Realm.Credentials.serverApiKey(apiKey);

### DIFF
--- a/examples/node/.gitignore
+++ b/examples/node/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store/
 node_modules/
 mongodb-realm/
+.env

--- a/source/react-native/authenticate.txt
+++ b/source/react-native/authenticate.txt
@@ -160,48 +160,15 @@ API key and pass it to ``App.logIn()``:
    .. tab::
       :tabid: javascript
       
-      .. code-block:: javascript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginApiKey(apiKey) {
-           // Create an API Key credential
-           const credentials = Realm.Credentials.apiKey(apiKey);
-           try {
-             // Authenticate the user
-             const user = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id)
-             return user
-           } catch(err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginApiKey("To0SQOPC...ZOU0xUYvWw").then(user => {
-           console.log("Successfully logged in!", user)
-         })
+      .. literalinclude:: /examples/generated/code/start/authenticate.codeblock.server-api-key-login.js
+         :language: javascript
    
    .. tab::
       :tabid: typescript
       
-      .. code-block:: typescript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginApiKey(apiKey: string) {
-           // Create an API Key credential
-           const credentials = Realm.Credentials.apiKey(apiKey);
-           try {
-             // Authenticate the user
-             const user: Realm.User = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id)
-             return user
-           } catch(err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginApiKey("To0SQOPC...ZOU0xUYvWw").then(user => {
-           console.log("Successfully logged in!", user)
-         })
+      .. literalinclude:: /examples/generated/code/start/authenticate.codeblock.server-api-key-login.ts
+         :language: typescript
+
 
 .. _react-native-login-custom-function:
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12646

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/mohammad.hunan/DOCSP-12646-Update-API-Key-Method/react-native/authenticate.html#api-key


### Passing Tests:
<img width="799" alt="Screen Shot 2020-10-21 at 10 10 36 AM" src="https://user-images.githubusercontent.com/52428905/96731890-c0bb2380-1385-11eb-8b69-cd994090c7c2.png">


