### PR TITLE
(DOCSP-14602): Threading examples

### DIFF
--- a/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/java/ThreadingTest.java
+++ b/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/java/ThreadingTest.java
@@ -1,0 +1,81 @@
+package com.mongodb.realm.examples.java;
+
+import com.mongodb.realm.examples.Expectation;
+import com.mongodb.realm.examples.RealmTest;
+import com.mongodb.realm.examples.model.kotlin.Frog;
+
+import org.junit.Test;
+import io.realm.Realm;
+import io.realm.RealmConfiguration;
+import io.realm.RealmResults;
+
+public class ThreadingTest extends RealmTest {
+    @Test
+    public void testRefreshRealm() {
+        Expectation expectation = new Expectation();
+        activity.runOnUiThread(() -> {
+            RealmConfiguration config = new RealmConfiguration.Builder()
+                    .allowQueriesOnUiThread(true)
+                    .allowWritesOnUiThread(true)
+                    .inMemory()
+                    .name("refresh-realm")
+                    .build();
+            Realm realm = Realm.getInstance(config);
+            // :code-block-start: refresh-realm
+            if (!realm.isAutoRefresh()) {
+                // manually refresh
+                realm.refresh();
+            }
+            // :code-block-end:
+            realm.close();
+            expectation.fulfill();
+        });
+        expectation.await();
+    }
+
+    @Test
+    public void testFreezeObjects() {
+        Expectation expectation = new Expectation();
+        activity.runOnUiThread(() -> {
+            RealmConfiguration config = new RealmConfiguration.Builder()
+                    .allowQueriesOnUiThread(true)
+                    .allowWritesOnUiThread(true)
+                    .inMemory()
+                    .name("freeze-object")
+                    .build();
+            Realm insertRealm = Realm.getInstance(config);
+            insertRealm.executeTransaction(transactionRealm -> {
+                insertRealm.createObject(Frog.class);
+            });
+
+            // :code-block-start: freeze-objects
+            Realm realm = Realm.getInstance(config);
+
+            // Get an immutable copy of the realm that can be passed across threads
+            Realm frozenRealm = realm.freeze();
+            assert(frozenRealm.isFrozen());
+
+            RealmResults<Frog> frogs = realm.where(Frog.class).findAll();
+            // You can freeze collections
+            RealmResults<Frog> frozenFrogs = frogs.freeze();
+            assert(frozenFrogs.isFrozen());
+
+            // You can still read from frozen realms
+            RealmResults<Frog> frozenFrogs2 = frozenRealm.where(Frog.class).findAll();
+            assert(frozenFrogs2.isFrozen());
+
+            Frog frog = frogs.first();
+            assert(!frog.getRealm().isFrozen());
+
+            // You can freeze objects
+            Frog frozenFrog = frog.freeze();
+            assert(frozenFrog.isFrozen());
+            // Frozen objects have a reference to a frozen realm
+            assert(frozenFrog.getRealm().isFrozen());
+            // :code-block-end:
+            expectation.fulfill();
+            realm.close();
+        });
+        expectation.await();
+    }
+}

