### PR TITLE
(DOCSP-14643): Port Swift FAQ info from Realm.io

### DIFF
--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -113,28 +113,28 @@ Realm Does Not Support Swift Structs
 ------------------------------------
 
 {+client-database+} does not currently support structs as models for a 
-variety of reasons. Foremost, {+service-short+}'s design focuses on 
-“live” objects. This concept is not compatible with value type structs. 
-By design, {+service-short+} provides features which are incompatible with 
-these semantics, such as:
+variety of reasons. {+service-short+}'s design focuses on “live” objects. 
+This concept is not compatible with value type structs. By design, 
+{+service-short+} provides features that are incompatible with these 
+semantics, such as:
  
-- Live data
-- Reactive APIs
+- :ref:`Live data <ios-live-object>`
+- :ref:`Reactive APIs <ios-react-to-changes>`
 - Low memory footprint of data
 - Good operation performance
-- Lazy and cheap access to partial data
+- :ref:`Lazy and cheap access to partial data <ios-live-queries>`
 - Lack of data serialization/deserialization
-- Keeping potentially complex object graphs synchronized
+- :ref:`Keeping potentially complex object graphs synchronized <ios-sync-changes-between-devices>`
 
 That said, it is sometimes useful to detach objects from their backing 
 {+realm+}. This typically isn't an ideal design decision. Instead, 
 developers use this as a workaround for temporary limitations in our 
 library. 
 
-To make this easier, we’ve implemented standalone/detached {+service-short+} 
-objects to behave like :apple:`Apple's NSObject <documentation/objectivec/nsobject>`. 
-We support making “in-memory copies” of {+service-short+} objects. Use an initializer 
-to create a standalone object by key-value coding copying a persisted object’s properties: 
+To make this easier, we've made unmanaged objects behave like 
+:apple:`Apple's NSObject <documentation/objectivec/nsobject>`. Use an 
+initializer to create an unmanaged object by key-value coding copying a 
+persisted object’s properties: 
 
 .. code-block:: swift
 

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -109,11 +109,13 @@ boilerplate query code and capacity for error.
    To learn how to add relationships to your Realm object, see
    :ref:`ios-declare-relationship-properties`.
 
-Realm Does Not Support Swift Structs
-------------------------------------
+.. _ios-structs:
 
-{+client-database+} does not currently support structs as models for a 
-variety of reasons. {+service-short+}'s design focuses on “live” objects. 
+Structs
+-------
+
+{+client-database+} does not support structs as models for a variety of 
+reasons. {+service-short+}'s design focuses on “live” objects. 
 This concept is not compatible with value type structs. By design, 
 {+service-short+} provides features that are incompatible with these 
 semantics, such as:
@@ -129,12 +131,11 @@ semantics, such as:
 That said, it is sometimes useful to detach objects from their backing 
 {+realm+}. This typically isn't an ideal design decision. Instead, 
 developers use this as a workaround for temporary limitations in our 
-library. 
+library.
 
-To make this easier, we've made unmanaged objects behave like 
-:apple:`Apple's NSObject <documentation/objectivec/nsobject>`. Use an 
-initializer to create an unmanaged object by key-value coding copying a 
-persisted object’s properties: 
+You can use key-value coding to initialize an unmanaged object as a copy of 
+a managed object. Then, you can work with that unmanaged object
+like any other :apple:`NSObject <documentation/objectivec/nsobject>`.
 
 .. code-block:: swift
 

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -111,10 +111,10 @@ boilerplate query code and capacity for error.
 
 .. _ios-structs:
 
-Structs
--------
+Swift Structs
+-------------
 
-{+client-database+} does not support structs as models for a variety of 
+{+client-database+} does not support Swift structs as models for a variety of 
 reasons. {+service-short+}'s design focuses on “live” objects. 
 This concept is not compatible with value type structs. By design, 
 {+service-short+} provides features that are incompatible with these 

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -132,9 +132,9 @@ developers use this as a workaround for temporary limitations in our
 library. 
 
 To make this easier, we’ve implemented standalone/detached {+service-short+} 
