### PR TITLE
(DOCSP-14626 & DOCSP-14630): Info about default realm + opening a local realm synchronously

### DIFF
--- a/examples/node/Examples/open-and-close-a-local-realm.js
+++ b/examples/node/Examples/open-and-close-a-local-realm.js
@@ -18,8 +18,23 @@ describe("Open and Close a Local Realm", () => {
       schema: [CarSchema],
     });
     // :code-block-end:
+
+    // :code-block-start: open-local-realm-synchronously
+    // :replace-start: {
+    //   "terms": {
+    //     "synchronouslyOpenedRealm": "realm"
+    //   }
+    // }
+    // Synchronously open a local realm file with a particular path & predefined CarSchema
+    const synchronouslyOpenedRealm = new Realm({
+      path: "myrealm",
+      schema: [CarSchema],
+    });
+    // :replace-end:
+    // :code-block-end:
+
     // you can test that a realm has been open in general (but not if a realm has been open with a specific path or schema)
-    expect(realm).toStrictEqual(new Realm());
+    expect(realm).toStrictEqual(synchronouslyOpenedRealm);
     // :code-block-start: close-local-realm
     realm.close();
     // :code-block-end:

--- a/source/examples/generated/node/open-and-close-a-local-realm.codeblock.open-local-realm-synchronously.js
+++ b/source/examples/generated/node/open-and-close-a-local-realm.codeblock.open-local-realm-synchronously.js
@@ -1,0 +1,5 @@
+// Synchronously open a local realm file with a particular path & predefined CarSchema
+const realm = new Realm({
+  path: "myrealm",
+  schema: [CarSchema],
+});

--- a/source/sdk/node/examples/open-and-close-a-local-realm.txt
+++ b/source/sdk/node/examples/open-and-close-a-local-realm.txt
@@ -19,11 +19,34 @@ Open a Local Realm
 
 To open a local (non-synced) {+realm+}, pass a :js-sdk:`Realm.Configuration
 <Realm.html#~Configuration>` object to either :js-sdk:`Realm.open()
-<Realm.html#.open>` or :js-sdk:`new Realm() <Realm.html>`.
+<Realm.html#.open>`.
+
+.. note:: Link Multiple Identities to One User Account
+
+   If the ``path`` property is not specified in your ``Configuration`` object,
+   the default path is used. You can access and change the default Realm path
+   using the ``Realm.defaultPath`` global property.
 
 .. literalinclude:: /examples/generated/node/open-and-close-a-local-realm.codeblock.open-local-realm-with-car-schema.js
   :language: javascript
   :emphasize-lines: 2
+  
+
+In the above example, the code shows how to open the {+realm+} *asynchronously*
+by calling ``realm.open()``. You can also open a realm synchronously by passing
+a ``Configuration object`` to a new instance of the :js-sdk:`Realm
+<Realm.html>` object. This works even if the device is offline. 
+
+.. code-block:: javascript
+
+   const realm = new Realm(config);
+
+.. note::
+
+   The first time a user logs on to your realm app, you should open the realm 
+   *asynchronously* to sync data from the server to the device. After that initial 
+   connection, you can open a realm *synchronously* to ensure the app works in 
+   an offline state. 
 
 .. _node-close-a-realm:
 

--- a/source/sdk/node/examples/open-and-close-a-local-realm.txt
+++ b/source/sdk/node/examples/open-and-close-a-local-realm.txt
@@ -18,7 +18,7 @@ Open a Local Realm
 ------------------
 
 To open a local (non-synced) {+realm+}, pass a :js-sdk:`Realm.Configuration
-<Realm.html#~Configuration>` object to either :js-sdk:`Realm.open()
+<Realm.html#~Configuration>` object to :js-sdk:`Realm.open()
 <Realm.html#.open>`.
 
 .. note:: Accessing the Default Realm Path
@@ -31,7 +31,6 @@ To open a local (non-synced) {+realm+}, pass a :js-sdk:`Realm.Configuration
   :language: javascript
   :emphasize-lines: 2
   
-
 In the above example, the code shows how to open the {+realm+} *asynchronously*
 by calling ``realm.open()``. You can also open a realm synchronously by passing
 a ``Configuration object`` to a new instance of the :js-sdk:`Realm

--- a/source/sdk/node/examples/open-and-close-a-local-realm.txt
+++ b/source/sdk/node/examples/open-and-close-a-local-realm.txt
@@ -21,7 +21,7 @@ To open a local (non-synced) {+realm+}, pass a :js-sdk:`Realm.Configuration
 <Realm.html#~Configuration>` object to either :js-sdk:`Realm.open()
 <Realm.html#.open>`.
 
-.. note:: Link Multiple Identities to One User Account
+.. note:: Accessing the Default Realm Path
 
    If the ``path`` property is not specified in your ``Configuration`` object,
    the default path is used. You can access and change the default Realm path
@@ -37,9 +37,9 @@ by calling ``realm.open()``. You can also open a realm synchronously by passing
 a ``Configuration object`` to a new instance of the :js-sdk:`Realm
 <Realm.html>` object. This works even if the device is offline. 
 
-.. code-block:: javascript
-
-   const realm = new Realm(config);
+.. literalinclude:: /examples/generated/node/open-and-close-a-local-realm.codeblock.open-local-realm-synchronously.js
+  :language: javascript
+  :emphasize-lines: 2
 
 .. note::
 

--- a/source/sdk/react-native/examples/open-and-close-a-local-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-local-realm.txt
@@ -18,13 +18,35 @@ Open a Local Realm
 ------------------
 
 To open a local (non-synced) {+realm+}, pass a :js-sdk:`Realm.Configuration
-<Realm.html#~Configuration>` object to either :js-sdk:`Realm.open()
-<Realm.html#.open>` or :js-sdk:`new Realm() <Realm.html>`.
+<Realm.html#~Configuration>` object to :js-sdk:`Realm.open()
+<Realm.html#.open>`.
+
+.. note:: Accessing the Default Realm Path
+
+   If the ``path`` property is not specified in your ``Configuration`` object,
+   the default path is used. You can access and change the default Realm path
+   using the ``Realm.defaultPath`` global property.
 
 .. literalinclude:: /examples/generated/node/open-and-close-a-local-realm.codeblock.open-local-realm-with-car-schema.js
   :language: javascript
   :emphasize-lines: 2
 
+In the above example, the code shows how to open the {+realm+} *asynchronously*
+by calling ``realm.open()``. You can also open a realm synchronously by passing
+a ``Configuration object`` to a new instance of the :js-sdk:`Realm
+<Realm.html>` object. This works even if the device is offline. 
+
+.. literalinclude:: /examples/generated/node/open-and-close-a-local-realm.codeblock.open-local-realm-synchronously.js
+  :language: javascript
+  :emphasize-lines: 2
+
+.. note::
+
+   The first time a user logs on to your realm app, you should open the realm 
+   *asynchronously* to sync data from the server to the device. After that initial 
+   connection, you can open a realm *synchronously* to ensure the app works in 
+   an offline state. 
+   
 .. _react-native-close-a-realm:
 
 Close a Realm


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
* https://jira.mongodb.org/browse/DOCSP-14626
* https://jira.mongodb.org/browse/DOCSP-14630

### Docs staging link (requires sign-in on MongoDB Corp SSO):
* Node: https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14626-the-default-realm-js/sdk/node/examples/open-and-close-a-local-realm/
* React Native: https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14626-the-default-realm-js/sdk/react-native/examples/open-and-close-a-local-realm/

### Docs staging build link:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6042821975e817aef7ec3c60

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
