### PR TITLE
(DOCSP-13771): Update JS MongoDB Service API

### DIFF
--- a/source/includes/steps-crud-snippets-react-native.yaml
+++ b/source/includes/steps-crud-snippets-react-native.yaml
@@ -19,9 +19,9 @@ level: 4
 content: |
   At the top of your source files where you want to use MongoDB Realm,
   add the following line to import the SDK.
-
+  
   .. code-block:: javascript
-
+     
      import Realm from "realm";
 
 ---
@@ -29,34 +29,19 @@ title: Instantiate a MongoDB Collection Handle
 ref: instantiate-a-mongodb-collection-handle
 level: 4
 content: |
-
-  .. code-block:: javascript
-     :emphasize-lines: 18
-
-
-     const appId = "<your App ID>"; // Set Realm app ID here.
-     const appConfig = {
-       id: appId,
-       timeout: 10000, // timeout in milliseconds
-     };
-
-     async function run() {
-       let user;
-       try {
-         const app = new Realm.App(appConfig);
-
-         // an authenticated user is required to access a MongoDB instance
-         user = await app.logIn(Realm.Credentials.anonymous());
-
-         const mongoClient = user.mongoClient("<atlas service name>");
-         const mongoCollection = mongoClient
-           .db("<database name>")
-           .collection("<collection name");
-
-           // the rest of your code ...
-
-        } finally {
-          user.logOut();
-        }
-      }
-      run().catch(console.dir);
+  To access a collection, create MongoDB service handle for the user that you
+  wish to access the collection with:
+  
+  .. tabs-realm-languages::
+     
+     .. tab::
+        :tabid: javascript
+        
+        .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.plants-collection-handle.js
+           :language: javascript
+     
+     .. tab::
+        :tabid: typescript
+        
+        .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.plants-collection-handle.ts
+           :language: typescript

--- a/source/includes/steps-crud-snippets-web.yaml
+++ b/source/includes/steps-crud-snippets-web.yaml
@@ -29,31 +29,19 @@ title: Instantiate a MongoDB Collection Handle
 ref: instantiate-a-mongodb-collection-handle
 level: 4
 content: |
-
-  .. code-block:: javascript
-     :emphasize-lines: 15,16
-
-     const appId = "<your App ID>"; // Set Realm App ID here.
-     const appConfig = {
-       id: appId,
-       timeout: 10000, // timeout in number of milliseconds
-     };
-
-     async function run() {
-       let user;
-       try {
-         const app = new Realm.App(appConfig);
-
-         // an authenticated user is required to access a MongoDB instance
-         user = await app.logIn(Realm.Credentials.anonymous());
-
-         const mongo = app.services.mongodb("<atlas service name>");
-         const mongoCollection = mongo.db("<database name>").collection("<collection name>");
-
-         // the rest of your code ...
-
-        } finally {
-          user.logOut();
-        }
-      }
-      run().catch(console.dir);
+  To access a collection, create MongoDB service handle for the user that you
+  wish to access the collection with:
+  
+  .. tabs-realm-languages::
+     
+     .. tab::
+        :tabid: javascript
+        
+        .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.plants-collection-handle.js
+           :language: javascript
+     
+     .. tab::
+        :tabid: typescript
+        
+        .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.plants-collection-handle.ts
+           :language: typescript

--- a/source/node/mongodb.txt
+++ b/source/node/mongodb.txt
@@ -72,6 +72,7 @@ document or documents to add to MongoDB as an argument and return a
 resolves to an object that contains the results of the execution of the
 operation.
 
+.. _node-mongodb-insertOne:
 
 Insert a Single Document
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -158,6 +159,8 @@ Running this snippet produces output resembling the following:
       .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-multiple-documents-result.ts
          :language: typescript
 
+.. _node-mongodb-read-documents:
+
 Read Documents
 --------------
 
@@ -212,6 +215,8 @@ Running this snippet produces output resembling the following:
       .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-a-single-document-result.ts
          :language: typescript
 
