### PR TITLE
[CLI V2] Custom User Data, GraphQL, and Incoming Webhooks

### DIFF
--- a/source/config/auth.txt
+++ b/source/config/auth.txt
@@ -151,6 +151,8 @@ configuration fields.
        - :ref:`Facebook <config-oauth2-facebook>`
        - :ref:`Apple ID <config-oauth2-apple>`
 
+.. _config-custom-user-data:
+
 Custom User Data
 ----------------
 

--- a/source/config/data_sources.txt
+++ b/source/config/data_sources.txt
@@ -126,6 +126,8 @@ MongoDB Data Lakes
 Databases & Collections
 -----------------------
 
+.. _config-collection-schema:
+
 Collection Schema
 ~~~~~~~~~~~~~~~~~
 
@@ -154,7 +156,7 @@ If the data source is not a :doc:`synced cluster </sync>` or a :ref:`data lake
 collection's ``rules.json`` configuration file.
 
 .. code-block:: json
-   :caption: /<service>/<database>/<collection>/rules.json
+   :caption: /data_sources/<service>/<database>/<collection>/rules.json
    
    {
      "database": "<Database Name>",

--- a/source/config/http_endpoints.txt
+++ b/source/config/http_endpoints.txt
@@ -53,6 +53,8 @@ service in its own subdirectory within ``/http_endpoints``.
      - Additional configuration options for the service. HTTP Endpoints
        currently have no additional configuration options.
 
+.. _config-incoming-webhooks:
+
 Incoming Webhooks
 -----------------
 

--- a/source/config/services.txt
+++ b/source/config/services.txt
@@ -72,6 +72,8 @@ Service Configuration
        for the service and the value of each field is the name of a
        :ref:`Secret <app-secret>` that stores the configuration value.
 
+
+
 Service Rules
 ~~~~~~~~~~~~~
 

--- a/source/graphql/expose-data.txt
+++ b/source/graphql/expose-data.txt
@@ -122,10 +122,11 @@ field matches a foreign key included in the local field.
       
       To define a relationship for a local collection using Realm CLI or another
       code deploy method, add a relationship definition to the ``relationships``
-      field of the collection's rules configuration file.
+      field of the collection's :ref:`schema configuration
+      <config-collection-schema>`.
       
       .. code-block:: json
-         :caption: /services/mongodb-atlas/rules/<db>.<collection>.json
+         :caption: /data_sources/<service>/<database>/<collection>/schema.json
          
          {
            ...,

--- a/source/includes/extracts-service-actions.yaml
+++ b/source/includes/extracts-service-actions.yaml
@@ -234,7 +234,7 @@ content: |
 
   .. list-table::
      :header-rows: 1
-     :widths: 10 80
+     :widths: 50 50
 
      * - Action
        - Description

--- a/source/includes/steps-create-a-service-webhook-cli.yaml
+++ b/source/includes/steps-create-a-service-webhook-cli.yaml
@@ -1,49 +1,55 @@
-title: Export Your Realm Application
-ref: export-your-realm-application
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  To create new incoming webhook with :doc:`realm-cli
-  </deploy/realm-cli-reference>`, you need a
-  previously created :ref:`application configuration <application-directory>`.
-
-  You can :doc:`export </deploy/export-realm-app>` your application from the
-  :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in the
-  {+ui+}, or by running the following command from an authenticated instance of
-  :doc:`realm-cli </deploy/realm-cli-reference>`:
-
-  .. code-block:: shell
-
-     realm-cli export --app-id=<App ID>
+  To define an incoming webhook with {+cli-bin+}, you need a local copy of your
+  application's configuration files.
+  
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
+     
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
+     
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Export App` screen in the {+ui+}.
 ---
 title: Add a Webhook Configuration Directory
 ref: add-a-webhook-configuration-directory
 content: |
-  Create a new subdirectory in the ``/<service>/incoming_webhooks``
-  folder of the application directory that you exported, where
-  ``<service>`` is the service that you want to add a webhook to. The
-  name of the subdirectory should match the configured name of the
-  webhook.
+  Create a new subdirectory with the same name as the webhook in
+  ``/http_endpoints/<service>/``:
 
   .. code-block:: shell
 
-     mkdir -p services/<service>/incoming_webhooks/<webhook name>
+     mkdir -p http_endpoints/<service>/<webhook name>
 ---
 title: Add a Webhook Configuration File
 ref: add-a-webhook-configuration-file
 content: |
-  Add a file named ``config.json`` to the new webhook directory.
+  Add an :ref:`incoming webhook configuration file <config-incoming-webhooks>`
+  named ``config.json`` to the new webhook directory.
+  
   The configuration file should have the following form:
 