--- a/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/ThreadingTest.kt
+++ b/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/ThreadingTest.kt
@@ -1,0 +1,79 @@
+package com.mongodb.realm.examples.kotlin
+
+import com.mongodb.realm.examples.Expectation
+import com.mongodb.realm.examples.RealmTest
+import com.mongodb.realm.examples.model.kotlin.Frog
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import org.junit.Test
+
+class ThreadingTest : RealmTest() {
+    @Test
+    fun testRefreshRealm() {
+        val expectation = Expectation()
+        activity!!.runOnUiThread {
+            val config = RealmConfiguration.Builder()
+                .allowQueriesOnUiThread(true)
+                .allowWritesOnUiThread(true)
+                .inMemory()
+                .name("refresh-realm")
+                .build()
+            val realm = Realm.getInstance(config)
+            // :code-block-start: refresh-realm
+            if (!realm.isAutoRefresh) {
+                // manually refresh
+                realm.refresh()
+            }
+            // :code-block-end:
+            realm.close()
+            expectation.fulfill()
+        }
+        expectation.await()
+    }
+
+    @Test
+    fun testFreezeObjects() {
+        val expectation = Expectation()
+        activity!!.runOnUiThread {
+            val config = RealmConfiguration.Builder()
+                .allowQueriesOnUiThread(true)
+                .allowWritesOnUiThread(true)
+                .inMemory()
+                .name("freeze-object")
+                .build()
+            val insertRealm = Realm.getInstance(config)
+            insertRealm.executeTransaction {
+                insertRealm.createObject(
+                    Frog::class.java
+                )
+            }
+
+            // :code-block-start: freeze-objects
+            val realm = Realm.getInstance(config)
+
+            // Get an immutable copy of the realm that can be passed across threads
+            val frozenRealm = realm.freeze()
+            assert(frozenRealm.isFrozen)
+            val frogs = realm.where(Frog::class.java).findAll()
+            // You can freeze collections
+            val frozenFrogs = frogs.freeze()
+            assert(frozenFrogs.isFrozen)
+
+            // You can still read from frozen realms
+            val frozenFrogs2 =
+                frozenRealm.where(Frog::class.java).findAll()
+            assert(frozenFrogs2.isFrozen)
+            val frog: Frog = frogs.first()!!
+            assert(!frog.realm.isFrozen)
+
+            // You can freeze objects
+            val frozenFrog: Frog = frog.freeze()
+            assert(frozenFrog.isFrozen)
+            assert(frozenFrog.realm.isFrozen)
+            // :code-block-end:
+            expectation.fulfill()
+            realm.close()
+        }
+        expectation.await()
+    }
+}

--- a/source/examples/generated/android/local/ThreadingTest.codeblock.freeze-objects.java
+++ b/source/examples/generated/android/local/ThreadingTest.codeblock.freeze-objects.java
@@ -1,0 +1,23 @@
+Realm realm = Realm.getInstance(config);
+
+// Get an immutable copy of the realm that can be passed across threads
+Realm frozenRealm = realm.freeze();
+assert(frozenRealm.isFrozen());
+
+RealmResults<Frog> frogs = realm.where(Frog.class).findAll();
+// You can freeze collections
+RealmResults<Frog> frozenFrogs = frogs.freeze();
+assert(frozenFrogs.isFrozen());
+
+// You can still read from frozen realms
+RealmResults<Frog> frozenFrogs2 = frozenRealm.where(Frog.class).findAll();
+assert(frozenFrogs2.isFrozen());
+
+Frog frog = frogs.first();
+assert(!frog.getRealm().isFrozen());
+
+// You can freeze objects
+Frog frozenFrog = frog.freeze();
+assert(frozenFrog.isFrozen());
+// Frozen objects have a reference to a frozen realm
+assert(frozenFrog.getRealm().isFrozen());

--- a/source/examples/generated/android/local/ThreadingTest.codeblock.freeze-objects.kt
+++ b/source/examples/generated/android/local/ThreadingTest.codeblock.freeze-objects.kt
@@ -1,0 +1,21 @@
+val realm = Realm.getInstance(config)
+
+// Get an immutable copy of the realm that can be passed across threads
+val frozenRealm = realm.freeze()
+assert(frozenRealm.isFrozen)
+val frogs = realm.where(Frog::class.java).findAll()
+// You can freeze collections
+val frozenFrogs = frogs.freeze()
+assert(frozenFrogs.isFrozen)
+
+// You can still read from frozen realms
+val frozenFrogs2 =
+    frozenRealm.where(Frog::class.java).findAll()
+assert(frozenFrogs2.isFrozen)
+val frog: Frog = frogs.first()!!
+assert(!frog.realm.isFrozen)
+
+// You can freeze objects
+val frozenFrog: Frog = frog.freeze()
+assert(frozenFrog.isFrozen)
+assert(frozenFrog.realm.isFrozen)

