### PR TITLE
(DOCSP-14639): Port info about default realms, file size, and property attributes

### DIFF
--- a/source/sdk/ios/advanced-guides/threading.txt
+++ b/source/sdk/ios/advanced-guides/threading.txt
@@ -68,6 +68,10 @@ Don't pass live objects, collections, or {+realms+} to other threads:
   :ref:`sharing objects across threads
   <ios-communication-across-threads>`.
 
+.. seealso::
+
+   :ref:`Realms: File Size <ios-file-size>`
+
 .. _ios-communication-across-threads:
 
 Communication Across Threads

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -37,7 +37,7 @@ Property Attributes
 Declare dynamic {+backend-short+} model properties in the Objective-C runtime. This 
 enables them to access the underlying database data. 
 
-- Use ``@objc dynamic var`` when declaring individual properties
+- Use ``@objc dynamic var`` to declare individual properties, or;
 - Use ``@objcMembers`` to declare a class. Then, declare individual 
   properties with ``dynamic var``. 
 

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -39,7 +39,7 @@ enables them to access the underlying database data.
 
 - Use ``@objc dynamic var`` when declaring individual properties
 - Use ``@objcMembers`` to declare a class. Then, declare individual 
-properties with ``dynamic var``. 
+  properties with ``dynamic var``. 
 
 Use ``let`` to declare ``LinkingObjects``, ``List``, and 
 ``RealmOptional``. The Objective-C runtime cannot represent these 

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -37,7 +37,7 @@ Property Attributes
 Declare dynamic {+backend-short+} model properties in the Objective-C runtime. This 
 enables them to access the underlying database data. 
 
-- Use ``@objc dynamic var`` to declare individual properties, or;
+- Use ``@objc dynamic var`` to declare individual properties -OR-
 - Use ``@objcMembers`` to declare a class. Then, declare individual 
   properties with ``dynamic var``. 
 

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -31,6 +31,25 @@ object that can be stored in that {+realm+}.
    To learn how to define a Realm object in Swift or Objective-C, see
    :ref:`ios-define-a-realm-object-schema`.
 
+Property Attributes
+-------------------
+
+Declare dynamic {+backend-short+} model properties in the Objective-C runtime. This 
+enables them to access the underlying database data. 
+
+- Use ``@objc dynamic var`` when declaring individual properties
+- Use ``@objcMembers`` to declare a class. Then, declare individual 
+properties with ``dynamic var``. 
+
+Use ``let`` to declare ``LinkingObjects``, ``List``, and 
+``RealmOptional``. The Objective-C runtime cannot represent these 
+generic properties.
+
+.. seealso::
+
+   Our :ref:`Supported Property Types <ios-supported-property-types>` 
+   page contains a property declaration cheatsheet.
+
 Primary Keys
 ------------
 

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -37,7 +37,9 @@ Property Attributes
 Declare dynamic {+backend-short+} model properties in the Objective-C runtime. This 
 enables them to access the underlying database data. 
 
-- Use ``@objc dynamic var`` to declare individual properties -OR-
+You can either:
+
+- Use ``@objc dynamic var`` to declare individual properties
 - Use ``@objcMembers`` to declare a class. Then, declare individual 
   properties with ``dynamic var``. 
 

--- a/source/sdk/ios/fundamentals/realms.txt
+++ b/source/sdk/ios/fundamentals/realms.txt
@@ -193,8 +193,8 @@ of {+backend-short+} instances. Avoid “pinning” old Realm transactions.
 Use auto-refreshing Realms and wrap the use of Realm APIs from background 
 threads in explicit autorelease pools.
 
-Realm File Growth When Threading
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Threading
+~~~~~~~~~
 
 Realm updates the version of your data that it accesses at the start of 
 a run loop iteration. While this gives you a consistent view of your 
@@ -203,11 +203,11 @@ data, it has file size implications.
 Imagine this scenario:
 
 - Thread A: Read some data from a Realm, and then block the thread on a 
-long-running operation.
+  long-running operation.
 - Thread B: Write data on another thread.
 - Thread A: The version that you're still holding on the read thread isn't 
-updated. Realm has to hold intermediate versions of the data, growing in 
-file size with every write. 
+  updated. Realm has to hold intermediate versions of the data, growing in 
+  file size with every write. 
 
 To avoid this issue, call ``invalidate`` to tell Realm that you no 
 longer need the objects you've read so far. This frees Realm from 
