### PR TITLE
added notifications page back

### DIFF
--- a/source/dotnet.txt
+++ b/source/dotnet.txt
@@ -129,6 +129,7 @@ To learn how to handle schema updates in your client application, see
    Writes </dotnet/writes>
    Reads </dotnet/reads>
    Query Engine </dotnet/query-engine>
+   Notifications </dotnet/notifications>
    Threading </dotnet/threading>
    Encrypt a Realm </dotnet/encrypt>
 

--- a/source/dotnet/notifications.txt
+++ b/source/dotnet/notifications.txt
@@ -1,0 +1,166 @@
+.. _dotnet-client-notifications:
+
+=============
+Notifications
+=============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+Any modern app should be able to react when data changes,
+regardless of where that change originated. When a user adds
+a new item to a list, you may want to update the UI, show a
+notification, or log a message. When someone updates that
+item, you may want to change its visual state or fire off a
+network request. Finally, when someone deletes the item, you
+probably want to remove it from the UI. Realm's notification
+system allows you to watch for and react to changes in your
+data, independent of the writes that caused the changes.
+
+Realm emits three kinds of notifications:
+
+- :ref:`Realm notifications <dotnet-realm-notifications>` whenever a specific Realm commits a write transaction.
+- :ref:`Collection notifications <dotnet-collection-notifications>` whenever any :term:`Realm object` in a collection changes, including inserts, updates, and deletes.
+- :ref:`Object notifications <dotnet-object-notifications>` whenever a specific Realm object changes, including updates and deletes.
+
+.. _dotnet-subscribe-to-changes:
+
+Subscribe to Changes
+--------------------
+
+Generally, this is how you observe a Realm, collection, or object:
+
+1. Create a notification handler for the Realm, collection, or object notification.
+2. Add the notification handler to the Realm, collection, or object that you want to observe.
+3. Receive a notification token from the call to add the handler. Retain this token as long as you want to observe.
+4. When you are done observing, invalidate the token.
+
+.. _dotnet-realm-notifications:
+
+Realm Notifications
+-------------------
+You can register a notification handler on an entire Realm.
+Realm Database calls the notification handler whenever any write
+transaction involving that Realm is committed. The
+handler receives no information about the change.
+
+This is useful when you want to know that there has been a
+change but do not care to know specifically what changed.
+For example, proof of concept apps often use this
+notification type and simply refresh the entire UI when
+anything changes. As the app becomes more sophisticated and
+performance-sensitive, the app developers shift to more
+granular notifications.
+
+.. example::
+
+  Suppose you are writing a real-time collaborative app. To
+  give the sense that your app is buzzing with collaborative
+  activity, you want to have an indicator that lights up when
+  any change is made. In that case, a realm notification
+  handler would be a great way to drive the code that controls
+  the indicator.
+
+  .. tabs-realm-languages::
+
+    .. tab::
+        :tabid: c-sharp
+
+        .. literalinclude:: /examples/Notifications/RealmNotification.cs
+          :language: csharp
+          :emphasize-lines: 2
+
+
+.. _dotnet-collection-notifications:
+
+Collection Notifications
+------------------------
+
+You can register a notification handler on a specific
+collection within a Realm. The handler receives a
+description of changes since the last notification.
+Specifically, this description consists of three lists of
+indices:
+
+- The indices of the objects that were deleted.
+- The indices of the objects that were inserted.
+- The indices of the objects that were modified.
+
+.. admonition:: Order Matters
+   :class: important
+
+   In collection notification handlers, always apply changes
+   in the following order: deletions, insertions, then
+   modifications. Handling insertions before deletions may
+   result in unexpected behavior.
+
+Realm Database emits an initial notification after retrieving the
+collection. After that, Realm Database delivers collection
+notifications asynchronously whenever a write transaction
+adds, changes, or removes objects in the collection.
+
+Unlike Realm notifications, collection notifications contain
+detailed information about the change. This enables
+sophisticated and selective reactions to changes. Collection
+notifications provide all the information needed to manage a
+list or other view that represents the collection in the UI.
+
+.. example::
+
+  The following code shows how to observe a collection for
+  changes in order to update the UI.
+
+  .. tabs-realm-languages::
+
+    .. tab::
+        :tabid: c-sharp
+
+        .. literalinclude:: /examples/Notifications/CollectionNotification.cs
+          :language: csharp
+          :emphasize-lines: 2
+
+
+.. _dotnet-object-notifications:
+
+Object Notifications
+--------------------
+
+You can register a notification handler on a specific object
+within a Realm. Realm Database notifies your handler:
+
+- When the object is deleted.
+- When any of the object's properties change.
+
+The handler receives information about what fields changed
+and whether the object was deleted.
+
+.. example::
+
+  The following code shows how to open a default realm, create
+  a new instance of a class, and observe that instance for
+  changes.
+
+  .. tabs-realm-languages::
+
+    .. tab::
+        :tabid: c-sharp
+
+        .. literalinclude:: /examples/Notifications/ObjectNotification.cs
+          :language: csharp
+          :emphasize-lines: 22
+
+
+Summary
+-------
+
+- Notifications allow you to watch for and react to changes on your objects, collections, and Realms.
+- When you add a notification handler to an object, collection, or Realm that you wish to observe, you receive a token. Retain this token as long as you wish to keep observing.
+- Realm Database has three notification types: Realm, collection, and object notifications. Realm notifications only tell you that something changed, while collection and object notifications allow for more granular observation.

