### PR TITLE
[CLI V2] Static Hosting

### DIFF
--- a/source/hosting/enable-hosting.txt
+++ b/source/hosting/enable-hosting.txt
@@ -36,6 +36,6 @@ the corresponding method.
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/enable-hosting-import-export.rst

--- a/source/hosting/flush-the-cdn-cache.txt
+++ b/source/hosting/flush-the-cdn-cache.txt
@@ -49,6 +49,6 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/flush-the-cdn-cache-import-export.rst

--- a/source/hosting/host-a-single-page-application.txt
+++ b/source/hosting/host-a-single-page-application.txt
@@ -44,6 +44,6 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/host-a-single-page-application-code-deploy.rst

--- a/source/hosting/use-a-custom-404-page.txt
+++ b/source/hosting/use-a-custom-404-page.txt
@@ -36,6 +36,6 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/use-a-custom-404-page-import-export.rst

--- a/source/hosting/use-a-custom-domain-name.txt
+++ b/source/hosting/use-a-custom-domain-name.txt
@@ -41,6 +41,6 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/use-a-custom-domain-name-import-export.rst

--- a/source/includes/steps-enable-hosting-import-export.yaml
+++ b/source/includes/steps-enable-hosting-import-export.yaml
@@ -18,7 +18,7 @@ content: |
 title: Create a Static Hosting Configuration
 ref: create-a-static-hosting-configuration
 content: |
-  In ``hosting/config.json``, set ``enabled`` to ``true`` then save the file.
+  In ``hosting/config.json``, set ``enabled`` to ``true``, then save the file.
 
   .. code-block:: json
      :caption: /hosting/config.json
@@ -29,9 +29,8 @@ content: |
 title: Deploy the Static Hosting Configuration
 ref: deploy-the-static-hosting-configuration
 content: |
-  Once you've defined and saved ``hosting/config.json`` you can push the updated
-  config to your remote app. {+cli+} immediately deploys your new configuration
-  on push.
+  Once you've enabled static hosting, you can push the updated config to your
+  remote app. {+cli+} immediately deploys your new configuration on push.
   
   .. code-block:: bash
      

--- a/source/includes/steps-enable-hosting-import-export.yaml
+++ b/source/includes/steps-enable-hosting-import-export.yaml
@@ -1,50 +1,46 @@
-title: Export Your Realm Application
-ref: export-your-application
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  To enable static hosting for your  application with
-  :doc:`realm-cli </deploy/realm-cli-reference>` you need to
-  export an :ref:`application directory <application-directory>`.
+  To enable static hosting with {+cli-bin+}, you need a local copy of your
+  application's configuration files.
   