+.. _node-mongodb-findMany:
+
 Find Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -257,6 +262,8 @@ Running this snippet produces output resembling the following:
       .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-multiple-documents-result.ts
          :language: typescript
 
+.. _node-mongodb-count:
+
 Count Documents in the Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -301,14 +308,18 @@ Running this snippet produces output resembling the following:
       .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.count-documents-in-the-collection-result.ts
          :language: typescript
 
+.. _node-mongodb-update-documents:
+
 Update Documents
 ----------------
 
 These code snippets demonstrate how to update data stored in a MongoDB
-collection from a mobile application. Update operations use query filters
-to specify which documents to update and :manual:`update operators
-</reference/operator/update>` to describe how to mutate documents that
-match the query. Update operations return a :mdn:`Promise <Web/JavaScript/Reference/Global_Objects/Promise>` that resolves to an object that contains the results of the execution of the operation.
+collection from a mobile application. Update operations use query filters to
+specify which documents to update and :manual:`update operators
+</reference/operator/update>` to describe how to mutate documents that match the
+query. Update operations return a :mdn:`Promise
+<Web/JavaScript/Reference/Global_Objects/Promise>` that resolves to an object
+that contains the results of the execution of the operation.
 
 .. _node-mongodb-updateOne:
 
@@ -355,6 +366,8 @@ Running this snippet produces output resembling the following:
       .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-a-single-document-result.ts
          :language: typescript
 
+.. _node-mongodb-updateMany:
+
 Update Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -397,6 +410,8 @@ Running this snippet produces output resembling the following:
       
       .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-multiple-documents-result.ts
          :language: typescript
+
+.. _node-mongodb-upsert:
 
 Upsert Documents
 ~~~~~~~~~~~~~~~~
@@ -452,6 +467,8 @@ Running this snippet produces output resembling the following:
       .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.upsert-documents-result.ts
          :language: typescript
 
+.. _node-mongodb-delete-documents:
+
 Delete Documents
 ----------------
 
@@ -506,6 +523,8 @@ Running this snippet produces output resembling the following:
       
       .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-a-single-document-result.ts
          :language: typescript
+
+.. _node-mongodb-deleteMany:
 
 Delete Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/react-native/mongodb.txt
+++ b/source/react-native/mongodb.txt
@@ -4,6 +4,13 @@
 MongoDB Data Access
 ===================
 
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
 
 The following actions enable access to a linked MongoDB Atlas cluster
 from a React Native application using the {+service-short+} Node SDK.
@@ -37,34 +44,49 @@ document or documents to add to MongoDB as an argument and return a
 resolves to an object that contains the results of the execution of the
 operation.
 
+.. _react-native-mongodb-insertOne:
 
 Insert a Single Document
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can insert a single document using :js-sdk:`collection.insertOne() <Realm.MongoDBCollection.html#insertOne>`.
+You can insert a single document by calling :js-sdk:`collection.insertOne()
+<Realm.MongoDBCollection.html#insertOne>`.
 
 The following snippet inserts a single document describing a "lily of the
 valley" plant into a
 :ref:`collection of documents that describe plants for sale in a group of stores
 <react-native-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const plant = {
-     name: "lily of the valley",
-     sunlight: "full",
-     color: "white",
-     type: "perennial",
-     _partition: "Store 47",
-   };
-   const insertOneResult = await mongoCollection.insertOne(plant);
-   console.log(insertOneResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-a-single-document.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-a-single-document.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-a-single-document-result.js
+         :language: javascript
 
-   { insertedId: 5f1f43972b0979dc01cd786c }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-a-single-document-result.ts
+         :language: typescript
 
 .. _react-native-mongodb-insertMany:
 
@@ -72,51 +94,44 @@ Insert Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can insert multiple documents at the same time using
-:js-sdk:`collection.insertOne() <Realm.MongoDBCollection.html#insertMany>`.
+:js-sdk:`collection.insertMany() <Realm.MongoDBCollection.html#insertMany>`.
 
 The following snippet inserts three documents describing plants into a
 :ref:`collection of documents that describe plants for sale in a group of stores
 <react-native-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const plants = [
-     {
-       name: "rhubarb",
-       sunlight: "full",
-       color: "red",
-       type: "perennial",
-       _partition: "Store 47",
-     },
-     {
-       name: "wisteria lilac",
-       sunlight: "partial",
-       color: "purple",
-       type: "perennial",
-       _partition: "Store 42",
-     },
-     {
-       name: "daffodil",
-       sunlight: "full",
-       color: "yellow",
-       type: "perennial",
-       _partition: "Store 42",
-     },
-   ];
-   const insertManyResult = await mongoCollection.insertMany(plants);
-   console.log(insertManyResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-multiple-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-multiple-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-multiple-documents-result.js
+         :language: javascript
 
-   {
-      insertedIds: [
-        5f1f4500e0ef86239b6d7ae6,
-        5f1f4500e0ef86239b6d7ae7,
-        5f1f4500e0ef86239b6d7ae8
-      ]
-   }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-multiple-documents-result.ts
+         :language: typescript
+
+.. _react-native-mongodb-read-documents:
 
 Read Documents
 --------------
@@ -137,51 +152,89 @@ Find a Single Document
 
 You can find a single document using :js-sdk:`collection.findOne() <Realm.MongoDBCollection.html#findOne>`.
 
