### PR TITLE
Rename "MongoDB Realm Cloud" -> "MongoDB Realm Application Services"

### DIFF
--- a/source/cloud.txt
+++ b/source/cloud.txt
@@ -1,8 +1,8 @@
 .. _realm-cloud:
 
-===================
-MongoDB Realm Cloud
-===================
+==================================
+MongoDB Realm Application Services
+==================================
 
 .. toctree::
    :titlesonly:
@@ -21,14 +21,14 @@ MongoDB Realm Cloud
    Logs </logs>
    Reference </reference>
 
-MongoDB Realm Cloud is a hosted application backend that enables real-time data
-sync between the :doc:`Realm SDKs </sdk>` and :atlas:`MongoDB Atlas <>`. It also
-includes a suite of tools for building cross-platform applications like user
-authentication providers, serverless functions & triggers, and dynamic data
-access rules.
+MongoDB Realm Application Services enable real-time data sync between
+the :doc:`Realm SDKs </sdk>` and :atlas:`MongoDB Atlas <>`. They also
+include a suite of tools for building cross-platform applications like
+user authentication providers, serverless functions & triggers, and
+dynamic data access rules.
 
-Get Started with MongoDB Realm Cloud
-------------------------------------
+Get Started with MongoDB Realm Application Services
+---------------------------------------------------
 
 Start Building
 ~~~~~~~~~~~~~~
@@ -45,8 +45,8 @@ Check Out the Tutorial
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Build a complete Task Tracker app in our :doc:`Task Tracker Tutorial
-</tutorial>`. The tutorial includes a MongoDB Realm Cloud application as well as
-a client app for every SDK.
+</tutorial>`. The tutorial includes a MongoDB Realm Application Services
+application as well as a client app for every SDK.
 
 Features & Services
 -------------------

--- a/source/index.txt
+++ b/source/index.txt
@@ -9,7 +9,7 @@ MongoDB Realm
    Get Started </get-started>
    Tutorial </tutorial>
    Realm Database SDKs </sdk>
-   MongoDB Realm Cloud </cloud>
+   MongoDB Realm Application Services </cloud>
    MongoDB Stitch (Legacy) </stitch>
 
 Welcome to the {+service+} documentation!

--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -13,9 +13,10 @@ Realm SDKs
    React Native SDK </react-native>
    Web SDK </web>
 
-The MongoDB Realm SDKs are client libraries that allow you to connect to local
-and synced Realm databases as well as authenticate users and interact with
-serverless :ref:`MongoDB Realm Cloud <realm-cloud>` applications.
+The MongoDB Realm SDKs are client libraries that allow you to connect to
+local and synced Realm databases as well as authenticate users and
+interact with serverless :ref:`MongoDB Realm Application Services
+<realm-cloud>` applications.
 
 Get Started
 -----------


### PR DESCRIPTION
Per official naming guidance doc, "MongoDB Realm Cloud" is not the correct name for this section:

- "Realm Cloud" already exists as the legacy Realm platform
- "MongoDB Realm Cloud" would exist under "MongoDB Cloud" (Atlas, etc.)

URI `/cloud/` remains as shorthand because `/services/` is already used by 3rd party services.

## Staged

https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/rename-cloud