--- a/source/dotnet/notifications.txt
+++ b/source/dotnet/notifications.txt
@@ -146,8 +146,7 @@ You can register a notification handler on a specific object
 within a Realm. Realm Database notifies your handler when any of the object's 
 properties change.
 
-The handler receives information about what fields changed
-and whether the object was deleted.
+The handler receives information about what fields have changed.
 
 .. example::
 

--- a/source/dotnet/notifications.txt
+++ b/source/dotnet/notifications.txt
@@ -16,17 +16,16 @@ Notifications
 
    Notifications only work when your {+realm+} regularly refreshes.
    In the Main or UI thread of your application, {+realm+} refreshes
-   happen automatically using a `Looper
-   <https://developer.xamarin.com/api/type/Android.OS.Looper/>`__.
-   In background threads, you need to handle this
+   happen automatically.
+   On background threads, you need to handle this
    yourself by either calling :dotnet-sdk:`Realm.Refresh()
    <reference/Realms.Realm.html#Realms_Realm_Refresh>` or installing a
    `SynchronizationContext
    <https://msdn.microsoft.com/en-us/library/system.threading.synchronizationcontext(v=vs.110).aspx>`__
    on the thread before opening the {+realm+}. The third-party library
    `Nito.AsyncEx.Context <https://www.nuget.org/packages/Nito.AsyncEx.Context/1.1.0>`__
-   provides an even easier method of regularly refreshing background
-   thread {+realm+}s.
+   provides a ``SynchronizationContext`` implementation and a convenient API to 
+   install it.
 
 Overview
 --------
@@ -36,35 +35,34 @@ regardless of where that change originated. When a user adds
 a new item to a list, you may want to update the UI, show a
 notification, or log a message. When someone updates that
 item, you may want to change its visual state or fire off a
-network request. Finally, when someone deletes the item, you
+network request. Finally, when someone deletes an item, you
 probably want to remove it from the UI. Realm's notification
 system allows you to watch for and react to changes in your
 data, independent of the writes that caused the changes.
 
 Realm emits three kinds of notifications:
 
-- :ref:`Realm notifications <dotnet-realm-notifications>` whenever a specific Realm commits a write transaction.
-- :ref:`Collection notifications <dotnet-collection-notifications>` whenever any :term:`Realm object` in a collection changes, including inserts, updates, and deletes.
-- :ref:`Object notifications <dotnet-object-notifications>` whenever a specific Realm object changes, including updates and deletes.
+- :ref:`Realm notifications <dotnet-realm-notifications>` whenever a specific 
+  Realm commits a write transaction.
+- :ref:`Collection notifications <dotnet-collection-notifications>` whenever 
+  any :term:`Realm object` in a collection changes, including inserts, updates, and deletes.
+- :ref:`Object notifications <dotnet-object-notifications>` whenever a specific 
+  Realm object changes.
 
 .. _dotnet-subscribe-to-changes:
 
 Subscribe to Changes
 --------------------
 
-Generally, this is how you observe a Realm, collection, or object:
-
-1. Create a notification handler for the Realm, collection, or object notification.
-2. Add the notification handler to the Realm, collection, or object that you want to observe.
-3. Receive a notification token from the call to add the handler. Retain this token as long as you want to observe.
-4. When you are done observing, invalidate the token.
+Generally, to observe changes, you create a 
+notification handler for the Realm, collection, or object that you want to watch. 
 
 .. _dotnet-realm-notifications:
 
 Realm Notifications
 -------------------
 You can register a notification handler on an entire Realm.
-Realm Database calls the notification handler whenever any write
+Realm Database invokes the notification handler whenever any write
 transaction involving that Realm is committed. The
 handler receives no information about the change.
 
