### PR TITLE
(DOCSP-14632): Port content on compacting from legacy Swift docs

### DIFF
--- a/examples/ios/Examples/Compacting.m
+++ b/examples/ios/Examples/Compacting.m
@@ -1,0 +1,32 @@
+#import <XCTest/XCTest.h>
+#import <Realm/Realm.h>
+#import "MyRealmApp.h"
+
+@interface CompactingObjc : XCTestCase
+
+@end
+
+@implementation CompactingObjc
+
+- (void)testCompacting {
+    // :code-block-start: compacting
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.shouldCompactOnLaunch = ^BOOL(NSUInteger totalBytes, NSUInteger usedBytes) {
+        // totalBytes refers to the size of the file on disk in bytes (data + free space)
+        // usedBytes refers to the number of bytes used by data in the file
+
+        // Compact if the file is over 100MB in size and less than 50% 'used'
+        NSUInteger oneHundredMB = 100 * 1024 * 1024;
+        return (totalBytes > oneHundredMB) && ((double)usedBytes / totalBytes) < 0.5;
+    };
+
+    NSError *error = nil;
+    // Realm is compacted on the first open if the configuration block conditions were met.
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:&error];
+    if (error) {
+        // handle error compacting or opening Realm
+    }
+    // :code-block-end:
+}
+
+@end

--- a/examples/ios/Examples/Compacting.swift
+++ b/examples/ios/Examples/Compacting.swift
@@ -1,0 +1,24 @@
+import XCTest
+import RealmSwift
+
+class Compacting: XCTestCase {
+
+    func testCompacting() {
+        // :code-block-start: compacting
+        let config = Realm.Configuration(shouldCompactOnLaunch: { totalBytes, usedBytes in
+            // totalBytes refers to the size of the file on disk in bytes (data + free space)
+            // usedBytes refers to the number of bytes used by data in the file
+
+            // Compact if the file is over 100MB in size and less than 50% 'used'
+            let oneHundredMB = 100 * 1024 * 1024
+            return (totalBytes > oneHundredMB) && (Double(usedBytes) / Double(totalBytes)) < 0.5
+        })
+        do {
+            // Realm is compacted on the first open if the configuration block conditions were met.
+            let realm = try Realm(configuration: config)
+        } catch {
+            // handle error compacting or opening Realm
+        }
+        // :code-block-end:
+    }
+}

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		48F38B5A252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */; };
 		48F38B5C2527A3FE00DDEB65 /* ManageApiKeys.m in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B5B2527A3FE00DDEB65 /* ManageApiKeys.m */; };
 		9185DB1925E82C0300AF1389 /* LocalOnlyCompleteQuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9185DB1825E82C0300AF1389 /* LocalOnlyCompleteQuickStart.swift */; };
+		91CEF5FE260E308100A029E0 /* Compacting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CEF5FD260E308100A029E0 /* Compacting.swift */; };
+		91CEF606260E325000A029E0 /* Compacting.m in Sources */ = {isa = PBXBuildFile; fileRef = 91CEF605260E325000A029E0 /* Compacting.m */; };
 		B9170656257F9CB924AEBA6F /* Pods_QuickStartSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AF8E651F4F80B36D8C460AF /* Pods_QuickStartSwiftUI.framework */; };
 /* End PBXBuildFile section */
 