-  You can :doc:`export </deploy/export-realm-app>` your application from the
-  :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in the
-  {+ui+}, or by running the following command from an authenticated instance of
-  :doc:`realm-cli </deploy/realm-cli-reference>`:
-
-  .. code-block:: none
-
-     realm-cli export --app-id=<App ID>
-
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
+     
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
+     
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Import/Export App` screen in the {+ui+}.
 ---
-title: Enable Hosting in the Application Configuration
-ref: enable-hosting-in-the-application-configuration
+title: Create a Static Hosting Configuration
+ref: create-a-static-hosting-configuration
 content: |
-  In :ref:`config.json <legacy-appschema-realm-config>`, set the value of
-  ``hosting.enabled`` to ``true`` then save the file.
+  In ``hosting/config.json``, set ``enabled`` to ``true`` then save the file.
 
   .. code-block:: json
-
-     "hosting": { "enabled": true }
+     :caption: /hosting/config.json
+     
+     { "enabled": true }
 
 ---
-title: Import the Updated Application Configuration
-ref: import-the-updated-application-configuration
+title: Deploy the Static Hosting Configuration
+ref: deploy-the-static-hosting-configuration
 content: |
-  Once you have enabled hosting in ``config.json``, you can import the
-  directory into your application.
-  Navigate to the root of the application directory and run the
-  following command:
-
-  .. code-block:: none
-
-     realm-cli import
-
-  {+service+} will begin provisioning hosting for your application after you
-  successfully import the application directory.
+  Once you've defined and saved ``hosting/config.json`` you can push the updated
+  config to your remote app. {+cli+} immediately deploys your new configuration
+  on push.
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>"
 
   .. note::
-
-     It may take a few minutes for {+service-short+} to finish provisioning hosting
-     for your application once you've enabled it. You can :doc:`upload
-     content to {+service-short+} </hosting/upload-content-to-realm>` immediately,
-     but you will need to wait for provisioning to complete before
+     
+     It may take a few minutes for {+service-short+} to finish provisioning
+     hosting for your application once you've enabled it. You can :doc:`upload
+     content to {+service-short+} </hosting/upload-content-to-realm>`
+     immediately, but you will need to wait for provisioning to complete before
      {+service-short+} serves your files.

--- a/source/includes/steps-flush-the-cdn-cache-import-export.yaml
+++ b/source/includes/steps-flush-the-cdn-cache-import-export.yaml
@@ -1,27 +1,27 @@
-title: Export Your Realm Application
-ref: export-your-application
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  To flush the CDN cache with :doc:`realm-cli
-  </deploy/realm-cli-reference>` you need to export an
-  :ref:`application directory <application-directory>` for your
-  application.
-
-  You can :doc:`export </deploy/export-realm-app>` your application from the
-  :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in the
-  {+ui+}, or by running the following command from an authenticated instance of
-  :doc:`realm-cli </deploy/realm-cli-reference>`:
-
-  .. code-block:: shell
-
-     realm-cli export --app-id=<App ID>
+  To purge the CDN cache with {+cli-bin+}, you need a local copy of your
+  application's configuration files.
+  
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
+     
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
+     
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Import/Export App` screen in the {+ui+}.
 ---
-title: Import the Application Directory
-ref: import-the-application-directory
+title: Deploy with the Reset CDN Cache Flag
+ref: deploy-with-the-reset-cdn-cache-flag
 content: |
-  To purge the CDN cache, simply include the ``--reset-cdn-cache`` flag
-  when you import the application directory:
-
-  .. code-block:: shell
-
-     realm-cli import --reset-cdn-cache
+  To purge the CDN cache, re-deploy your application configuration with the
+  ``--reset-cdn-cache`` flag:
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>" --reset-cdn-cache
 ...

--- a/source/includes/steps-host-a-single-page-application-code-deploy.yaml
+++ b/source/includes/steps-host-a-single-page-application-code-deploy.yaml
@@ -1,24 +1,19 @@
-title: Get a Local Copy of Your Realm App
-ref: get-a-local-copy-of-your-realm-app
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  To use code deploy to configure a SPA, you need a local copy of your
-  :ref:`application directory <application-directory>` that is
-  up-to-date with the latest version of your {+app+}. Clone
-  the most recent version of your {+app+} from GitHub or export it
-  directly from {+backend+}.
-
-  .. note:: Export Your Application
+  To configure a single-page application with {+cli-bin+}, you need a local copy
+  of your application's configuration files.
+  
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
      
-     You can :doc:`export </deploy/export-realm-app>` a copy of the
-     latest version of your application directory from the
-     :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in
-     the {+ui+}, or by running the following command from an
-     authenticated instance of :doc:`realm-cli
-     </deploy/realm-cli-reference>`:
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
      
