### PR TITLE
[CLI V2] MongoDB Data Source Configuration

### DIFF
--- a/source/config/data_sources.txt
+++ b/source/config/data_sources.txt
@@ -26,6 +26,8 @@ MongoDB Data Source Configuration Files
 Service Configuration
 ---------------------
 
+.. _config-mongodb-cluster:
+
 MongoDB Clusters
 ~~~~~~~~~~~~~~~~
 
@@ -38,6 +40,7 @@ MongoDB Clusters
      "config": {
        "clusterName": "<Atlas Cluster Name>",
        "readPreference": "<Read Preference>",
+       "sync": { <Sync Configuration> },
        "wireProtocolEnabled": <Boolean>
      }
    }
@@ -51,24 +54,19 @@ MongoDB Clusters
    
    * - | ``name``
        | String
-     - The name of the MongoDB  service. The name may be at most 64 characters
-       long and can only contain ASCII letters, numbers, underscores,
-       and hyphens.
+     - Required. Default: ``mongodb-atlas``
        
-       .. important::
-          
-          MongoDB service names are not necessarily the same as their linked
-          data source's name in Atlas. For linked clusters, the default MongoDB
-          service name is ``mongodb-atlas``. For linked Data Lakes, the default
-          service name is ``mongodb-datalake``.
+       The service name used to refer to the cluster within this Realm
+       app. The name may be at most 64 characters long and must only
+       contain ASCII letters, numbers, underscores, and hyphens.
    
    * - | ``type``
        | String
-     - For MongoDB Atlas clusters, this value is always ``"mongodb-atlas"``.
+     - Required. For MongoDB Atlas clusters, this value is always ``"mongodb-atlas"``.
    
    * - | ``config.clusterName``
        | String
-     - The name of the service's linked cluster in MongoDB Atlas.
+     - Required. The name of the cluster in Atlas.
 
    * - | ``config.readPreference``
        | String
@@ -77,24 +75,114 @@ MongoDB Clusters
        
        .. include:: /mongodb/tables/read-preference-modes.rst
    
+   * - | ``config.sync``
+       | Document
+     - A configuration document that determines if a cluster is :doc:`synced
+       </sync>` and, if it is, defines the rules for sync operations on the
+       cluster.
+
+       For detailed information on sync configuration documents, see
+       :ref:`Synced Cluster Configuration <config-synced-cluster>`.
+   
    * - | ``config.wireProtocolEnabled``
        | Boolean   
      - If ``true``, clients may :ref:`connect to the app over the MongoDB Wire
        Protocol <wire-protocol-connect>`.
 
-MongoDB Data Lakes
-~~~~~~~~~~~~~~~~~~
+.. _config-synced-cluster:
+
+Synced Cluster Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``config.sync`` field of ``config.json`` determines if a cluster is
+:doc:`synced </sync>` and, if it is, defines the rules for sync operations on
+the cluster.
 
 .. code-block:: json
    :caption: config.json
 
    {
+     ...,
+     "config": {
+       ...,
+       "sync": {
+         "state": <Boolean>,
+         "development_mode_enabled": <Boolean>,
+         "database_name": "<Developer Mode Database Name>",
+         "partition": {
+           "key": "<Partition Key Field Name>",
+           "type": "<Partition Key Value Type>",
+           "permissions": {
+             "read": <JSON Expression>,
+             "write": <JSON Expression>
+           }
+         }
+       }
+     }
+   }
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 30
+
+   * - Field
+     - Description
+   
+   * - | ``sync.state``
+       | Boolean
+     - If ``true``, :doc:`Sync </sync>` is enabled for the cluster, which means
+       that client applications can sync data in the cluster with Realm Database
+       and that :ref:`non-sync collection rules <mongodb-service-rules>` do not
+       apply.
+   
+   * - | ``sync.development_mode_enabled``
+       | Boolean
+     - If ``true``, :term:`development mode` is enabled for the cluster. While
+       enabled, Realm does not enforce sync rules, stores synced objects in a
+       specific database within the cluster, and mirrors object types in that
+       database's collection schemas.
+
+   * - | ``sync.database_name``
+       | String
+     - The name of the database in the synced cluster where Realm should store
+       synced objects.
+       
+       When :term:`development mode` is enabled, Realm stores synced objects in
+       this database. Each object type maps to its own collection in the
+       database with a schema that matches the synced objects.
+   
+   * - | ``sync.partition.key``
+       | String
+     - The name of the field that :ref:`partitions <partitioning>` data into
+       client Realms.
+   
+   * - | ``sync.partition.type``
+       | String
+     - The type of the partition key field value.
+   
+   * - | ``sync.partition.permissions``
+       | Document
+     - A document that defines the ``read`` and ``write`` permissions for the
+       synced cluster. Permissions are defined with :ref:`rule expressions
+       <expressions>` that Realm evaluates per-user, per-partition. The
+       expressions have access to the :json-expansion:`%%user` and
+       :json-expansion:`%%partition` expansions.
+
+.. _config-datalake:
+
+MongoDB Data Lakes
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: json
+   :caption: /data_sources/<Service Name>/config.json
+   
+   {
      "name": "<Service Name>",
      "type": "datalake",
      "config": {
-        "dataLakeName": "<Data Lake Name>"
+        "dataLakeName": "<Data Lake>"
       }
-    }
+   }
 
 .. list-table::
    :header-rows: 1