@@ -149,6 +151,8 @@
 		7D033479B74D15FCF29CFE1B /* Pods_RealmExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82A9EC393EF912515E8527A0 /* Pods-RealmObjcExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmObjcExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-RealmObjcExampleTests/Pods-RealmObjcExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9185DB1825E82C0300AF1389 /* LocalOnlyCompleteQuickStart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalOnlyCompleteQuickStart.swift; sourceTree = "<group>"; };
+		91CEF5FD260E308100A029E0 /* Compacting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compacting.swift; sourceTree = "<group>"; };
+		91CEF605260E325000A029E0 /* Compacting.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Compacting.m; sourceTree = "<group>"; };
 		930065835B0988B74FE25746 /* Pods-RealmExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExampleTests.release.xcconfig"; path = "Target Support Files/Pods-RealmExampleTests/Pods-RealmExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		BE555C3FD2D6ABFD03EF1B48 /* Pods-RealmSwiftExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmSwiftExamples.debug.xcconfig"; path = "Target Support Files/Pods-RealmSwiftExamples/Pods-RealmSwiftExamples.debug.xcconfig"; sourceTree = "<group>"; };
 		D547E1ADA4590104AE4C46DD /* Pods-RealmExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExamples.debug.xcconfig"; path = "Target Support Files/Pods-RealmExamples/Pods-RealmExamples.debug.xcconfig"; sourceTree = "<group>"; };
@@ -235,6 +239,8 @@
 				48BD8FEB25800AA3009DE2E6 /* AnonymouslyLoggedInTestCase.m */,
 				48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */,
 				48E63FB7252646A700F883B1 /* Authenticate.swift */,
+				91CEF605260E325000A029E0 /* Compacting.m */,
+				91CEF5FD260E308100A029E0 /* Compacting.swift */,
 				48BF3415251076E4004139AF /* CompleteQuickStart.swift */,
 				48F38B5325278ECB00DDEB65 /* CustomUserData.m */,
 				48F38B512527843B00DDEB65 /* CustomUserData.swift */,
@@ -613,6 +619,7 @@
 				48BF3416251076E4004139AF /* CompleteQuickStart.swift in Sources */,
 				48BD8FEC25800AA3009DE2E6 /* AnonymouslyLoggedInTestCase.m in Sources */,
 				48F38B5A252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift in Sources */,
+				91CEF5FE260E308100A029E0 /* Compacting.swift in Sources */,
 				4896EE58251051C800D1FABF /* ExampleObjcTestCase.m in Sources */,
 				485C5D18258A9F960069AAE8 /* EmbeddedObjects.swift in Sources */,
 				4896EE55251051A600D1FABF /* ExampleSwiftTestCase.swift in Sources */,
@@ -623,6 +630,7 @@
 				48924BBB2515309F00CC9567 /* MultipleUsers.m in Sources */,
 				4898DDB025A3768600416375 /* Threading.swift in Sources */,
 				487F77CD253F9A4900BDC8CE /* Models.swift in Sources */,
+				91CEF606260E325000A029E0 /* Compacting.m in Sources */,
 				48944D9025C08D500092B8AC /* ObjectModels.m in Sources */,
 				48F38B5425278ECB00DDEB65 /* CustomUserData.m in Sources */,
 				48924B8C2514FEFC00CC9567 /* TestSetup.swift in Sources */,

--- a/source/examples/generated/code/start/Compacting.codeblock.compacting.m
+++ b/source/examples/generated/code/start/Compacting.codeblock.compacting.m
@@ -1,0 +1,16 @@
+RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+config.shouldCompactOnLaunch = ^BOOL(NSUInteger totalBytes, NSUInteger usedBytes) {
+    // totalBytes refers to the size of the file on disk in bytes (data + free space)
+    // usedBytes refers to the number of bytes used by data in the file
+
+    // Compact if the file is over 100MB in size and less than 50% 'used'
+    NSUInteger oneHundredMB = 100 * 1024 * 1024;
+    return (totalBytes > oneHundredMB) && ((double)usedBytes / totalBytes) < 0.5;
+};
+
+NSError *error = nil;
+// Realm is compacted on the first open if the configuration block conditions were met.
+RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:&error];
+if (error) {
+    // handle error compacting or opening Realm
+}

--- a/source/examples/generated/code/start/Compacting.codeblock.compacting.swift
+++ b/source/examples/generated/code/start/Compacting.codeblock.compacting.swift
@@ -1,0 +1,14 @@
+let config = Realm.Configuration(shouldCompactOnLaunch: { totalBytes, usedBytes in
+    // totalBytes refers to the size of the file on disk in bytes (data + free space)
+    // usedBytes refers to the number of bytes used by data in the file
+
+    // Compact if the file is over 100MB in size and less than 50% 'used'
+    let oneHundredMB = 100 * 1024 * 1024
+    return (totalBytes > oneHundredMB) && (Double(usedBytes) / Double(totalBytes)) < 0.5
+})
+do {
+    // Realm is compacted on the first open if the configuration block conditions were met.
+    let realm = try Realm(configuration: config)
+} catch {
+    // handle error compacting or opening Realm
+}

