### PR TITLE
Add :uses-rst: flag to openapi directive

### DIFF
--- a/source/admin/api/v3.txt
+++ b/source/admin/api/v3.txt
@@ -171,3 +171,4 @@ Resources
    :class: twocols
 
 .. openapi:: /openapi-admin-v3.yaml
+   :uses-rst:


### PR DESCRIPTION
In preparation for changes to the default way the `openapi` directive is parsed in the upcoming snooty release, we will be requiring the addition of the `uses-rst` flag for this repo's use case. Adding this flag will allow snooty to parse the contents of the OpenAPI spec file as it currently does.

The staging link below should show the contents rendered the same as it is on the actual site. Please feel free to merge this in after tomorrow's release. Thank you!

Staging link:
[Realm - /admin/api/v3](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/snooty-test-24022021/admin/api/v3/#resources)