--- a/source/examples/generated/android/local/ThreadingTest.codeblock.refresh-realm.java
+++ b/source/examples/generated/android/local/ThreadingTest.codeblock.refresh-realm.java
@@ -1,0 +1,4 @@
+if (!realm.isAutoRefresh()) {
+    // manually refresh
+    realm.refresh();
+}

--- a/source/examples/generated/android/local/ThreadingTest.codeblock.refresh-realm.kt
+++ b/source/examples/generated/android/local/ThreadingTest.codeblock.refresh-realm.kt
@@ -1,0 +1,4 @@
+if (!realm.isAutoRefresh) {
+    // manually refresh
+    realm.refresh()
+}

--- a/source/sdk/android/advanced-guides/threading.txt
+++ b/source/sdk/android/advanced-guides/threading.txt
@@ -146,6 +146,20 @@ beginning of that thread's loop. However, you must manually refresh
 {+realm+} instances that do not exist on loop threads or that have
 auto-refresh disabled.
 
+.. tabs-realm-languages::
+   
+   .. tab::
+       :tabid: kotlin
+
+       .. literalinclude:: /examples/generated/android/local/ThreadingTest.codeblock.refresh-realm.kt
+         :language: kotlin
+
+   .. tab::
+       :tabid: java
+
+       .. literalinclude:: /examples/generated/android/local/ThreadingTest.codeblock.refresh-realm.java
+         :language: java
+
 .. _android-frozen-objects:
 
 Frozen Objects
@@ -186,6 +200,20 @@ time of freezing.
 
 When you freeze a {+realm+}, its child objects also become
 frozen.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+       :tabid: kotlin
+
+       .. literalinclude:: /examples/generated/android/local/ThreadingTest.codeblock.freeze-objects.kt
+         :language: kotlin
+
+   .. tab::
+       :tabid: java
+
+       .. literalinclude:: /examples/generated/android/local/ThreadingTest.codeblock.freeze-objects.java
+         :language: java
 
 Frozen objects remain valid as long as the live {+realm+} that
 spawned them stays open. Therefore, avoid closing the live

--- a/source/sdk/android/advanced-guides/threading.txt
+++ b/source/sdk/android/advanced-guides/threading.txt
@@ -215,9 +215,9 @@ frozen.
        .. literalinclude:: /examples/generated/android/local/ThreadingTest.codeblock.freeze-objects.java
          :language: java
 
-Frozen objects remain valid as long as the live {+realm+} that
-spawned them stays open. Therefore, avoid closing the live
-{+realm+} until all threads are done with the frozen objects.
+Avoid closing the live {+realm+} until all threads are done 
+with frozen objects. Frozen objects remain valid for as long 
+as the {+realm+} that spawned them stays open.
 You can close frozen {+realm+} before the live {+realm+} is closed.
 
 .. important:: On caching frozen objects

--- a/source/sdk/android/data-types/counters.txt
+++ b/source/sdk/android/data-types/counters.txt
@@ -65,9 +65,7 @@ Usage
 
 The :java-sdk:`counter.increment() <io/realm/MutableRealmInteger.html#increment-long->`
 and :java-sdk:`counter.decrement() <io/realm/MutableRealmInteger.html#decrement-long->`
-operators implement a
-:wikipedia:`conflict free replicated data type <Conflict-free_replicated_data_type>`;
-this ensures that increments and decrements from multiple distributed
+operators ensure that increments and decrements from multiple distributed
 clients are aggregated correctly.
 
 To change a :java-sdk:`MutableRealmInteger


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14602
Also includes a small fix to remove mentions of CRDTs from the Counters page (the mention of CRDTs in the realm.io docs was erroneous)

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14602/sdk/android/advanced-guides/threading/ (freeze objects and refresh examples)

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
