### PR TITLE
[CLI V2] Generic CLI Deploy

### DIFF
--- a/source/deploy/deploy-cli.txt
+++ b/source/deploy/deploy-cli.txt
@@ -15,10 +15,9 @@ Deploy Changes with Realm CLI
 Overview
 --------
 
-You can deploy changes to your {+app+} with :doc:`{+cli+}
-</deploy/realm-cli-reference>` by importing an :ref:`application
-directory <app-directory>` with configuration files that define the
-updated app.
+You can deploy changes to your {+app+} with :ref:`{+cli+} <realm-cli>` by
+importing an :ref:`application directory <app-directory>` with configuration
+files that define the updated app.
 
 Prerequisites
 -------------
@@ -31,6 +30,6 @@ Prerequisites
 Procedure
 ---------
       
-.. include:: /includes/note-procedure-uses-cli-v1.rst
+.. include:: /includes/note-procedure-uses-cli-v2.rst
 
 .. include:: /includes/steps/deploy-cli.rst

--- a/source/includes/steps-deploy-cli.yaml
+++ b/source/includes/steps-deploy-cli.yaml
@@ -1,80 +1,41 @@
-title: Prepare the Application Directory
-ref: prepare-application-directory
+title: Log In to MongoDB Cloud
+ref: log-in-to-mongodb-cloud
 content: |
-  :doc:`Export </deploy/export-realm-app>` your application to a local
-  application directory. Alternatively, create a new application
-  directory that contains a :ref:`config.json <legacy-appschema-realm-config>`
-  file with your application's ``app_id``.
+  To configure your app with {+cli-bin+}, you must log in to MongoDB Cloud using
+  an :atlas:`API key </reference/api/apiKey>` scoped to the organization or
+  project that contains the app.
   
-  .. code-block:: json
+  .. code-block:: bash
      
-     {
-       "app_id": "<Your Application ID>"
-     }
+     realm-cli login --api-key="<MongoDB Cloud Public API Key>" --private-api-key="<MongoDB Cloud Private API Key>"
 ---
-title: Add or Update Application Entities
-ref: add-update-application-entities
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  Add sub-directories and configuration files for any new entities you're
-  importing, or update the values in existing entity files. Every configuration
-  file must conform to its :ref:`configuration file schema <app-configuration>`.
----
-title: Authenticate a MongoDB Atlas User
-ref: authenticate-atlas-user
-content: |
-  To import or update a {+app+} with {+cli-bin+}, users
-  must authenticate with `{+atlas+} <https://www.mongodb.com/cloud/atlas?tck=docs_realm>`_
-  using an API Key.
-
-  .. code-block:: shell
-
-     realm-cli login --api-key="<my api key>" --private-api-key="<my private api key>"
----
-title: Run the Import Command
-ref: run-import-command
-content: |
-  Use the {+cli-bin+} :ref:`import <realm-cli-import>` to deploy
-  your changes:
-
-  .. code-block:: shell
+  You'll need a local copy of your application's configuration files. To pull a
+  local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
      
-     realm-cli import --strategy=merge
-
-  .. note:: Import Strategy
+     realm-cli pull --remote="<Your App ID>"
+  
+  .. tip::
      
-     The ``--strategy`` flag indicates how you want {+service-short+} to handle
-     configuration files that are missing or duplicated compared to the
-     currently deployed version of your application. For more
-     information, see :ref:`import strategies
-     <realm-import-strategies>`.
-
-  If you want to :doc:`upload static assets to {+service-short+} Hosting
-  </hosting/upload-content-to-realm>`, include the static assets in the
-  ``/hosting/files`` directory and specify the
-  :option:`--include-hosting <realm-cli import --include-hosting>`
-  option:
-
-  .. code-block:: shell
-
-     realm-cli import --strategy=merge --include-hosting
-
-  If you want to :doc:`upload external dependencies
-  </functions/upload-external-dependencies>`, include your archived
-  ``node_modules`` in the ``/functions`` directory and specify the
-  :option:`--include-dependencies
-  <realm-cli import --include-dependencies>` option:
-
-  .. code-block:: shell
-
-     realm-cli import --strategy=merge --include-dependencies
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deploy > Import/Export App` screen in the {+ui+}.
 ---
-title: Review and Confirm Import Diff
-ref: confirm-import-diff
+title: Update Your Application
+ref: update-your-application
 content: |
-  Before committing the import, {+cli-bin+} will show you a diff of
-  the changes that will be made to your application. Review the diff to
-  ensure that all changes are correct then confirm the import.
-
-  After successfully importing your application, {+service-short+} will
-  automatically deploy a new version of your app and update your local
-  application directory to match the new deployment.
+  Add, delete, and modify :ref:`configuration files <app-configuration> for your
+  application's various components.
+---
+title: Deploy the Updated App
+ref: deploy-the-updated-app
+content: |
+  Once you've updated your app's configuration files, you can push them to your
+  remote app. {+cli+} immediately deploys the updated configurations on push.
+  
+  .. code-block:: bash
+     
+     realm-cli push --remote="<Your App ID>"

--- a/source/reference/cli-auth-with-api-token.txt
+++ b/source/reference/cli-auth-with-api-token.txt
@@ -29,7 +29,5 @@ Generate an API Key
 
 Authenticate with an API Key
 ----------------------------
-      
-.. include:: /includes/note-procedure-uses-cli-v1.rst
 
 .. include:: /includes/steps/realm-cli-auth-with-api-key.rst


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:

- (DOCSP-14963): [CLI V2] Deploy with Realm CLI
- (DOCSP-14964): [CLI V2] Realm CLI Authenticate With API Token

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [Deploy with Realm CLI](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-guides/deploy/deploy-cli)
- [Realm CLI Authenticate With API Token](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-guides/reference/cli-auth-with-api-token) **(No significant changes)**


### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
