### PR TITLE
Update install-realm-cli.rst

### DIFF
--- a/source/includes/install-realm-cli.rst
+++ b/source/includes/install-realm-cli.rst
@@ -11,14 +11,14 @@
 
          .. code-block:: shell
 
-            npm install -g mongodb-realm-cli
+            npm install -g mongodb-realm-cli@1.1.0
 
          You can also install the CLI from npm with `Yarn
          <https://yarnpkg.com/en/>`_:
 
          .. code-block:: shell
 
-            yarn global add mongodb-realm-cli
+            yarn global add mongodb-realm-cli@1.1.0
 
      - id: manual-install
        name: Manual Install

--- a/source/tutorial/realm-app.txt
+++ b/source/tutorial/realm-app.txt
@@ -150,6 +150,12 @@ manager or the ``realm-cli`` binary:
 
 .. include:: /includes/install-realm-cli.rst
 
+.. note:: ``realm-cli`` Version Compatibility
+
+   This tutorial is compatible with version ``1.1.0`` of ``realm-cli``.
+   If you encounter an error importing this app, try switching to
+   version ``1.1.0``.
+
 After installing the ``realm-cli``, you can run the
 following command to confirm that your installation was successful:
 

--- a/source/tutorial/realm-app.txt
+++ b/source/tutorial/realm-app.txt
@@ -150,7 +150,7 @@ manager or the ``realm-cli`` binary:
 
 .. include:: /includes/install-realm-cli.rst
 
-.. note:: ``realm-cli`` Version Compatibility
+.. note:: Realm CLI Version Compatibility
 
    This tutorial is compatible with version ``1.1.0`` of ``realm-cli``.
    If you encounter an error importing this app, try switching to


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
- realm-cli 1.3.0 and 1.4.0 require an "environment" directory, which breaks the realm app tutorial. Recommanding version 1.1.0 until then.

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/recommand-cli-1.1.0/tutorial/realm-app/#c.-install-the-realm-cli

### Docs staging build link:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6036c5aa75e817aef7cf8941