### PR TITLE
(DOCSP-14952): Update Enable Development Mode to CLI V2

### DIFF
--- a/source/includes/steps-development-mode-cli.yaml
+++ b/source/includes/steps-development-mode-cli.yaml
@@ -110,17 +110,15 @@ title: Enable Development Mode
 ref: enable-development-mode
 content: |
   You can turn development mode on and off by setting a boolean value for
-  ``sync.development_mode_enabled`` in your app's ``sync/config.json`` file. To
+  ``development_mode_enabled`` in your app's ``sync/config.json`` file. To
   enable dev mode, set the value to ``true``:
 
   .. code-block:: json
-     :caption: config.json
+     :caption: sync/config.json
      
      {
        ...,
-       "sync": {
-         "development_mode_enabled": true
-       }
+       "development_mode_enabled": true
      }
 ---
 title: Deploy the Updated App Configuration

--- a/source/includes/steps-development-mode-cli.yaml
+++ b/source/includes/steps-development-mode-cli.yaml
@@ -1,13 +1,11 @@
-title: Update Your Local Application
-ref: update-your-local-application
+title: Pull the Latest Version of Your App
+ref: pull-the-latest-version-of-your-app
 content: |
-  To configure development mode through the CLI, you need an :ref:`up-to-date
-  application directory <application-directory>`. To export the latest version
-  of your app, run the following command from your shell:
-
-  .. code-block:: shell
+  To pull a local copy of the latest version of your app, run the following:
+  
+  .. code-block:: bash
      
-     realm-cli export --app-id=<Your App ID>
+     realm-cli pull --remote="<Your App ID>"
 ---
 title: Select a Cluster to Sync
 ref: select-a-cluster-to-sync
@@ -112,7 +110,7 @@ title: Enable Development Mode
 ref: enable-development-mode
 content: |
   You can turn development mode on and off by setting a boolean value for
-  ``sync.development_mode_enabled`` in your app's ``config.json`` file. To
+  ``sync.development_mode_enabled`` in your app's ``sync/config.json`` file. To
   enable dev mode, set the value to ``true``:
 
   .. code-block:: json
@@ -135,4 +133,4 @@ content: |
 
   .. code-block:: shell
      
-     realm-cli import
+     realm-cli push --remote="<Your App ID>"

--- a/source/includes/steps-development-mode-cli.yaml
+++ b/source/includes/steps-development-mode-cli.yaml
@@ -117,7 +117,6 @@ content: |
      :caption: sync/config.json
      
      {
-       ...,
        "development_mode_enabled": true
      }
 ---

--- a/source/sync/enable-development-mode.txt
+++ b/source/sync/enable-development-mode.txt
@@ -41,6 +41,6 @@ Procedure
    .. tab::
       :tabid: cli
       
-      .. include:: /includes/note-procedure-uses-cli-v1.rst
+      .. include:: /includes/note-procedure-uses-cli-v2.rst
       
       .. include:: /includes/steps/development-mode-cli.rst


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14952

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14952-Enable-Development-Mode/sync/enable-development-mode/
### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
