### PR TITLE
(DOCSP-14647): Port 'Copying objects between Realms' to Usage Examples

### DIFF
--- a/examples/ios/Examples/LocalOnlyCompleteQuickStart.swift
+++ b/examples/ios/Examples/LocalOnlyCompleteQuickStart.swift
@@ -23,7 +23,6 @@ class LocalOnlyQsTask: Object {
 
 // Entrypoint. Call this to run the example.
 func runLocalOnlyExample() {
-    
     // :code-block-start: quick-start-local-open-realm-without-config-param
     // Open the local-only default realm
     let localRealm = try! Realm()

--- a/examples/ios/Examples/ReadWriteData.m
+++ b/examples/ios/Examples/ReadWriteData.m
@@ -398,6 +398,36 @@ RLM_ARRAY_TYPE(ReadWriteDataObjcExample_Person)
     // :code-block-end:
 }
 
+- (void)testCopyToAnotherRealm {
+    // :code-block-start: copy-to-another-realm
+    RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
+    configuration.inMemoryIdentifier = @"first realm";
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:configuration error:nil];
+
+    [realm transactionWithBlock:^{
+        ReadWriteDataObjcExample_Dog *dog = [[ReadWriteDataObjcExample_Dog alloc] init];
+        dog.name = @"Wolfie";
+        dog.age = 1;
+        [realm addObject:dog];
+    }];
+
+    // Later, fetch the instance we want to copy
+    ReadWriteDataObjcExample_Dog *wolfie = [[ReadWriteDataObjcExample_Dog objectsInRealm:realm where:@"name == 'Wolfie'"] firstObject];
+
+    // Open the other realm
+    RLMRealmConfiguration *otherConfiguration = [RLMRealmConfiguration defaultConfiguration];
+    otherConfiguration.inMemoryIdentifier = @"second realm";
+    RLMRealm *otherRealm = [RLMRealm realmWithConfiguration:otherConfiguration error:nil];
+    [otherRealm transactionWithBlock:^{
+        // Copy to the other realm
+        ReadWriteDataObjcExample_Dog *wolfieCopy = [[wolfie class] createInRealm:otherRealm withValue:wolfie];
+        wolfieCopy.age = 2;
+        
+        // Verify that the copy is separate from the original
+        XCTAssertNotEqual(wolfie.age, wolfieCopy.age);
+    }];
+    // :code-block-end:
+}
 @end
 
 // :replace-end:

--- a/examples/ios/Examples/ReadWriteData.swift
+++ b/examples/ios/Examples/ReadWriteData.swift
@@ -398,6 +398,33 @@ class ReadWriteData: XCTestCase {
         people.filter("dogs.@sum.age > 10")
         // :code-block-end:
     }
+
+    func testCopyToAnotherRealm() {
+        // :code-block-start: copy-to-another-realm
+        let realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "first realm"))
+
+        try! realm.write {
+            let dog = ReadWriteDataExamples_Dog()
+            dog.name = "Wolfie"
+            dog.age = 1
+            realm.add(dog)
+        }
+
+        // Later, fetch the instance we want to copy
+        let wolfie = realm.objects(ReadWriteDataExamples_Dog.self).first(where: { $0.name == "Wolfie" })!
+
+        // Open the other realm
+        let otherRealm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "second realm"))
+        try! otherRealm.write {
+            // Copy to the other realm
+            let wolfieCopy = otherRealm.create(type(of: wolfie), value: wolfie)
+            wolfieCopy.age = 2
+
+            // Verify that the copy is separate from the original
+            XCTAssertNotEqual(wolfie.age, wolfieCopy.age)
+        }
+        // :code-block-end:
+    }
 }
 
 // :replace-end:

