### PR TITLE
Move service advice into the table, no longer say "deprecated"

### DIFF
--- a/source/android/migrate.txt
+++ b/source/android/migrate.txt
@@ -27,15 +27,6 @@ New Features
 - The {+service-short+} Android SDK now includes {+client-database+}, which includes
   local object storage and :ref:`{+sync+} <android-sync-data>`.
 
-Deprecated Features
--------------------
-
-- The {+service-short+} SDKs do not provide hooks for calling Services (like the 
-  :ref:`Twilio <twilio-service>` and :ref:`AWS <aws-service>` services). We 
-  recommend using the AWS and/or Twilio ``npm`` packages within {+realm+} 
-  functions to connect to these services moving forward. For more information, 
-  see :doc:`Upload External Dependencies </functions/upload-external-dependencies>`.
-
 Changes
 -------
 
@@ -72,3 +63,6 @@ Changes
 
    * - The BSON package, which contains MongoDB query filters and the ``Document`` data type for reading/writing to MongoDB Atlas has moved from ``com.mongodb.stitch.core.internal.common`` to ``org.bson``.
      - Refactor all imports of the BSON package to use ``io.realm.mongodb.mongo``.
+     
+   * - The {+service-short+} SDK does not provide an interface for calling services such as :ref:`Twilio <twilio-service>` and :ref:`AWS <aws-service>`.
+     - Convert SDK service API usage in your application to Realm functions using the corresponding npm packages. For more information, see :doc:`Upload External Dependencies </functions/upload-external-dependencies>`.


### PR DESCRIPTION
## Pull Request Info

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/deprecated-to-removed/android/migrate
