### PR TITLE
(DOCSP-14623): Reusing RealmResults and RealmObjects, Android

### DIFF
--- a/source/sdk/android/examples/react-to-changes.txt
+++ b/source/sdk/android/examples/react-to-changes.txt
@@ -58,6 +58,15 @@ granular notifications.
           :language: kotlin
           :emphasize-lines: 12
 
+.. important:: Automatic Refresh
+
+   All threads that contain a ``Looper`` automatically refresh
+   ``RealmObject`` and ``RealmResult`` instances when new changes are
+   written to the {+realm+}. As a result, it isn't necessary to fetch
+   those objects again when reacting to a ``RealmChangeListener``, since
+   those objects are already updated and ready to be redrawn to the
+   screen.
+
 .. _android-register-a-collection-change-listener:
 .. _android-collection-notifications:
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14623

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14623/sdk/android/examples/react-to-changes/#register-a-realm-change-listener (note at bottom of section)

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