@@ -84,8 +82,6 @@ granular notifications.
   any change is made. In that case, a realm notification
   handler would be a great way to drive the code that controls
   the indicator.
-
-
 
   .. literalinclude:: /examples/Notifications/RealmNotification.cs
     :language: csharp
@@ -129,13 +125,17 @@ list or other view that represents the collection in the UI.
 .. example::
 
   The following code shows how to observe a collection for
-  changes in order to update the UI.
+  changes in order to update the UI. 
 
 
   .. literalinclude:: /examples/Notifications/CollectionNotification.cs
     :language: csharp
     :emphasize-lines: 2
 
+.. note::
+
+   Every Realm collection implements ``INotifyCollectionChanged``, which allows 
+   you to use a collection directly in data-binding scenarios.
 
 .. _dotnet-object-notifications:
 
@@ -143,10 +143,8 @@ Object Notifications
 --------------------
 
 You can register a notification handler on a specific object
-within a Realm. Realm Database notifies your handler:
-
-- When the object is deleted.
-- When any of the object's properties change.
+within a Realm. Realm Database notifies your handler when any of the object's 
+properties change.
 
 The handler receives information about what fields changed
 and whether the object was deleted.
@@ -161,10 +159,21 @@ and whether the object was deleted.
     :language: csharp
     :emphasize-lines: 22
 
+Unsubscribing from Events
+-------------------------
+When you no longer want to receive notifications on an event, you unsubscribe. 
+The following code demonstrates this:
+
+.. literalinclude:: /examples/Notifications/NotificationUnsub.cs
+   :language: csharp
 
 Summary
 -------
 
-- Notifications allow you to watch for and react to changes on your objects, collections, and Realms.
-- When you add a notification handler to an object, collection, or Realm that you wish to observe, you receive a token. Retain this token as long as you wish to keep observing.
-- Realm Database has three notification types: Realm, collection, and object notifications. Realm notifications only tell you that something changed, while collection and object notifications allow for more granular observation.
+- Notifications allow you to watch for and react to changes on your objects, 
+  collections, and Realms.
+- When you know longer want to receive notifications, you unsubscript from the 
+  event.
+- Realm Database has three notification types: Realm, collection, and object 
+  notifications. Realm notifications only tell you that something changed, while 
+  collection and object notifications allow for more granular observation.

--- a/source/dotnet/notifications.txt
+++ b/source/dotnet/notifications.txt
@@ -85,14 +85,11 @@ granular notifications.
   handler would be a great way to drive the code that controls
   the indicator.
 
-  .. tabs-realm-languages::
 
-    .. tab::
-        :tabid: c-sharp
 
-        .. literalinclude:: /examples/Notifications/RealmNotification.cs
-          :language: csharp
-          :emphasize-lines: 2
+  .. literalinclude:: /examples/Notifications/RealmNotification.cs
+    :language: csharp
+    :emphasize-lines: 2
 
 
 .. _dotnet-collection-notifications:
@@ -134,14 +131,10 @@ list or other view that represents the collection in the UI.
   The following code shows how to observe a collection for
   changes in order to update the UI.
 
-  .. tabs-realm-languages::
 
-    .. tab::
-        :tabid: c-sharp
-
-        .. literalinclude:: /examples/Notifications/CollectionNotification.cs
-          :language: csharp
-          :emphasize-lines: 2
+  .. literalinclude:: /examples/Notifications/CollectionNotification.cs
+    :language: csharp
+    :emphasize-lines: 2
 
 
 .. _dotnet-object-notifications:
@@ -164,14 +157,9 @@ and whether the object was deleted.
   a new instance of a class, and observe that instance for
   changes.
 
-  .. tabs-realm-languages::
-
-    .. tab::
-        :tabid: c-sharp
-
-        .. literalinclude:: /examples/Notifications/ObjectNotification.cs
-          :language: csharp
-          :emphasize-lines: 22
+  .. literalinclude:: /examples/Notifications/ObjectNotification.cs
+    :language: csharp
+    :emphasize-lines: 22
 
 
 Summary

--- a/source/dotnet/notifications.txt
+++ b/source/dotnet/notifications.txt
@@ -12,6 +12,22 @@ Notifications
    :depth: 2
    :class: singlecol
 
