### PR TITLE
add Decimal128 to supported types

### DIFF
--- a/source/android/objects.txt
+++ b/source/android/objects.txt
@@ -155,8 +155,8 @@ You can configure the following constraints for a given property:
        - String
        - Date
        - Data
-       - org.bson.Decimal128
-       - org.bson.ObjectId
+       - Decimal128 from ``org.bson.types``
+       - ObjectId from ``org.bson.types``
 
    * - Optional
      - Optional properties may contain a null value or be entirely

--- a/source/android/objects.txt
+++ b/source/android/objects.txt
@@ -152,11 +152,11 @@ You can configure the following constraints for a given property:
        - Boolean
        - Integer
        - Double
-       - Decimal128
        - String
        - Date
        - Data
-       - ObjectId
+       - org.bson.Decimal128
+       - org.bson.ObjectId
 
    * - Optional
      - Optional properties may contain a null value or be entirely

--- a/source/android/objects.txt
+++ b/source/android/objects.txt
@@ -137,7 +137,7 @@ You can configure the following constraints for a given property:
 .. list-table::
    :header-rows: 1
    :widths: 20 80
-   
+
    * - Parameter
      - Description
 
@@ -146,12 +146,13 @@ You can configure the following constraints for a given property:
        type. A property's type can be a primitive data type or an object
        type defined in the same {+realm+}. The type also specifies whether
        the property contains a single value or a list of values.
-       
+
        {+client-database+} supports the following primitive data types:
 
        - Boolean
        - Integer
        - Double
+       - Decimal128
        - String
        - Date
        - Data
@@ -166,7 +167,7 @@ You can configure the following constraints for a given property:
      - If a client application creates a new object that does not have a
        value for a defined property, the object uses the default value
        instead.
-       
+
        Objects that are missing a required field without a defined
        default value will fail validation when you attempt to create
        them and will not persist to the {+realm+}.

--- a/source/ios/objects.txt
+++ b/source/ios/objects.txt
@@ -106,6 +106,7 @@ Objective-C.
 
       - Boolean ``Bool``
       - Integral types ``Int``, ``Int8``, ``Int16``, ``Int32``, ``Int64``
+      - ``Decimal128``
       - ``Double``
       - ``String``
       - ``Date``
@@ -127,6 +128,7 @@ Objective-C.
 
       - Boolean types ``BOOL``, ``bool``
       - Integral types ``int``, ``NSInteger``, ``long``, ``long long``
+      - ``RLMDecimal128``
       - ``double``
       - ``NSString``
       - ``NSDate``

--- a/source/node/include/property-schema.rst
+++ b/source/node/include/property-schema.rst
@@ -9,7 +9,7 @@ You can configure the following constraints for a given property:
 .. list-table::
    :header-rows: 1
    :widths: 20 80
-   
+
    * - Parameter
      - Description
 
@@ -18,11 +18,12 @@ You can configure the following constraints for a given property:
        type. A property's type can be a primitive data type or an object
        type defined in the same {+realm+}. The type also specifies whether
        the property contains a single value or a list of values.
-       
+
        {+client-database+} supports the following primitive data types:
 
        - ``bool`` for boolean values
        - ``int`` and ``double``, which map to JavaScript ``number`` values
+       - ``Decimal128`` for high precision numbers
        - ``string``
        - ``date``, which maps to :mdn:`Date <Web/JavaScript/Reference/Global_Objects/Date>`
        - ``data``, which maps to :mdn:`ArrayBuffer <Web/JavaScript/Reference/Global_Objects/ArrayBuffer>`
@@ -35,7 +36,7 @@ You can configure the following constraints for a given property:
        optional, append a question mark (``?``) to its name.
 
        .. example::
-      
+
           The following schema defines an optional string property, ``breed``:
 
           .. literalinclude:: /examples/Schemas/DogSchema.js
@@ -54,7 +55,7 @@ You can configure the following constraints for a given property:
 
        .. code-block:: javascript
           :emphasize-lines: 6
-          
+
           const CarSchema = {
             name: 'Car',
             properties: {


### PR DESCRIPTION
## Pull Request Info
This lists Decimal128 as being supported in iOS (Swift and ObjC), Java, and Node.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12828

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-12828/ios/objects.html#object-model