-  .. code-block:: javascript
-
+  .. code-block:: json
+     :caption: http_endpoints/<Service Name>/<Webhook Name>/config.json
+     
      {
-       "name": "<Unique Webhook Name>",
-       "respond_result": <boolean>,
-       "run_as_authed_user": <boolean>,
+       "name": "<Webhook Name>",
+       "can_evaluate": { <JSON Expression> },
+       "run_as_authed_user": <Boolean>,
        "run_as_user_id": "<Realm User ID>",
-       "run_as_user_id_script_source": "<Stringified Function>",
-       "can_evaluate": <JSON Expression>,
-       "disable_arg_logs": <boolean>,
-       "options": <document>,
+       "run_as_user_id_script_source": "<Function Source Code>",
+       "respond_result": <Boolean>,
+       "fetch_custom_user_data": <Boolean>,
+       "create_user_on_auth": <Boolean>,
+       "options": {
+         "httpMethod": "<HTTP Method>",
+         "validationMethod": "<Webhook Validation Method>",
+         "secret": "<Webhook Secret>"
+       }
      }
 ---
 title: Name the New Webhook
@@ -349,15 +355,13 @@ content: |
      :emphasize-lines: 3, 10-11, 14-15
 
 ---
-title: Import the Webhook
-ref: import-the-webhook
+title: Deploy the Incoming Webhook Configuration
+ref: deploy-the-incoming-webhook-configuration
 content: |
-  Once you have added the appropriate configuration files to the webhook
-  subdirectory, you can import the webhook into your application.
-
-  Navigate to the root of the application directory and run the
-  following command:
-
-  .. code-block:: shell
-
-     realm-cli import
+  Once you've set the read preference for the cluster in ``config.json``, you
+  can push the config to your remote app. {+cli+} immediately deploys the
+  update on push.
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>"

--- a/source/includes/steps-define-custom-user-data-import-export.yaml
+++ b/source/includes/steps-define-custom-user-data-import-export.yaml
@@ -41,9 +41,8 @@ content: |
 title: Deploy the Custom User Data Configuration
 ref: deploy-the-custom-user-data-configuration
 content: |
-  Once you've configured custom user in ``/auth/custom_user_data.json``, you can
-  push the config to your remote app. {+cli+} immediately deploys the update on
-  push.
+  Once you've configured custom user data, you can push the updated config to
+  your remote app. {+cli+} immediately deploys the update on push.
   
   .. code-block:: bash
      

--- a/source/includes/steps-define-custom-user-data-import-export.yaml
+++ b/source/includes/steps-define-custom-user-data-import-export.yaml
@@ -1,106 +1,50 @@
-title: Export Your Realm Application
-ref: export-your-realm-application
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  You can set up and enable custom user data through {+cli-bin+} or
-  automatic GitHub deployment. To configure custom user data, you need
-  the latest version of the :ref:`application directory
-  <application-directory>` for your application.
-
-  You can :doc:`export </deploy/export-realm-app>` your application from the
-  :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in the
-  {+ui+}, or by running the following command from an authenticated instance of
-  :doc:`realm-cli </deploy/realm-cli-reference>`:
-
-  .. code-block:: shell
-
-     realm-cli export --app-id=<App ID>
+  To define custom user data with {+cli-bin+}, you need a local copy of your
+  application's configuration files.
+  
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
+     
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
+     
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Export App` screen in the {+ui+}.
 ---
 title: Configure Custom User Data
 ref: configure-custom-user-data
 content: |
-  You must store the custom data for your application's users in a
-  single collection of a linked `{+atlas+} <https://www.mongodb.com/cloud/atlas?tck=docs_realm>`_ 
-  cluster. Every document in the collection should have a field that
-  contains the user ID of the {+service-short+} user that it describes.
+  You must store the custom data for your application's users in a single
+  collection of a :ref:`linked Atlas cluster <link-a-data-source>`. Every
+  document in the collection should include a specific field that contains the
+  user ID of the {+service-short+} user that it describes.
 
-  To configure your application to read user data from this collection,
-  specify a configuration document in the ``custom_user_data_config``
-  field of ``config.json``:
+  To configure your application to read user data from this collection, define a
+  :ref:`custom user data configuration document <config-custom-user-data>` in
+  the ``/auth/custom_user_data.json``:
 
-  .. code-block:: json
-     :caption: config.json
-
+  .. code-block:: javascript
+     :caption: /auth/custom_user_data.json
+     
      {
-       ...,
-       "custom_user_data_config": {
-         "enabled": <boolean>,
-         "mongo_service_id": "<Linked MongoDB Cluster Service ID>",
-         "database_name": "<Database Name>",
-         "collection_name": "<Collection Name>",
-         "user_id_field": "<User ID Field Name>"
-       }
+       "enabled": <Boolean>,
+       "mongo_service_name": "<MongoDB Data Source Name>",
+       "database_name": "<Database Name>",
+       "collection_name": "<Collection Name>",
+       "user_id_field": "<Field Name>"
      }
-
-  .. list-table::
-     :header-rows: 1
-     :widths: 20 80
-     
-     * - Field
-       - Description
-     
-     * - ``enabled``
-       - A boolean that, if ``true``, indicates that {+service-short+} should
-         associate data in the specified collection with application
-         users.
-     
-     * - ``mongo_service_id``
-       - The service ID of the :doc:`linked MongoDB cluster </mongodb>`
-         that contains the custom user data collection.
-     
-     * - ``database_name``
-       - The name of the MongoDB database that contains the custom user
-         data collection.
-     
-     * - ``collection_name``
-       - The name of the MongoDB collection that contains custom user
-         data.
-     
-     * - ``user_id_field``
-       - The name of the field that maps each document to a specific application
-         user. The field must have the same name in each document and contain
-         the user's ID as a string.
-         
-         .. note::
-            
-            If two documents contain the same user ID, {+service-short+} only
-            maps the first matching document to the user.
 ---
