### PR TITLE
Hotfix for security page incorrect IP

### DIFF
--- a/source/security.txt
+++ b/source/security.txt
@@ -68,7 +68,7 @@ copy this list to an allowlist on your firewall:
    52.63.26.53
    54.203.157.107
    54.69.74.169
-   54.76.145.13
+   54.76.145.131
 
 You can find this information in computer-friendly formats at these
 URLs:


### PR DESCRIPTION
Context: https://mongodb.slack.com/archives/CLY6HQWUE/p1617641307068700

Staging link:
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/security-ip-hotfix/security/
