### PR TITLE
(DOCSP-14644) Add Property Cheatsheet for both Swift and Objective-C

### DIFF
--- a/examples/ios/Examples/ObjectModels.m
+++ b/examples/ios/Examples/ObjectModels.m
@@ -132,6 +132,17 @@ RLM_ARRAY_TYPE(ObjectModelsExamplesObjc_Task)
 @end
 // :code-block-end:
 
+@interface ObjectModelsExamplesObjc_TestProperties : RLMObject
+@property RLMDecimal128 *decimal;
+// @property NSNumber<RLMDecimal128> *value;
+@property RLMObjectId *objectId;
+
+@end
+
+@implementation ObjectModelsExamplesObjc_TestProperties
+
+@end
+
 @interface ObjectModelsObjc : XCTestCase
 @end
 

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -113,11 +113,11 @@ Supported Property Types - iOS SDK
            - ``@property RLMObjectId *objectId;``
            - ``@property RLMObjectId *objectId;``
          * - :objc-sdk:`RLMArray <Classes/RLMArray.html>`
-           - ``@property RLMArray<MyArray *><MyArray> *arrayItems;``
-           - ``@property RLMArray<MyArray *><MyArray> *arrayItems;``
+           - ``@property RLMArray<MyClass *><MyClass> *items;``
+           - ``@property RLMArray<MyClass *><MyClass> *items;``
          * - User-defined :objc-sdk:`RLMObject<Classes/RLMObject.html>`
            - N/A
-           - ``@interface MyClass : RLMObject``
+           - ``@property MyClass *value;``
 
       Additionally:
 

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -58,13 +58,12 @@ Supported Property Types - iOS SDK
            - ``let value = List<Type>()``
            - 
          * - User-defined :swift-sdk:`Object <Extensions/Object.html>`
-           - N/A: Must be optional
-           - ``@objc dynamic var value: Class?``
+           - N/A
+           - ``@objc dynamic var value: MyClass?``
       
       Additionally:
 
-      - User-defined :swift-sdk:`Object <Extensions/Object.html>`- and 
-        :swift-sdk:`EmbeddedObject <Extensions/EmbeddedObject.html>`-derived types
+      - :swift-sdk:`EmbeddedObject <Extensions/EmbeddedObject.html>`-derived types
       - :swift-sdk:`Enum <Protocols.html#/s:10RealmSwift0A4EnumP>`
 
       You can use :swift-sdk:`RealmOptional <Classes/RealmOptional.html>` to
@@ -107,15 +106,23 @@ Supported Property Types - iOS SDK
          * - Date
            - ``@property NSDate *value;``
            - ``@property NSDate *value;``
+         * - Decimal128
+           - ``@property RLMDecimal128 *value;``
+           - ``@property RLMDecimal128 *value;``
+         * - :objc-sdk:`RLMObjectId <Classes/RLMObjectId.html>`
+           - ``@property RLMObjectId *objectId;``
+           - ``@property RLMObjectId *objectId;``
+         * - :objc-sdk:`RLMArray <Classes/RLMArray.html>`
+           - ``@property RLMArray<MyArray *><MyArray> *arrayItems;``
+           - ``@property RLMArray<MyArray *><MyArray> *arrayItems;``
+         * - User-defined :objc-sdk:`RLMObject<Classes/RLMObject.html>`
+           - N/A
+           - ``@interface MyClass : RLMObject``
 
       Additionally:
 
       - Integral types ``int``, ``NSInteger``, ``long``, ``long long``
-      - ``RLMDecimal128``
-      - :objc-sdk:`RLMObjectId <Classes/RLMObjectId.html>`
-      - User-defined :objc-sdk:`RLMObject<Classes/RLMObject.html>`- and 
-        :objc-sdk:`RLMEmbeddedObject<Classes/RLMEmbeddedObject.html>`-derived types
-      - :objc-sdk:`RLMArray <Classes/RLMArray.html>`
+      - :objc-sdk:`RLMEmbeddedObject<Classes/RLMEmbeddedObject.html>`-derived types
 
       ``CGFloat`` properties are discouraged, as the type is not
       platform independent.

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -56,11 +56,13 @@ Supported Property Types - iOS SDK
            - ``@objc dynamic var objectIdOpt: ObjectId?``
          * - :swift-sdk:`List <Classes/List.html>`
            - ``let value = List<Type>()``
