### PR TITLE
(DOCSP-14870): Fix filtered watch() example for web

### DIFF
--- a/examples/node/Examples/mongodb.js
+++ b/examples/node/Examples/mongodb.js
@@ -337,7 +337,7 @@ describe("Aggregation Stages", () => {
         { _id: "annual", numItems: 1 },
         { _id: "perennial", numItems: 5 },
       ]
-      // :code-block-end
+      // :code-block-end:
     );
   });
 
@@ -368,7 +368,7 @@ describe("Aggregation Stages", () => {
         { "name": "daffodil", "storeNumber": "42" },
         { "name": "sweet basil", "storeNumber": "47" }
       ]
-      // :code-block-end
+      // :code-block-end:
     )
   });
   test("Add Fields to Documents", async () => {
@@ -428,7 +428,7 @@ describe("Watch for Changes", () => {
   test("Watch for Changes in a Collection", async () => {
     const plants = await getPlantsCollection();
     // :code-block-start: watch-a-collection
-    // :hide-start:
+    // :state-start: start
     try {
       const watching = plants.watch();
       const next = watching.next();
@@ -442,46 +442,46 @@ describe("Watch for Changes", () => {
     }
     expect.assertions(1);
     return;
-    /* eslint-disable no-unreachable */
-    // :replace-with:
-    for await (const change of plants.watch()) {
-      const { operationType } = change;
-      switch (operationType) {
-        case "insert": {
-          const { documentKey, fullDocument } = change;
-          console.log(`new document: ${documentKey}`, fullDocument);
-          break;
-        }
-        case "update": {
-          const { documentKey, fullDocument } = change;
-          console.log(`updated document: ${documentKey}`, fullDocument);
-          break;
-        }
-        case "replace": {
-          const { documentKey, fullDocument } = change;
-          console.log(`replaced document: ${documentKey}`, fullDocument);
-          break;
-        }
-        case "delete": {
-          const { documentKey } = change;
-          console.log(`deleted document: ${documentKey}`);
-          break;
-        }
-      }
-      // :hide-end:
-      // :code-block-end:
-      /* eslint-enable no-unreachable */
-    }
+    // :state-end:
+    // :state-uncomment-start: final
+    // for await (const change of plants.watch()) {
+    //   switch (change.operationType) {
+    //     case "insert": {
+    //       const { documentKey, fullDocument } = change;
+    //       console.log(`new document: ${documentKey}`, fullDocument);
+    //       break;
+    //     }
+    //     case "update": {
+    //       const { documentKey, fullDocument } = change;
+    //       console.log(`updated document: ${documentKey}`, fullDocument);
+    //       break;
+    //     }
+    //     case "replace": {
+    //       const { documentKey, fullDocument } = change;
+    //       console.log(`replaced document: ${documentKey}`, fullDocument);
+    //       break;
+    //     }
+    //     case "delete": {
+    //       const { documentKey } = change;
+    //       console.log(`deleted document: ${documentKey}`);
+    //       break;
+    //     }
+    //   }
+    // }
+    // :state-uncomment-end:
+    // :code-block-end:
   });
 
   test("Watch for Changes in a Collection with a Filter", async () => {
     const plants = await getPlantsCollection();
     // :code-block-start: watch-a-collection-with-filter
-    // :hide-start:
+    // :state-start: start
     try {
       const watching = plants.watch({
-        operationType: "insert",
-        "fullDocument.type": "perennial",
+        filter: {
+          operationType: "insert",
+          "fullDocument.type": "perennial",
+        },
       });
       const next = watching.next();
       jest.runOnlyPendingTimers();
@@ -494,17 +494,19 @@ describe("Watch for Changes", () => {
     }
     expect.assertions(1);
     return;
-    /* eslint-disable no-unreachable */
-    // :replace-with:
-    for await (const change of plants.watch({
-      operationType: "insert",
-      "fullDocument.type": "perennial",
-    })) {
-      // The change event will always represent a newly inserted perennial
-      const { documentKey, fullDocument } = change;
-      console.log(`new document: ${documentKey}`, fullDocument);
-    }
-    // :hide-end:
+    // :state-end:
+    // :state-uncomment-start: final
+    // for await (const change of plants.watch({
+    //   filter: {
+    //     operationType: "insert",
+    //     "fullDocument.type": "perennial",
+    //   },
+    // })) {
+    //   // The change event will always represent a newly inserted perennial
+    //   const { documentKey, fullDocument } = change;
+    //   console.log(`new document: ${documentKey}`, fullDocument);
+    // }
+    // :state-uncomment-end:
     // :code-block-end:
     /* eslint-enable no-unreachable */
   });

--- a/examples/node/Examples/mongodb.ts
+++ b/examples/node/Examples/mongodb.ts
@@ -384,7 +384,7 @@ describe("Aggregation Stages", () => {
         { _id: "annual", numItems: 1 },
         { _id: "perennial", numItems: 5 },
       ]
-      // :code-block-end
+      // :code-block-end:
     );
   });
 
@@ -415,7 +415,7 @@ describe("Aggregation Stages", () => {
         { "name": "daffodil", "storeNumber": "42" },
         { "name": "sweet basil", "storeNumber": "47" }
       ]
-      // :code-block-end
+      // :code-block-end:
     )
   });
   test("Add Fields to Documents", async () => {
@@ -443,7 +443,7 @@ describe("Aggregation Stages", () => {
         { "_id": ObjectId("5f87a0dffc9013565c233613"), "_partition": "Store 42", "color": "yellow", "name": "daffodil", "storeNumber": "42", "sunlight": "full", "type": "perennial" },
         { "_id": ObjectId("5f1f63055512f2cb67f460a3"), "_partition": "Store 47", "color": "green", "name": "sweet basil", "storeNumber": "47", "sunlight": "full", "type": "perennial" }
       ]
-      // :code-block-end
+      // :code-block-end:
     )
   });
   test("Unwind Array Values", async () => {
@@ -475,7 +475,7 @@ describe("Watch for Changes", () => {
   test("Watch for Changes in a Collection", async () => {
     const plants = await getPlantsCollection();
     // :code-block-start: watch-a-collection
-    // :hide-start:
+    // :state-start: start
     try {
       const watching = plants.watch();
       const next = watching.next();
@@ -489,55 +489,55 @@ describe("Watch for Changes", () => {
     }
     expect.assertions(1);
     return;
-    // :replace-with:
-    for await (const change of plants.watch()) {
-      const { operationType } = change;
-      switch (operationType) {
-        case "insert": {
-          const {
-            documentKey,
-            fullDocument,
-          } = change as Realm.Services.MongoDB.InsertEvent<Plant>;
-          console.log(`new document with _id: ${documentKey}`, fullDocument);
-          break;
-        }
-        case "update": {
-          const {
-            documentKey,
-            fullDocument,
-          } = change as Realm.Services.MongoDB.UpdateEvent<Plant>;
-          console.log(`updated document: ${documentKey}`, fullDocument);
-          break;
-        }
-        case "replace": {
-          const {
-            documentKey,
-            fullDocument,
-          } = change as Realm.Services.MongoDB.ReplaceEvent<Plant>;
-          console.log(`replaced document: ${documentKey}`, fullDocument);
-          break;
-        }
-        case "delete": {
-          const { documentKey } = change as Realm.Services.MongoDB.DeleteEvent<
-            Plant
-          >;
-          console.log(`deleted document: ${documentKey}`);
-          break;
-        }
-      }
-    }
-    // :hide-end:
+    // :state-end:
+    // :state-uncomment-start: final
+    // for await (const change of plants.watch()) {
+    //   switch (change.operationType) {
+    //     case "insert": {
+    //       const {
+    //         documentKey,
+    //         fullDocument,
+    //       } = change;
+    //       console.log(`new document with _id: ${documentKey}`, fullDocument);
+    //       break;
+    //     }
+    //     case "update": {
+    //       const {
+    //         documentKey,
+    //         fullDocument,
+    //       } = change;
+    //       console.log(`updated document: ${documentKey}`, fullDocument);
+    //       break;
+    //     }
+    //     case "replace": {
+    //       const {
+    //         documentKey,
+    //         fullDocument,
+    //       } = change;
+    //       console.log(`replaced document: ${documentKey}`, fullDocument);
+    //       break;
+    //     }
+    //     case "delete": {
+    //       const { documentKey } = change;
+    //       console.log(`deleted document: ${documentKey}`);
+    //       break;
+    //     }
+    //   }
+    // }
+    // :state-uncomment-end:
     // :code-block-end:
   });
 
   test("Watch for Changes in a Collection with a Filter", async () => {
     const plants = await getPlantsCollection();
     // :code-block-start: watch-a-collection-with-filter
-    // :hide-start:
+    // :state-start: start
     try {
       const watching = plants.watch({
-        operationType: "insert",
-        "fullDocument.type": "perennial",
+        filter: {
+          operationType: "insert",
+          "fullDocument.type": "perennial",
+        },
       });
       const next = watching.next();
       jest.runOnlyPendingTimers();
@@ -550,19 +550,22 @@ describe("Watch for Changes", () => {
     }
     expect.assertions(1);
     return;
-    // :replace-with:
-    for await (const change of plants.watch({
-      operationType: "insert",
-      "fullDocument.type": "perennial",
-    })) {
-      // The change event will always represent a newly inserted perennial
-      const {
-        documentKey,
-        fullDocument,
-      } = change as Realm.Services.MongoDB.InsertEvent<Plant>;
-      console.log(`new document: ${documentKey}`, fullDocument);
-    }
-    // :hide-end:
+    // :state-end:
+    // :state-uncomment-start: final
+    // for await (const change of plants.watch({
+    //   filter: {
+    //     operationType: "insert",
+    //     "fullDocument.type": "perennial",
+    //   },
+    // })) {
+    //   // The change event will always represent a newly inserted perennial
+    //   const {
+    //     documentKey,
+    //     fullDocument,
+    //   } = change as Realm.Services.MongoDB.InsertEvent<Plant>;
+    //   console.log(`new document: ${documentKey}`, fullDocument);
+    // }
+    // :state-uncomment-end:
     // :code-block-end:
   });
 });

--- a/source/examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.js
+++ b/source/examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.js
@@ -1,0 +1,10 @@
+for await (const change of plants.watch({
+  filter: {
+    operationType: "insert",
+    "fullDocument.type": "perennial",
+  },
+})) {
+  // The change event will always represent a newly inserted perennial
+  const { documentKey, fullDocument } = change;
+  console.log(`new document: ${documentKey}`, fullDocument);
+}

--- a/source/examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.ts
+++ b/source/examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.ts
@@ -1,0 +1,13 @@
+for await (const change of plants.watch({
+  filter: {
+    operationType: "insert",
+    "fullDocument.type": "perennial",
+  },
+})) {
+  // The change event will always represent a newly inserted perennial
+  const {
+    documentKey,
+    fullDocument,
+  } = change as Realm.Services.MongoDB.InsertEvent<Plant>;
+  console.log(`new document: ${documentKey}`, fullDocument);
+}

--- a/source/examples/generated/node/mongodb.codeblock.watch-a-collection.js
+++ b/source/examples/generated/node/mongodb.codeblock.watch-a-collection.js
@@ -1,0 +1,24 @@
+for await (const change of plants.watch()) {
+  switch (change.operationType) {
+    case "insert": {
+      const { documentKey, fullDocument } = change;
+      console.log(`new document: ${documentKey}`, fullDocument);
+      break;
+    }
+    case "update": {
+      const { documentKey, fullDocument } = change;
+      console.log(`updated document: ${documentKey}`, fullDocument);
+      break;
+    }
+    case "replace": {
+      const { documentKey, fullDocument } = change;
+      console.log(`replaced document: ${documentKey}`, fullDocument);
+      break;
+    }
+    case "delete": {
+      const { documentKey } = change;
+      console.log(`deleted document: ${documentKey}`);
+      break;
+    }
+  }
+}

--- a/source/examples/generated/node/mongodb.codeblock.watch-a-collection.ts
+++ b/source/examples/generated/node/mongodb.codeblock.watch-a-collection.ts
@@ -1,0 +1,33 @@
+for await (const change of plants.watch()) {
+  switch (change.operationType) {
+    case "insert": {
+      const {
+        documentKey,
+        fullDocument,
+      } = change;
+      console.log(`new document with _id: ${documentKey}`, fullDocument);
+      break;
+    }
+    case "update": {
+      const {
+        documentKey,
+        fullDocument,
+      } = change;
+      console.log(`updated document: ${documentKey}`, fullDocument);
+      break;
+    }
+    case "replace": {
+      const {
+        documentKey,
+        fullDocument,
+      } = change;
+      console.log(`replaced document: ${documentKey}`, fullDocument);
+      break;
+    }
+    case "delete": {
+      const { documentKey } = change;
+      console.log(`deleted document: ${documentKey}`);
+      break;
+    }
+  }
+}

--- a/source/react-native/mongodb.txt
+++ b/source/react-native/mongodb.txt
@@ -569,13 +569,13 @@ To watch for all changes in a collection, call :js-sdk:`collection.watch()
    .. tab::
       :tabid: javascript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection.js
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection.js
          :language: javascript
 
    .. tab::
       :tabid: typescript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection.ts
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection.ts
          :language: typescript
 
 
@@ -593,13 +593,13 @@ specific change event values to watch:
    .. tab::
       :tabid: javascript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection-with-filter.js
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.js
          :language: javascript
 
    .. tab::
       :tabid: typescript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection-with-filter.ts
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.ts
          :language: typescript
 
 .. _react-native-mongodb-aggregation-pipelines:

--- a/source/sdk/node/examples/query-mongodb.txt
+++ b/source/sdk/node/examples/query-mongodb.txt
@@ -561,13 +561,13 @@ To watch for all changes in a collection, call :js-sdk:`collection.watch()
    .. tab::
       :tabid: javascript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection.js
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection.js
          :language: javascript
 
    .. tab::
       :tabid: typescript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection.ts
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection.ts
          :language: typescript
 
 .. _node-watch-for-specific-changes-in-a-collection:
@@ -585,13 +585,13 @@ To watch for specific changes in a collection, pass a query filter that matches
    .. tab::
       :tabid: javascript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection-with-filter.js
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.js
          :language: javascript
 
    .. tab::
       :tabid: typescript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection-with-filter.ts
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.ts
          :language: typescript
 
 Aggregation Operations

--- a/source/web/mongodb.txt
+++ b/source/web/mongodb.txt
@@ -569,13 +569,13 @@ To watch for all changes in a collection, call :js-sdk:`collection.watch()
    .. tab::
       :tabid: javascript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection.js
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection.js
          :language: javascript
 
    .. tab::
       :tabid: typescript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection.ts
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection.ts
          :language: typescript
 
 .. _web-mongodb-watch-a-collection-with-filter:
@@ -592,13 +592,13 @@ specific change event values to watch:
    .. tab::
       :tabid: javascript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection-with-filter.js
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.js
          :language: javascript
 
    .. tab::
       :tabid: typescript
       
-      .. literalinclude:: /examples/generated/code/start/mongodb.codeblock.watch-a-collection-with-filter.ts
+      .. literalinclude:: /examples/generated/node/mongodb.codeblock.watch-a-collection-with-filter.ts
          :language: typescript
 
 .. _web-mongodb-aggregation-pipelines:


### PR DESCRIPTION
## Pull Request Info

Note: We should have a followup PR that regenerates all the examples in `/source/examples/<sdk>` instead of the full project structure that we currently use for most generated examples (i.e. with start/final states)

### Issue JIRA link:

(DOCSP-14870): Fix filtered watch() example for web

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [Node.js > Query MongoDB > Watch for Changes in a Collection](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/watch-fix/sdk/node/examples/query-mongodb/#watch-for-all-changes-in-a-collection)
- Identical copies in rn/web docs

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
