### PR TITLE
(DOCSP-12984): [REALMC] Support OpenID with Google OAuth

### DIFF
--- a/source/android/authenticate.txt
+++ b/source/android/authenticate.txt
@@ -46,13 +46,13 @@ See the table below to find the method that instantiates the
    * - :ref:`Custom JWT <android-login-custom-jwt>`
      - ``Credentials.jwt(String jwtToken)``
 
-   * - :ref:`Google OAuth <android-login-google>`
+   * - :ref:`Google Authentication <android-login-google>`
      - ``Credentials.google(String googleToken)``
 
-   * - :ref:`Facebook OAuth <android-login-facebook>`
+   * - :ref:`Facebook Authentication <android-login-facebook>`
      - ``Credentials.facebook(String accessToken)``
    
-   * - :ref:`Sign-in With Apple <android-login-apple>`
+   * - :ref:`Apple Authentication <android-login-apple>`
      - ``Credentials.apple(String idToken)``
 
 .. _android-login:
@@ -231,8 +231,8 @@ to ``app.login()`` or ``app.loginAsync()``.
 
 .. _android-login-facebook:
 
-Facebook OAuth
-~~~~~~~~~~~~~~
+Facebook Authentication
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Facebook </authentication/facebook>` authentication provider allows
 you to authenticate users through a Facebook app using their existing Facebook
@@ -268,8 +268,8 @@ create a {+service-short+} Facebook credential and then log the user into your
 
 .. _android-login-google:
 
-Google OAuth
-~~~~~~~~~~~~
+Google Authentication
+~~~~~~~~~~~~~~~~~~~~~
 
 .. important::
    
@@ -303,8 +303,8 @@ credential and then log the user into your {+service-short+} app.
 
 .. _android-login-apple:
 
-Sign-in with Apple
-~~~~~~~~~~~~~~~~~~
+Apple Authentication
+~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Sign-in with Apple authentication provider </authentication/apple>`
 enables users to log in to your application with a custom token provided

--- a/source/authentication/google.txt
+++ b/source/authentication/google.txt
@@ -159,7 +159,7 @@ options:
    * - | :guilabel:`OpenID Connect`
        | *config.openId*
 
-     - Optional. Default ``False``.
+     - Optional. Default ``false``.
      
        If ``true``, the provider uses :google:`OpenID Connect
        <identity/protocols/oauth2/openid-connect>` to authenticate users.

--- a/source/authentication/google.txt
+++ b/source/authentication/google.txt
@@ -1,3 +1,4 @@
+
 .. _google-authentication:
 
 =====================