+           - 
          * - User-defined :swift-sdk:`Object <Extensions/Object.html>`
            - N/A: Must be optional
            - ``@objc dynamic var value: Class?``
       
       Additionally:
+
       - User-defined :swift-sdk:`Object <Extensions/Object.html>`- and 
         :swift-sdk:`EmbeddedObject <Extensions/EmbeddedObject.html>`-derived types
       - :swift-sdk:`Enum <Protocols.html#/s:10RealmSwift0A4EnumP>`
@@ -107,6 +109,7 @@ Supported Property Types - iOS SDK
            - ``@property NSDate *value;``
 
       Additionally:
+
       - Integral types ``int``, ``NSInteger``, ``long``, ``long long``
       - ``RLMDecimal128``
       - :objc-sdk:`RLMObjectId <Classes/RLMObjectId.html>`

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -50,10 +50,10 @@ Supported Property Types - iOS SDK
            - ``@objc dynamic var value: Date? = nil``
          * - Decimal128
            - ``@objc dynamic var decimal: Decimal128 = 0``
-           - ``@objc dynamic var decimalOpt: Decimal128?``
+           - ``@objc dynamic var decimal: Decimal128?``
          * - :swift-sdk:`ObjectId <Classes/ObjectId.html>`
-           - ``@objc dynamic var objectId = ObjectId()``
-           - ``@objc dynamic var objectIdOpt: ObjectId?``
+           - ``@objc dynamic var objectId = ObjectId.generate()``
+           - ``@objc dynamic var objectId: ObjectId?``
          * - :swift-sdk:`List <Classes/List.html>`
            - ``let value = List<Type>()``
            - 
@@ -85,10 +85,10 @@ Supported Property Types - iOS SDK
          * - Type
            - Required
            - Optional
-         * - Bool
+         * - Boolean
            - ``@property BOOL value;``
            - ``@property NSNumber<RLMBool> *value;``
-         * - Int
+         * - Integer
            - ``@property int value;``
            - ``@property NSNumber<RLMInt> *value;``
          * - Float

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -20,23 +20,52 @@ Supported Property Types - iOS SDK
       You can use the following types to define your object model
       properties:
 
-      - ``Bool``
-      - Integral types ``Int``, ``Int8``, ``Int16``, ``Int32``, ``Int64``
-      - ``Decimal128``
-      - ``Double``
-      - ``String``
-      - ``Date``
-      - ``Data``
-      - :swift-sdk:`ObjectId <Classes/ObjectId.html>`
+      .. list-table::
+         :header-rows: 1
+         :stub-columns: 1
+      
+         * - Type
+           - Required
+           - Optional
+         * - Bool
+           - ``@objc dynamic var value = false``
+           - ``let value = RealmOptional<Bool>()``
+         * - Int, Int8, Int16, Int32, Int64
+           - ``@objc dynamic var value = 0``
+           - ``let value = RealmOptional<Int>()``
+         * - Float
+           - ``@objc dynamic var value: Float = 0.0``
+           - ``let value = RealmOptional<Float>()``
+         * - Double
+           - ``@objc dynamic var value: Double = 0.0``
+           - ``let value = RealmOptional<Double>()``
+         * - String
+           - ``@objc dynamic var value = ""``
+           - ``@objc dynamic var value: String? = nil``
+         * - Data
+           - ``@objc dynamic var value = Data()``
+           - ``@objc dynamic var value: Data? = nil``
+         * - Date
+           - ``@objc dynamic var value = Date()``
+           - ``@objc dynamic var value: Date? = nil``
+         * - Decimal128
+           - ``@objc dynamic var decimal: Decimal128 = 0``
+           - ``@objc dynamic var decimalOpt: Decimal128?``
+         * - :swift-sdk:`ObjectId <Classes/ObjectId.html>`
+           - ``@objc dynamic var objectId = ObjectId()``
+           - ``@objc dynamic var objectIdOpt: ObjectId?``
+         * - :swift-sdk:`List <Classes/List.html>`
+           - ``let value = List<Type>()``
+         * - User-defined :swift-sdk:`Object <Extensions/Object.html>`
+           - N/A: Must be optional
+           - ``@objc dynamic var value: Class?``
+      
+      Additionally:
       - User-defined :swift-sdk:`Object <Extensions/Object.html>`- and 
         :swift-sdk:`EmbeddedObject <Extensions/EmbeddedObject.html>`-derived types
