### PR TITLE
(DOCSP-14653): Add key-value coding to docs

### DIFF
--- a/examples/ios/Examples/ReadWriteData.swift
+++ b/examples/ios/Examples/ReadWriteData.swift
@@ -435,7 +435,7 @@ class ReadWriteData: XCTestCase {
 
         try! realm.write {
             allDogs.first?.setValue("Sparky", forKey: "name")
-            // An international dognapping ring moves all the dogs to Toronto
+            // Move the dogs to Toronto for vacation
             allDogs.setValue("Toronto", forKey: "currentCity")
         }
         // :code-block-end:

--- a/examples/ios/Examples/ReadWriteData.swift
+++ b/examples/ios/Examples/ReadWriteData.swift
@@ -14,6 +14,7 @@ class ReadWriteDataExamples_DogToy: Object {
 class ReadWriteDataExamples_Dog: Object {
     @objc dynamic var name = ""
     @objc dynamic var age = 0
+    @objc dynamic var currentCity = ""
 
     // To-one relationship
     @objc dynamic var favoriteToy: ReadWriteDataExamples_DogToy?
@@ -434,7 +435,8 @@ class ReadWriteData: XCTestCase {
 
         try! realm.write {
             allDogs.first?.setValue("Sparky", forKey: "name")
-            allDogs.first?.setValue(3, forKey: "age")
+            // An international dognapping ring moves all the dogs to Toronto
+            allDogs.setValue("Toronto", forKey: "currentCity")
         }
         // :code-block-end:
     }

--- a/examples/ios/Examples/ReadWriteData.swift
+++ b/examples/ios/Examples/ReadWriteData.swift
@@ -425,6 +425,19 @@ class ReadWriteData: XCTestCase {
         }
         // :code-block-end:
     }
+    
+    func testKeyValueCoding() {
+        // :code-block-start: key-value-coding
+        let realm = try! Realm()
+
+        let allDogs = realm.objects(ReadWriteDataExamples_Dog.self)
+
+        try! realm.write {
+            allDogs.first?.setValue("Sparky", forKey: "name")
+            allDogs.first?.setValue(3, forKey: "age")
+        }
+        // :code-block-end:
+    }
 }
 
 // :replace-end:

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.key-value-coding.swift
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.key-value-coding.swift
@@ -1,0 +1,8 @@
+let realm = try! Realm()
+
+let allDogs = realm.objects(Dog.self)
+
+try! realm.write {
+    allDogs.first?.setValue("Sparky", forKey: "name")
+    allDogs.first?.setValue(3, forKey: "age")
+}

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.key-value-coding.swift
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.key-value-coding.swift
@@ -4,5 +4,6 @@ let allDogs = realm.objects(Dog.self)
 
 try! realm.write {
     allDogs.first?.setValue("Sparky", forKey: "name")
-    allDogs.first?.setValue(3, forKey: "age")
+    // An international dognapping ring moves all the dogs to Toronto
+    allDogs.setValue("Toronto", forKey: "currentCity")
 }

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.key-value-coding.swift
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.key-value-coding.swift
@@ -4,6 +4,6 @@ let allDogs = realm.objects(Dog.self)
 
 try! realm.write {
     allDogs.first?.setValue("Sparky", forKey: "name")
-    // An international dognapping ring moves all the dogs to Toronto
+    // Move the dogs to Toronto for vacation
     allDogs.setValue("Toronto", forKey: "currentCity")
 }

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.models.swift
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.models.swift
@@ -5,6 +5,7 @@ class DogToy: Object {
 class Dog: Object {
     @objc dynamic var name = ""
     @objc dynamic var age = 0
+    @objc dynamic var currentCity = ""
 
     // To-one relationship
     @objc dynamic var favoriteToy: DogToy?

--- a/source/sdk/ios/examples/read-and-write-data.txt
+++ b/source/sdk/ios/examples/read-and-write-data.txt
@@ -344,6 +344,9 @@ Copy an Object to Another Realm
 Modify an Object
 ~~~~~~~~~~~~~~~~
 
+Access Properties Directly
+''''''''''''''''''''''''''
+
 You can modify properties of a Realm object inside of a write
 transaction in the same way that you would update any other Swift or
 Objective-C object.
@@ -372,6 +375,21 @@ Objective-C object.
    object.
 
 .. _ios-upsert-an-object:
+
+Use Key-value Coding to Update Properties
+'''''''''''''''''''''''''''''''''''''''''
+
+``Object``, ``Result``, and ``List`` all conform to 
+:apple:`key-value coding<library/archive/documentation/Cocoa/Conceptual/KeyValueCoding/>`. 
+This can be useful when you need to determine which property to update 
+at runtime.
+
+Applying KVC to a collection is a great way to update objects in bulk. 
+Avoid the overhead of iterating over a collection while creating 
+accessors for every item.
+
+.. literalinclude:: /examples/generated/code/start/ReadWriteData.codeblock.key-value-coding.swift
+   :language: swift
 
 Upsert an Object
 ~~~~~~~~~~~~~~~~

--- a/source/sdk/ios/examples/read-and-write-data.txt
+++ b/source/sdk/ios/examples/read-and-write-data.txt
@@ -344,9 +344,6 @@ Copy an Object to Another Realm
 Modify an Object
 ~~~~~~~~~~~~~~~~
 
-Access Properties Directly
-''''''''''''''''''''''''''
-
 You can modify properties of a Realm object inside of a write
 transaction in the same way that you would update any other Swift or
 Objective-C object.
@@ -376,8 +373,8 @@ Objective-C object.
 
 .. _ios-upsert-an-object:
 
-Use Key-value Coding to Update Properties
-'''''''''''''''''''''''''''''''''''''''''
+Update Properties with Key-value Coding
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``Object``, ``Result``, and ``List`` all conform to 
 :apple:`key-value coding<library/archive/documentation/Cocoa/Conceptual/KeyValueCoding/>`. 


### PR DESCRIPTION
## Pull Request Info

Porting the KVC example from Realm.io legacy docs.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14653

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14653/sdk/ios/examples/read-and-write-data/#update-properties-with-key-value-coding

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
