### PR TITLE
(DOCSP-14046): Update "Object Notifications" code to adhere to JS conventions (unused parameters + descriptive variables)

### DIFF
--- a/source/examples/Notifications/ObjectNotification.js
+++ b/source/examples/Notifications/ObjectNotification.js
@@ -10,9 +10,8 @@ async function example() {
   });
 
   // Observe object notifications.
-  dog.addListener((obj, changes) => {
-    // obj === dog
-    console.log(`object is deleted? ${changes.deleted}`);
+  dog.addListener((_changedDog, changes) => {
+    console.log(`dog is deleted? ${changes.deleted}`);
     console.log(`${changes.changedProperties.length} properties have been changed:`);
     changes.changedProperties.forEach((prop) => {
       console.log(` ${prop}`);


### PR DESCRIPTION

## Pull Request Info

### Issue JIRA link:
- https://jira.mongodb.org/browse/DOCSP-14046

### Docs staging link (requires sign-in on MongoDB Corp SSO):
- node: https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/Hotfix-ObjectNotifications-Snippet-JS-Conventions/node/notifications#object-notifications
- rn: https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/Hotfix-ObjectNotifications-Snippet-JS-Conventions/react-native/notifications#object-notifications


### What's changed:
- Changed "obj" in the callback to "_changedDog" to adhere to JS coding standards. 

#### What was wrong with "obj":
- non-descriptive (notably the old variation had an "obj === dog" which seems counterintuitive, might as well describe the parameter upfront rather than in a comment)
- That parameter is unused. Unused parameters should have an underscore in front of them (see: https://stackoverflow.com/questions/37558984/underscore-as-argument-to-javascript-function or ) 