-objects to behave like typical ``NSObject``s. We support making “in-memory 
-copies” of Realm objects. Use an initializer to create a standalone object 
-by key-value coding copying a persisted object’s properties: 
+objects to behave like :apple:`Apple's NSObject <documentation/objectivec/nsobject>`. 
+We support making “in-memory copies” of {+service-short+} objects. Use an initializer 
+to create a standalone object by key-value coding copying a persisted object’s properties: 
 
 .. code-block:: swift
 

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -109,6 +109,37 @@ boilerplate query code and capacity for error.
    To learn how to add relationships to your Realm object, see
    :ref:`ios-declare-relationship-properties`.
 
+Realm Does Not Support Swift Structs
+------------------------------------
+
+{+client-database+} does not currently support structs as models for a 
+variety of reasons. Foremost, {+service-short+}'s design focuses on 
+“live” objects. This concept is not compatible with value type structs. 
+By design, {+service-short+} provides features which are incompatible with 
+these semantics, such as:
+ 
+- Live data
+- Reactive APIs
+- Low memory footprint of data
+- Good operation performance
+- Lazy and cheap access to partial data
+- Lack of data serialization/deserialization
+- Keeping potentially complex object graphs synchronized
+
+That said, it is sometimes useful to detach objects from their backing 
+{+realm+}. This typically isn't an ideal design decision. Instead, 
+developers use this as a workaround for temporary limitations in our 
+library. 
+
+To make this easier, we’ve implemented standalone/detached {+service-short+} 
+objects to behave like typical ``NSObject``s. We support making “in-memory 
+copies” of Realm objects. Use an initializer to create a standalone object 
+by key-value coding copying a persisted object’s properties: 
+
+.. code-block:: swift
+
+   let standaloneModelObject = MyModel(value: persistedModelObject)
+
 Summary
 -------
 
@@ -121,3 +152,6 @@ Summary
 
 - You can define to-one, to-many, and inverse relationships in your schema.
   Inverse relationships automatically form backlinks.
+
+- {+service-short+} does not currently support structs. When required, 
+  create "in-memory copies" of {+service-short+} objects.

--- a/source/sdk/ios/fundamentals/realms.txt
+++ b/source/sdk/ios/fundamentals/realms.txt
@@ -131,8 +131,8 @@ Realm Files
 -----------
 
 Realm Database stores a binary encoded version of every object and type in a
-realm in a single ``.realm`` file. The file is located at a specific path that
-you define when you open the realm.
+realm in a single ``.realm`` file. The file is located at :ref:`a specific 
+path <find-the-default-realm-path>` that you define when you open the realm.
 
 .. note:: Auxiliary Realm Files
    
@@ -236,6 +236,15 @@ dispatch pool deallocates the {+realm+} object. Use an explicit
 autorelease pool when accessing {+realm+} from a dispatch queue.
 
 .. _ios-default-realm:
+
+App Download File Size
+~~~~~~~~~~~~~~~~~~~~~~
+
+{+client-database+} should only add around 5 to 8 MB to your app’s download 
+size. The releases we distribute are significantly larger because they 
+include support for the iOS, watchOS and tvOS simulators, some debug symbols, 
+and bitcode, all of which are stripped by the App Store automatically when 
+apps are downloaded.
 
 Default Realm
 -------------

--- a/source/sdk/ios/fundamentals/realms.txt
+++ b/source/sdk/ios/fundamentals/realms.txt
@@ -235,6 +235,8 @@ code. Realm cannot reuse intermediate versions of the data until the
 dispatch pool deallocates the {+realm+} object. Use an explicit 
 autorelease pool when accessing {+realm+} from a dispatch queue.
 
+.. _ios-app-download-file-size:
+
 App Download File Size
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/sdk/ios/fundamentals/realms.txt
+++ b/source/sdk/ios/fundamentals/realms.txt
@@ -235,8 +235,6 @@ code. Realm cannot reuse intermediate versions of the data until the
 dispatch pool deallocates the {+realm+} object. Use an explicit 
 autorelease pool when accessing {+realm+} from a dispatch queue.
 
-.. _ios-default-realm:
-
 App Download File Size
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -245,6 +243,8 @@ size. The releases we distribute are significantly larger because they
 include support for the iOS, watchOS and tvOS simulators, some debug symbols, 
 and bitcode, all of which are stripped by the App Store automatically when 
 apps are downloaded.
+
+.. _ios-default-realm:
 
 Default Realm
 -------------