-The following snippet finds a single document from the a
+The following snippet finds the document that describes venus flytraps in the
 :ref:`collection of documents that describe plants for sale in a group of stores
-<react-native-mongodb-example-dataset>` where the plant document's ``type``
-field contains the string value "perennial":
+<react-native-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = { type: "perennial" };
-   const perennialResultDocument = await mongoCollection.findOne(queryFilter);
-   console.log(perennialResultDocument);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-a-single-document.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-a-single-document.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-a-single-document-result.js
+         :language: javascript
 
-   {
-     _id: 5f1f4266e0ef86239b6c416c,
-     name: 'venus flytrap',
-     sunlight: 'full',
-     color: 'white',
-     type: 'perennial',
-     _partition: 'Store 42'
-   }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-a-single-document-result.ts
+         :language: typescript
+
+.. _react-native-mongodb-findMany:
 
 Find Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 You can find multiple documents using :js-sdk:`collection.find() <Realm.MongoDBCollection.html#find>`.
 
+The following snippet finds all documents that describe perennial plants in the
+:ref:`collection of documents that describe plants for sale in a group of stores
+<react-native-mongodb-example-dataset>`:
+
 The following snippet finds all documents in a
 :ref:`collection of documents that describe plants for sale in a group of stores
-<react-native-mongodb-example-dataset>` that contain a field named
+<android-mongodb-example-dataset>` that contain a field named
 ``_partition`` with a value of "Store 42":
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const findManyQueryFilter = { _partition: "Store 42" };
-   const allPlantsFromStore42Result = await mongoCollection.find(findManyQueryFilter);
-   console.log(allPlantsFromStore42Result);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-multiple-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-multiple-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-multiple-documents-result.js
+         :language: javascript
 
-   [ { _id: 5f1f4266e0ef86239b6c416c, name: 'venus flytrap', sunlight: 'full', color: 'white', type: 'perennial', _partition: 'Store 42' }, { _id: 5f1f4266e0ef86239b6c416d, name: 'sweet basil', sunlight: 'partial', color: 'green', type: 'annual', _partition: 'Store 42' }, { _id: 5f1f4266e0ef86239b6c416e, name: 'thai basil', sunlight: 'partial', color: 'green', type: 'perennial', _partition: 'Store 42' }, { _id: 5f1f4266e0ef86239b6c416f, name: 'helianthus', sunlight: 'full', color: 'yellow', type: 'annual', _partition: 'Store 42' }, { _id: 5f1f4500e0ef86239b6d7ae7, name: 'wisteria lilac', sunlight: 'partial', color: 'purple', type: 'perennial', _partition: 'Store 42' }, { _id: 5f1f4500e0ef86239b6d7ae8, name: 'daffodil', sunlight: 'full', color: 'yellow', type: 'perennial', _partition: 'Store 42' } ]
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-multiple-documents-result.ts
+         :language: typescript
+
+.. _react-native-mongodb-count:
 
 Count Documents in the Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -196,25 +249,49 @@ The following snippet counts the number of documents in a
 :ref:`collection of documents that describe plants for sale in a group of stores
 <react-native-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const countResult = await mongoCollection.count();
