### PR TITLE
(DOCSP-14603): Android UI Thread Reads & Writes

### DIFF
--- a/source/includes/android-synchronous-reads-writes-ui-thread.rst
+++ b/source/includes/android-synchronous-reads-writes-ui-thread.rst
@@ -1,7 +1,8 @@
 .. important:: Synchronous Reads and Writes on the UI Thread
    
    By default, you can only read or write to a {+realm+} in your
-   application's UI thread using asynchronous transactions. That is,
+   application's UI thread using
+   :ref:`asynchronous transactions <android-async-api>`. That is,
    you can only use ``Realm`` methods whose name ends with the word
    ``Async`` in the main thread of your Android application unless you
    explicitly allow the use of synchronous methods.

--- a/source/sdk/android/examples/open-and-close-a-local-realm.txt
+++ b/source/sdk/android/examples/open-and-close-a-local-realm.txt
@@ -93,6 +93,8 @@ To configure settings for a {+realm+}, create a
        .. literalinclude:: /examples/generated/android/local/OpenARealmTest.codeblock.configure-a-realm-local.java
          :language: java
 
+.. include:: /includes/android-synchronous-reads-writes-ui-thread.rst
+
 .. seealso::
 
    :ref:`Fundamentals: Realms <android-realms>`

--- a/source/sdk/android/examples/read-and-write-data.txt
+++ b/source/sdk/android/examples/read-and-write-data.txt
@@ -65,6 +65,8 @@ All query, filter, and sort operations return a
 collections are live, meaning they always contain the latest
 results of the associated query.
 
+.. include:: /includes/android-synchronous-reads-writes-ui-thread.rst
+
 .. seealso::
 
    :ref:`Fundamentals: Live Queries <android-live-queries>`
@@ -343,6 +345,8 @@ transaction, see :ref:`Write Transactions <android-write-transactions>`.
    :ref:`notifications <android-react-to-changes>` to any subscribed
    listeners. As a result, you should only write to {+service-short+}
    objects when necessary to persist data.
+
+.. include:: /includes/android-synchronous-reads-writes-ui-thread.rst
 
 .. _android-create-a-new-object:
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14603
- because the MongoDB Realm SDK disables synchronous operations on the UI thread by default, I'm just making the warning about this option more visible by including it on the "open a realm" page, and in both the "reads" and "writes" sections of the "read and write" page. Since UI thread sync operations are harder to do now, the ANR warning isn't really relevant any more.

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14603/sdk/android/examples/open-and-close-a-local-realm/#local-realm-configuration (new important admonition include)
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14603/sdk/android/examples/read-and-write-data/#read-from-realm-database (new important admonition include)
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14603/sdk/android/examples/read-and-write-data/#write-operations (new important admonition include)
Note that the admonition already existed and has already been through copy/technical review.

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