+.. note::
+
+   Notifications only work when your {+realm+} regularly refreshes.
+   In the Main or UI thread of your application, {+realm+} refreshes
+   happen automatically using a `Looper
+   <https://developer.xamarin.com/api/type/Android.OS.Looper/>`.
+   In background threads, you need to handle this
+   yourself by either calling :dotnet-sdk:`Realm.Refresh()
+   <reference/Realms.Realm.html#Realms_Realm_Refresh>` or installing a
+   `SynchronizationContext
+   <https://msdn.microsoft.com/en-us/library/system.threading.synchronizationcontext(v=vs.110).aspx>`__
+   on the thread before opening the {+realm+}. The third-party library
+   `Nito.AsyncEx.Context <https://www.nuget.org/packages/Nito.AsyncEx.Context/1.1.0>`__
+   provides an even easier method of regularly refreshing background
+   thread {+realm+}s.
+
 Overview
 --------
 

--- a/source/dotnet/notifications.txt
+++ b/source/dotnet/notifications.txt
@@ -17,7 +17,7 @@ Notifications
    Notifications only work when your {+realm+} regularly refreshes.
    In the Main or UI thread of your application, {+realm+} refreshes
    happen automatically using a `Looper
-   <https://developer.xamarin.com/api/type/Android.OS.Looper/>`.
+   <https://developer.xamarin.com/api/type/Android.OS.Looper/>`__.
    In background threads, you need to handle this
    yourself by either calling :dotnet-sdk:`Realm.Refresh()
    <reference/Realms.Realm.html#Realms_Realm_Refresh>` or installing a

--- a/source/dotnet/notifications.txt
+++ b/source/dotnet/notifications.txt
@@ -150,8 +150,7 @@ The handler receives information about what fields have changed.
 
 .. example::
 
-  The following code shows how to open a default realm, create
-  a new instance of a class, and observe that instance for
+  The following code shows how to observe a specific object for
   changes.
 
   .. literalinclude:: /examples/Notifications/ObjectNotification.cs

--- a/source/examples/Notifications/NotificationUnsub.cs
+++ b/source/examples/Notifications/NotificationUnsub.cs
@@ -1,0 +1,21 @@
+private IQueryable<Task> tasks;
+
+public void LoadUI()
+{
+    tasks = realm.All<Task>();
+
+    // Subscribe for notifications - since tasks is IQueryable<Task>, we're
+    // using the AsRealmCollection extension method to cast it to IRealmCollection
+    tasks.AsRealmCollection().CollectionChanged += OnTasksChanged;
+}
+
+public void UnloadUI()
+{
+    // Unsubscribe from notifications
+    tasks.AsRealmCollection().CollectionChanged -= OnTasksChanged;
+}
+
+private void OnTasksChanged(object sender, NotifyCollectionChangedEventArgs args)
+{
+    // Do something with the notification information
+}

--- a/source/examples/Notifications/ObjectNotification.cs
+++ b/source/examples/Notifications/ObjectNotification.cs
@@ -3,27 +3,15 @@ public class Dog : RealmObject
 {
     [MapTo("name")]
     public string Name { get; set; }
+
+    // etc..
 }
 
-// ... elsewhere, as a method of another class
-async void example()
-{
-    // Open the default realm.
-    var realm = await Realm.GetInstanceAsync();
-    var dog = new Dog();
-    dog.Name = "Max";
-    // Add the dog to the realm.
-    realm.Write(() =>
-    {
-        realm.Add(dog);
-    });
+// ... elsewhere:
 
     // Observe object notifications.
     dog.PropertyChanged += (sender, eventArgs) =>
     {
         Debug.WriteLine($"New value set for '{eventArgs.PropertyName}'");
     };
-
-    // Update the dog to trigger the notification.
-    realm.Write(() => dog.Name = "Wolfie"); // => "New value set for 'name'"
 }

--- a/source/examples/Notifications/ObjectNotification.cs
+++ b/source/examples/Notifications/ObjectNotification.cs
@@ -1,17 +1,7 @@
-// Define the dog class.
-public class Dog : RealmObject
+var theKing = realm.All<Person>()
+    .FirstOrDefault(p => p.Name == "Elvis Presley");
+
+theKing.PropertyChanged += (s, e) =>
 {
-    [MapTo("name")]
-    public string Name { get; set; }
-
-    // etc..
-}
-
-// ... elsewhere:
-
-    // Observe object notifications.
-    dog.PropertyChanged += (sender, eventArgs) =>
-    {
-        Debug.WriteLine($"New value set for '{eventArgs.PropertyName}'");
-    };
-}
+    Debug.WriteLine($"New value set for The King: {eventArgs.PropertyName}");
+};


### PR DESCRIPTION
## Pull Request Info
Trying to fix some broken links that currently point to this page (and boast about this functionality).

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/dotnetnotificationsadd/dotnet/notifications.html
