### PR TITLE
cursor.skip() for queries/aggregations in functions

### DIFF
--- a/source/includes/extracts-mongodb-action.yaml
+++ b/source/includes/extracts-mongodb-action.yaml
@@ -404,11 +404,13 @@ content: |
             documents using ``cursor.next()`` or ``cursor.toArray()``.
 
      * - ``cursor.skip(amount)``
-       - Specifies the number of matching documents to skip before
-         including matches in the query result set.
-
+       - Specifies a number of matching documents to omit from the query result
+         set. MongoDB omits documents from the result set in sort order until it
+         has skipped the specified number. If the query also specifies a limit,
+         skipped documents do not count towards the limit threshold.
+         
          .. note::
-
+            
             You cannot call this method after retrieving one or more
             documents using ``cursor.next()`` or ``cursor.toArray()``.
 
@@ -471,6 +473,16 @@ content: |
 
                collection.aggregate(pipeline).toArray()
                  .then(docs => console.log("all documents", docs))
+
+     * - ``cursor.skip(amount)``
+       - Specifies a number of matching documents to omit from the aggregation
+         result set. MongoDB omits documents from the result set in sort order
+         until it has skipped the specified number.
+         
+         .. note::
+            
+            You cannot call this method after retrieving one or more
+            documents using ``cursor.next()`` or ``cursor.toArray()``.
 ---
 ref: mongodb-action-params-findOneAndUpdate
 content: |

--- a/source/includes/extracts-mongodb-action.yaml
+++ b/source/includes/extracts-mongodb-action.yaml
@@ -403,6 +403,15 @@ content: |
             You cannot call this method after retrieving one or more
             documents using ``cursor.next()`` or ``cursor.toArray()``.
 
+     * - ``cursor.skip(amount)``
+       - Specifies the number of matching documents to skip before
+         including matches in the query result set.
+
+         .. note::
+
+            You cannot call this method after retrieving one or more
+            documents using ``cursor.next()`` or ``cursor.toArray()``.
+
      * - ``cursor.next()``
        - Iterates the cursor and returns a :mdn:`Promise
          <Web/JavaScript/Reference/Global_Objects/Promise>` that
@@ -914,4 +923,3 @@ content: |
               - optional session to use for this operation
 
 ...
-


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:

(DOCSP-13202): [REALMC] cursor.skip() for queries/aggregations in functions

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [Cursor.skip()](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/skip/mongodb/actions/collection.find#return-value)
- [AggregationCursor.skip()](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/skip/mongodb/actions/collection.aggregate#return-value)