@@ -217,11 +217,10 @@ access it, Realm will have the latest version of the objects.
 You can also use these two methods to compact your Realm:
 
 - Set :swift-sdk:`shouldCompactOnLaunch<Structs/Realm/Configuration.html>`
-- Use :swift-sdk:`writeCopy(toFile:encryptionKey:) 
-<Structs/Realm.html>`
+- Use :swift-sdk:`writeCopy(toFile:encryptionKey:)<Structs/Realm.html>`
 
-Realm File Growth When Using Dispatch Queues
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Dispatch Queues
+~~~~~~~~~~~~~~~
 
 When accessing Realm using :apple:`Grand Central Dispatch 
 <documentation/dispatch>`, you may see similar file growth. A dispatch 
@@ -236,9 +235,10 @@ Default Realm
 -------------
 
 Calling ``Realm()`` opens the default Realm. This method returns a ``Realm`` 
-object that maps to a file named ``default.realm``. You can find this file 
-in the Documents folder (iOS) or Application Support folder (macOS) of 
-your app.
+object that maps to a file named ``default.realm``. You can find this file:
+
+- iOS: in the Documents folder of your app
+- macOS: in the Application Support folder of your app
 
 
 .. _ios-synced-realm:

--- a/source/sdk/ios/fundamentals/realms.txt
+++ b/source/sdk/ios/fundamentals/realms.txt
@@ -188,24 +188,24 @@ comparable SQLite database. Unexpected file growth may be related to the
 
 .. tip:: Avoid pinning old Realm transactions
 
-{+backend-short+} ties read transaction lifetimes to the memory lifetime 
-of {+backend-short+} instances. Avoid “pinning” old Realm transactions. 
-Use auto-refreshing Realms and wrap the use of Realm APIs from background 
-threads in explicit autorelease pools.
+   {+backend-short+} ties read transaction lifetimes to the memory lifetime 
+   of {+backend-short+} instances. Avoid “pinning” old Realm transactions. 
+   Use auto-refreshing {+backend-short+}s, and wrap the use of Realm APIs 
+   from background threads in explicit autorelease pools.
 
 Threading
 ~~~~~~~~~
 
-Realm updates the version of your data that it accesses at the start of 
-a run loop iteration. While this gives you a consistent view of your 
-data, it has file size implications. 
+{+backend-short+} updates the version of your data that it accesses at 
+the start of a run loop iteration. While this gives you a consistent 
+view of your data, it has file size implications. 
 
 Imagine this scenario:
 
-- Thread A: Read some data from a Realm, and then block the thread on a 
+- **Thread A**: Read some data from a Realm, and then block the thread on a 
   long-running operation.
-- Thread B: Write data on another thread.
-- Thread A: The version that you're still holding on the read thread isn't 
+- **Thread B**: Write data on another thread.
+- **Thread A**: The version that you're still holding on the read thread isn't 
   updated. Realm has to hold intermediate versions of the data, growing in 
   file size with every write. 
 

--- a/source/sdk/ios/fundamentals/realms.txt
+++ b/source/sdk/ios/fundamentals/realms.txt
@@ -177,6 +177,70 @@ closed.
 
    To open an in-memory realm, see :ref:`ios-open-an-in-memory-realm`.
 
+.. _ios-file-size:
+
+File Size
+---------
+
+Generally, {+client-database+} takes less space on disk than a 
+comparable SQLite database. Unexpected file growth may be related to the 
+{+backend-short+} referring to outdated data.
+
+.. tip:: Avoid pinning old Realm transactions
+
+{+backend-short+} ties read transaction lifetimes to the memory lifetime 
+of {+backend-short+} instances. Avoid “pinning” old Realm transactions. 
+Use auto-refreshing Realms and wrap the use of Realm APIs from background 
+threads in explicit autorelease pools.
+
+Realm File Growth When Threading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Realm updates the version of your data that it accesses at the start of 
+a run loop iteration. While this gives you a consistent view of your 
+data, it has file size implications. 
+
+Imagine this scenario:
+
+- Thread A: Read some data from a Realm, and then block the thread on a 
+long-running operation.
+- Thread B: Write data on another thread.
+- Thread A: The version that you're still holding on the read thread isn't 
+updated. Realm has to hold intermediate versions of the data, growing in 
+file size with every write. 
+
+To avoid this issue, call ``invalidate`` to tell Realm that you no 
+longer need the objects you've read so far. This frees Realm from 
+tracking intermediate versions of those objects. The next time you 
+access it, Realm will have the latest version of the objects.
+
+You can also use these two methods to compact your Realm:
+
+- Set :swift-sdk:`shouldCompactOnLaunch<Structs/Realm/Configuration.html>`
+- Use :swift-sdk:`writeCopy(toFile:encryptionKey:) 
+<Structs/Realm.html>`
+
+Realm File Growth When Using Dispatch Queues
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When accessing Realm using :apple:`Grand Central Dispatch 
+<documentation/dispatch>`, you may see similar file growth. A dispatch 
+queue's autorelease pool may not be drained immediately upon executing 
+your code. If the Realm object is not yet deallocated, the intermediate 
+versions of data cannot be reused. Use an explicit autorelease pool when 
+accessing Realm from a dispatch queue.
+
+.. _ios-default-realm:
+
+Default Realm
+-------------
+
+Calling ``Realm()`` opens the default Realm. This method returns a ``Realm`` 
+object that maps to a file named ``default.realm``. You can find this file 
+in the Documents folder (iOS) or Application Support folder (macOS) of 
+your app.
+
+
 .. _ios-synced-realm:
 
 Synced Realms

