### PR TITLE
(DOCSP-12901) Add Carthage to iOS Install Instructions

### DIFF
--- a/source/sdk/ios/install.txt
+++ b/source/sdk/ios/install.txt
@@ -29,13 +29,11 @@ meets the following prerequisites:
 
 - `Xcode <https://developer.apple.com/xcode/>`__ version 10.0 or higher.
 - Target of iOS 8.0 or higher, macOS 10.9 or higher, tvOS 9.0 or higher, or watchOS 2.0 or higher.
-- If you are installing with `CocoaPods <https://guides.cocoapods.org/using/getting-started.html>`__, you need CocoaPods 1.10.0 or later.
-- If you are installing with `Carthage <https://github.com/Carthage/Carthage#installing-carthage>`__, you need Carthage 0.33 or later.
 
 Installation
 ------------
 
-Follow the procedure for either ``SwiftPM`` or ``CocoaPods`` below to add the
+You can use ``SwiftPM``, ``CocoaPods``, or ``Carthage`` to add the
 {+service+} Apple platform SDK to your project.
 
 .. tabs::
@@ -48,10 +46,14 @@ Follow the procedure for either ``SwiftPM`` or ``CocoaPods`` below to add the
    .. tab:: CocoaPods
       :tabid: cocoapods
 
+      If you are installing with `CocoaPods <https://guides.cocoapods.org/using/getting-started.html>`__, you need CocoaPods 1.10.0 or later.
+
       .. include:: /includes/steps/install-cocoapods.rst
 
    .. tab:: Carthage
       :tabid: carthage
+
+      If you are installing with `Carthage <https://github.com/Carthage/Carthage#installing-carthage>`__, you need Carthage 0.33 or later.
 
       .. include:: /includes/steps/install-carthage.rst
 

--- a/source/sdk/ios/install.txt
+++ b/source/sdk/ios/install.txt
@@ -30,6 +30,7 @@ meets the following prerequisites:
 - `Xcode <https://developer.apple.com/xcode/>`__ version 10.0 or higher.
 - Target of iOS 8.0 or higher, macOS 10.9 or higher, tvOS 9.0 or higher, or watchOS 2.0 or higher.
 - If you are installing with `CocoaPods <https://guides.cocoapods.org/using/getting-started.html>`__, you need CocoaPods 1.10.0 or later.
+- If you are installing with `Carthage <https://github.com/Carthage/Carthage#installing-carthage>`__, you need Carthage 0.33 or later.
 
 Installation
 ------------
@@ -37,15 +38,22 @@ Installation
 Follow the procedure for either ``SwiftPM`` or ``CocoaPods`` below to add the
 {+service+} Apple platform SDK to your project.
 
-SwiftPM
-=======
+.. tabs::
 
-.. include:: /includes/steps/install-swiftpm.rst
+   .. tab:: SwiftPM
+      :tabid: swiftpm
 
-CocoaPods
-=========
+      .. include:: /includes/steps/install-swiftpm.rst
 
-.. include:: /includes/steps/install-cocoapods.rst
+   .. tab:: CocoaPods
+      :tabid: cocoapods
+
+      .. include:: /includes/steps/install-cocoapods.rst
+
+   .. tab:: Carthage
+      :tabid: carthage
+
+      .. include:: /includes/steps/install-carthage.rst
 
 Import Realm
 ------------


### PR DESCRIPTION
## Pull Request Info

For some context:
- The title of the ticket is to "Add iOS Carthage install workaround"
- The description body says "Current docs do not list the cocoapods workaround for installing RealmSwift"

Taken together with the link, which lists SwiftPM, CocoaPods, and Carthage install instructions, I've interpreted this ticket to be asking to include Carthage install instructions on our docs site as a workaround for using CocoaPods to install RealmSwift.

These instructions were already present in the `/includes` directory, so I've merely added the tabs back to the page and have referenced the existing instructions. Looks like they were added in [pull request 11](https://github.com/mongodb/docs-realm/pull/11/) and removed in [pull request 237](https://github.com/mongodb/docs-realm/pull/237), with the instruction that they could be re-added later.

I did follow the instructions to confirm that they still work, and was able to successfully use Carthage to add Realm to my Xcode project and build the project.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12901

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-12901/sdk/ios/install/

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
