### PR TITLE
Add tip to refer to app-configuration for backend tutorial

### DIFF
--- a/source/tutorial/realm-app.txt
+++ b/source/tutorial/realm-app.txt
@@ -342,6 +342,11 @@ see a {+app+} named ``tasktracker``:
    :alt: A newly created TaskTracker backend in the Atlas UI.
    :width: 600px
 
+.. tip::
+
+   To understand the purpose of the files in the backend app repo, see
+   :ref:`app-configuration`.
+
 .. _tutorial-task-tracker-verify-configuration:
 
 F. Verify that the Task Tracker Backend is Properly Configured


### PR DESCRIPTION
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/tutorial-backend-tip/tutorial/realm-app/#e.-use-the-realm-cli-to-create-a-new-task-tracker-backend-realm-app