--- a/source/sdk/ios/advanced-guides.txt
+++ b/source/sdk/ios/advanced-guides.txt
@@ -10,12 +10,14 @@ Realm Advanced Guides - iOS SDK
    Custom User Data </sdk/ios/advanced-guides/custom-user-data>
    Multi-User Applications </sdk/ios/advanced-guides/multi-user-applications>
    Link User Identities </sdk/ios/advanced-guides/link-user-identities>
+   Compacting </sdk/ios/advanced-guides/compacting>
 
 Realm-Database (Non-Sync)
 -------------------------
 
 - :doc:`Threading </sdk/ios/advanced-guides/threading>`
 - :doc:`Encrypt a Realm </sdk/ios/advanced-guides/encrypt-a-realm>`
+- :doc:`Compacting </sdk/ios/advanced-guides/compacting>`
 
 MongoDB Realm Cloud (Sync)
 --------------------------

--- a/source/sdk/ios/advanced-guides.txt
+++ b/source/sdk/ios/advanced-guides.txt
@@ -10,14 +10,14 @@ Realm Advanced Guides - iOS SDK
    Custom User Data </sdk/ios/advanced-guides/custom-user-data>
    Multi-User Applications </sdk/ios/advanced-guides/multi-user-applications>
    Link User Identities </sdk/ios/advanced-guides/link-user-identities>
-   Compacting </sdk/ios/advanced-guides/compacting>
+   Compact a Realm </sdk/ios/advanced-guides/compacting>
 
 Realm-Database (Non-Sync)
 -------------------------
 
 - :doc:`Threading </sdk/ios/advanced-guides/threading>`
 - :doc:`Encrypt a Realm </sdk/ios/advanced-guides/encrypt-a-realm>`
-- :doc:`Compacting </sdk/ios/advanced-guides/compacting>`
+- :doc:`Compact a Realm </sdk/ios/advanced-guides/compacting>`
 
 MongoDB Realm Cloud (Sync)
 --------------------------

--- a/source/sdk/ios/advanced-guides/compacting.txt
+++ b/source/sdk/ios/advanced-guides/compacting.txt
@@ -1,8 +1,8 @@
-.. _ios-client-compacting:
+.. _ios-client-compact-a-realm:
 
-====================
-Compacting - iOS SDK
-====================
+=========================
+Compact a Realm - iOS SDK
+=========================
 
 .. default-domain:: mongodb
 
@@ -17,26 +17,32 @@ Overview
 
 The size of a {+client-database+} file is always larger than the total 
 size of the objects stored within it. This architecture enables some of 
-{+client-database+}s great performance, concurrency, and safety benefits. 
+{+realm+}'s great performance, concurrency, and safety benefits. 
 
 To avoid making expensive system calls, {+realm+} files are rarely 
 shrunk at runtime. Instead, they grow by specific size increments. 
-{+realm+} writes new data within unused space tracked inside the file. 
+{+backend-short+} writes new data within unused space tracked inside the file. 
 In some situations, unused space may comprise a significant portion of a 
 {+realm+} file. 
 
-.. _ios-compacting-realms:
+.. _ios-how-to-compact-a-realm:
 
-Compacting Realms
-~~~~~~~~~~~~~~~~~
+Compact a Realm
+~~~~~~~~~~~~~~~
 
-Use ``shouldCompactOnLaunch()`` on a Realm's configuration object to 
-manage compacting. This method is a boolean that determines whether to 
+Use ``shouldCompactOnLaunch()`` on a {+realm+}'s configuration object to 
+compact a {+realm+}. This method is a boolean that determines whether to 
 compact a realm when it first opens. Specify conditions to execute this 
 method, such as:
 
 - The size of the file on disk
 - How much free space the file contains
