### PR TITLE
(DOCSP-14344): Remove unnecessary 'can' based on docs feedback

### DIFF
--- a/source/get-started/introduction-mobile.txt
+++ b/source/get-started/introduction-mobile.txt
@@ -143,7 +143,7 @@ provides components to fulfill several common application requirements:
 - Use the :ref:`GraphQL API <graphql-api>` to access data stored in a
   linked MongoDB cluster using any standard GraphQL client.
 
-The {+service-short+} Mobile SDKs let you can call functions, authenticate users,
+The {+service-short+} Mobile SDKs let you call functions, authenticate users,
 sync remote {+realms+}, and query your local {+realms+}.
 
 Get Started with MongoDB Realm


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14344

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14344/

Specific page where I made the correction: 
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14344/get-started/introduction-mobile

Build log, confirming no new build errors:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=601c0304ab23346c20f14f03