### PR TITLE
(DOCSP-14353): Node Client Resets Documentation

### DIFF
--- a/examples/node/Examples/sync-changes-between-devices.js
+++ b/examples/node/Examples/sync-changes-between-devices.js
@@ -17,7 +17,7 @@ describe("Sync Changes Between Devices", () => {
     const credentials = Realm.Credentials.anonymous();
     await app.logIn(credentials);
     // :code-block-start: sync-changes-between-devices-perform-a-client-reset
-    let realm;
+    let realm = await Realm.open(config);
     function errorSync(_session, error) {
       if (realm) {
         if (error.name === "ClientReset") {
@@ -26,7 +26,7 @@ describe("Sync Changes Between Devices", () => {
           realm.close();
 
           console.log(`Error ${error.message}, need to reset ${realmPath}…`);
-          Realm.App.Sync.initiateClientReset(app, realmPath);
+          Realm.App.Sync.initiateClientReset(app, realmPath); // pass your realm app instance, and realm path to initiateClientReset()
           console.log(`Creating backup from ${error.config.path}…`);
           // Move backup file to a known location for a restore
           fs.renameSync(error.config.path, realmPath + "~");
@@ -37,7 +37,7 @@ describe("Sync Changes Between Devices", () => {
         }
       }
     }
-    const config = {
+    var config = {
       schema: [DogSchema], // predefined schema
       sync: {
         user: app.currentUser,
@@ -45,7 +45,6 @@ describe("Sync Changes Between Devices", () => {
         error: errorSync,
       },
     };
-    realm = await Realm.open(config);
     // :code-block-end:
     expect(1).toBe(2);
     realm.close();

--- a/examples/node/Examples/sync-changes-between-devices.js
+++ b/examples/node/Examples/sync-changes-between-devices.js
@@ -1,0 +1,53 @@
+import Realm from "realm";
+import fs from "fs";
+
+const DogSchema = {
+  name: "Dog",
+  properties: {
+    name: "string",
+    age: "int?",
+  },
+};
+
+describe("Sync Changes Between Devices", () => {
+  // this test is skipped because we currently are unable to test Synced Realms
+  // via jest, to track the progress of this issue see: https://jira.mongodb.org/browse/RJS-1008
+  test.skip("should perform a client reset", async () => {
+    const app = new Realm.App({ id: "<Your App ID>" });
+    const credentials = Realm.Credentials.anonymous();
+    await app.logIn(credentials);
+    // :code-block-start: sync-changes-between-devices-perform-a-client-reset
+    let realm;
+    function errorSync(_session, error) {
+      if (realm != undefined) {
+        if (error.name === "ClientReset") {
+          const realmPath = "<Your Realm Path>";
+
+          realm.close();
+
+          console.log(`Error ${error.message}, need to reset ${realmPath}…`);
+          Realm.App.Sync.initiateClientReset(app, realmPath);
+          console.log(`Creating backup from ${error.config.path}…`);
+          // Move backup file to a known location for a restore
+          fs.renameSync(error.config.path, realmPath + "~");
+          // Discard the reference to the realm instance
+          realm = null;
+        } else {
+          console.log(`Received error ${error.message}`);
+        }
+      }
+    }
+    const config = {
+      schema: [DogSchema], // predefined schema
+      sync: {
+        user: app.currentUser,
+        partitionValue: "MyPartitionValue",
+        error: errorSync,
+      },
+    };
+    realm = await Realm.open(config);
+    // :code-block-end:
+    expect(1).toBe(2);
+    realm.close();
+  });
+});

--- a/examples/node/Examples/sync-changes-between-devices.js
+++ b/examples/node/Examples/sync-changes-between-devices.js
@@ -19,7 +19,7 @@ describe("Sync Changes Between Devices", () => {
     // :code-block-start: sync-changes-between-devices-perform-a-client-reset
     let realm;
     function errorSync(_session, error) {
-      if (realm != undefined) {
+      if (realm) {
         if (error.name === "ClientReset") {
           const realmPath = "<Your Realm Path>";
 

--- a/source/examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-perform-a-client-reset.js
+++ b/source/examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-perform-a-client-reset.js
@@ -1,0 +1,29 @@
+let realm;
+function errorSync(_session, error) {
+  if (realm != undefined) {
+    if (error.name === "ClientReset") {
+      const realmPath = "<Your Realm Path>";
+
+      realm.close();
+
+      console.log(`Error ${error.message}, need to reset ${realmPath}…`);
+      Realm.App.Sync.initiateClientReset(app, realmPath);
+      console.log(`Creating backup from ${error.config.path}…`);
+      // Move backup file to a known location for a restore
+      fs.renameSync(error.config.path, realmPath + "~");
+      // Discard the reference to the realm instance
+      realm = null;
+    } else {
+      console.log(`Received error ${error.message}`);
+    }
+  }
+}
+const config = {
+  schema: [DogSchema], // predefined schema
+  sync: {
+    user: app.currentUser,
+    partitionValue: "MyPartitionValue",
+    error: errorSync,
+  },
+};
+realm = await Realm.open(config);

--- a/source/examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-perform-a-client-reset.js
+++ b/source/examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-perform-a-client-reset.js
@@ -1,6 +1,6 @@
 let realm;
 function errorSync(_session, error) {
-  if (realm != undefined) {
+  if (realm) {
     if (error.name === "ClientReset") {
       const realmPath = "<Your Realm Path>";
 

--- a/source/examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-perform-a-client-reset.js
+++ b/source/examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-perform-a-client-reset.js
@@ -1,4 +1,4 @@
-let realm;
+let realm = await Realm.open(config);
 function errorSync(_session, error) {
   if (realm) {
     if (error.name === "ClientReset") {
@@ -7,7 +7,7 @@ function errorSync(_session, error) {
       realm.close();
 
       console.log(`Error ${error.message}, need to reset ${realmPath}…`);
-      Realm.App.Sync.initiateClientReset(app, realmPath);
+      Realm.App.Sync.initiateClientReset(app, realmPath); // pass your realm app instance, and realm path to initiateClientReset()
       console.log(`Creating backup from ${error.config.path}…`);
       // Move backup file to a known location for a restore
       fs.renameSync(error.config.path, realmPath + "~");
@@ -18,7 +18,7 @@ function errorSync(_session, error) {
     }
   }
 }
-const config = {
+var config = {
   schema: [DogSchema], // predefined schema
   sync: {
     user: app.currentUser,
@@ -26,4 +26,3 @@ const config = {
     error: errorSync,
   },
 };
-realm = await Realm.open(config);

--- a/source/sdk/node/advanced.txt
+++ b/source/sdk/node/advanced.txt
@@ -11,6 +11,7 @@ Realm Integrations - Node.js SDK
    Link User Identities </sdk/node/advanced/link-identities>
    Encrypt a Realm </sdk/node/advanced/encrypt>
    Query Engine </sdk/node/advanced/query-engine>
+   Client Reset </sdk/node/advanced/client-reset>
 
 Realm-Database (Non-Sync)
 -------------------------
@@ -22,3 +23,4 @@ MongoDB Realm Cloud (Sync)
 - :doc:`Access Custom User Data </sdk/node/advanced/access-custom-user-data>`
 - :doc:`Multi-User Applications </sdk/node/advanced/multi-user-applications>`
 - :doc:`Link User Identities </sdk/node/advanced/link-identities>`
+- :doc:`Client Reset </sdk/node/advanced/client-reset>

--- a/source/sdk/node/advanced/client-reset.txt
+++ b/source/sdk/node/advanced/client-reset.txt
@@ -12,6 +12,10 @@ Client Resets - Node SDK
    :depth: 2
    :class: singlecol
 
+
+Overview
+--------
+
 When using :doc:`{+sync+} </sync>`, a **client
 reset** is a serious error recovery task that your client
 app must perform in the following situation:

--- a/source/sdk/node/advanced/client-reset.txt
+++ b/source/sdk/node/advanced/client-reset.txt
@@ -43,11 +43,11 @@ Initiate a client reset if the ``error.name`` is ``"ClientReset"``. Call
 <Realm.App.Sync.html#.initiateClientReset>` with the {+realm+} ``App`` and the
 ``realm path``.
 
-The error object also contains the location of the backup copy
-of the Realm file once the client reset process is carried out via the
-``error.config.path``. You can optionally move this backup file, using the
-`<https://nodejs.org/api/fs.html#fs_fs_renamesync_oldpath_newpath>`_ method, to a
-known location for a restore.
+The error object also contains the location of the backup copy of the Realm file
+once the client reset process is carried out via the ``error.config.path``. You
+can optionally move this backup file, using the :nodejs:`fs.renameSync
+</api/fs.html#fs_fs_renamesync_oldpath_newpath>` method, to a known location for
+a restore.
 
 Discard the reference to the realm instance by setting the realm to ``null``.
 

--- a/source/sdk/node/advanced/client-reset.txt
+++ b/source/sdk/node/advanced/client-reset.txt
@@ -1,0 +1,57 @@
+.. _node-client-resets:
+
+===========================
+Client Resets - Node SDK
+===========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+When using :doc:`{+sync+} </sync>`, a **client
+reset** is a serious error recovery task that your client
+app must perform in the following situation:
+
+- The given synced {+realm+} on the server was restored from a backup.
+  For example, due to a {+service-short+} server crash.
+
+- The client app made changes to that {+realm+} since the backup was made,
+  but did not sync those changes back to the server before the server
+  was restored.
+
+In other words, the client app must carry out a client reset
+on a given synced {+realm+} if the server is restored to a
+version older than the version on the client.
+
+.. warning::
+
+   A client reset erases all local data and downloads a new copy of the
+   data stored in MongoDB Atlas. Performing a client reset loses all local
+   changes made since the client last successfully synced.
+
+Example
+-------
+Define an error handler function in your :js-sdk:`SyncConfiguration
+<Realm.App.Sync.html#~SyncConfiguration>` object. 
+
+Initiate a client reset if the ``error.name`` is ``"ClientReset"``. Call
+:js-sdk:`Realm.App.Sync.initiateClientReset()
+<Realm.App.Sync.html#~initiateClientReset>` with the {+realm+} ``App`` and the
+``realm path``.
+
+The error object also contains the location of the backup copy
+of the Realm file once the client reset process is carried out via the
+``error.config.path``. You can optionally move this backup file to a known
+location for a restore via the `fs.nameSync()
+<https://nodejs.org/api/fs.html#fs_fs_renamesync_oldpath_newpath>`_ method.
+
+Discard the reference to the realm instance by setting the realm to ``null``.
+
+.. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-perform-a-client-reset.js
+   :language: javascript
+
+

--- a/source/sdk/node/advanced/client-reset.txt
+++ b/source/sdk/node/advanced/client-reset.txt
@@ -40,14 +40,14 @@ Define an error handler function in your :js-sdk:`SyncConfiguration
 
 Initiate a client reset if the ``error.name`` is ``"ClientReset"``. Call
 :js-sdk:`Realm.App.Sync.initiateClientReset()
-<Realm.App.Sync.html#~initiateClientReset>` with the {+realm+} ``App`` and the
+<Realm.App.Sync.html#.initiateClientReset>` with the {+realm+} ``App`` and the
 ``realm path``.
 
 The error object also contains the location of the backup copy
 of the Realm file once the client reset process is carried out via the
-``error.config.path``. You can optionally move this backup file to a known
-location for a restore via the `fs.nameSync()
-<https://nodejs.org/api/fs.html#fs_fs_renamesync_oldpath_newpath>`_ method.
+``error.config.path``. You can optionally move this backup file, using the
+<https://nodejs.org/api/fs.html#fs_fs_renamesync_oldpath_newpath>`_ method, to a
+known location for a restore.
 
 Discard the reference to the realm instance by setting the realm to ``null``.
 

--- a/source/sdk/node/advanced/client-reset.txt
+++ b/source/sdk/node/advanced/client-reset.txt
@@ -46,7 +46,7 @@ Initiate a client reset if the ``error.name`` is ``"ClientReset"``. Call
 The error object also contains the location of the backup copy
 of the Realm file once the client reset process is carried out via the
 ``error.config.path``. You can optionally move this backup file, using the
-<https://nodejs.org/api/fs.html#fs_fs_renamesync_oldpath_newpath>`_ method, to a
+`<https://nodejs.org/api/fs.html#fs_fs_renamesync_oldpath_newpath>`_ method, to a
 known location for a restore.
 
 Discard the reference to the realm instance by setting the realm to ``null``.

--- a/source/sdk/node/examples/sync-changes-between-devices.txt
+++ b/source/sdk/node/examples/sync-changes-between-devices.txt
@@ -64,3 +64,13 @@ To enable session multiplexing, call :js-sdk:`Realm.App.Sync.enableSessionMultip
    
    .. literalinclude:: /examples/SyncChanges/enable-session-multiplexing.js
       :language: javascript
+
+
+Perform a Client Reset
+----------------------
+
+You can customize behavior in the event of a :ref:`client reset
+<node-client-resets>` error with a custom error handler function:
+
+.. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-perform-a-client-reset.js
+   :language: javascript


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14353

### Docs staging link (requires sign-in on MongoDB Corp SSO):
* Sync Changes Between Devices > "Perform a Client Reset" Subsection: https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14353-Node-Client-Resets/sdk/node/examples/sync-changes-between-devices/#perform-a-client-reset
* Node Client Reset Doc: https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14353-Node-Client-Resets/sdk/node/advanced/client-reset/#std-label-node-client-resets