### PR TITLE
(DOCSP-14270): Fix broken literalinclude on Electron React QuickStart

### DIFF
--- a/source/examples/QuickStarts/electron/quickstart-setup-react-electron.js
+++ b/source/examples/QuickStarts/electron/quickstart-setup-react-electron.js
@@ -1,3 +1,4 @@
+
 const electron = require("electron");
 const path = require("path");
 

--- a/source/examples/QuickStarts/electron/quickstart-setup-react-electron.js
+++ b/source/examples/QuickStarts/electron/quickstart-setup-react-electron.js
@@ -1,4 +1,3 @@
-
 const electron = require("electron");
 const path = require("path");
 

--- a/source/includes/steps-realm-with-electron-using-create-react-app.yaml
+++ b/source/includes/steps-realm-with-electron-using-create-react-app.yaml
@@ -61,6 +61,7 @@ content: |
   application. Add the following to this file:
 
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-cracoconfig.js
+     :language: javascript
 
   The `target <https://webpack.js.org/configuration/target/>`_ is set to
   "electron-renderer" to compile your application for browser environments for
@@ -105,6 +106,8 @@ content: |
   ``public`` directory:
 
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-electron.js
+     :language: javascript
+     :emphasize-lines: 18
 
   Your application should now include the following files. Some additional files
   in your project, such as CSS, service worker, and test files aren't included

--- a/source/includes/steps-realm-with-electron-using-create-react-app.yaml
+++ b/source/includes/steps-realm-with-electron-using-create-react-app.yaml
@@ -106,10 +106,6 @@ content: |
 
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-electron.js
 
-  testapples
-
-  .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-electron.js
-
   Your application should now include the following files. Some additional files in
    your project, such as CSS, service worker, and test files aren't included below.
 

--- a/source/includes/steps-realm-with-electron-using-create-react-app.yaml
+++ b/source/includes/steps-realm-with-electron-using-create-react-app.yaml
@@ -105,7 +105,9 @@ content: |
   ``public`` directory:
 
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-cracoconfig.js
+
   testfizbuzz
+
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-electron.js
 
    Your application should now include the following files. Some additional files in

--- a/source/includes/steps-realm-with-electron-using-create-react-app.yaml
+++ b/source/includes/steps-realm-with-electron-using-create-react-app.yaml
@@ -104,13 +104,13 @@ content: |
   Add the following code to a new file called ``electron.js`` in the
   ``public`` directory:
 
-  .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-cracoconfig.js
+  .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-electron.js
 
-  testfizbuzzfpp
+  testapples
 
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-electron.js
 
-   Your application should now include the following files. Some additional files in
+  Your application should now include the following files. Some additional files in
    your project, such as CSS, service worker, and test files aren't included below.
 
   .. code-block:: text

--- a/source/includes/steps-realm-with-electron-using-create-react-app.yaml
+++ b/source/includes/steps-realm-with-electron-using-create-react-app.yaml
@@ -106,7 +106,7 @@ content: |
 
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-cracoconfig.js
 
-  testfizbuzz
+  testfizbuzzfpp
 
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-electron.js
 

--- a/source/includes/steps-realm-with-electron-using-create-react-app.yaml
+++ b/source/includes/steps-realm-with-electron-using-create-react-app.yaml
@@ -106,8 +106,9 @@ content: |
 
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-electron.js
 
-  Your application should now include the following files. Some additional files in
-   your project, such as CSS, service worker, and test files aren't included below.
+  Your application should now include the following files. Some additional files
+  in your project, such as CSS, service worker, and test files aren't included
+  below.
 
   .. code-block:: text
      :emphasize-lines: 7, 9, 10

--- a/source/includes/steps-realm-with-electron-using-create-react-app.yaml
+++ b/source/includes/steps-realm-with-electron-using-create-react-app.yaml
@@ -104,6 +104,8 @@ content: |
   Add the following code to a new file called ``electron.js`` in the
   ``public`` directory:
 
+  .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-cracoconfig.js
+  testfizbuzz
   .. literalinclude:: /examples/QuickStarts/electron/quickstart-setup-react-electron.js
 
    Your application should now include the following files. Some additional files in


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14270

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14270-Electron-cra-broken-link/node/electron-cra