### PR TITLE
(DOCSP-11206): Add links to client SDK examples of auth providers

### DIFF
--- a/source/authentication/anonymous.txt
+++ b/source/authentication/anonymous.txt
@@ -111,6 +111,52 @@ Configuration
    The anonymous authentication provider does not have any
    provider-specific configuration options.
 
+.. _anonymous-authentication-examples:
+
+Examples
+--------
+
+For code examples that demonstrate how to register and log in using
+anonymous authentication, see the documentation for the Realm SDKs:
+
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      To register or log in an anonymous user from the Android Client SDK, see the
+      :ref:`Android SDK guide to anonymous authentication <android-login-anonymous>`.
+
+   .. tab::
+      :tabid: ios
+
+      To register or log in an anonymous user from the iOS Client SDK, see the
+      :ref:`iOS SDK guide to anonymous authentication <ios-login-anonymous>`.
+
+   .. tab::
+      :tabid: web
+
+      To register or log in an anonymous user from the Web Client SDK, see the
+      :ref:`Web SDK guide to anonymous authentication <web-login-anonymous>`.
+
+   .. tab::
+      :tabid: node
+      
+      To register or log in an anonymous user from the Node Client SDK, see the
+      :ref:`Node SDK guide to anonymous authentication <node-login-anonymous>`.
+
+   .. tab::
+      :tabid: react-native
+
+      To register or log in an anonymous user from the React Native Client SDK, see the
+      :ref:`React Native SDK guide to anonymous authentication <react-native-login-anonymous>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      To register or log in an anonymous user from the .NET Client SDK, see the
+      :ref:`.NET SDK guide to anonymous authentication <dotnet-login-anonymous>`.
+
 .. _anonymous-authentication-summary:
 
 Summary

--- a/source/authentication/api-key.txt
+++ b/source/authentication/api-key.txt
@@ -101,6 +101,52 @@ Key`. Enter a unique name for the key and click :guilabel:`Save`.
    Once you leave the provider configuration page or disable the key you
    cannot retrieve the value from the {+ui+}.
 
+.. _api-key-authentication-examples:
+
+Examples
+--------
+
+For code examples that demonstrate how to register and log in using
+API Key authentication, see the documentation for the Realm SDKs:
+
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      To register or log in an API Key user from the Android Client SDK, see the
+      :ref:`Android SDK guide to API Key authentication <android-login-api-key>`.
+
+   .. tab::
+      :tabid: ios
+
+      To register or log in an API Key user from the iOS Client SDK, see the
+      :ref:`iOS SDK guide to API Key authentication <ios-login-api-key>`.
+
+   .. tab::
+      :tabid: web
+
+      To register or log in an API Key user from the Web Client SDK, see the
+      :ref:`Web SDK guide to API Key authentication <web-login-api-key>`.
+
+   .. tab::
+      :tabid: node
+      
+      To register or log in an API Key user from the Node Client SDK, see the
+      :ref:`Node SDK guide to API Key authentication <node-login-api-key>`.
+
+   .. tab::
+      :tabid: react-native
+
+      To register or log in an API Key user from the React Native Client SDK, see the
+      :ref:`React Native SDK guide to API Key authentication <react-native-login-api-key>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      To register or log in an API Key user from the .NET Client SDK, see the
+      :ref:`.NET SDK guide to API Key authentication <dotnet-login-api-key>`.
+
 .. _api-key-authentication-summary:
 
 Summary

--- a/source/authentication/apple.txt
+++ b/source/authentication/apple.txt
@@ -56,3 +56,49 @@ Configure Apple ID Authentication
 ---------------------------------
 
 .. include:: /includes/steps/apple-auth-configure.rst
+
+.. _apple-authentication-examples:
+
+Examples
+--------
+
+For code examples that demonstrate how to register and log in using
+Apple authentication, see the documentation for the Realm SDKs:
+
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      To register or log in an Apple user from the Android Client SDK, see the
+      :ref:`Android SDK guide to Apple authentication <android-login-apple>`.
+
+   .. tab::
+      :tabid: ios
+
+      To register or log in an Apple user from the iOS Client SDK, see the
+      :ref:`iOS SDK guide to Apple authentication <ios-login-apple>`.
+
+   .. tab::
+      :tabid: web
+
+      To register or log in an Apple user from the Web Client SDK, see the
+      :ref:`Web SDK guide to Apple authentication <web-login-apple>`.
+
+   .. tab::
+      :tabid: node
+      
+      To register or log in an Apple user from the Node Client SDK, see the
+      :ref:`Node SDK guide to Apple authentication <node-login-apple>`.
+
+   .. tab::
+      :tabid: react-native
+
+      To register or log in an Apple user from the React Native Client SDK, see the
+      :ref:`React Native SDK guide to Apple authentication <react-native-login-apple>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      To register or log in an Apple user from the .NET Client SDK, see the
+      :ref:`.NET SDK guide to Apple authentication <dotnet-login-google>`.