-      - :swift-sdk:`List <Classes/List.html>`
       - :swift-sdk:`Enum <Protocols.html#/s:10RealmSwift0A4EnumP>`
 
-      You can use optionals such as ``String?``, ``Date?``, ``Data?``,
-      and ``ObjectId?`` to mark a property optional in the model. You
-      *must* make user-defined Object properties optional. You can use
-      :swift-sdk:`RealmOptional <Classes/RealmOptional.html>` to
+      You can use :swift-sdk:`RealmOptional <Classes/RealmOptional.html>` to
       represent integers, doubles, and other types as optional.
 
       ``CGFloat`` properties are discouraged, as the type is not
@@ -48,25 +77,42 @@ Supported Property Types - iOS SDK
       You can use the following types to define your object model
       properties:
 
-      - Boolean types ``BOOL``, ``bool``
+      .. list-table::
+         :header-rows: 1
+         :stub-columns: 1
+      
+         * - Type
+           - Required
+           - Optional
+         * - Bool
+           - ``@property BOOL value;``
+           - ``@property NSNumber<RLMBool> *value;``
+         * - Int
+           - ``@property int value;``
+           - ``@property NSNumber<RLMInt> *value;``
+         * - Float
+           - ``@property float value;``
+           - ``@property NSNumber<RLMFloat> *value;``
+         * - Double
+           - ``@property double value;``
+           - ``@property NSNumber<RLMDouble> *value;``
+         * - String
+           - ``@property NSString *value;``
+           - ``@property NSString *value;``
+         * - Data
+           - ``@property NSData *value;``
+           - ``@property NSData *value;``
+         * - Date
+           - ``@property NSDate *value;``
+           - ``@property NSDate *value;``
+
+      Additionally:
       - Integral types ``int``, ``NSInteger``, ``long``, ``long long``
       - ``RLMDecimal128``
-      - ``double``
-      - ``NSString``
-      - ``NSDate``
-      - ``NSData``
       - :objc-sdk:`RLMObjectId <Classes/RLMObjectId.html>`
       - User-defined :objc-sdk:`RLMObject<Classes/RLMObject.html>`- and 
         :objc-sdk:`RLMEmbeddedObject<Classes/RLMEmbeddedObject.html>`-derived types
       - :objc-sdk:`RLMArray <Classes/RLMArray.html>`
-
-      Additionally, you can represent optional number types with
-      ``NSNumber`` tagged with ``RLMInt``, ``RLMDouble``,
-      or ``RLMBool``:
-
-      .. code-block:: objective-c
-
-         @property NSNumber<RLMInt> *age;
 
       ``CGFloat`` properties are discouraged, as the type is not
       platform independent.


### PR DESCRIPTION
## Pull Request Info

Couple of notes:
- The property cheat sheet from the Realm legacy doc site lists Float, which is not on our current page listing supported property types, but there are tests for it in the realm-cocoa repo.
- The property cheat sheet page from the Realm legacy docs does _not_ list Decimal128, which _is_ on our current page listing supported property types, so I've attempted to add appropriate declarations, but would love confirmation that I've done it correctly.

The Jira ticket doesn't request the Objective-C property cheatsheet, but since both tabs exist in our current documentation set, I've ported over the Objective-C properties, too.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14644

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14644/sdk/ios/data-types/supported-property-types/

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