-title: Deploy the Updated Application
-ref: deploy-the-updated-application
+title: Deploy the Custom User Data Configuration
+ref: deploy-the-custom-user-data-configuration
 content: |
-  Once you have configured the custom user data collection, you can
-  make custom user data available to client applications by deploying
-  your application.
-
-  To deploy a draft application with {+cli-bin+}:
-
-  .. code-block:: shell
-
-     realm-cli import
-
-  To deploy a draft application with automatic :doc:`GitHub deployment
-  </deploy/deploy-automatically-with-github>`:
-
-  .. code-block:: shell
-
-     git add config.json
-     git commit -m "Configure and Enable Custom User Data"
-     git push origin <branch name>
-
-  Once the application successfully deploys, {+service+} begins to associate
-  custom data with users. When a user logs in, {+service-short+} automatically
-  queries the custom user data collection for a document where the
-  specified :guilabel:`User ID Field` contains the user's ID. If a
-  document matches, {+service-short+} exposes the data in the document in the
-  ``custom_data`` field of that user's :ref:`user object
-  <user-objects>`.
+  Once you've configured custom user in ``/auth/custom_user_data.json``, you can
+  push the config to your remote app. {+cli+} immediately deploys the update on
+  push.
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>"

--- a/source/services/configure/service-webhooks.txt
+++ b/source/services/configure/service-webhooks.txt
@@ -16,11 +16,9 @@ Overview
 --------
 
 Some external services allow you to create :ref:`incoming webhooks
-<service-webhooks>` that external clients can call over HTTP. You can
-create webhooks for these services from the Realm UI or by
-:doc:`importing </deploy/deploy-cli>` a service
-configuration directory that contains a webhook configuration. Select
-the tab below that corresponds to the method you want to use.
+<service-webhooks>` that external clients can call over HTTP. You can create
+webhooks for these services from the Realm UI or with {+cli+}. Select the tab
+below that corresponds to the method you want to use.
 
 Procedure
 ---------
@@ -35,6 +33,6 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/create-a-service-webhook-cli.rst

--- a/source/services/http.txt
+++ b/source/services/http.txt
@@ -56,7 +56,7 @@ You will need to provide values for the following parameters when you
       :tabid: cli
 
       .. code-block:: json
-         :caption: <Service Name>/config.json
+         :caption: /http_endpoints/<Service Name>/config.json
 
          {
            "name": "<Service Name>",
@@ -114,21 +114,27 @@ Configuration
 
      - id: cli
        content: |
-         You will need to provide a configuration file of the following
-         form when you :doc:`configure an HTTP incoming webhook
+         You will need to provide a :ref:`configuration file
+         <config-incoming-webhooks>` of the following form when you
+         :doc:`configure an HTTP incoming webhook
          </services/configure/service-webhooks>`:
-
-         .. code-block:: javascript
-
+         
+         .. code-block:: json
+            :caption: http_endpoints/<Service Name>/<Webhook Name>/config.json
+            
             {
-              "name": <string>,
-              "respond_result": <boolean>,
-              "run_as_user_id": <string>,
-              "run_as_user_id_script_source": <string>,
+              "name": "<Webhook Name>",
+              "can_evaluate": { <JSON Expression> },
+              "run_as_authed_user": <Boolean>,
+              "run_as_user_id": "<Realm User ID>",
+              "run_as_user_id_script_source": "<Function Source Code>",
+              "respond_result": <Boolean>,
+              "fetch_custom_user_data": <Boolean>,
+              "create_user_on_auth": <Boolean>,
               "options": {
-                "httpMethod": <string>,
-                "secret": <string>,
-                "validationMethod": <string>
+                "httpMethod": "<HTTP Method>",
+                "validationMethod": "<Webhook Validation Method>",
+                "secret": "<Webhook Secret>"
               }
             }
 

--- a/source/users/enable-custom-user-data.txt
+++ b/source/users/enable-custom-user-data.txt
@@ -105,13 +105,14 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/define-custom-user-data-import-export.rst
 
 
 Access Custom User Data from a Client Application
 -------------------------------------------------
+
 .. tabs-realm-sdks::
    
    .. tab::


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:

- (DOCSP-14936): [CLI V2] Enable Custom User Data
- (DOCSP-14953): [CLI V2] Expose Data in a Collection
- (DOCSP-14957): [CLI V2] HTTP Service
- (DOCSP-14956): [CLI V2] Configure Service Webhooks

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [Enable Custom User Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-grabbag/users/enable-custom-user-data)
- [Expose Data in a Collection](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-grabbag/graphql/expose-data)
- [HTTP Service](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-grabbag/services/http)
- [Configure Service Webhooks](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-grabbag/services/configure/service-webhooks)

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
