### PR TITLE
Update function example to fix failing test

### DIFF
--- a/examples/ios/Examples/Functions.swift
+++ b/examples/ios/Examples/Functions.swift
@@ -22,8 +22,8 @@ class Functions: AnonymouslyLoggedInTestCase {
                 print("Function call failed: \(error!.localizedDescription)")
                 return
             }
-            guard case let .double(value) = sum else {
-                print("Unexpected non-double result: \(sum ?? "nil")")
+            guard case let .int64(value) = sum else {
+                print("Unexpected non-int64 result: \(sum ?? "nil")")
                 return
             }
             print("Called function 'sum' and got result: \(value)")

--- a/source/examples/generated/code/start/Functions.codeblock.call-a-function.swift
+++ b/source/examples/generated/code/start/Functions.codeblock.call-a-function.swift
@@ -14,8 +14,8 @@ user.functions.sum([1, 2]) { sum, error in
         print("Function call failed: \(error!.localizedDescription)")
         return
     }
-    guard case let .double(value) = sum else {
-        print("Unexpected non-double result: \(sum ?? "nil")")
+    guard case let .int64(value) = sum else {
+        print("Unexpected non-int64 result: \(sum ?? "nil")")
         return
     }
     print("Called function 'sum' and got result: \(value)")


### PR DESCRIPTION
## Pull Request Info

The Functions example test was failing, with an error: `Unexpected non-double result: int64(3)`

@cbush noted a recent change to the JS VM caused similar issues for someone else. This fix resolves the issue.

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