@@ -23,6 +24,7 @@ provides {+service+} with an `OAuth 2.0 access token
 {+service-short+} uses the token to identify the user and access approved data from
 Google APIs on their behalf.
 
+.. _openIdConnect:
 .. _auth-google-configuration:
 
 Configuration
@@ -57,7 +59,8 @@ Configuration
            "type": "oauth2-google",
            "disabled": <boolean>,
            "config": {
-             "clientId": <string>
+             "clientId": <string>,
+             "openId": <boolean>
            },
            "secret_config": {
              "clientSecret": <string>
@@ -152,6 +155,21 @@ options:
           If you've specified any domain restrictions, you must also
           require the email address field in the :guilabel:`Metadata
           Fields` setting.
+
+   * - | :guilabel:`OpenID Connect`
+       | *config.openId*
+
+     - Optional. Default ``False``.
+     
+       If ``true``, the provider uses :google:`OpenID Connect
+       <identity/protocols/oauth2/openid-connect>` to authenticate users.
+       
+       .. important:: OpenID Connect Does Not Support Metadata Fields
+          
+          Google supports OpenID as part of their OAuth 2.0 implementation but does
+          not provide access to restricted scopes for OpenID authentication. This
+          means that Realm cannot access metadata fields for users authenticated
+          with OpenID Connect.
 
 .. _auth-gcp-project-setup:
 

--- a/source/dotnet/authenticate.txt
+++ b/source/dotnet/authenticate.txt
@@ -149,8 +149,9 @@ you can log in using the following code:
 
 .. _dotnet-login-apple:
 
-Sign-in with Apple
-~~~~~~~~~~~~~~~~~~
+Apple Authentication
+~~~~~~~~~~~~~~~~~~~~
+
 If you have enabled :ref:`Sign-in with Apple authentication <apple-id-authentication>`,
 you can log in using the following code:
 

--- a/source/ios/authenticate.txt
+++ b/source/ios/authenticate.txt
@@ -143,8 +143,9 @@ The value that you pass to the credential depends on whether or not you have
 
 .. _ios-login-apple:
 
-Sign-in with Apple
-~~~~~~~~~~~~~~~~~~
+Apple Authentication
+~~~~~~~~~~~~~~~~~~~~
+
 If you have enabled :ref:`Sign-in with Apple authentication <apple-id-authentication>`,
 you can log in using the following code:
 

--- a/source/ios/authenticate.txt
+++ b/source/ios/authenticate.txt
@@ -122,9 +122,20 @@ Google Authentication
 Follow the official :google:`Google Sign-In for iOS Integration Guide
 <identity/sign-in/ios/start-integrating>` to set up the authentication flow for
 your application. In the sign-in completion handler, create a {+service-short+}
-Google credential with the logged in user's :google:`server auth code
-<identity/sign-in/ios/reference/Classes/GIDGoogleUser#serverauthcode>` and log
-the user into your {+service-short+} app.
+Google credential and log the user into your {+service-short+} app.
+
+The value that you pass to the credential depends on whether or not you have
+:ref:`enabled OpenID Connect <openIdConnect>` for the provider:
+
+- If OpenID Connect is enabled, pass the ``id_token``
+  :google:`included in the Google OAuth response
+  <identity/sign-in/ios/backend-auth>` to :swift-sdk:`Credentials.googleId(token:)
+  <Enums/Credentials.html#/s:10RealmSwift11CredentialsO8googleIdyACSS_tcACmF>`.
+
+- If OpenID Connect is not enabled, pass the user's :google:`server auth code
+  <identity/sign-in/ios/reference/Classes/GIDGoogleUser#serverauthcode>` to
+  :swift-sdk:`Credentials.google(serverAuthCode:)
+  <Enums/Credentials.html#/s:10RealmSwift11CredentialsO6googleyACSS_tcACmF>`.
 
 .. literalinclude:: /examples/generated/code/start/Authenticate.codeblock.google.swift
    :language: swift

--- a/source/node/authenticate.txt
+++ b/source/node/authenticate.txt
@@ -172,8 +172,8 @@ and pass it to ``App.logIn()``:
 
 .. _node-login-facebook:
 
-Facebook OAuth
-~~~~~~~~~~~~~~
+Facebook Authentication
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Facebook </authentication/facebook>` authentication provider allows
 you to authenticate users through a Facebook app using their existing Facebook
@@ -220,8 +220,8 @@ to your Node.js app and use to finish logging the user in to your app.
 
 .. _node-login-google:
 
-Google OAuth
-~~~~~~~~~~~~
+Google Authentication
+~~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Google </authentication/google>` authentication provider allows you to
 authenticate users through a Google project using their existing Google account.
@@ -268,8 +268,8 @@ use to finish logging the user in to your app.
 
 .. _node-login-apple:
 
-Sign-in with Apple
-~~~~~~~~~~~~~~~~~~
+Apple Authentication
+~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Apple </authentication/apple>` authentication provider allows you to
 authenticate users through Sign-in With Apple.

--- a/source/react-native/authenticate.txt
+++ b/source/react-native/authenticate.txt
@@ -292,8 +292,8 @@ and pass it to ``App.logIn()``:
 
 .. _react-native-login-facebook:
 
-Facebook OAuth
-~~~~~~~~~~~~~~
+Facebook Authentication
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Facebook </authentication/facebook>` authentication provider allows
 you to authenticate users through a Facebook app using their existing Facebook