+
+.. important:: Compacting may not occur
+
+   If another process is accessing the {+realm+}, compacting does not occur. 
+   It doesn't matter if the configuration block's conditions apply. 
+   Compacting cannot be safely performed while a {+realm+} is being accessed.
 
 .. tabs-realm-languages::
 
@@ -49,23 +55,17 @@ method, such as:
    .. tab::
       :tabid: objective-c
 
-      .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.swift
-        :language: swift
-
-.. important:: Compacting may not occur
-
-   If another process is accessing the {+realm+}, compacting does not occur. 
-   It doesn't matter if the configuration block's conditions apply. 
-   Compacting cannot be safely performed while a Realm is being accessed.
+      .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.m
+        :language: objectivec
 
 .. _ios-how-compacting-works:
 
 How Compacting Works
 ~~~~~~~~~~~~~~~~~~~~
 
-Realm compacting works by:
+{+backend-short+} compacting works by:
 
-1. Reading the entire contents of the {+client-database+} file
+1. Reading the entire contents of the {+realm+} file
 2. Writing the contents to a new file at a different location
 3. Replacing the original file
 
@@ -75,18 +75,18 @@ Best Practices
 ~~~~~~~~~~~~~~
 
 Experiment with conditions to find the right balance of how often to 
-compact a {+client-database+} file. Because the operation can be 
+compact a {+realm+} file. Because the operation can be 
 expensive, don't compact every time you open a {+realm+}. Do compact 
 often enough to prevent the file size from growing too large.
 
 Summary
 -------
 
-- {+client-database+}s architecture enables benefits, but can result in 
+- {+client-database+}'s architecture enables benefits, but can result in 
   file size growth.
 
 - Use compacting to manage file size growth.
 
-- Define conditions for ``shouldCompactOnLaunch()`` to manage compacting.
+- Define conditions for ``shouldCompactOnLaunch()`` to compact a {+realm+}.
 
 - Compacting cannot occur if another process is accessing the {+realm+}.

--- a/source/sdk/ios/advanced-guides/compacting.txt
+++ b/source/sdk/ios/advanced-guides/compacting.txt
@@ -56,7 +56,7 @@ as:
    .. tab::
       :tabid: objective-c
 
-      For more info, see: :objc-sdk:`shouldCompactOnLaunch<Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)shouldCompactOnLaunch`
+      For more info, see: :objc-sdk:`shouldCompactOnLaunch<Classes/RLMRealmConfiguration.html`
 
       .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.m
         :language: objectivec

--- a/source/sdk/ios/advanced-guides/compacting.txt
+++ b/source/sdk/ios/advanced-guides/compacting.txt
@@ -1,0 +1,92 @@
+.. _ios-client-compacting:
+
+====================
+Compacting - iOS SDK
+====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+The size of a {+client-database+} file is always larger than the total 
+size of the objects stored within it. This architecture enables some of 
+{+client-database+}s great performance, concurrency, and safety benefits. 
+
+To avoid making expensive system calls, {+realm+} files are rarely 
+shrunk at runtime. Instead, they grow by specific size increments. 
+{+realm+} writes new data within unused space tracked inside the file. 
+In some situations, unused space may comprise a significant portion of a 
+{+realm+} file. 
+
+.. _ios-compacting-realms:
+
+Compacting Realms
+~~~~~~~~~~~~~~~~~
+
+Use ``shouldCompactOnLaunch()`` on a Realm's configuration object to 
+manage compacting. This method is a boolean that determines whether to 
+compact a realm when it first opens. Specify conditions to execute this 
+method, such as:
+
+- The size of the file on disk
+- How much free space the file contains
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: swift
+
+      .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.swift
+        :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.swift
+        :language: swift
+
+.. important:: Compacting may not occur
+
+   If another process is accessing the {+realm+}, compacting does not occur. 
+   It doesn't matter if the configuration block's conditions apply. 
+   Compacting cannot be safely performed while a Realm is being accessed.
+
+.. _ios-how-compacting-works:
+
+How Compacting Works
+~~~~~~~~~~~~~~~~~~~~
+
+Realm compacting works by:
+
+1. Reading the entire contents of the {+client-database+} file
+2. Writing the contents to a new file at a different location
+3. Replacing the original file
+
+If the file contains a lot of data, this can be an expensive operation.
+
+Best Practices
+~~~~~~~~~~~~~~
+
+Experiment with conditions to find the right balance of how often to 
+compact a {+client-database+} file. Because the operation can be 
+expensive, don't compact every time you open a {+realm+}. Do compact 
+often enough to prevent the file size from growing too large.
+
+Summary
+-------
+
+- {+client-database+}s architecture enables benefits, but can result in 
+  file size growth.
+
+- Use compacting to manage file size growth.
+
+- Define conditions for ``shouldCompactOnLaunch()`` to manage compacting.
+
+- Compacting cannot occur if another process is accessing the {+realm+}.