@@ -105,23 +193,20 @@ MongoDB Data Lakes
    
    * - | ``name``
        | String
-     - The name of the MongoDB  service. The name may be at most 64 characters
-       long and can only contain ASCII letters, numbers, underscores,
-       and hyphens.
+     - Required. Default: ``mongodb-datalake``
        
-       .. important::
-          
-          MongoDB service names are not necessarily the same as their linked
-          data source's name in Atlas. For linked Data Lakes, the default
-          service name is ``mongodb-datalake``.
+       The service name used to refer to the data lake within this Realm
+       app. The name may be at most 64 characters long and must only
+       contain ASCII letters, numbers, underscores, and hyphens.
    
    * - | ``type``
        | String
-     - For Data Lakes, this value is always ``"datalake"``.
+     - Required. For MongoDB Atlas data lakes, this value is always ``"datalake"``.
    
    * - | ``config.dataLakeName``
        | String   
-     - The name of the Data Lake that you want to link to your application.
+     - Required. The name of the data lake in Atlas.
+
 
 Databases & Collections
 -----------------------

--- a/source/config/data_sources.txt
+++ b/source/config/data_sources.txt
@@ -138,9 +138,13 @@ the cluster.
    * - | ``sync.development_mode_enabled``
        | Boolean
      - If ``true``, :term:`development mode` is enabled for the cluster. While
-       enabled, Realm does not enforce sync rules, stores synced objects in a
-       specific database within the cluster, and mirrors object types in that
-       database's collection schemas.
+       enabled, Realm automatically stores synced objects in a specific database
+       within the cluster and mirrors objects types in that database's
+       collection schemas.
+       
+       .. important::
+          
+          Realm does not enforce rules when development mode is enabled.
 
    * - | ``sync.database_name``
        | String

--- a/source/includes/steps-enable-wire-protocol-import-export.yaml
+++ b/source/includes/steps-enable-wire-protocol-import-export.yaml
@@ -1,45 +1,49 @@
-title: Export Your Realm Application
-ref: export-your-application
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  To enable wire protocol connections with :doc:`realm-cli
-  </deploy/realm-cli-reference>` you need to export an
-  :ref:`application directory <application-directory>` for your
-  application.
-
-  You can :doc:`export </deploy/export-realm-app>` your application from the
-  :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in the
-  {+ui+}, or by running the following command from an authenticated instance of
-  :doc:`realm-cli </deploy/realm-cli-reference>`:
-
-  .. code-block:: shell
-
-     realm-cli export --app-id=<App ID>
+  To enable MongoDB wire protocol connections with {+cli-bin+}, you need a local
+  copy of your application's configuration files.
+  
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
+     
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
+     
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Export App` screen in the {+ui+}.
 ---
 title: Enable Wire Protocol for the Cluster
 ref: enable-wire-protocol-for-the-cluster
 content: |
-  The ``config.json`` configuration file in the :doc:`linked cluster
-  </mongodb/link-a-data-source>`'s service directory configures wire protocol
-  connections.
-
-  In the configuration file, set ``config.wireProtocolEnabled`` to ``true``:
+  To enable wire protocol connections for a linked cluster, open the cluster's
+  ``config.json`` file and set the value of ``config.wireProtocolEnabled`` to
+  ``true``:
 
   .. code-block:: json
+     :emphasize-lines: 5
 
      {
-       "config": { "wireProtocolEnabled": true }
+       "name": "mongodb-atlas",
+       "type": "mongodb-atlas",
+       "config": {
+         "wireProtocolEnabled": true,
+         ...
+       }
      }
 
   .. include:: /includes/data-lake-wire-protocol-note.rst
 
 ---
-title: Import Your Application Directory
-ref: import-your-application-directory
+title: Deploy the Updated Data Source Configuration
+ref: deploy-the-updated-data-source-configuration
 content: |
-  Save the cluster configuration file, then navigate to
-  the root of the exported application directory and run the following
-  command to import the directory:
-
-  .. code-block:: shell
-
-     realm-cli import
+  Once you've enabled wire protocol connections for the cluster in
+  ``config.json``, you can push the config to your remote app. {+cli+}
+  immediately deploys the update on push.
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>"

--- a/source/includes/steps-link-a-data-source-import-export.yaml
+++ b/source/includes/steps-link-a-data-source-import-export.yaml
@@ -1,56 +1,89 @@
-title: Export Your Realm Application
-ref: export-your-application
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  To link a MongoDB Atlas cluster to your {+app+} with
-  :doc:`realm-cli </deploy/realm-cli-reference>`, you need a
-  previously created :ref:`application configuration <application-directory>`.
+  To link a MongoDB Atlas cluster or data lake with {+cli-bin+}, you need a
+  local copy of your application's configuration files.
   
-  You can :doc:`export </deploy/export-realm-app>` your application from the
-  :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in the
-  {+ui+}, or by running the following command from an authenticated instance of
-  :doc:`realm-cli </deploy/realm-cli-reference>`:
-
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
+     
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
+     
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Export App` screen in the {+ui+}.
+---
+title: Create a Data Source Configuration Directory
+ref: create-a-data-source-configuration-directory
+content: |
+  Create a new subdirectory with the name that you'll use for the data source in
+  ``/data_sources``.
+  
   .. code-block:: shell
