### PR TITLE
Docsp 12991

### DIFF
--- a/source/includes/steps-install-swiftpm.yaml
+++ b/source/includes/steps-install-swiftpm.yaml
@@ -1,0 +1,30 @@
+title: Add Package Dependency
+ref: swiftpm-add-dependency
+content: |
+
+  In Xcode, select ``File`` > ``Swift Packages`` > ``Add Package Dependency``.
+
+---
+title: Specify the Repository
+ref: swiftpm-specify-repository
+content: |
+
+  Copy and paste the following into the search/input box, then click ``Next``.
+
+  .. code-block:: sh
+
+     https://github.com/realm/realm-cocoa.git
+
+---
+title: Specify Options
+ref: swiftpm-specify-options
+content: |
+
+  Leave the default value of ``Up to Next Major``, then click ``Next``.
+
+---
+title: Select the Package Products
+ref: swiftpm-package-products
+content: |
+
+  Select both ``Realm`` and ``RealmSwift``, then click ``Finish``.

--- a/source/ios/install.txt
+++ b/source/ios/install.txt
@@ -34,8 +34,16 @@ meets the following prerequisites:
 Installation
 ------------
 
-Follow these steps to add the {+service+} Apple platform SDK to
-your project.
+Follow the procedure for either ``SwiftPM`` or ``CocoaPods`` below to add the
+{+service+} Apple platform SDK to your project.
+
+SwiftPM
+=======
+
+.. include:: /includes/steps/install-swiftpm.rst
+
+CocoaPods
+=========
 
 .. include:: /includes/steps/install-cocoapods.rst
 


### PR DESCRIPTION
## Pull Request Info
This adds SwiftPM steps to iOS installation and positions them above CocoaPods.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12991

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-12991/ios/install.html#installation
