### PR TITLE
(DOCSP-15144): Add ObjectId comparison example

### DIFF
--- a/examples/ios/Examples/ReadWriteData.swift
+++ b/examples/ios/Examples/ReadWriteData.swift
@@ -39,6 +39,13 @@ class ReadWriteDataExamples_DogClub: Object {
 }
 // :code-block-end:
 
+// :code-block-start: object-id-model
+class ReadWriteDataExamples_User: Object {
+    @objc dynamic var id = ObjectId.generate()
+    @objc dynamic var name = ""
+}
+// :code-block-end:
+
 class ReadWriteData: XCTestCase {
     override func tearDown() {
         let realm = try! Realm()
@@ -273,6 +280,22 @@ class ReadWriteData: XCTestCase {
         print(puppies.count)
         print(dogsWithoutFavoriteToy.count)
         print(dogsWhoLikeTennisBalls.count)
+    }
+
+    func testQueryObjectId() {
+        // :code-block-start: query-object-id
+        let realm = try! Realm()
+
+        let users = realm.objects(ReadWriteDataExamples_User.self)
+
+        // Get specific user by ObjectId id
+        let specificUser = users.filter("id = %@", ObjectId("11223344556677889900aabb")).first
+
+        // WRONG: Realm will not convert the string to an object id
+        // users.filter("id = '11223344556677889900aabb'") // not ok
+        // users.filter("id = %@", "11223344556677889900aabb") // not ok
+        // :code-block-end:
+        print("\(specificUser ?? ReadWriteDataExamples_User())")
     }
 
     func testTransaction() {

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.object-id-model.swift
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.object-id-model.swift
@@ -1,0 +1,4 @@
+class User: Object {
+    @objc dynamic var id = ObjectId.generate()
+    @objc dynamic var name = ""
+}

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.query-object-id.swift
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.query-object-id.swift
@@ -1,0 +1,10 @@
+let realm = try! Realm()
+
+let users = realm.objects(User.self)
+
+// Get specific user by ObjectId id
+let specificUser = users.filter("id = %@", ObjectId("11223344556677889900aabb")).first
+
+// WRONG: Realm will not convert the string to an object id
+// users.filter("id = '11223344556677889900aabb'") // not ok
+// users.filter("id = %@", "11223344556677889900aabb") // not ok

--- a/source/sdk/ios/examples/filter-data.txt
+++ b/source/sdk/ios/examples/filter-data.txt
@@ -95,9 +95,9 @@ Expressions
 Filters consist of **expressions** in an NSPredicate. An expression consists of
 one of the following:
 
-- The name of a property of the object currently being evaluated.
+- The name (keypath) of a property of the object currently being evaluated.
 - An operator and up to two argument expression(s).
-- A literal string, number, or date.
+- A value, such as a string (``'hello'``) or a number (``5``).
 
 Dot Notation
 ~~~~~~~~~~~~
@@ -190,6 +190,20 @@ Comparison Operators
 
 The most straightforward operation in a search is to compare
 values.
+
+.. important:: Types Must Match
+
+   The type on both sides of the operator much be equivalent. You can
+   compare a string with string, date with date, and ObjectId with
+   ObjectId, but you cannot compare a string with date, date with
+   number, or :ref:`ObjectId with string <ios-filter-object-id>`. Type
+   mismatch will result in a precondition failure with a message similar
+   to: ``"Expected object of type object id for property 'id' on object
+   of type 'User', but received: 11223344556677889900aabb (Invalid
+   value)"``.
+   
+   You can compare any :ref:`numeric type
+   <ios-supported-property-types>` with any other numeric type.
 
 .. list-table::
    :header-rows: 1

--- a/source/sdk/ios/examples/filter-data.txt
+++ b/source/sdk/ios/examples/filter-data.txt
@@ -193,14 +193,12 @@ values.
 
 .. important:: Types Must Match
 
-   The type on both sides of the operator much be equivalent. You can
-   compare a string with string, date with date, and ObjectId with
-   ObjectId, but you cannot compare a string with date, date with
-   number, or :ref:`ObjectId with string <ios-filter-object-id>`. Type
-   mismatch will result in a precondition failure with a message similar
-   to: ``"Expected object of type object id for property 'id' on object
-   of type 'User', but received: 11223344556677889900aabb (Invalid
-   value)"``.
+   The type on both sides of the operator must be equivalent. For
+   example, comparing an :ref:`ObjectId with string
+   <ios-filter-object-id>` will result in a precondition failure with a
+   message like: ``"Expected object of type object id for property 'id'
+   on object of type 'User', but received: 11223344556677889900aabb
+   (Invalid value)"``.
    
    You can compare any :ref:`numeric type
    <ios-supported-property-types>` with any other numeric type.

--- a/source/sdk/ios/examples/read-and-write-data.txt
+++ b/source/sdk/ios/examples/read-and-write-data.txt
@@ -148,7 +148,7 @@ Filter on Object ID Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The types in your predicate must match the types of the
-properties. In particular, avoid inadvertently comparing
+properties. Avoid comparing
 :swift-sdk:`ObjectId <Classes/ObjectId.html>` properties to strings, as
 {+client-database+} does not automatically convert strings to ObjectIds.
 

--- a/source/sdk/ios/examples/read-and-write-data.txt
+++ b/source/sdk/ios/examples/read-and-write-data.txt
@@ -147,7 +147,7 @@ engine that you can use to define filters.
 Filter on Object ID Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It's important that the types in your predicate match the types of the
+The types in your predicate must match the types of the
 properties. In particular, avoid inadvertently comparing
 :swift-sdk:`ObjectId <Classes/ObjectId.html>` properties to strings, as
 {+client-database+} does not automatically convert strings to ObjectIds.

--- a/source/sdk/ios/examples/read-and-write-data.txt
+++ b/source/sdk/ios/examples/read-and-write-data.txt
@@ -142,6 +142,25 @@ engine that you can use to define filters.
    
    :ref:`ios-filter-data`
 
+.. _ios-filter-object-id:
+
+Filter on Object ID Properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It's important that the types in your predicate match the types of the
+properties. In particular, avoid inadvertently comparing
+:swift-sdk:`ObjectId <Classes/ObjectId.html>` properties to strings, as
+{+client-database+} does not automatically convert strings to ObjectIds.
+
+The following example shows the correct and incorrect way to write a
+query with an ObjectId given the following Realm object:
+
+.. literalinclude:: /examples/generated/code/start/ReadWriteData.codeblock.object-id-model.swift
+   :language: swift
+
+.. literalinclude:: /examples/generated/code/start/ReadWriteData.codeblock.query-object-id.swift
+   :language: swift
+
 .. _ios-sort-query-results:
 
 Sort Query Results


### PR DESCRIPTION
Users can fall into the trap 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-15144

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fruit/sdk/ios/examples/read-and-write-data/#filter-on-object-id-properties

and new warning here:

https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fruit/sdk/ios/examples/filter-data/#comparison-operators

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
