### PR TITLE
finally fix auto-cap on iOS

### DIFF
--- a/tutorial/dotnet/realm-tutorial-dotnet/LoginPage.xaml
+++ b/tutorial/dotnet/realm-tutorial-dotnet/LoginPage.xaml
@@ -6,8 +6,8 @@
         <Frame BackgroundColor="#2196F3" Padding="14" CornerRadius="0">
             <Label Text="Log In" HorizontalTextAlignment="Center" TextColor="White" FontSize="20" FlexLayout.AlignSelf="Start"/>
         </Frame>
-        <Entry Placeholder="Email" TextChanged="Email_Entry_Completed"/>
-        <Entry Placeholder="Password" IsPassword="True" TextChanged="Password_Entry_Completed"/>
+        <Entry Placeholder="Email" TextChanged="Email_Entry_Completed" IsTextPredictionEnabled="False" Keyboard="Plain" />
+        <Entry Placeholder="Password" IsPassword="True" TextChanged="Password_Entry_Completed" IsTextPredictionEnabled="False" Keyboard="Plain" />
         <Button Text="Log In" Clicked="Login_Button_Clicked"/>
         <Button Text="Create New Account" Clicked="Register_Button_CLicked"/>
     </StackLayout>


### PR DESCRIPTION
There has been a long-standing iOS issue of the OS initial-capping the user's logon info. This fixes it. 