@@ -377,8 +377,8 @@ app.
 
 .. _react-native-login-google:
 
-Google OAuth
-~~~~~~~~~~~~
+Google Authentication
+~~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Google </authentication/google>` authentication provider allows you to
 authenticate users through a Google project using their existing Google account.
@@ -513,8 +513,8 @@ authorization code to finish logging the user in to your app.
 
 .. _react-native-login-apple:
 
-Sign-in with Apple
-~~~~~~~~~~~~~~~~~~
+Apple Authentication
+~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Apple </authentication/apple>` authentication provider allows you to
 authenticate users through Sign-in With Apple.

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -339,8 +339,8 @@ account. You can use the :ref:`built-in authentication flow
 
 .. _web-facebook-builtin:
 
-Built-In OAuth 2.0 Flow
-+++++++++++++++++++++++
+Use the Built-In Facebook OAuth 2.0 Flow
+++++++++++++++++++++++++++++++++++++++++
 
 The Realm Web SDK includes methods to handle the OAuth 2.0 process and does not
 require you to install the Facebook SDK. The built in flow follows three main steps:
@@ -447,8 +447,8 @@ in to your app.
 
 .. _web-login-google:
 
-Google OAuth
-~~~~~~~~~~~~
+Google Authentication
+~~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Google </authentication/google>` authentication provider allows you to
 authenticate users through a Google project using their existing Google account.
@@ -458,10 +458,26 @@ authenticate users through a Google project using their existing Google account.
    To authenticate a Google user, you must configure the :doc:`Google
    authentication provider </authentication/google>`.
 
-You can use the :google:`official Google SDK <identity/sign-in/web/sign-in>` to
-handle the user authentication and redirect flow. Once authenticated, the Google
-SDK returns an authorization code that you can use to finish logging the user in
-to your app.
+Logging a Google user in to your Realm app is a two step process:
+
+1. First, you authenticate the user with Google. You can use a library like
+   :google:`Google One Tap
+   <identity/one-tap/web/guides/get-google-api-clientid>` for a streamlined
+   experience.
+
+2. Second, you log the user in to your Realm app with an authentication token
+   returned by Google upon successful user authentication.
+
+.. _web-google-onetap:
+
+Authenticate with Google One Tap
+++++++++++++++++++++++++++++++++
+
+.. note:: Requires OpenID Connect
+   
+   Google OneTap only supports user authentication through OpenID Connect. To
+   log Google users in to your web app, you must :ref:`enable OpenID Connect
+   <openIdConnect>` in the authentication provider configuration.
 
 .. tabs-realm-languages::
    
@@ -470,80 +486,117 @@ to your app.
       
       .. code-block:: javascript
          
-         // Get the access token from the Google SDK
-         function getGoogleAuthCode() {
-           return new Promise(() => {
-             gapi.auth2.authorize({
-               client_id: "<Google Client ID>",
-               // Scopes should match the metadata fields in the provider configuration
-               scope: "<scopes>",
-               response_type: "code",
-             }, ({ code, error }) => {
-               if(error) {
-                 reject(error)
-               }
-               resolve(code)
-             })
-           })
-         }
-         getGoogleAuthCode()
-           .then(code => {
-             // Define credentials with the authorization code from the Google SDK
-             const credentials = Realm.Credentials.google(code)
-             // Log the user in to your app
-             return app.logIn(credentials)
-           })
-           .then(user => {
-             console.log(`Logged in with id: ${user.id}`);
-           });
+         import * as Realm from "realm-web";
+         import googleOneTap from 'google-one-tap';
+         
+         const app = new Realm.App("<Your Realm App ID>");
+         const client_id = "<Your Google Client ID>";
+         
+         // Open the Google One Tap menu
+         googleOneTap({ client_id }, async (response) => {
+           // Upon successful Google authentication, log in to Realm with the user's credential
+           const credentials = Realm.Credentials.google(response.credential)
+           const user = await app.logIn(credentials);
+           console.log(`Logged in with id: ${user.id}`);
+         });
 
    .. tab::
       :tabid: typescript
       
       .. code-block:: typescript
          
