### PR TITLE
(DOCSP-12903): Add a Realm Studio page to the top-level ToC

### DIFF
--- a/source/includes/realm-studio.rst
+++ b/source/includes/realm-studio.rst
@@ -6,8 +6,8 @@ Linux.
 .. image:: /images/realm-studio.png
    :alt: A screenshot of Realm Studio
 
-See :github:`Releases on GitHub <realm/realm-studio/releases/tag/v10.0.0-beta.2>`:
+See :github:`Releases on GitHub <realm/realm-studio/releases/latest>`:
 
-- :github:`Download for Linux <realm/realm-studio/releases/download/v10.0.0-beta.2/realm-studio-10.0.0-beta.2.tar.gz>`
-- :github:`Download for Mac <realm/realm-studio/releases/download/v10.0.0-beta.2/MongoDB.Realm.Studio-10.0.0-beta.2-mac.zip>`
-- :github:`Download for Windows <realm/realm-studio/releases/download/v10.0.0-beta.2/MongoDB.Realm.Studio-10.0.0-beta.2-win.zip>`
+- `Download for Linux <https://studio-releases.realm.io/latest/download/linux-appimage>`__
+- `Download for Mac <https://studio-releases.realm.io/latest/download/mac-dmg>`__
+- `Download for Windows <https://studio-releases.realm.io/latest/download/win-setup>`__

--- a/source/index.txt
+++ b/source/index.txt
@@ -10,6 +10,7 @@ MongoDB Realm
    Tutorial </tutorial>
    Realm Database SDKs </sdk>
    MongoDB Realm </cloud>
+   Realm Studio </studio>
    Realm (Legacy) </realm-legacy>
    MongoDB Stitch (Legacy) </stitch>
 

--- a/source/studio.txt
+++ b/source/studio.txt
@@ -1,0 +1,10 @@
+.. _realm-studio:
+
+============
+Realm Studio
+============
+
+Get Started with Realm Studio
+-----------------------------
+
+.. include:: /includes/realm-studio.rst

--- a/source/studio.txt
+++ b/source/studio.txt
@@ -7,4 +7,16 @@ Realm Studio
 Get Started with Realm Studio
 -----------------------------
 
-.. include:: /includes/realm-studio.rst
+Realm Studio is a developer tool for desktop operating systems that
+allows you to manage Realm Database instances. With Realm Studio, you
+can open and edit local and synced realms. It supports Mac, Windows, and
+Linux.
+
+.. image:: /images/realm-studio.png
+   :alt: A screenshot of Realm Studio
+
+See :github:`Releases on GitHub <realm/realm-studio/releases/latest>`:
+
+- `Download for Linux <https://studio-releases.realm.io/latest/download/linux-appimage>`_
+- `Download for Mac <https://studio-releases.realm.io/latest/download/mac-dmg>`_
+- `Download for Windows <https://studio-releases.realm.io/latest/download/win-setup>`_


### PR DESCRIPTION
## Pull Request Info

### Jira

The linked Jira ticket is for providing a prominent place per SDK for Realm Studio, but we're giving it a prominent place at top-level ToC, so I think that satisfies this ticket. After we merge this, I'll add links to any SDK debugging pages to point to the top-level Realm Studio page.

- https://jira.mongodb.org/browse/DOCSP-12903

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm Studio](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-12903/studio/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
