### PR TITLE
[NextGen Migration] restored graphql type to graphql codeblocks.

### DIFF
--- a/source/graphql.txt
+++ b/source/graphql.txt
@@ -116,7 +116,7 @@ For more information and examples, including a list of all automatically
 generated query types, see :ref:`Query Resolvers
 <graphql-query-resolvers>`.
 
-.. code-block:: text
+.. code-block:: graphql
 
    # Find a single movie by name
    query {
@@ -165,7 +165,7 @@ For more information and examples, including a list of all automatically
 generated mutation types, see :ref:`Mutation Resolvers
 <graphql-mutation-resolvers>`.
 
-.. code-block:: text
+.. code-block:: graphql
 
    # Insert a new movie
    mutation {

--- a/source/graphql/custom-resolvers.txt
+++ b/source/graphql/custom-resolvers.txt
@@ -50,7 +50,7 @@ The resolvers all reference ``Sale`` documents, which have the following schema:
    .. tab:: GraphQL Schema
       :tabid: graphql-schema
       
-      .. code-block:: text
+      .. code-block:: graphql
          
          type Sale {
            _id: ObjectId!
@@ -92,8 +92,7 @@ returns aggregated sales data for a specific month.
 Realm generates schema definitions for the resolver's custom input and payload
 types and adds the resolver to its parent type, the root-level ``Query``:
 
-.. code-block:: text
-   
+.. code-block:: graphql
    
    type Query {
      averageSaleForMonth(input: AverageSaleForMonthInput): AverageSaleForMonthPayload
@@ -155,7 +154,7 @@ The resolver uses the following configuration:
           .. tab:: GraphQL Schema
              :tabid: graphql-schema
              
-             .. code-block:: text
+             .. code-block:: graphql
                 
                 input AverageSalesForMonthInput {
                   month: String!;
@@ -229,7 +228,7 @@ Example Usage
 
 To call this custom query, you could use the following operation and variables:
 
-.. code-block:: text
+.. code-block:: graphql
    
    query GetAverageSaleForMonth($averageSaleInput: AverageSaleForMonthInput!) {
      averageSaleForMonth(input: $averageSaleInput) {
@@ -256,7 +255,7 @@ adds a string note to a specific ``Sale`` document, identified by its ``_id``.
 Realm generates schema definitions for the resolver's custom input type and adds
 the resolver to its parent type, the root-level ``Mutation``:
 
-.. code-block:: text
+.. code-block:: graphql
    
    type Mutation {
      addNoteToSale(input: AddNoteToSaleInput): Sale
@@ -312,7 +311,7 @@ The resolver uses the following configuration:
           .. tab:: GraphQL Schema
              :tabid: graphql-schema
              
-             .. code-block:: text
+             .. code-block:: graphql
                 
                 input AddNoteToSaleInput {
                   sale_id: ObjectId!;
@@ -328,7 +327,7 @@ The resolver uses the following configuration:
           .. tab:: GraphQL Schema
              :tabid: graphql-schema
              
-             .. code-block:: text
+             .. code-block:: graphql
                 
                 type Sale {
                   _id: ObjectId!
@@ -381,7 +380,7 @@ Example Usage
 
 To call this custom query, you could use the following operation and variables:
 
-.. code-block:: text
+.. code-block:: graphql
    
    mutation AddNoteToSale($addNoteToSaleInput: AddNoteToSaleInput) {
      addNoteToSale(input: $addNoteToSaleInput) {
@@ -416,7 +415,7 @@ returns support cases filed by the associated customer.
 Realm generates schema definitions for the resolver's custom payload type and
 adds the resolver to its parent type, ``Sale``:
 
-.. code-block:: text
+.. code-block:: graphql
    :emphasize-lines: 8
    
    type Sale {
@@ -481,7 +480,7 @@ The resolver uses the following configuration:
           .. tab:: GraphQL Schema
              :tabid: graphql-schema
              
-             .. code-block:: text
+             .. code-block:: graphql
                 :emphasize-lines: 13
                 
                 type CustomerSupportCase {
@@ -515,7 +514,7 @@ Example Usage
 
 To use this custom computed property, you could run the following operation:
 
-.. code-block:: text
+.. code-block:: graphql
    :emphasize-lines: 9-12
    
    query GetSalesWithSupportCases {

--- a/source/graphql/expose-data.txt
+++ b/source/graphql/expose-data.txt
@@ -73,7 +73,7 @@ documents in GraphQL read and write operations. For example, you can
 query for a person and include the full document for each of their
 children from the same ``people`` collection:
 
-.. code-block:: text
+.. code-block:: graphql
    
    query {
      person(query: { name: "Molly Weasley" }) {
@@ -322,7 +322,7 @@ There are three situations where you can set the ``title`` field:
       {+service-short+} generates two queries, ``mouse`` (singular) and ``mice``
       (plural), based on the schema:
 
-      .. code-block:: text
+      .. code-block:: graphql
          
          query Mice {
            mouse(query: { _id: "5ebe6819197003ddb1f74475" }) {

--- a/source/graphql/types-and-resolvers.txt
+++ b/source/graphql/types-and-resolvers.txt
@@ -84,7 +84,7 @@ documents in a collection based on the collection schema. The type uses the name
 set in the ``title`` field of the schema or the collection name if no ``title``
 is specified.
 
-.. code-block:: text
+.. code-block:: graphql
    
    type Movie {
      _id: ObjectId
@@ -187,7 +187,7 @@ automatically generates based on each field's type.
      The query returns the title of all movies released in the year 2000 that
      are rated R.
      
-     .. code-block:: text
+     .. code-block:: graphql
         
         movies(query: { rated: "R", year: 2000 }) {
           title
@@ -206,7 +206,7 @@ automatically generates based on each field's type.
      The query returns the title of all movies released after the year 2000 that
      are rated either G or PG-13.
      
-     .. code-block:: text
+     .. code-block:: graphql
         
         movies(query: { rated_in: ["G", "PG-13"], year_gt: 2000 }) {
           title
@@ -254,7 +254,7 @@ Comparison operator fields have the following form:
           
           This query finds all movies that were released after the year 2000:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              movies(query: { year_gt: 2000 }) {
                title
@@ -275,7 +275,7 @@ Comparison operator fields have the following form:
           
           This query finds all movies that were released in or after the year 2000:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              movies(query: { year_gte: 2000 }) {
                title
@@ -295,7 +295,7 @@ Comparison operator fields have the following form:
           
           This query finds all movies that were released before the year 2000:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              movies(query: { year_lt: 2000 }) {
                title
@@ -316,7 +316,7 @@ Comparison operator fields have the following form:
           
           This query finds all movies that were released in or before the year 2000:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              movies(query: { year_lte: 2000 }) {
                title
@@ -337,7 +337,7 @@ Comparison operator fields have the following form:
           
           This query finds all movies that were released in any year other than 2000:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              movies(query: { year_ne: 2000 }) {
                title
@@ -362,7 +362,7 @@ Comparison operator fields have the following form:
           This query finds all movies that feature either or both of Emma Stone
           and Ryan Gosling:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              movies(query: { cast_in: ["Emma Stone", "Ryan Gosling"] }) {
                title
@@ -387,7 +387,7 @@ Comparison operator fields have the following form:
           
           This query finds all movies that are not rated either G or PG-13:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              movies(query: { rated_nin: ["G", "PG-13"] }) {
                title
@@ -428,7 +428,7 @@ Logical operator fields have the following form:
           This query finds all movies that are rated PG-13 *and* have a runtime
           of less than 120 minutes:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              query {
                movies(query: { AND: [{ rated: "PG-13" }, { runtime_lt: 120 }] }) {
@@ -445,7 +445,7 @@ Logical operator fields have the following form:
           
           This query finds all movies that are rated either G or PG-13:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              query {
                movies(query: { OR: [{ rated: "G" }, { rated: "PG-13" }] }) {
@@ -490,7 +490,7 @@ Element operator fields have the following form:
           This query finds all movies that do not have a value defined for the
           ``year`` field:
           
-          .. code-block:: text
+          .. code-block:: graphql
           
              query {
                movies(query: { year_exists: false }) {
@@ -517,7 +517,7 @@ fields.
    
    The mutation inserts a new movie named "My Fake Film".
    
-   .. code-block:: text
+   .. code-block:: graphql
       
       insertOneMovie(input: {
         title: "My Fake Film",
@@ -542,7 +542,7 @@ GraphQL document type.
    The following mutation includes an ``UpdateInput`` that sets the ``title``
    field to "My Super Real Film".
    
-   .. code-block:: text
+   .. code-block:: graphql
       
       updateOneMovie(
         query: { title: "My Fake Film" }
@@ -559,7 +559,7 @@ field in the mutated document. You can reference documents that already exist in
 the related collection with the ``link`` field and insert new documents into the
 related collection with the ``create`` field.
 
-.. code-block:: text
+.. code-block:: graphql
    
    type RelationInput {
      link: [ObjectId]
@@ -576,7 +576,7 @@ related collection with the ``create`` field.
    The mutation sets the relationship to point to one newly created document and
    two existing documents in the ``reviews`` collection.
    
-   .. code-block:: text
+   .. code-block:: graphql
       
       updateOneMovie(
         query: { title: "My Fake Film" }
@@ -610,7 +610,7 @@ direction, either ``ASC`` or ``DESC``.
    The following query returns movies sorted by the year they were released with
    the most recent movies listed first.
    
-   .. code-block:: text
+   .. code-block:: graphql
       
       movies(sortBy: YEAR_DESC) {
         title
@@ -657,7 +657,7 @@ queried type and accepts the following parameters:
        If you do not specify a ``query`` parameter then the query
        operation matches all documents.
 
-.. code-block:: text
+.. code-block:: graphql
    
    query {
      movie(query: { title: "The Matrix" }) {
@@ -722,7 +722,7 @@ accepts the following parameters:
        operation does not guarantee the order of documents in the result
        set.
 
-.. code-block:: text
+.. code-block:: graphql
    
    query {
      movies(
@@ -772,7 +772,7 @@ accepts the following parameters:
        converts GraphQL types in the ``InsertInput`` object into their
        respective BSON type.
 
-.. code-block:: text
+.. code-block:: graphql
    
    mutation {
      insertOneMovie(data: {
@@ -813,7 +813,7 @@ accepts the following parameters:
        GraphQL types in the ``InsertInput`` object into their respective
        BSON type as defined in the collection schema.
 
-.. code-block:: text
+.. code-block:: graphql
    
    mutation {
      insertManyMovies(data: [
@@ -873,7 +873,7 @@ accepts the following parameters:
        unchanged. Realm automatically converts GraphQL types in the
        ``UpdateInput`` object into their respective BSON type.
 
-.. code-block:: text
+.. code-block:: graphql
    
    mutation {
      updateOneMovie(
@@ -924,7 +924,7 @@ modified and accepts the following parameters:
        unchanged. Realm automatically converts GraphQL types in the
        ``UpdateInput`` object into their respective BSON type.
 
-.. code-block:: text
+.. code-block:: graphql
    
    mutation {
      updateManyMovies(
@@ -976,7 +976,7 @@ parameters:
        for that field. Realm automatically converts GraphQL types in
        the ``InsertInput`` object into their respective BSON type.
 
-.. code-block:: text
+.. code-block:: graphql
    
    mutation {
      upsertOneMovie(
@@ -1031,7 +1031,7 @@ accepts the following parameters:
        converts GraphQL types in the ``InsertInput`` object into their
        respective BSON type.
 
-.. code-block:: text
+.. code-block:: graphql
    
    mutation {
      replaceOneMovie(
@@ -1078,7 +1078,7 @@ accepts the following parameters:
        the first document in the result set, which is likely but not
        guaranteed to be the most recently inserted document.
 
-.. code-block:: text
+.. code-block:: graphql
    
    mutation {
      deleteOneMovie(query: { title: "The Room" }) {
@@ -1120,7 +1120,7 @@ accepts the following parameters:
        If you do not specify a ``query`` argument then the mutation
        deletes all documents in the collection.
 
-.. code-block:: text
+.. code-block:: graphql
    
    mutation {
      deleteManyMovies(query: { director: "Tommy Wiseau" }) {

--- a/source/includes/steps-custom-resolvers-ui.yaml
+++ b/source/includes/steps-custom-resolvers-ui.yaml
@@ -49,7 +49,7 @@ content: |
             A custom resolver for a query named ``myCustomQuery`` has the
             following generated schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                type Query {
                  myCustomQuery: DefaultPayload
@@ -64,7 +64,7 @@ content: |
             A custom resolver for a mutation named ``myCustomMutation`` has the
             following generated schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                type Mutation {
                  myCustomMutation: DefaultPayload
@@ -82,7 +82,7 @@ content: |
             type named ``myCustomTaskProperty`` has the following generated
             schema:
 
-            .. code-block:: text
+            .. code-block:: graphql
                
                type Task {
                  myCustomTaskProperty: DefaultPayload
@@ -123,7 +123,7 @@ content: |
             A custom resolver named ``myCustomQuery`` that does not accept an
             input has the following generated schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                type Query {
                  myCustomQuery: DefaultPayload
@@ -147,7 +147,7 @@ content: |
             :guilabel:`Scalar Type` option to specify an input type of
             ``DateTiem`` has the following generated schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                type Query {
                  myCustomQuery(input: DateTime): DefaultPayload
@@ -171,7 +171,7 @@ content: |
             :guilabel:`Existing Type` option to specify an input type of
             ``TaskInsertInput`` has the following generated schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                type Query {
                  myCustomQuery(input: TaskInsertInput): DefaultPayload
@@ -195,7 +195,7 @@ content: |
             :guilabel:`Custom Type` option with an input type named
             ``MyCustomQueryInput`` has the following generated schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                input MyCustomQueryInput {
                  someArgument: String;
@@ -228,7 +228,7 @@ content: |
        - The resolver returns the automatically generated ``DefaultPayload``
          type which has the following signature:
          
-         .. code-block:: text
+         .. code-block:: graphql
             
             type DefaultPayload {
               status: String!
@@ -237,7 +237,7 @@ content: |
          The ``status`` field will always resolve to ``"complete"`` regardless
          of the resolver function's return value.
          
-         .. code-block:: text
+         .. code-block:: graphql
             
             {
               status: "complete"
@@ -253,7 +253,7 @@ content: |
             :guilabel:`DefaultPayload` option has the following generated
             schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                type Query {
                  myCustomQuery: DefaultPayload
@@ -277,7 +277,7 @@ content: |
             :guilabel:`Scalar Type` option to specify a payload type of
             ``DateTime`` has the following generated schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                type Query {
                  myCustomQuery: DateTime
@@ -305,7 +305,7 @@ content: |
             :guilabel:`Existing Type` option to specify a payload type of
             ``[Task]`` has the following generated schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                type Query {
                  myCustomQuery: [Task]
@@ -329,7 +329,7 @@ content: |
             :guilabel:`Custom Type` option with a payload type named
             ``MyCustomQueryPayload`` has the following generated schema:
             
-            .. code-block:: text
+            .. code-block:: graphql
                
                input MyCustomQueryPayload {
                  someValue: String;


### PR DESCRIPTION
## Pull Request Info

### Docs staging link (requires sign-in on MongoDB Corp SSO):
(all graphql code snippets in the GraphQL section are effected)
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/graphql-codeblocks/graphql.html

Restored graphql type to all codeblocks containing graphql, since the [fixit PR](https://github.com/mongodb/docs-realm/pull/578) changed these codeblocks to type "text" to remove oldgen/sphinx build warnings. Since nextgen has done away with pygments in favor of leafygreen syntax highlighting, graphql syntax will finally be supported.

Please do not merge this PR until we're ready for nextgen.