-
-     realm-cli export --app-id=<App ID>
-
+     
+     mkdir -p data_sources/<Data Source Name>
 ---
-title: Create a MongoDB Service Configuration Directory
-ref: create-a-mongodb-service-configuration-directory
+title: Add a Data Source Configuration File
+ref: add-a-data-source-configuration-file
 content: |
-  Create a new subdirectory in the ``/services`` folder of the
-  application directory that you exported. The name of the subdirectory
-  should match the name of the MongoDB service you're creating.
+  Add a file named ``config.json`` to the data source subdirectory. The file can
+  configure either a MongoDB Atlas cluster or an Atlas data lake.
+  
+  The configuration file should have the following general form:
+  
+  .. tabs::
+     
+     .. tab:: Atlas Cluster
+        :tabid: cluster
 
-  .. code-block:: shell
-
-     mkdir -p services/<MongoDB Service Name>
-
+        .. code-block:: json
+           :caption: /data_sources/<Service Name>/config.json
+           
+           {
+             "name": "<Service Name>",
+             "type": "mongodb-atlas",
+             "config": {
+               "clusterName": "<Atlas Cluster Name>",
+               "readPreference": "<Read Preference>",
+               "wireProtocolEnabled": <Boolean>,
+               "sync": <Sync Configuration>
+             }
+           }
+        
+        .. note::
+           
+           For detailed information on the contents of a cluster configuration
+           file, see :ref:`Linked MongoDB Cluster Configuration
+           <config-mongodb-cluster>`.
+     
+     .. tab:: Atlas Data Lake
+        :tabid: datalake
+        
+        .. code-block:: json
+           :caption: /data_sources/<Service Name>/config.json
+           
+           {
+             "name": "<Service Name>",
+             "type": "datalake",
+             "config": {
+                "dataLakeName": "<Data Lake>"
+              }
+           }
+        
+        .. note::
+           
+           For detailed information on the contents of a data lake configuration
+           file, see :ref:`Linked Data Lake Configuration <config-datalake>`.
 ---
-title: Add a MongoDB Service Configuration File
-ref: add-a-mongodb-service-configuration-file
+title: Deploy the Data Source Configuration
+ref: deploy-the-data-source-configuration
 content: |
-  Add a file named ``config.json`` to the new service directory.
-
-  .. include:: /includes/data-source-configuration.rst
-
----
-title: Import the Application Directory
-ref: import-the-application-directory
-content: |
-  Once you've added the MongoDB service configuration, all that's left
-  is to import the function.
-
-  A. Save the ``config.json``. 
-  #. Navigate to the root of the exported application directory.
-  #. Log in to MongoDB Atlas with {+cli-bin+}:  
-
-     .. code-block:: shell
-
-        realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
-
-  #. Import the directory:
-
-     .. code-block:: shell
-
-        realm-cli import
+  Once you've defined and saved a ``config.json`` file for the data source, you
+  can push the config to your remote app. {+cli+} immediately begins to link the
+  data source on push.
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>"

