### PR TITLE
fixed emphasize-lines incorrect line

### DIFF
--- a/source/dotnet/notifications.txt
+++ b/source/dotnet/notifications.txt
@@ -129,8 +129,8 @@ list or other view that represents the collection in the UI.
 
 
   .. literalinclude:: /examples/Notifications/CollectionNotification.cs
-    :language: csharp
-    :emphasize-lines: 2
+     :language: csharp
+     :emphasize-lines: 2
 
 .. note::
 
@@ -154,8 +154,8 @@ The handler receives information about what fields have changed.
   changes.
 
   .. literalinclude:: /examples/Notifications/ObjectNotification.cs
-    :language: csharp
-    :emphasize-lines: 4
+     :language: csharp
+     :emphasize-lines: 4
 
 Unsubscribing from Events
 -------------------------

--- a/source/dotnet/notifications.txt
+++ b/source/dotnet/notifications.txt
@@ -155,7 +155,7 @@ The handler receives information about what fields have changed.
 
   .. literalinclude:: /examples/Notifications/ObjectNotification.cs
     :language: csharp
-    :emphasize-lines: 22
+    :emphasize-lines: 4
 
 Unsubscribing from Events
 -------------------------


### PR DESCRIPTION
## Pull Request Info

There ain't 22 lines in that code snippet lol

https://docs-mongodbcom-staging.corp.mongodb.com/realm/nathan.contino/notificationsfix/dotnet/notifications.html

For some reason syntax highlights are still broken, though.
