### PR TITLE
Port iOS 'auxiliary files' page

### DIFF
--- a/source/sdk/ios/advanced-guides.txt
+++ b/source/sdk/ios/advanced-guides.txt
@@ -7,6 +7,7 @@ Realm Advanced Guides - iOS SDK
 
    Threading </sdk/ios/advanced-guides/threading>
    Encrypt a Realm </sdk/ios/advanced-guides/encrypt-a-realm>
+   Auxiliary Files </sdk/ios/advanced-guides/auxiliary-files>
    Custom User Data </sdk/ios/advanced-guides/custom-user-data>
    Multi-User Applications </sdk/ios/advanced-guides/multi-user-applications>
    Link User Identities </sdk/ios/advanced-guides/link-user-identities>
@@ -16,6 +17,7 @@ Realm-Database (Non-Sync)
 
 - :doc:`Threading </sdk/ios/advanced-guides/threading>`
 - :doc:`Encrypt a Realm </sdk/ios/advanced-guides/encrypt-a-realm>`
+- :doc:`Auxiliary Files </sdk/ios/advanced-guides/auxiliary-files>`
 
 MongoDB Realm Cloud (Sync)
 --------------------------

--- a/source/sdk/ios/advanced-guides/auxiliary-files.txt
+++ b/source/sdk/ios/advanced-guides/auxiliary-files.txt
@@ -1,0 +1,27 @@
+.. _ios-auxiliary-files:
+
+===============
+Auxiliary Files
+===============
+
+Realm generates and maintains additional files and directories for its
+own internal operations:
+
+.realm.lock
+  A lock file for resource locks.
+
+.realm.management
+  Directory of interprocess lock files.
+
+.realm.note
+  A named pipe for interprocess notifications.
+
+These files don’t have any effect on .realm database files, and won’t
+cause any erroneous behavior if their parent database file is deleted or
+replaced.
+
+.. note::
+
+   When reporting Realm issues, please be sure to include these
+   auxiliary files along with your main .realm file as they contain
+   useful information for debugging purposes.


### PR DESCRIPTION
The Realm IA doc says this should go under Advanced Guides.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14642

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/carb/sdk/ios/advanced-guides/auxiliary-files/

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
