### PR TITLE
(DOCSP-13993): Add User Id Type for Realm Custom User Data

### DIFF
--- a/source/includes/steps-define-custom-user-data-import-export.yaml
+++ b/source/includes/steps-define-custom-user-data-import-export.yaml
@@ -69,6 +69,10 @@ content: |
        - The name of a field that contains an application user's ID
          value. All user documents in the collection must have this
          field and no two documents may contain the same user ID.
+
+         The name of the field that maps each document to a specific application
+         user. The field must have the same name in each document and contain
+         the user's ID as a string.
 ---
 title: Deploy the Updated Application
 ref: deploy-the-updated-application

--- a/source/includes/steps-define-custom-user-data-import-export.yaml
+++ b/source/includes/steps-define-custom-user-data-import-export.yaml
@@ -66,13 +66,14 @@ content: |
          data.
      
      * - ``user_id_field``
-       - The name of a field that contains an application user's ID
-         value. All user documents in the collection must have this
-         field and no two documents may contain the same user ID.
-
-         The name of the field that maps each document to a specific application
+       - The name of the field that maps each document to a specific application
          user. The field must have the same name in each document and contain
          the user's ID as a string.
+         
+         .. note::
+            
+            If two documents contain the same user ID, {+service-short+} only
+            maps the first matching document to the user.
 ---
 title: Deploy the Updated Application
 ref: deploy-the-updated-application

--- a/source/includes/steps-define-custom-user-data-realm-ui.yaml
+++ b/source/includes/steps-define-custom-user-data-realm-ui.yaml
@@ -43,8 +43,10 @@ content: |
 title: Specify the User ID Field
 ref: specify-the-user-id-field
 content: |
-  Every document in the custom user data collection should have a field
-  that contains the user ID of the {+service-short+} user that it describes.
+  Every document in the custom user data collection should have a field that
+  maps it to a specific application user. The field must have the same name in
+  each document and contain the user's ID as a string.
+  
   Specify the name of the field that contains each user's ID in the
   :guilabel:`User ID Field` input.
 ---

--- a/source/includes/steps-define-custom-user-data-realm-ui.yaml
+++ b/source/includes/steps-define-custom-user-data-realm-ui.yaml
@@ -44,8 +44,8 @@ title: Specify the User ID Field
 ref: specify-the-user-id-field
 content: |
   Every document in the custom user data collection should have a field that
-  maps it to a specific application user. The field must have the same name in
-  each document and contain the user's ID as a string.
+  maps it to a specific application user. The field must be present in every
+  document that maps to a user and contain the user's ID as a string.
   
   Specify the name of the field that contains each user's ID in the
   :guilabel:`User ID Field` input.

--- a/source/includes/steps-define-custom-user-data-realm-ui.yaml
+++ b/source/includes/steps-define-custom-user-data-realm-ui.yaml
@@ -49,6 +49,11 @@ content: |
   
   Specify the name of the field that contains each user's ID in the
   :guilabel:`User ID Field` input.
+         
+  .. note::
+     
+     If two documents contain the same user ID, {+service-short+} only
+     maps the first matching document to the user.
 ---
 title: Deploy the Updated Application
 ref: deploy-the-updated-application


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:

(DOCSP-13993): Add User Id Type for Realm Custom User Data

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [Enable Custom User Data > Procedure (Realm UI & CLI)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/custom-user-id/users/enable-custom-user-data/#procedure)
  ^ Each changed page maps to a tabbed procedure