-     .. code-block:: shell
-     
-        realm-cli export --app-id=<App ID>
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Import/Export App` screen in the {+ui+}.
 ---
 title: Add Your Built Application Code
 ref: add-your-built-application-code
@@ -37,44 +32,26 @@ content: |
 title: Configure Realm to Serve Your Application
 ref: configure-realm-to-serve-your-application
 content: |
-  In :ref:`config.json <legacy-appschema-realm-config>`, set the value of
-  ``hosting.default_response_code`` to ``200`` and set the value of
-  ``hosting.default_error_path`` to the :ref:`resource path
-  <hosting-resource-path>` of your SPA's root HTML file. Make sure to
-  save the file when you're done.
+  In ``hosting/config.json``, set ``default_response_code`` to ``200`` and set
+  ``default_error_path`` to the :ref:`resource path <hosting-resource-path>` of
+  your SPA's root HTML file. Make sure to save the file when you're done.
 
   .. code-block:: json
-     :caption: config.json
+     :caption: hosting/config.json
   
-     "hosting": {
+     {
        "enabled": true,
        "default_response_code": 200,
        "default_error_path": "/index.html",
      }
 ---
-title: Deploy Your Changes
-ref: deploy-your-changes
+title: Deploy the Updated Hosting Configuration
+ref: deploy-the-updated-hosting-configuration
 content: |
-  Now that you've added the SPA code to the ``hosting/files`` directory
-  and configured {+service-short+} to serve the root HTML file, all that's left is
-  to deploy the changes.
-
-  Navigate to the application directory root and then run the command
-  that matches your deployment method.
-
-  If you want to :doc:`deploy with {+cli+}
-  </deploy/deploy-cli>`:
+  Once you've updated and saved ``hosting/config.json`` you can push the updated
+  config to your remote app. {+cli+} immediately supports your SPA on push.
   
-  .. code-block:: shell
+  .. code-block:: bash
      
-     realm-cli import --include-hosting
-  
-  If you want to :doc:`deploy automatically with GitHub
-  </deploy/deploy-automatically-with-github>`:
-
-  .. code-block:: shell
-     
-     git add -A
-     git commit -m "<descriptive commit message>"
-     git push <github remote> <branch>
+     realm-cli push --remote="<Your App ID>"
 ...

--- a/source/includes/steps-use-a-custom-404-page-import-export.yaml
+++ b/source/includes/steps-use-a-custom-404-page-import-export.yaml
@@ -1,28 +1,29 @@
-title: Create a Custom 404 Page HTML File
-ref: upload-the-404-page-html-file
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  You can use any valid HTML file for your application's 404 page.
-  Consider incorporating the following elements:
+  To configure a custom 404 page with {+cli-bin+}, you need a local copy of your
+  application's configuration files.
+  
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
+     
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
+     
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Import/Export App` screen in the {+ui+}.
+---
+title: Create a Custom 404 Page HTML File
+ref: create-a-custom-404-page-html-file
+content: |
+  You can use any valid HTML file for your application's 404 page. Consider
+  incorporating the following elements:
 
   - A short message indicating the error, e.g. "This page does not
     exist."
   - Alternative links or options for the user to continue navigating.
----
-title: Export Your Realm Application
-ref: export-your-application
-content: |
-  To configure a custom 404 page with :doc:`realm-cli
-  </deploy/realm-cli-reference>` you need to export an
-  :ref:`application directory <application-directory>`.
-
-  You can :doc:`export </deploy/export-realm-app>` your application from the
-  :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in the
-  {+ui+}, or by running the following command from an authenticated instance of
-  :doc:`realm-cli </deploy/realm-cli-reference>`:
-
-  .. code-block:: shell
-
-     realm-cli export --app-id=<App ID>
 ---
 title: Host the HTML File in Realm
 ref: host-the-html-file-in-realm