--- a/source/examples/generated/code/start/LocalOnlyCompleteQuickStart.codeblock.complete-quick-start-local.swift
+++ b/source/examples/generated/code/start/LocalOnlyCompleteQuickStart.codeblock.complete-quick-start-local.swift
@@ -14,7 +14,6 @@ class LocalOnlyQsTask: Object {
 
 // Entrypoint. Call this to run the example.
 func runLocalOnlyExample() {
-    
     // Open the local-only default realm
     let localRealm = try! Realm()
     // Get all tasks in the realm

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.copy-to-another-realm.m
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.copy-to-another-realm.m
@@ -1,0 +1,26 @@
+RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
+configuration.inMemoryIdentifier = @"first realm";
+RLMRealm *realm = [RLMRealm realmWithConfiguration:configuration error:nil];
+
+[realm transactionWithBlock:^{
+    Dog *dog = [[Dog alloc] init];
+    dog.name = @"Wolfie";
+    dog.age = 1;
+    [realm addObject:dog];
+}];
+
+// Later, fetch the instance we want to copy
+Dog *wolfie = [[Dog objectsInRealm:realm where:@"name == 'Wolfie'"] firstObject];
+
+// Open the other realm
+RLMRealmConfiguration *otherConfiguration = [RLMRealmConfiguration defaultConfiguration];
+otherConfiguration.inMemoryIdentifier = @"second realm";
+RLMRealm *otherRealm = [RLMRealm realmWithConfiguration:otherConfiguration error:nil];
+[otherRealm transactionWithBlock:^{
+    // Copy to the other realm
+    Dog *wolfieCopy = [[wolfie class] createInRealm:otherRealm withValue:wolfie];
+    wolfieCopy.age = 2;
+    
+    // Verify that the copy is separate from the original
+    XCTAssertNotEqual(wolfie.age, wolfieCopy.age);
+}];

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.copy-to-another-realm.swift
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.copy-to-another-realm.swift
@@ -1,0 +1,22 @@
+let realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "first realm"))
+
+try! realm.write {
+    let dog = Dog()
+    dog.name = "Wolfie"
+    dog.age = 1
+    realm.add(dog)
+}
+
+// Later, fetch the instance we want to copy
+let wolfie = realm.objects(Dog.self).first(where: { $0.name == "Wolfie" })!
+
+// Open the other realm
+let otherRealm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "second realm"))
+try! otherRealm.write {
+    // Copy to the other realm
+    let wolfieCopy = otherRealm.create(type(of: wolfie), value: wolfie)
+    wolfieCopy.age = 2
+
+    // Verify that the copy is separate from the original
+    XCTAssertNotEqual(wolfie.age, wolfieCopy.age)
+}

--- a/source/sdk/ios/examples/read-and-write-data.txt
+++ b/source/sdk/ios/examples/read-and-write-data.txt
@@ -303,6 +303,42 @@ Create a New Object
       .. literalinclude:: /examples/generated/code/start/ReadWriteData.codeblock.create.m
          :language: objectivec
 
+
+.. _ios-copy-an-object-to-another-realm:
+
+Copy an Object to Another Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      To copy an object from one {+realm+} to another, pass the original
+      object to :swift-sdk:`Realm.create(_:value:update:):
+      <Structs/Realm.html#/s:10RealmSwift0A0V6create_5value6updatexxm_ypAC12UpdatePolicyOtSo0aB6ObjectCRbzlF>`:
+
+      .. literalinclude:: /examples/generated/code/start/ReadWriteData.codeblock.copy-to-another-realm.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      To copy an object from one {+realm+} to another, pass the original
+      object to :objc-sdk:`+[RLMObject createInRealm:withValue:]
+      <Classes/RLMObject.html#/c:objc(cs)RLMObject(cm)createInRealm:withValue:>`:
+
+      .. literalinclude:: /examples/generated/code/start/ReadWriteData.codeblock.copy-to-another-realm.m
+         :language: objectivec
+
+
+.. important::
+
+   The ``create`` methods do not support handling cyclical object
+   graphs. Do not pass in an object containing relationships involving
+   objects that refer back to their parents, either directly or
+   indirectly.
+
 .. _ios-modify-an-object:
 
 Modify an Object


### PR DESCRIPTION
- Add obj-c and swift code example
- Change to LocalOnly is due to SwiftLint

## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14647

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/carb5/sdk/ios/examples/read-and-write-data/#copy-an-object-to-another-realm

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
