### PR TITLE
Remove claim that Realm Functions support static array funcs

### DIFF
--- a/source/functions/js-feature-compatibility.txt
+++ b/source/functions/js-feature-compatibility.txt
@@ -141,7 +141,7 @@ Built-In Object Methods & Properties
      - Yes
    
    * - :mdn:`Array static methods <Web/JavaScript/Reference/Global_Objects/Array#Static_methods>`
-     - Yes
+     - No
    
    * - :mdn:`Array.prototype methods <Web/JavaScript/Reference/Global_Objects/Array#Instance_methods>`
      - Yes


### PR DESCRIPTION
## Pull Request Info

### Issue link:
https://mongodb.slack.com/archives/CG53S529Y/p1610474713000600

https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/array-static-methods-are-not-supported-in-functions/