@@ -30,16 +31,15 @@ content: |
   Once you've created the custom HTML file, you need to :doc:`host it in
   {+service-short+} </hosting/upload-content-to-realm>`.
 
-  If you aren't already hosting the HTML file in {+service-short+}, add it to the
-  :guilabel:`/hosting` subdirectory of the exported directory.
+  If you aren't already hosting the HTML file in {+service-short+}, add it to
+  the ``hosting/files/`` directory.
 ---
 title: Specify the 404 Page in the Application Configuration
 ref: specify-the-404-page-in-the-application-configuration
 content: |
-  In :ref:`config.json <legacy-appschema-realm-config>`, set the value of
-  ``hosting.default_error_path`` to the :ref:`resource path
-  <hosting-resource-path>` of the HTML file then save the configuration
-  file.
+  In ``hosting/config.json``, set ``default_error_path`` to the :ref:`resource
+  path <hosting-resource-path>` of the 404 page HTML file then save the
+  configuration file.
 
   .. code-block:: json
 
@@ -48,17 +48,14 @@ content: |
        "default_error_path": "/pages/custom_404.html"
      }
 ---
-title: Import the Updated Application Directory
-ref: import-the-updated-application-directory
+title: Deploy the Updated Hosting Configuration
+ref: deploy-the-updated-hosting-configuration
 content: |
-  Once you have specified the custom 404 page path in ``config.json``,
-  you can import the directory into your application. If you added the
-  custom HTML file to ``/hosting``, make sure to use the
-  ``--include-hosting`` flag.
-
-  .. code-block:: shell
-
-     realm-cli import --include-hosting
-
-  After you have successfully imported the changes, {+backend+} will begin
-  serving your custom HTML instead of the default 404 page.
+  Once you've updated ``hosting/config.json`` you can push the updated config to
+  your remote app. If you also added the 404 page, make sure to use the
+  ``--include-hosting`` flag. {+cli+} immediately starts to serve your custom
+  404 page on push.
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>" --include-hosting

--- a/source/includes/steps-use-a-custom-domain-name-import-export.yaml
+++ b/source/includes/steps-use-a-custom-domain-name-import-export.yaml
@@ -5,42 +5,42 @@ content: |
   from. If you don't already own the domain that you want to use, you
   will need to purchase it from a domain name registrar.
 ---
-title: Export Your Realm Application
-ref: export-your-application
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  To specify a custom domain name with :doc:`realm-cli
-  </deploy/realm-cli-reference>` you need to export an :ref:`application
-  directory <application-directory>` for your application.
-
-  You can :doc:`export </deploy/export-realm-app>` your application from the
-  :guilabel:`Import/Export App` tab of the :guilabel:`Deploy` page in the
-  {+ui+}, or by running the following command from an authenticated instance of
-  :doc:`realm-cli </deploy/realm-cli-reference>`:
-
-  .. code-block:: shell
-
-     realm-cli export --app-id=<App ID>
+  To configure a custom domain name with {+cli-bin+}, you need a local copy of
+  your application's configuration files.
+  
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
+     
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
+     
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Import/Export App` screen in the {+ui+}.
 ---
 title: Specify the Custom Domain
 ref: specify-the-custom-domain
 content: |
-  In :ref:`config.json <legacy-appschema-realm-config>`, set the value of
-  ``hosting.custom_domain`` to your custom domain name then save the
-  file.
-
+  In ``hosting/config.json``, set ``custom_domain`` to your custom domain name
+  then save the file.
+  
   .. code-block:: json
-
-     "hosting": {
+     :caption: hosting/config.json
+     
+     {
        "enabled": true,
        "custom_domain": "example.com"
      }
-
+  
   .. note::
-
+     
      The value of ``custom_domain`` should be the root domain without
      any subdomains. For example, you should enter ``example.com``
      instead of ``www.example.com``.
-
 ---
 title: Import the Application Directory
 ref: import-the-application-directory
@@ -54,6 +54,18 @@ content: |
   .. code-block:: shell
 
      realm-cli import --include-hosting
+---
+title: Deploy the Updated Hosting Configuration
+ref: deploy-the-updated-hosting-configuration
+content: |
+  Once you've updated and saved ``hosting/config.json`` you can push the updated
+  config to your remote app. {+cli+} immediately deploys the configuration on
+  push and Realm immediately starts trying to verify your domain name.
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>"
+
 ---
 title: Add a Validation CNAME Record
 ref: add-a-validation-cname-record


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:

- (DOCSP-14958): [CLI V2] Enable Hosting
- (DOCSP-14959): [CLI V2] Flush the CDN Cache
- (DOCSP-14959): [CLI V2] Host a Single-Page Application
- (DOCSP-14961): [CLI V2] Use a Custom 404 Page
- (DOCSP-14962): [CLI V2] Use a Custom Domain Name

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [Enable Hosting](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-hosting/hosting/enable-hosting)
- [Flush the CDN Cache](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-hosting/hosting/flush-the-cdn-cache)
- [Host a Single-Page Application](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-hosting/hosting/host-a-single-page-application)
- [Use a Custom 404 Page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-hosting/hosting/use-a-custom-404-page)
- [Use a Custom Domain Name](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-hosting/hosting/use-a-custom-domain-name)

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