--- a/source/sdk/ios/fundamentals/realms.txt
+++ b/source/sdk/ios/fundamentals/realms.txt
@@ -202,40 +202,48 @@ view of your data, it has file size implications.
 
 Imagine this scenario:
 
-- **Thread A**: Read some data from a Realm, and then block the thread on a 
+- **Thread A**: Read some data from a {+realm+}, and then block the thread on a 
   long-running operation.
 - **Thread B**: Write data on another thread.
-- **Thread A**: The version that you're still holding on the read thread isn't 
-  updated. Realm has to hold intermediate versions of the data, growing in 
-  file size with every write. 
+- **Thread A**: The version on the read thread isn't updated. Realm has 
+  to hold intermediate versions of the data, growing in file size with 
+  every write. 
 
-To avoid this issue, call ``invalidate`` to tell Realm that you no 
-longer need the objects you've read so far. This frees Realm from 
-tracking intermediate versions of those objects. The next time you 
-access it, Realm will have the latest version of the objects.
+To avoid this issue, call :swift-sdk:`invalidate() <Structs/Realm.html#/s:10RealmSwift0A0V10invalidateyyF>` 
+on the {+realm+}. This tells the {+realm+} that you no longer need the 
+objects you've read so far. This frees {+realm+} from tracking 
+intermediate versions of those objects. The next time you access it, 
+{+realm+} will have the latest version of the objects.
 
 You can also use these two methods to compact your Realm:
 
 - Set :swift-sdk:`shouldCompactOnLaunch<Structs/Realm/Configuration.html>`
+  in the configuration
 - Use :swift-sdk:`writeCopy(toFile:encryptionKey:)<Structs/Realm.html>`
+
+.. seealso::
+
+   :ref:`Advanced Guides: Threading <ios-client-threading>`
 
 Dispatch Queues
 ~~~~~~~~~~~~~~~
 
 When accessing Realm using :apple:`Grand Central Dispatch 
 <documentation/dispatch>`, you may see similar file growth. A dispatch 
-queue's autorelease pool may not be drained immediately upon executing 
-your code. If the Realm object is not yet deallocated, the intermediate 
-versions of data cannot be reused. Use an explicit autorelease pool when 
-accessing Realm from a dispatch queue.
+queue's autorelease pool may not drain immediately upon executing your 
+code. Realm cannot reuse intermediate versions of the data until the 
+dispatch pool deallocates the {+realm+} object. Use an explicit 
+autorelease pool when accessing {+realm+} from a dispatch queue.
 
 .. _ios-default-realm:
 
 Default Realm
 -------------
 
-Calling ``Realm()`` opens the default Realm. This method returns a ``Realm`` 
-object that maps to a file named ``default.realm``. You can find this file:
+Calling :swift-sdk:`Realm()<Structs/Realm.html>` or 
+:objc-sdk:`RLMRealm<Classes/RLMRealm.html>` opens the default {+realm+}. 
+This method returns a {+realm+} object that maps to a file named 
+``default.realm``. You can find this file:
 
 - iOS: in the Documents folder of your app
 - macOS: in the Application Support folder of your app


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14639

### Docs staging link (requires sign-in on MongoDB Corp SSO):
New sections on the [Fundamentals -> Realms page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14639/sdk/ios/fundamentals/realms): 
- File Size
- Default Realm

New section on [Fundamentals -> Object Models & Schemas page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14639/sdk/ios/fundamentals/object-models-and-schemas/#property-attributes):
- Property Attributes

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