-   console.log(`successfully counted, number of documents in the collection: ${countResult}`);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.count-documents-in-the-collection.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.count-documents-in-the-collection.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.count-documents-in-the-collection-result.js
+         :language: javascript
 
-   successfully counted, number of documents in the collection: 5
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.count-documents-in-the-collection-result.ts
+         :language: typescript
+
+.. _react-native-mongodb-update-documents:
 
 Update Documents
 ----------------
 
 These code snippets demonstrate how to update data stored in a MongoDB
-collection from a mobile application. Update operations use query filters
-to specify which documents to update and :manual:`update operators
-</reference/operator/update>` to describe how to mutate documents that
-match the query. Update operations return a :mdn:`Promise <Web/JavaScript/Reference/Global_Objects/Promise>` that resolves to an object that contains the results of the execution of the operation.
+collection from a mobile application. Update operations use query filters to
+specify which documents to update and :manual:`update operators
+</reference/operator/update>` to describe how to mutate documents that match the
+query. Update operations return a :mdn:`Promise
+<Web/JavaScript/Reference/Global_Objects/Promise>` that resolves to an object
+that contains the results of the execution of the operation.
 
 .. _react-native-mongodb-updateOne:
 
@@ -230,18 +307,38 @@ The following snippet updates a single document in a
 where the ``name`` field contains the value "petunia" and changes the value
 of the first matched document's ``sunlight`` field to "partial":
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = { name: "petunia" };
-   const updateDocument = { sunlight: "partial" };
-   const updateResult = await mongoCollection.updateOne(queryFilter, updateDocument);
-   console.log(updateResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-a-single-document.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-a-single-document.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-a-single-document-result.js
+         :language: javascript
 
-   { matchedCount: 1, modifiedCount: 1 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-a-single-document-result.ts
+         :language: typescript
+
+.. _react-native-mongodb-updateMany:
 
 Update Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -255,18 +352,38 @@ The following snippet updates multiple documents in a
 where the ``_partition`` field contains the value "Store 47" and changes
 the value of the ``_partition`` field of each matching document to "Store 51":
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = { _partition: "Store 47" };
-   const updateDocument = { _partition: "Store 51" };
-   const updateResult = await mongoCollection.updateMany(queryFilter, updateDocument);
-   console.log(updateResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-multiple-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-multiple-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-multiple-documents-result.js
+         :language: javascript
 
-   { matchedCount: 2, modifiedCount: 2 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-multiple-documents-result.ts
+         :language: typescript
+
+.. _react-native-mongodb-upsert:
 
 Upsert Documents
 ~~~~~~~~~~~~~~~~
@@ -291,33 +408,38 @@ Because this snippet sets the ``upsert`` option to ``true``, if no
 document matches the query, MongoDB creates a new document that includes
 both the query filter and specified updates:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = {
-     sunlight: "full",
-     type: "perennial",
-     color: "green",
-     _partition: "Store 47",
-   };
-   const updateDocument = {
-     name: "sweet basil",
-   };
-   const updateOptions = {
-     upsert: true,
-   };
- 
-   const upsertResult = await mongoCollection.updateOne(
-     queryFilter,
-     updateDocument,
-     updateOptions
-   );
-   console.log(upsertResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.upsert-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.upsert-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.upsert-documents-result.js
+         :language: javascript
 
-   { matchedCount: 0, modifiedCount: 0, upsertedId: 5f1f63055512f2cb67f460a3 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.upsert-documents-result.ts
+         :language: typescript
+
+.. _react-native-mongodb-delete-documents:
 
 Delete Documents
 ----------------
@@ -343,17 +465,38 @@ The following snippet deletes one document in a
 document where the ``color`` field has a value of "green" and deletes
 the first document that matches the query:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = { color: "green" };
-   const deleteResult = await mongoCollection.deleteOne(queryFilter);
-   console.log(deleteResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-a-single-document.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-a-single-document.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-a-single-document-result.js
+         :language: javascript
 
-   { deletedCount: 1 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-a-single-document-result.ts
+         :language: typescript
+
+.. _react-native-mongodb-deleteMany:
 
 Delete Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -361,27 +504,40 @@ Delete Multiple Documents
 You can delete multiple items from a collection using
 :js-sdk:`collection.deleteMany() <Realm.MongoDBCollection.html#deleteMany>`.
 
-The following snippet deletes all documents in a
-:ref:`collection of documents that describe plants for sale in a group of stores
-<android-mongodb-example-dataset>`
-that match the query filter that matches documents containing both
-a ``sunlight`` field value of "full" and a ``type`` field value of
-"annual".
+The following snippet deletes all documents for plants that are in "Store 51" in
+a :ref:`collection of documents that describe plants for sale in a group of
+stores <react-native-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = {
-     sunlight: "full",
-     type: "annual",
-   };
-   const deleteManyResult = await mongoCollection.deleteMany(queryFilter);
-   console.log(deleteManyResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-multiple-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-multiple-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-multiple-documents-result.js
+         :language: javascript
 
-   { deletedCount: 2 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-multiple-documents-result.ts
+         :language: typescript
 
 .. _react-native-mongodb-watch:
 
@@ -475,18 +631,36 @@ The following snippet groups all documents in the ``plants``
 collection by their ``type`` value and aggregates a count of the
 number of each type:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const aggregationResult = await mongoCollection.aggregate([
-     { $group: { _id: "$type", total: { $sum: 1 } } },
-   ]);
-   console.log(aggregationResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.aggregate-documents-in-a-collection.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.aggregate-documents-in-a-collection.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.aggregate-documents-in-a-collection-result.js
+         :language: javascript
 
-   [ { _id: 'perennial', total: 2 }, { _id: 'annual', total: 1 } ]
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.aggregate-documents-in-a-collection-result.ts
+         :language: typescript
 
 Aggregation Stages
 ------------------

--- a/source/web/mongodb.txt
+++ b/source/web/mongodb.txt
@@ -4,6 +4,13 @@
 MongoDB Data Access
 ===================
 
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
 
 The following actions enable access to a linked MongoDB Atlas cluster
 from a Web app using the  {+service-short+} Web SDK.
@@ -37,34 +44,49 @@ document or documents to add to MongoDB as an argument and return a
 resolves to an object that contains the results of the execution of the
 operation.
 
+.. _web-mongodb-insertOne:
 
 Insert a Single Document
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can insert a single document using :js-sdk:`collection.insertOne() <Realm.MongoDBCollection.html#insertOne>`.
+You can insert a single document by calling :js-sdk:`collection.insertOne()
+<Realm.MongoDBCollection.html#insertOne>`.
 
 The following snippet inserts a single document describing a "lily of the
 valley" plant into a
 :ref:`collection of documents that describe plants for sale in a group of stores
 <web-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const plant = {
-     name: "lily of the valley",
-     sunlight: "full",
-     color: "white",
-     type: "perennial",
-     _partition: "Store 47",
-   };
-   const insertOneResult = await mongoCollection.insertOne(plant);
-   console.log(insertOneResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-a-single-document.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-a-single-document.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-a-single-document-result.js
+         :language: javascript
 
-   { insertedId: 5f1f43972b0979dc01cd786c }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-a-single-document-result.ts
+         :language: typescript
 
 .. _web-mongodb-insertMany:
 
@@ -72,51 +94,44 @@ Insert Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can insert multiple documents at the same time using
-:js-sdk:`collection.insertOne() <Realm.MongoDBCollection.html#insertMany>`.
+:js-sdk:`collection.insertMany() <Realm.MongoDBCollection.html#insertMany>`.
 
 The following snippet inserts three documents describing plants into a
 :ref:`collection of documents that describe plants for sale in a group of stores
 <web-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const plants = [
-     {
-       name: "rhubarb",
-       sunlight: "full",
-       color: "red",
-       type: "perennial",
-       _partition: "Store 47",
-     },
-     {
-       name: "wisteria lilac",
-       sunlight: "partial",
-       color: "purple",
-       type: "perennial",
-       _partition: "Store 42",
-     },
-     {
-       name: "daffodil",
-       sunlight: "full",
-       color: "yellow",
-       type: "perennial",
-       _partition: "Store 42",
-     },
-   ];
-   const insertManyResult = await mongoCollection.insertMany(plants);
-   console.log(insertManyResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-multiple-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-multiple-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-multiple-documents-result.js
+         :language: javascript
 
-   {
-      insertedIds: [
-        5f1f4500e0ef86239b6d7ae6,
-        5f1f4500e0ef86239b6d7ae7,
-        5f1f4500e0ef86239b6d7ae8
-      ]
-   }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.insert-multiple-documents-result.ts
+         :language: typescript
+
+.. _web-mongodb-read-documents:
 
 Read Documents
 --------------
@@ -137,51 +152,89 @@ Find a Single Document
 
 You can find a single document using :js-sdk:`collection.findOne() <Realm.MongoDBCollection.html#findOne>`.
 
-The following snippet finds a single document from the
+The following snippet finds the document that describes venus flytraps in the
 :ref:`collection of documents that describe plants for sale in a group of stores
-<web-mongodb-example-dataset>` where the plant document's ``type``
-field contains the string value "perennial":
+<web-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = { type: "perennial" };
-   const perennialResultDocument = await mongoCollection.findOne(queryFilter);
-   console.log(perennialResultDocument);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-a-single-document.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-a-single-document.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-a-single-document-result.js
+         :language: javascript
 
-   {
-     _id: 5f1f4266e0ef86239b6c416c,
-     name: 'venus flytrap',
-     sunlight: 'full',
-     color: 'white',
-     type: 'perennial',
-     _partition: 'Store 42'
-   }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-a-single-document-result.ts
+         :language: typescript
+
+.. _web-mongodb-findMany:
 
 Find Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 You can find multiple documents using :js-sdk:`collection.find() <Realm.MongoDBCollection.html#find>`.
 
+The following snippet finds all documents that describe perennial plants in the
+:ref:`collection of documents that describe plants for sale in a group of stores
+<web-mongodb-example-dataset>`:
+
 The following snippet finds all documents in a
 :ref:`collection of documents that describe plants for sale in a group of stores
 <android-mongodb-example-dataset>` that contain a field named
 ``_partition`` with a value of "Store 42":
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const findManyQueryFilter = { _partition: "Store 42" };
-   const allPlantsFromStore42Result = await mongoCollection.find(findManyQueryFilter);
-   console.log(allPlantsFromStore42Result);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-multiple-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-multiple-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-multiple-documents-result.js
+         :language: javascript
 
-   [ { _id: 5f1f4266e0ef86239b6c416c, name: 'venus flytrap', sunlight: 'full', color: 'white', type: 'perennial', _partition: 'Store 42' }, { _id: 5f1f4266e0ef86239b6c416d, name: 'sweet basil', sunlight: 'partial', color: 'green', type: 'annual', _partition: 'Store 42' }, { _id: 5f1f4266e0ef86239b6c416e, name: 'thai basil', sunlight: 'partial', color: 'green', type: 'perennial', _partition: 'Store 42' }, { _id: 5f1f4266e0ef86239b6c416f, name: 'helianthus', sunlight: 'full', color: 'yellow', type: 'annual', _partition: 'Store 42' }, { _id: 5f1f4500e0ef86239b6d7ae7, name: 'wisteria lilac', sunlight: 'partial', color: 'purple', type: 'perennial', _partition: 'Store 42' }, { _id: 5f1f4500e0ef86239b6d7ae8, name: 'daffodil', sunlight: 'full', color: 'yellow', type: 'perennial', _partition: 'Store 42' } ]
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.find-multiple-documents-result.ts
+         :language: typescript
+
+.. _web-mongodb-count:
 
 Count Documents in the Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -196,25 +249,49 @@ The following snippet counts the number of documents in a
 :ref:`collection of documents that describe plants for sale in a group of stores
 <web-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const countResult = await mongoCollection.count();
-   console.log(`successfully counted, number of documents in the collection: ${countResult}`);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.count-documents-in-the-collection.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.count-documents-in-the-collection.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.count-documents-in-the-collection-result.js
+         :language: javascript
 
-   successfully counted, number of documents in the collection: 5
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.count-documents-in-the-collection-result.ts
+         :language: typescript
+
+.. _web-mongodb-update-documents:
 
 Update Documents
 ----------------
 
 These code snippets demonstrate how to update data stored in a MongoDB
-collection from a mobile application. Update operations use query filters
-to specify which documents to update and :manual:`update operators
-</reference/operator/update>` to describe how to mutate documents that
-match the query. Update operations return a :mdn:`Promise <Web/JavaScript/Reference/Global_Objects/Promise>` that resolves to an object that contains the results of the execution of the operation.
+collection from a mobile application. Update operations use query filters to
+specify which documents to update and :manual:`update operators
+</reference/operator/update>` to describe how to mutate documents that match the
+query. Update operations return a :mdn:`Promise
+<Web/JavaScript/Reference/Global_Objects/Promise>` that resolves to an object
+that contains the results of the execution of the operation.
 
 .. _web-mongodb-updateOne:
 
@@ -230,18 +307,38 @@ The following snippet updates a single document in a
 where the ``name`` field contains the value "petunia" and changes the value
 of the first matched document's ``sunlight`` field to "partial":
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = { name: "petunia" };
-   const updateDocument = { sunlight: "partial" };
-   const updateResult = await mongoCollection.updateOne(queryFilter, updateDocument);
-   console.log(updateResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-a-single-document.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-a-single-document.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-a-single-document-result.js
+         :language: javascript
 
-   { matchedCount: 1, modifiedCount: 1 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-a-single-document-result.ts
+         :language: typescript
+
+.. _web-mongodb-updateMany:
 
 Update Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -255,18 +352,38 @@ The following snippet updates multiple documents in a
 where the ``_partition`` field contains the value "Store 47" and changes
 the value of the ``_partition`` field of each matching document to "Store 51":
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = { _partition: "Store 47" };
-   const updateDocument = { _partition: "Store 51" };
-   const updateResult = await mongoCollection.updateMany(queryFilter, updateDocument);
-   console.log(updateResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-multiple-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-multiple-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-multiple-documents-result.js
+         :language: javascript
 
-   { matchedCount: 2, modifiedCount: 2 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.update-multiple-documents-result.ts
+         :language: typescript
+
+.. _web-mongodb-upsert:
 
 Upsert Documents
 ~~~~~~~~~~~~~~~~
@@ -291,33 +408,38 @@ Because this snippet sets the ``upsert`` option to ``true``, if no
 document matches the query, MongoDB creates a new document that includes
 both the query filter and specified updates:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = {
-     sunlight: "full",
-     type: "perennial",
-     color: "green",
-     _partition: "Store 47",
-   };
-   const updateDocument = {
-     name: "sweet basil",
-   };
-   const updateOptions = {
-     upsert: true,
-   };
- 
-   const upsertResult = await mongoCollection.updateOne(
-     queryFilter,
-     updateDocument,
-     updateOptions
-   );
-   console.log(upsertResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.upsert-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.upsert-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.upsert-documents-result.js
+         :language: javascript
 
-   { matchedCount: 0, modifiedCount: 0, upsertedId: 5f1f63055512f2cb67f460a3 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.upsert-documents-result.ts
+         :language: typescript
+
+.. _web-mongodb-delete-documents:
 
 Delete Documents
 ----------------
@@ -337,23 +459,44 @@ Delete a Single Document
 You can delete a single document from a collection using
 :js-sdk:`collection.deleteOne() <Realm.MongoDBCollection.html#deleteOne>`.
 
-The following snippet deletes one document from a
+The following snippet deletes one document in a
 :ref:`collection of documents that describe plants for sale in a group of stores
 <android-mongodb-example-dataset>`. This operation queries for a
 document where the ``color`` field has a value of "green" and deletes
 the first document that matches the query:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = { color: "green" };
-   const deleteResult = await mongoCollection.deleteOne(queryFilter);
-   console.log(deleteResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-a-single-document.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-a-single-document.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-a-single-document-result.js
+         :language: javascript
 
-   { deletedCount: 1 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-a-single-document-result.ts
+         :language: typescript
+
+.. _web-mongodb-deleteMany:
 
 Delete Multiple Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -361,27 +504,40 @@ Delete Multiple Documents
 You can delete multiple items from a collection using
 :js-sdk:`collection.deleteMany() <Realm.MongoDBCollection.html#deleteMany>`.
 
-The following snippet deletes all documents in a
-:ref:`collection of documents that describe plants for sale in a group of stores
-<web-mongodb-example-dataset>`
-that match the query filter that matches documents containing both
-a ``sunlight`` field value of "full" and a ``type`` field value of
-"annual".
+The following snippet deletes all documents for plants that are in "Store 51" in
+a :ref:`collection of documents that describe plants for sale in a group of
+stores <web-mongodb-example-dataset>`:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const queryFilter = {
-     sunlight: "full",
-     type: "annual",
-   };
-   const deleteManyResult = await mongoCollection.deleteMany(queryFilter);
-   console.log(deleteManyResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-multiple-documents.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-multiple-documents.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-multiple-documents-result.js
+         :language: javascript
 
-   { deletedCount: 2 }
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.delete-multiple-documents-result.ts
+         :language: typescript
 
 .. _web-mongodb-watch:
 
@@ -474,18 +630,36 @@ The following snippet groups all documents in the ``plants``
 collection by their ``type`` value and aggregates a count of the
 number of each type:
 
-.. code-block:: javascript
+.. tabs-realm-languages::
    
-   const aggregationResult = await mongoCollection.aggregate([
-     { $group: { _id: "$type", total: { $sum: 1 } } },
-   ]);
-   console.log(aggregationResult);
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.aggregate-documents-in-a-collection.js
+         :language: javascript
+
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.aggregate-documents-in-a-collection.ts
+         :language: typescript
 
 Running this snippet produces output resembling the following:
 
-.. code-block:: shell
+.. tabs-realm-languages::
+   :hidden: true
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.aggregate-documents-in-a-collection-result.js
+         :language: javascript
 
-   [ { _id: 'perennial', total: 2 }, { _id: 'annual', total: 1 } ]
+   .. tab::
+      :tabid: typescript
+      
+      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.aggregate-documents-in-a-collection-result.ts
+         :language: typescript
 
 Aggregation Stages
 ------------------


### PR DESCRIPTION
* Updates the setup instructions for Web/RN to show `User.mongoClient` instead of `App.services.mongodb`
* Updates Web/RN examples to use tested Bluehawk snippets (same as Node)
* Adds an "On this page" sidebar (i.e. `.. contents::`) to the Web/RN pages

## Pull Request Info

### Issue JIRA link:

(DOCSP-13771): Update JS MongoDB Service API

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [MongoDB Data Access (Web)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/mongodb/web/mongodb)
- [MongoDB Data Access (RN)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/mongodb/react-native/mongodb)
- [MongoDB Data Access (Node)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/mongodb/node/mongodb) (no user-facing changes here - Web/RN examples should be identical to this page but w/ modified refs & link targets)
