### PR TITLE
removed broken links to dotnet notifications page

### DIFF
--- a/source/dotnet/collections.txt
+++ b/source/dotnet/collections.txt
@@ -26,8 +26,7 @@ You can filter and sort any collection using {+client-database+}'s
 :ref:`query engine <dotnet-client-query-engine>`. Collections are
 :ref:`live <dotnet-live-object>`, so they always reflect the
 current state of the :term:`{+realm+} instance` on the current
-thread. You can also listen for changes in the collection by subscribing
-to :ref:`collection notifications <dotnet-collection-notifications>`.
+thread.
 
 {+client-database+} has two kinds of collections: **lists** and **results**.
 
@@ -69,9 +68,8 @@ There are three cases when a collection is **not** live:
 - The collection is unmanaged, e.g. a List property of a {+service-short+} object that has not been added to a {+realm+} yet or that has been copied from a {+realm+}.
 - The collection is :ref:`frozen <dotnet-frozen-objects>`.
 
-Combined with :ref:`collection notifications
-<dotnet-collection-notifications>`, live collections enable clean,
-reactive code. For example, suppose your view displays the
+Live collections enable clean, reactive code. For example,
+suppose your view displays the
 results of a query. You can keep a reference to the results
 collection in your view class, then read the results
 collection as needed without having to refresh it or

--- a/source/dotnet/objects.txt
+++ b/source/dotnet/objects.txt
@@ -20,8 +20,7 @@ that each contain one or more primitive data types or other {+service-short+}
 objects. :term:`{+service-short+} objects <Realm object>` are essentially the same
 as regular objects, but they also include
 additional features like
-:ref:`real-time updating data views <dotnet-live-object>` and reactive
-:ref:`change event handlers <dotnet-client-notifications>`.
+:ref:`real-time updating data views <dotnet-live-object>`.
 
 Every {+service-short+} object has an *object type* that refers to the object's
 class. Objects of the same type share an :ref:`object schema
@@ -57,9 +56,7 @@ Live Object
 
 Objects in {+service-short+} clients are **live objects** that
 update automatically to reflect data changes, including
-:doc:`synced </sync>` remote changes, and emit
-:ref:`notification events <dotnet-client-notifications>` that you
-can subscribe to whenever their underlying data changes. You
+:doc:`synced </sync>` remote changes. You
 can use live objects to work with object-oriented data
 natively without an :wikipedia:`ORM
 <Object-relational_mapping>` tool.

--- a/source/dotnet/realms.txt
+++ b/source/dotnet/realms.txt
@@ -21,10 +21,8 @@ than one type of data as long as a schema exists for each type.
 
 A {+realm+} allows you to partition data according to who uses it and when they use it.
 Every {+realm+} stores data in a separate :term:`{+realm+} file` that contains a binary
-encoding of each object in the {+realm+}. You can automatically :doc:`synchronize
-a {+realm+} across multiple devices </sync>` and set up :ref:`reactive event handlers
-<dotnet-client-notifications>` that call a function any time an object in a {+realm+} is
-created, modified, or deleted.
+encoding of each object in the {+realm+}. You can automatically synchronize
+a {+realm+} across multiple devices with :doc:`{+sync+} </sync>`.
 
 Comparison with Other Databases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/dotnet/threading.txt
+++ b/source/dotnet/threading.txt
@@ -103,9 +103,6 @@ several options depending on your use case:
 - To work modify the data on two threads, :ref:`query <dotnet-client-query-engine>`
   for the object on both threads.
 
-- To react to changes made on any thread, use {+client-database+}'s
-  :ref:`notifications <dotnet-client-notifications>`.
-
 - To see changes from other threads in the {+realm+} on the current
   thread, :ref:`refresh <dotnet-refreshing-realms>` your {+realm+} instance.
 


### PR DESCRIPTION
## Pull Request Info
Noticed warnings for all of the links to the dotnet notifications ref. Removing those broken links to prevent user confusion about a missing feature and fix warnings in the build.

### Docs staging link (requires sign-in on MongoDB Corp SSO):
Changes to the objects, realms, collections, and threading dotnet pages:
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/dotnetnotificationsremove/dotnet.html