-         // Get the access token from the Google SDK
-         function getGoogleAuthCode(): Promise<string> {
-           return new Promise(() => {
-             gapi.auth2.authorize({
-               client_id: "<Google Client ID>",
-               // Scopes should match the metadata fields in the provider configuration
-               scope: "<scopes>",
-               response_type: "code",
-             }, ({ code, error }) => {
-               if(error) {
-                 reject(error)
-               }
-               resolve(code)
-             })
-           })
-         }
-         getGoogleAuthCode()
-           .then((code: string) => {
-             // Define credentials with the authorization code from the Google SDK
-             const credentials = Realm.Credentials.google(code)
-             // Log the user in to your app
-             return app.logIn(credentials)
-           })
-           .then((user: Realm.User) => {
-             console.log(`Logged in with id: ${user.id}`);
-           });
+         import * as Realm from "realm-web";
+         import googleOneTap from 'google-one-tap';
+         
+         const app = new Realm.App("<Your Realm App ID>");
+         const client_id = "<Your Google Client ID>";
+         
+         // Open the Google One Tap menu
+         googleOneTap({ client_id }, async (response: { credential: string }) => {
+           // Upon successful Google authentication, log in to Realm with the user's credential
+           const credentials = Realm.Credentials.google(response.credential)
+           const user = await app.logIn(credentials);
+           console.log(`Logged in with id: ${user.id}`);
+         });
+
+.. _web-google-builtin:
+
+Use the Built-In Google OAuth 2.0 Flow
+++++++++++++++++++++++++++++++++++++++
+
+The Realm Web SDK includes methods to handle the OAuth 2.0 process and does not
+require you to install a Google SDK. The built in flow follows three main steps:
+
+1. You call ``app.logIn()`` with a Google credential. The credential must
+   specify a URL for your app that is also listed as a redirect URI in the
+   provider configuration.
+
+2. A new window opens to a Google authentication screen and the user
+   authenticates and authorizes your app in that window. Once complete, the new
+   window redirects to the URL specified in the credential.
+
+3. You call ``handleAuthRedirect()`` on the redirected page, which stores the
+   user's Realm access token and closes the window. Your original app window will
+   automatically detect the access token and finish logging the user in.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. code-block:: javascript
+         
+         // The redirect URI should be on the same domain as this app and
+         // specified in the auth provider configuration.
+         const redirectUri = "https://app.example.com/handleOAuthLogin";
+         const credentials = Realm.Credentials.google(redirectUri);
+         
+         // Calling logIn() opens a Google authentication screen in a new window.
+         app.logIn(credentials).then(user => {
+           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
+           // from the new window after the user has successfully authenticated.
+           console.log(`Logged in with id: ${user.id}`);
+         })
+         
+         // When the user is redirected back to your app, handle the redirect to
+         // save the user's access token and close the redirect window. This
+         // returns focus to the original application window and automatically
+         // logs the user in.
+         Realm.handleAuthRedirect();
+
+   .. tab::
+      :tabid: typescript
+      
+      .. code-block:: typescript
+         
+         // The redirect URI should be on the same domain as this app and
+         // specified in the auth provider configuration.
+         const redirectUri = "https://app.example.com/handleOAuthLogin";
+         const credentials = Realm.Credentials.google(redirectUri);
+         
+         // Calling logIn() opens a Google authentication screen in a new window.
+         app.logIn(credentials).then((user: Realm.User) => {
+           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
+           // from the new window after the user has successfully authenticated.
+           console.log(`Logged in with id: ${user.id}`);
+         })
+         
+         // When the user is redirected back to your app, handle the redirect to
+         // save the user's access token and close the redirect window. This
+         // returns focus to the original application window and automatically
+         // logs the user in.
+         Realm.handleAuthRedirect();
 
 .. important:: Built-In OAuth 2.0 Redirect Limitations for Google
    
