### PR TITLE
DOP-1883:Update links to Android SDK to /latest

### DIFF
--- a/source/sdk/android.txt
+++ b/source/sdk/android.txt
@@ -15,8 +15,8 @@ MongoDB Realm Android SDK
    Data Types </sdk/android/data-types>
    Usage Examples </sdk/android/examples>
    Advanced Guides </sdk/android/advanced-guides>
-   Java Reference Manual (Javadoc) <https://docs.mongodb.com/realm-sdks/java/10.3.1>
-   Kotlin Extensions Reference Manual <https://docs.mongodb.com/realm-sdks/kotlin/10.3.1>
+   Java Reference Manual (Javadoc) <https://docs.mongodb.com/realm-sdks/java/latest/>
+   Kotlin Extensions Reference Manual <https://docs.mongodb.com/realm-sdks/kotlin/latest/kotlin-extensions/>
    Upgrade from Stitch to Realm </sdk/android/migrate>
    Release Notes <https://github.com/realm/realm-java/blob/releases/CHANGELOG.md>
 


### PR DESCRIPTION
## Pull Request Info

Turns out the TOC links are also causing redirection woes 😁 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOP-1883

### Staging (built on our QA servers using the build we'll be releasing tomorrow)
https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOP-1883-TOC/

Alternative solution would be to add `/kotlin-extensions/` after `10.3.1` for Kotlin and a trailing slash to the Javadoc link, but this seems like it would save some maintenance burden? Let me know what y'all would prefer.