### PR TITLE
Add schema versions and migrations page to iOS

### DIFF
--- a/source/sdk/ios/examples/modify-an-object-schema.txt
+++ b/source/sdk/ios/examples/modify-an-object-schema.txt
@@ -56,10 +56,10 @@ version.
    ``fullName`` field instead of the separate ``firstName`` and
    ``lastName`` fields. 
 
-    To migrate the {+realm+} to conform to the updated ``Person`` schema,
-    the developer sets the {+realm+}'s schema version to ``2`` and defines a
-    migration function to set the value of ``fullName`` based on the
-    existing ``firstName`` and ``lastName`` properties.
+   To migrate the {+realm+} to conform to the updated ``Person`` schema,
+   the developer sets the {+realm+}'s schema version to ``2`` and
+   defines a migration function to set the value of ``fullName`` based
+   on the existing ``firstName`` and ``lastName`` properties.
 
    .. tabs-realm-languages::
    
@@ -81,3 +81,12 @@ version.
          .. literalinclude:: /examples/generated/code/start/Migrations.codeblock.local-migration.m
             :language: objectivec
 
+
+.. _ios-additional-migration-examples:
+
+Additional Migration Examples
+-----------------------------
+
+Please check out the additional migration examples on the
+:github:`realm-cocoa repo
+<realm/realm-cocoa/tree/master/examples/ios/swift/Migration>`.

--- a/source/sdk/ios/fundamentals/schema-versions-and-migrations.txt
+++ b/source/sdk/ios/fundamentals/schema-versions-and-migrations.txt
@@ -1,8 +1,8 @@
 .. _ios-schema-versions-and-migrations:
 
-============================
-Schema Versions & Migrations
-============================
+======================================
+Schema Versions & Migrations - iOS SDK
+======================================
 
 .. default-domain:: mongodb
 
@@ -11,3 +11,50 @@ Schema Versions & Migrations
    :backlinks: none
    :depth: 2
    :class: singlecol
+
+.. _ios-schema-version:
+
+Schema Version
+--------------
+
+A **schema version** identifies the state of a :ref:`{+backend-schema+}
+<ios-realm-schema>` at some point in time. {+client-database+} tracks the schema
+version of each {+realm+} and uses it to map the objects in each {+realm+}
+to the correct schema.
+
+Schema versions are integers that you may include
+in the {+realm+} configuration when you open a {+realm+}. If a client
+application does not specify a version number when it opens a {+realm+} then
+the {+realm+} defaults to version ``0``.
+
+.. important:: Increment Versions Monotonically
+
+   :ref:`Migrations <ios-client-migrations>` must update a {+realm+} to a
+   higher schema version. {+client-database+} will throw an error if a client
+   application opens a {+realm+} with a schema version that is lower than
+   the {+realm+}'s current version or if the specified schema version is the
+   same as the {+realm+}'s current version but includes different
+   :ref:`object schemas <ios-object-schema>`.
+
+.. tip::
+
+   To learn how to change the {+realm+} version and perform a migration,
+   see :ref:`ios-modify-an-object-schema`.
+
+.. _ios-migrations:
+
+Migrations
+----------
+
+A **local migration** is a migration for a {+realm+} that does
+not automatically :doc:`{+sync-short+} </sync>` with
+another {+realm+}. Local migrations have access to the existing
+{+backend-schema+}, version, and objects and define logic that
+incrementally updates the {+realm+} to its new schema version.
+To perform a local migration you must specify a new schema
+version that is higher than the current version and provide
+a migration function when you open the out-of-date {+realm+}.
+
+In iOS, you can update underlying data to reflect schema changes using
+manual migrations. During such a manual migration, you can define new
+and deleted properties when they are added or removed from your schema.


### PR DESCRIPTION
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/new-ia-ios-versions/sdk/ios/fundamentals/schema-versions-and-migrations/

Bonus: includes link to https://github.com/realm/realm-cocoa/pull/7102 content