-   The Realm Web SDK includes a built-in process to handle OAuth 2.0 redirect
-   flows. The process opens a new window where the user authorizes your app and
-   then redirects to URL that you provide, which allows you to get an access
-   token and finish logging the user in.
-   
    Due to changes in OAuth application verification requirements, the built-in
-   process faces limitations when authenticating :ref:`Google
+   OAuth 2.0 process faces limitations when authenticating :ref:`Google
    <google-authentication>` users. If you use the Google login redirect flow
    using Realm's redirect flow, a maximum of 100 Google users may authenticate
    while the app is in development/testing/staging and all users will see an
    unverified application notification before they authenticate.
    
-   To avoid these limitations, we advise that you use the official Google SDK to
+   To avoid these limitations, we advise that you use an official Google SDK to
    get a user access token as described above.
 
 .. _web-login-apple:
@@ -563,8 +616,8 @@ SDK <web-apple-auth-token>`.
 
 .. _web-apple-builtin:
 
-Built-In OAuth 2.0 Flow
-+++++++++++++++++++++++
+Use the Built-In Apple OAuth 2.0 Flow
++++++++++++++++++++++++++++++++++++++
 
 The Realm Web SDK includes methods to handle the OAuth 2.0 process and does not
 require you to install the Apple JS SDK. The built in flow follows three main

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -324,8 +324,8 @@ and pass it to ``App.logIn()``:
 
 .. _web-login-facebook:
 
-Facebook OAuth
-~~~~~~~~~~~~~~
+Facebook Authentication
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Facebook </authentication/facebook>` authentication provider allows
 you to authenticate users through a Facebook app using their existing Facebook
@@ -601,8 +601,8 @@ require you to install a Google SDK. The built-in flow follows three main steps:
 
 .. _web-login-apple:
 
-Apple OAuth
-~~~~~~~~~~~
+Apple Authentication
+~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`Apple </authentication/apple>` authentication provider allows you to
 authenticate users through Sign-in With Apple. You can use the :ref:`built-in

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -475,7 +475,7 @@ Authenticate with Google One Tap
 
 .. note:: Requires OpenID Connect
    
-   Google OneTap only supports user authentication through OpenID Connect. To
+   Google One Tap only supports user authentication through OpenID Connect. To
    log Google users in to your web app, you must :ref:`enable OpenID Connect
    <openIdConnect>` in the authentication provider configuration.
 

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -525,7 +525,7 @@ Use the Built-In Google OAuth 2.0 Flow
 ++++++++++++++++++++++++++++++++++++++
 
 The Realm Web SDK includes methods to handle the OAuth 2.0 process and does not
-require you to install a Google SDK. The built in flow follows three main steps:
+require you to install a Google SDK. The built-in flow follows three main steps:
 
 1. You call ``app.logIn()`` with a Google credential. The credential must
    specify a URL for your app that is also listed as a redirect URI in the


### PR DESCRIPTION
## Pull Request Info

- Add OneTap (OpenID) instructions for web
- Re-add code sample for Google built-in flow (no OpenID)
- Adds info on iOS google credentials (`google` vs `googleId`)

### Issue JIRA link:

(DOCSP-12984): [REALMC] Support OpenID with Google OAuth

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [Google Authentication](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/openid/authentication/google)
- [Authenticate > Google (Web)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/openid/web/authenticate#google-authentication)
- [Authenticate > Google (iOS)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/openid/ios/authenticate#google-authentication)