--- a/source/includes/steps-specify-cluster-read-preference-import-export.yaml
+++ b/source/includes/steps-specify-cluster-read-preference-import-export.yaml
@@ -1,33 +1,29 @@
-title: Export Your Realm Application
-ref: export-your-application
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  You can configure the read preference for a linked cluster by
-  importing an :ref:`application directory <application-directory>` that
-  includes a cluster configuration file with your desired settings.
-  If you're configuring read preference for an existing {+app+},
-  the most straightforward method is to :doc:`export
-  </deploy/export-realm-app>` your application, update the
-  cluster configuration, and then import the updated directory.
-  To export your application, click the :guilabel:`Export App` button on
-  the :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in the
-  {+ui+} or run the following command from an authenticated instance
-  of :doc:`realm-cli </deploy/realm-cli-reference>`:
-
-  .. code-block:: shell
-
-     realm-cli export --app-id=<App ID>
+  To define the read preference for a linked cluster with {+cli-bin+}, you need
+  a local copy of your application's configuration files.
+  
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
+     
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
+     
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Export App` screen in the {+ui+}.
 ---
 title: Specify a Cluster Read Preference
 ref: specify-a-cluster-read-preference
 content: |
-  Configure the read preference for a linked cluster in the cluster's
-  ``config.json`` file. Locate this file in the cluster's
-  :ref:`configuration directory <legacy-appschema-services>` within the
-  application directory (``/services/<MongoDB Service Name>``). To
-  specify a read preference, set the value of ``config.readPreference``:
+  To configure the read preference for a linked cluster, open the cluster's
+  ``config.json`` file and set the value of ``config.readPreference``:
 
   .. code-block:: json
      :emphasize-lines: 5
+     :caption: /data_sources/<Service Name>/config.json
 
      {
         "name": "<MongoDB Service Name>",
@@ -36,9 +32,9 @@ content: |
            "readPreference": "<Read Preference Mode>"
         }
      }
-
+  
   The following read preference modes are available:
-
+  
   .. include:: /mongodb/tables/read-preference-modes.rst
 
 ---
@@ -57,6 +53,7 @@ content: |
 
   .. code-block:: json
      :emphasize-lines: 6-9
+     :caption: /data_sources/<Service Name>/config.json
 
      {
         "name": "<MongoDB Service Name>",
@@ -77,24 +74,13 @@ content: |
      on which tags are defined nodes in an Atlas cluster, see :atlas:`Atlas
      Replica Set Tags </reference/replica-set-tags>`.
 ---
-title: Import Your Application Directory
-ref: import-your-application-directory
+title: Deploy the Updated Data Source Configuration
+ref: deploy-the-updated-data-source-configuration
 content: |
-  Once you have specified a :guilabel:`Read Preference` and any
-  :guilabel:`Read Preference Tags`, navigate to the root of the
-  application directory and run the following command from an
-  authenticated instance of :doc:`realm-cli
-  </deploy/realm-cli-reference>`:
-
-  .. code-block:: shell
-
-     realm-cli import
-
-  Once the import completes, {+backend+} immediately routes all incoming
-  database read requests for the cluster according to your preference.
-
-  .. note::
-
-     For a detailed walkthrough of importing an application directory,
-     see :doc:`Deploy Changes with {+cli+}
-     </deploy/deploy-cli>`
+  Once you've set the read preference for the cluster in ``config.json``, you
+  can push the config to your remote app. {+cli+} immediately deploys the
+  update on push.
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>"

--- a/source/includes/steps-specify-cluster-read-preference-import-export.yaml
+++ b/source/includes/steps-specify-cluster-read-preference-import-export.yaml
@@ -77,9 +77,8 @@ content: |
 title: Deploy the Updated Data Source Configuration
 ref: deploy-the-updated-data-source-configuration
 content: |
-  Once you've set the read preference for the cluster in ``config.json``, you
-  can push the config to your remote app. {+cli+} immediately deploys the
-  update on push.
+  Once you've set the read preference for the cluster, you can push the updated
+  config to your remote app. {+cli+} immediately deploys the update on push.
   
   .. code-block:: bash
      

--- a/source/mongodb/enable-wire-protocol-connections.txt
+++ b/source/mongodb/enable-wire-protocol-connections.txt
@@ -34,6 +34,6 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/enable-wire-protocol-import-export.rst

--- a/source/mongodb/link-a-data-source.txt
+++ b/source/mongodb/link-a-data-source.txt
@@ -46,7 +46,7 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/link-a-data-source-import-export.rst
 

--- a/source/mongodb/specify-cluster-read-preference.txt
+++ b/source/mongodb/specify-cluster-read-preference.txt
@@ -59,6 +59,6 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/specify-cluster-read-preference-import-export.rst


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:

- (DOCSP-14945): [CLI V2] Link a MongoDB Data Source
- (DOCSP-14946): [CLI V2] Specify Read Preference for a MongoDB Cluster
- (DOCSP-14947): [CLI V2] Enable Wire Protocol Connections

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [Link a MongoDB Data Source](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-datasource/mongodb/link-a-data-source)
- [Specify Read Preference for a MongoDB Cluster](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-datasource/mongodb/specify-cluster-read-preference)
- [Enable Wire Protocol Connections](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-datasource/mongodb/enable-wire-protocol-connections)

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