--- a/source/authentication/custom-function.txt
+++ b/source/authentication/custom-function.txt
@@ -57,6 +57,52 @@ Configuration
 
       .. include:: /includes/steps/configure-custom-function-auth-import-export.rst
 
+.. _custom-function-authentication-examples:
+
+Examples
+--------
+
+For code examples that demonstrate how to register and log in using
+Custom Function authentication, see the documentation for the Realm SDKs:
+
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      To register or log in a Custom Function user from the Android Client SDK, see the
+      :ref:`Android SDK guide to Custom Function authentication <android-login-custom-function>`.
+
+   .. tab::
+      :tabid: ios
+
+      To register or log in a Custom Function user from the iOS Client SDK, see the
+      :ref:`iOS SDK guide to Custom Function authentication <ios-login-custom-function>`.
+
+   .. tab::
+      :tabid: web
+
+      To register or log in a Custom Function user from the Web Client SDK, see the
+      :ref:`Web SDK guide to Custom Function authentication <web-login-custom-function>`.
+
+   .. tab::
+      :tabid: node
+      
+      To register or log in a Custom Function user from the Node Client SDK, see the
+      :ref:`Node SDK guide to Custom Function authentication <node-login-custom-function>`.
+
+   .. tab::
+      :tabid: react-native
+
+      To register or log in a Custom Function user from the React Native Client SDK, see the
+      :ref:`React Native SDK guide to Custom Function authentication <react-native-login-custom-function>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      To register or log in a Custom Function user from the .NET Client SDK, see the
+      :ref:`.NET SDK guide to Custom Function authentication <dotnet-login-custom-function>`.
+
 .. _custom-function-authentication-summary:
 
 Summary

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -589,6 +589,52 @@ algorithm specified in the ``"alg"`` field of the header.
      signingKey
    )
 
+.. _custom-jwt-authentication-examples:
+
+Examples
+--------
+
+For code examples that demonstrate how to register and log in using
+Custom JWT authentication, see the documentation for the Realm SDKs:
+
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      To register or log in a Custom JWT user from the Android Client SDK, see the
+      :ref:`Android SDK guide to Custom JWT authentication <android-login-custom-jwt>`.
+
+   .. tab::
+      :tabid: ios
+
+      To register or log in a Custom JWT user from the iOS Client SDK, see the
+      :ref:`iOS SDK guide to Custom JWT authentication <ios-login-custom-jwt>`.
+
+   .. tab::
+      :tabid: web
+
+      To register or log in a Custom JWT user from the Web Client SDK, see the
+      :ref:`Web SDK guide to Custom JWT authentication <web-login-custom-jwt>`.
+
+   .. tab::
+      :tabid: node
+      
+      To register or log in a Custom JWT user from the Node Client SDK, see the
+      :ref:`Node SDK guide to Custom JWT authentication <node-login-custom-jwt>`.
+
+   .. tab::
+      :tabid: react-native
+
+      To register or log in a Custom JWT user from the React Native Client SDK, see the
+      :ref:`React Native SDK guide to Custom JWT authentication <react-native-login-custom-jwt>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      To register or log in a Custom JWT user from the .NET Client SDK, see the
+      :ref:`.NET SDK guide to Custom JWT authentication <dotnet-login-custom-jwt>`.
+
 .. _custom-jwt-authentication-summary:
 
 Summary

--- a/source/authentication/email-password.txt
+++ b/source/authentication/email-password.txt
@@ -474,6 +474,52 @@ A custom password reset function is generally structured as follows:
    to always return a ``pending`` status after sending the actual account owner
    a message via a trusted mode of communication.
 
