### PR TITLE
(DOCSP-13617): QuickFix Remove Electron Not Supported 

### DIFF
--- a/source/node/install.txt
+++ b/source/node/install.txt
@@ -31,9 +31,6 @@ development.
 - For cross-platform mobile app development using web frameworks, use the
   {+service+} :doc:`React Native SDK </react-native/install>`.
 
-- {+service+} does not officially support other front-end frameworks, such as
-  `Electron <https://electronjs.org/>`__.
-
 Prerequisites
 -------------
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13617

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13617-quickfix-electron-support/node/install