--- a/source/sdk/ios/advanced-guides/compacting.txt
+++ b/source/sdk/ios/advanced-guides/compacting.txt
@@ -30,10 +30,9 @@ In some situations, unused space may comprise a significant portion of a
 Compact a Realm
 ~~~~~~~~~~~~~~~
 
-Use ``shouldCompactOnLaunch()`` on a {+realm+}'s configuration object to 
-compact a {+realm+}. This method is a boolean that determines whether to 
-compact a realm when it first opens. Specify conditions to execute this 
-method, such as:
+Use ``shouldCompactOnLaunch()`` or on a {+realm+}'s configuration object 
+to compact a {+realm+}. Specify conditions to execute this method, such 
+as:
 
 - The size of the file on disk
 - How much free space the file contains
@@ -49,11 +48,15 @@ method, such as:
    .. tab::
       :tabid: swift
 
+      For more info, see: :swift-sdk:`shouldCompactOnLaunch()<Structs/Realm/Configuration.html>`
+
       .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.swift
         :language: swift
 
    .. tab::
       :tabid: objective-c
+
+      For more info, see: :objc-sdk:`shouldCompactOnLaunch<Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)shouldCompactOnLaunch`
 
       .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.m
         :language: objectivec

--- a/source/sdk/ios/advanced-guides/compacting.txt
+++ b/source/sdk/ios/advanced-guides/compacting.txt
@@ -30,7 +30,7 @@ In some situations, unused space may comprise a significant portion of a
 Compact a Realm
 ~~~~~~~~~~~~~~~
 
-Use ``shouldCompactOnLaunch()`` or on a {+realm+}'s configuration object 
+Use ``shouldCompactOnLaunch`` on a {+realm+}'s configuration object 
 to compact a {+realm+}. Specify conditions to execute this method, such 
 as:
 
@@ -56,7 +56,7 @@ as:
    .. tab::
       :tabid: objective-c
 
-      For more info, see: :objc-sdk:`shouldCompactOnLaunch <Classes/RLMRealmConfiguration.html`
+      For more info, see: :objc-sdk:`shouldCompactOnLaunch <Classes/RLMRealmConfiguration.html>`
 
       .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.m
         :language: objectivec

--- a/source/sdk/ios/advanced-guides/compacting.txt
+++ b/source/sdk/ios/advanced-guides/compacting.txt
@@ -56,7 +56,7 @@ as:
    .. tab::
       :tabid: objective-c
 
-      For more info, see: :objc-sdk:`shouldCompactOnLaunch<Classes/RLMRealmConfiguration.html`
+      For more info, see: :objc-sdk:`shouldCompactOnLaunch <Classes/RLMRealmConfiguration.html`
 
       .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.m
         :language: objectivec

--- a/source/sdk/ios/advanced-guides/compacting.txt
+++ b/source/sdk/ios/advanced-guides/compacting.txt
@@ -19,6 +19,10 @@ The size of a {+client-database+} file is always larger than the total
 size of the objects stored within it. This architecture enables some of 
 {+realm+}'s great performance, concurrency, and safety benefits. 
 