+.. _email-password-authentication-examples:
+
+Examples
+--------
+
+For code examples that demonstrate how to register and log in using
+email/password authentication, see the documentation for the Realm SDKs:
+
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      To register or log in an email/password user from the Android Client SDK, see the
+      :ref:`Android SDK guide to email/password authentication <android-login-email-password>`.
+
+   .. tab::
+      :tabid: ios
+
+      To register or log in an email/password user from the iOS Client SDK, see the
+      :ref:`iOS SDK guide to email/password authentication <ios-login-email-password>`.
+
+   .. tab::
+      :tabid: web
+
+      To register or log in an email/password user from the Web Client SDK, see the
+      :ref:`Web SDK guide to email/password authentication <web-login-email-password>`.
+
+   .. tab::
+      :tabid: node
+      
+      To register or log in an email/password user from the Node Client SDK, see the
+      :ref:`Node SDK guide to email/password authentication <node-login-email-password>`.
+
+   .. tab::
+      :tabid: react-native
+
+      To register or log in an email/password user from the React Native Client SDK, see the
+      :ref:`React Native SDK guide to email/password authentication <react-native-login-email-password>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      To register or log in an email/password user from the .NET Client SDK, see the
+      :ref:`.NET SDK guide to email/password authentication <dotnet-login-email-password>`.
+
 .. _email-password-authentication-summary:
 
 Summary

--- a/source/authentication/facebook.txt
+++ b/source/authentication/facebook.txt
@@ -176,3 +176,50 @@ walk through creating the app, setting up Facebook Login,
 and configuring the provider to connect with the app.
 
 .. include:: /includes/steps/auth-facebook-app-setup.rst
+
+.. _facebook-authentication-examples:
+
+Examples
+--------
+
+For code examples that demonstrate how to register and log in using
+Facebook authentication, see the documentation for the Realm SDKs:
+
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      To register or log in a Facebook user from the Android Client SDK, see the
+      :ref:`Android SDK guide to Facebook authentication <android-login-facebook>`.
+
+   .. tab::
+      :tabid: ios
+
+      To register or log in a Facebook user from the iOS Client SDK, see the
+      :ref:`iOS SDK guide to Facebook authentication <ios-login-facebook>`.
+
+   .. tab::
+      :tabid: web
+
+      To register or log in a Facebook user from the Web Client SDK, see the
+      :ref:`Web SDK guide to Facebook authentication <web-login-facebook>`.
+
+   .. tab::
+      :tabid: node
+      
+      To register or log in a Facebook user from the Node Client SDK, see the
+      :ref:`Node SDK guide to Facebook authentication <node-login-facebook>`.
+
+   .. tab::
+      :tabid: react-native
+
+      To register or log in a Facebook user from the React Native Client SDK, see the
+      :ref:`React Native SDK guide to Facebook authentication <react-native-login-facebook>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      To register or log in a Facebook user from the .NET Client SDK, see the
+      :ref:`.NET SDK guide to Facebook authentication <dotnet-login-facebook>`.
+

--- a/source/authentication/google.txt
+++ b/source/authentication/google.txt
@@ -176,3 +176,49 @@ following steps walk through creating the project, generating OAuth
 credentials, and configuring the provider to connect with the project.
 
 .. include:: /includes/steps/auth-google-project-setup.rst
+
+.. _google-authentication-examples:
+
+Examples
+--------
+
+For code examples that demonstrate how to register and log in using
+Google authentication, see the documentation for the Realm SDKs:
+
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      To register or log in a Google user from the Android Client SDK, see the
+      :ref:`Android SDK guide to Google authentication <android-login-google>`.
+
+   .. tab::
+      :tabid: ios
+
+      To register or log in a Google user from the iOS Client SDK, see the
+      :ref:`iOS SDK guide to Google authentication <ios-login-google>`.
+
+   .. tab::
+      :tabid: web
+
+      To register or log in a Google user from the Web Client SDK, see the
+      :ref:`Web SDK guide to Google authentication <web-login-google>`.
+
+   .. tab::
+      :tabid: node
+      
+      To register or log in a Google user from the Node Client SDK, see the
+      :ref:`Node SDK guide to Google authentication <node-login-google>`.
+
+   .. tab::
+      :tabid: react-native
+
+      To register or log in a Google user from the React Native Client SDK, see the
+      :ref:`React Native SDK guide to Google authentication <react-native-login-google>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      To register or log in a Google user from the .NET Client SDK, see the
+      :ref:`.NET SDK guide to Google authentication <dotnet-login-google>`.

--- a/source/functions/call-a-function.txt
+++ b/source/functions/call-a-function.txt
@@ -107,3 +107,9 @@ a Client SDK or over the :ref:`wire protocol <wire-protocol-usage-call-function>
 
       To execute a function from the React Native Client SDK, see the
       :ref:`React Native SDK guide for calling a function <react-native-call-a-function>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      To execute a function from the .NET Client SDK, see the
+      :ref:`.NET SDK guide for calling a function <dotnet-call-a-function>`.


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-11206

### Docs staging link (requires sign-in on MongoDB Corp SSO):
All auth pages in the "Users & Authentication" section:
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12889/authentication/apple.html#examples
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12889/authentication/anonymous.html#examples
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12889/authentication/email-password.html#examples
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12889/authentication/custom-jwt.html#examples
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12889/authentication/custom-function.html#examples
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12889/authentication/api-key.html#examples
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12889/authentication/facebook.html#examples
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12889/authentication/google.html#examples

and added a dotnet link to the "call a function" page:
https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/DOCSP-12889/functions/call-a-function.html#call-from-a-client-application
