### PR TITLE
(DOCSP-15199): Add 'product=Atlas' as a possible parameter for the /apps Admin API endpoint

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -132,6 +132,13 @@ paths:
       summary: >-
         List all Realm apps within an |atlas|
         :atlas:`project/group </tutorial/manage-projects/>`.
+      parameters:
+        - name: product
+          in: query
+          description: "Specify ``product=atlas`` to include :atlas:`Atlas trigger </triggers>` apps."
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: "Successfully listed."


### PR DESCRIPTION
## Pull Request Info

_**NOTE: The param is actually lowercase "atlas", not "Atlas"**_

### Issue JIRA link:

(DOCSP-15199): Add 'product=Atlas' as a possible parameter for the /apps Admin API endpoint

### Docs staging link (requires sign-in on MongoDB Corp SSO):

- [GET /​groups/​{groupId}/​apps](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/atlas-query-param/admin/api/v3/#get-/groups/%7Bgroupid%7D/apps)

### Review Guidelines
[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