+.. seealso::
+
+   :ref:`ios-client-threading`
+
 To avoid making expensive system calls, {+realm+} files are rarely 
 shrunk at runtime. Instead, they grow by specific size increments. 
 {+backend-short+} writes new data within unused space tracked inside the file. 
@@ -30,33 +34,29 @@ In some situations, unused space may comprise a significant portion of a
 Compact a Realm
 ~~~~~~~~~~~~~~~
 
-Use ``shouldCompactOnLaunch`` on a {+realm+}'s configuration object 
-to compact a {+realm+}. Specify conditions to execute this method, such 
-as:
+Use :swift-sdk:`shouldCompactOnLaunch()<Structs/Realm/Configuration.html>` 
+(Swift) or :objc-sdk:`shouldCompactOnLaunch <Classes/RLMRealmConfiguration.html>` 
+(Objective-C) on a {+realm+}'s configuration object to compact a {+realm+}. 
+Specify conditions to execute this method, such as:
 
 - The size of the file on disk
 - How much free space the file contains
 
 .. important:: Compacting may not occur
 
-   If another process is accessing the {+realm+}, compacting does not occur. 
-   It doesn't matter if the configuration block's conditions apply. 
-   Compacting cannot be safely performed while a {+realm+} is being accessed.
+   Compacting cannot occur while a {+realm+} is being accessed, 
+   regardless of any configuration settings.
 
 .. tabs-realm-languages::
 
    .. tab::
       :tabid: swift
 
-      For more info, see: :swift-sdk:`shouldCompactOnLaunch()<Structs/Realm/Configuration.html>`
-
       .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.swift
         :language: swift
 
    .. tab::
       :tabid: objective-c
-
-      For more info, see: :objc-sdk:`shouldCompactOnLaunch <Classes/RLMRealmConfiguration.html>`
 
       .. literalinclude:: /examples/generated/code/start/Compacting.codeblock.compacting.m
         :language: objectivec
@@ -85,8 +85,8 @@ often enough to prevent the file size from growing too large.
 Summary
 -------
 
-- {+client-database+}'s architecture enables benefits, but can result in 
-  file size growth.
+- {+client-database+}'s architecture enables :ref:`threading-related benefits <ios-client-threading>`, 
+  but can result in file size growth.
 
 - Use compacting to manage file size growth.
 

--- a/source/sdk/ios/advanced-guides/compacting.txt
+++ b/source/sdk/ios/advanced-guides/compacting.txt
@@ -23,11 +23,10 @@ size of the objects stored within it. This architecture enables some of
 
    :ref:`ios-client-threading`
 
-To avoid making expensive system calls, {+realm+} files are rarely 
-shrunk at runtime. Instead, they grow by specific size increments. 
-{+backend-short+} writes new data within unused space tracked inside the file. 
-In some situations, unused space may comprise a significant portion of a 
-{+realm+} file. 
+{+backend-short+} writes new data within unused space tracked inside 
+file. In some situations, unused space may comprise a significant 
+portion of a {+realm+} file. If file size grows large enough to 
+negatively impact performance, compact the {+realm+}. 
 
 .. _ios-how-to-compact-a-realm:
 


### PR DESCRIPTION
## Pull Request Info

The scope of this ticket is to port the content from the [compacting realms section of the legacy Swift docs](https://docs.mongodb.com/realm-legacy/docs/swift/latest/index.html#compacting-realms).

Specifically, this documentation covers `shouldCompactOnLaunch`.

However, PR #929 adds a section about File Size that lists another method to manage compacting: `writeCopy(toFile:encryptionKey:)`. That isn't covered in the legacy documentation.

I do plan to link between the two places, so it seems a bit odd to me that the File Sizes page lists two methods to manage compacting a Realm, but the actual page on compacting makes no mention of the second method. However, that seems out of scope for this ticket on porting legacy content.

Thoughts on how to proceed, reviewer?

### Jira

- https://jira.mongodb.org/browse/DOCSP-14632

### Staged Changes (Requires MongoDB Corp SSO)

- [Compact a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14632/sdk/ios/advanced-guides/compacting/)
- [Adding page to Advanced Guides](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14632/sdk/ios/advanced-guides/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
