### PR TITLE
add link to Client Reset in dotnet and android SDKs

### DIFF
--- a/source/sdk/android/advanced-guides.txt
+++ b/source/sdk/android/advanced-guides.txt
@@ -11,11 +11,7 @@ Advanced Guides - Android SDK
    Link User Identities </sdk/android/advanced-guides/link-user-identities>
    Multi-User Applications </sdk/android/advanced-guides/multi-user-applications>
    Custom User Data </sdk/android/advanced-guides/custom-user-data>
-
-.. TODO: Create these pages
-   Testing </sdk/android/advanced-guides/testing>
-   Error Handling </sdk/android/advanced-guides/error-handling>
-   Debugging </sdk/android/advanced-guides/debugging>
+   Client Resets </sdk/android/advanced-guides/client-reset>
 
 Realm-Database (Non-Sync)
 -------------------------
@@ -23,10 +19,6 @@ Realm-Database (Non-Sync)
 - :doc:`Encryption </sdk/android/advanced-guides/encryption>`
 - :doc:`Threading </sdk/android/advanced-guides/threading>`
 
-.. TODO: Create these pages
-.. - :doc:`Error Handling </sdk/android/advanced-guides/error-handling>`
-.. - :doc:`Debugging </sdk/android/advanced-guides/debugging>`
-.. - :doc:`Testing </sdk/android/advanced-guides/testing>`
 
 MongoDB Realm Cloud (Sync)
 --------------------------
@@ -34,3 +26,4 @@ MongoDB Realm Cloud (Sync)
 - :doc:`Link User Identities </sdk/android/advanced-guides/link-user-identities>`
 - :doc:`Multi-User Applications </sdk/android/advanced-guides/multi-user-applications>`
 - :doc:`Custom User Data </sdk/android/advanced-guides/custom-user-data>`
+- :doc:`Client Resets </sdk/android/advanced-guides/client-reset>`

--- a/source/sdk/dotnet/advanced-guides.txt
+++ b/source/sdk/dotnet/advanced-guides.txt
@@ -11,11 +11,7 @@ Advanced Guides - .NET SDK
    Link User Identities </sdk/dotnet/advanced-guides/link-user-identities>
    Multi-User Applications </sdk/dotnet/advanced-guides/multi-user-applications>
    Custom User Data </sdk/dotnet/advanced-guides/custom-user-data>
-
-.. TODO: Create these pages
-   Testing </sdk/dotnet/advanced-guides/testing>
-   Error Handling </sdk/dotnet/advanced-guides/error-handling>
-   Debugging </sdk/dotnet/advanced-guides/debugging>
+   Client Resets </sdk/dotnet/advanced-guides/client-reset>
 
 Realm-Database (Non-Sync)
 -------------------------
@@ -23,14 +19,10 @@ Realm-Database (Non-Sync)
 - :doc:`Encryption </sdk/dotnet/advanced-guides/encrypt-a-realm>`
 - :doc:`Threading </sdk/dotnet/advanced-guides/threading>`
 
-.. TODO: Create these pages
-.. - :doc:`Error Handling </sdk/dotnet/advanced-guides/error-handling>`
-.. - :doc:`Debugging </sdk/dotnet/advanced-guides/debugging>`
-.. - :doc:`Testing </sdk/dotnet/advanced-guides/testing>`
-
 MongoDB Realm Cloud (Sync)
 --------------------------
 
 - :doc:`Link User Identities </sdk/dotnet/advanced-guides/link-user-identities>`
 - :doc:`Multi-User Applications </sdk/dotnet/advanced-guides/multi-user-applications>`
 - :doc:`Custom User Data </sdk/dotnet/advanced-guides/custom-user-data>`
+- :doc:`Client Resets </sdk/dotnet/advanced-guides/client-reset>`


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-NNNN

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/resets/sdk/android/advanced-guides/client-reset/
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/resets/sdk/dotnet/advanced-guides/client-reset/
