### PR TITLE
add apple auth to provider list for triggers docs

### DIFF
--- a/source/includes/auth-provider-internal-names.rst
+++ b/source/includes/auth-provider-internal-names.rst
@@ -1,3 +1,4 @@
+-  ``"oauth2-apple"``
 -  ``"oauth2-google"``
 -  ``"oauth2-facebook"``
 -  ``"custom-token"``


### PR DESCRIPTION
## Pull Request Info
This lists Apple authentication as a potential value (via "oauth2-apple") to be used in authentication triggers.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12862

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-12862/triggers/authentication-triggers.html#authentication-trigger-configuration
