### PR TITLE
DOP-1883: use canonical links for redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,16 +1,16 @@
 define: base https://docs.mongodb.com/realm
 
-raw: realm/tutorials -> ${base}/tutorial
-raw: realm/deploy/application-schema -> ${base}/deploy/application-configuration-files
-raw: realm/mongodb/link-a-cluster -> ${base}/mongodb/link-a-data-source
-raw: realm/node/remotely-access-mongodb -> ${base}/node/mongodb
-raw: realm/react-native/remotely-access-mongodb -> ${base}/react-native/mongodb
-raw: realm/web/remotely-access-mongodb -> ${base}/web/mongodb
-raw: realm/import-export/realm-cli-reference -> ${base}/deploy/realm-cli-reference 
-raw: realm/admin/users-and-groups -> ${base}/security
-raw: realm/authentication/linking -> ${base}/authentication
-raw: realm/getting-started/configure-rules-based-access-to-mongodb -> ${base}/mongodb/define-roles-and-permissions
-raw: realm/procedures/create-stitch-app -> ${base}/get-started/create-realm-app
+raw: realm/tutorials -> ${base}/tutorial/
+raw: realm/deploy/application-schema -> ${base}/deploy/application-configuration-files/
+raw: realm/mongodb/link-a-cluster -> ${base}/mongodb/link-a-data-source/
+raw: realm/node/remotely-access-mongodb -> ${base}/node/mongodb/
+raw: realm/react-native/remotely-access-mongodb -> ${base}/react-native/mongodb/
+raw: realm/web/remotely-access-mongodb -> ${base}/web/mongodb/
+raw: realm/import-export/realm-cli-reference -> ${base}/deploy/realm-cli-reference /
+raw: realm/admin/users-and-groups -> ${base}/security/
+raw: realm/authentication/linking -> ${base}/authentication/
+raw: realm/getting-started/configure-rules-based-access-to-mongodb -> ${base}/mongodb/define-roles-and-permissions/
+raw: realm/procedures/create-stitch-app -> ${base}/get-started/create-realm-app/
 raw: realm/graphql/graphql-types-and-resolvers/index.html -> ${base}/graphql/types-and-resolvers/
 raw: realm/triggers/overview -> ${base}/triggers/
 raw: realm/sync/overview -> ${base}/sync/


### PR DESCRIPTION
## Pull Request Info

Updates redirects to use canonical (with `/`) URLs to avoid an extra redirection step. This is part of the Croud SEO project that we're working on with Marketing.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOP-1883