--- a/source/studio.txt
+++ b/source/studio.txt
@@ -20,3 +20,34 @@ See :github:`Releases on GitHub <realm/realm-studio/releases/latest>`:
 - `Download for Linux <https://studio-releases.realm.io/latest/download/linux-appimage>`_
 - `Download for Mac <https://studio-releases.realm.io/latest/download/mac-dmg>`_
 - `Download for Windows <https://studio-releases.realm.io/latest/download/win-setup>`_
+
+.. _find-the-default-realm-path:
+
+Find the Realm File(s)
+----------------------
+
+{+client-database+} stores a binary encoded version of every object and type in a
+realm in a single ``.realm`` file. The file is located at a specific path that
+you define when you open the realm.
+
+   .. tabs-realm-languages::
+
+      .. tab::
+         :tabid: swift
+
+         In Swift app development, you can find the current path of the
+         default {+realm+} by pausing the simulator and using the LLDB console:
+
+         .. code-block:: swift
+
+            (lldb) po Realm.Configuration.defaultConfiguration.fileURL
+
+      .. tab::
+         :tabid: objective-c
+
+         In Objective-C app development, you can find the current path of the
+         default {+realm+} by pausing the simulator and using the LLDB console:
+
+         .. code-block:: objective-c
+
+            (lldb) po [RLMRealmConfiguration defaultConfiguration].fileURL

--- a/source/studio.txt
+++ b/source/studio.txt
@@ -30,24 +30,24 @@ Find the Realm File(s)
 realm in a single ``.realm`` file. The file is located at a specific path that
 you define when you open the realm.
 
-   .. tabs-realm-languages::
+.. tabs-realm-languages::
 
-      .. tab::
-         :tabid: swift
+   .. tab::
+      :tabid: swift
 
-         In Swift app development, you can find the current path of the
+      In Swift app development, you can find the current path of the
+      default {+realm+} by pausing the simulator and using the LLDB console:
+
+      .. code-block:: swift
+
+         (lldb) po Realm.Configuration.defaultConfiguration.fileURL
+
+   .. tab::
+      :tabid: objective-c
+
+      In Objective-C app development, you can find the current path of the
          default {+realm+} by pausing the simulator and using the LLDB console:
 
-         .. code-block:: swift
+      .. code-block:: objective-c
 
-            (lldb) po Realm.Configuration.defaultConfiguration.fileURL
-
-      .. tab::
-         :tabid: objective-c
-
-         In Objective-C app development, you can find the current path of the
-         default {+realm+} by pausing the simulator and using the LLDB console:
-
-         .. code-block:: objective-c
-
-            (lldb) po [RLMRealmConfiguration defaultConfiguration].fileURL
+         (lldb) po [RLMRealmConfiguration defaultConfiguration].fileURL


### PR DESCRIPTION
## Pull Request Info

From the legacy doc [Swift: FAQ](https://docs.mongodb.com/realm-legacy/docs/swift/latest/index.html#faq)

I did not port content for:
- Is Realm open source?
- I see a network call to Mixpanel when I run my app

The first question seemed more like a top-level Realm docs question than a Realm Swift question, and I'm not sure it warrants a FAQ. 

The second bullet also seems to apply to more than just the Swift SDK, and I was uncertain how/where we'd want to comment on this, if at all. The example linked to in the ["source code" link](https://github.com/realm/realm-cocoa/blob/master/Realm/RLMAnalytics.mm) is the Realm Cocoa implementation of analytics, but I found stuff in several of the SDK repos related to this, so I think it applies more broadly.

And finally, I added info on finding the Realm file path to the Realm Studio page for Swift and Objective-C, but if we want to keep this there, we should probably make a ticket to add corresponding info for the other SDKs/frameworks.

### Jira

- https://jira.mongodb.org/browse/DOCSP-14643

### Staged Changes (Requires MongoDB Corp SSO)

- [Fundamentals -> Object Models & Schemas -> Realm Does Not Support Swift Structs](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14643/sdk/ios/fundamentals/object-models-and-schemas/#realm-does-not-support-swift-structs)
- [Fundamentals -> Realms -> App Download File Size](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14643/sdk/ios/fundamentals/realms/#app-download-file-size)
- [Realm Studio -> Find the Realm File(s)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14643/sdk/ios/fundamentals/realms/#app-download-file-size)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
