### PR TITLE
Removed duplicate contents directives on pages

### DIFF
--- a/source/admin/api/v3.txt
+++ b/source/admin/api/v3.txt
@@ -164,11 +164,5 @@ Asset metadata documents describe hosted asset files.
 Resources
 ---------
 
-.. contents::
-   :local:
-   :backlinks: none
-   :depth: 1
-   :class: twocols
-
 .. openapi:: /openapi-admin-v3.yaml
    :uses-rst:

--- a/source/graphql/custom-resolvers.txt
+++ b/source/graphql/custom-resolvers.txt
@@ -29,12 +29,6 @@ Procedure
 Custom Resolver Examples
 ------------------------
 
-.. contents:: Custom Resolver Examples
-   :local:
-   :backlinks: none
-   :depth: 2
-   :class: singlecol
-
 Scenario & Schemas
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/mongodb/query-roles.txt
+++ b/source/mongodb/query-roles.txt
@@ -54,12 +54,6 @@ Role Templates
 This section demonstrates patterns for common use cases that
 you might encounter when you define roles for your collection.
 
-.. contents:: Templates
-   :local:
-   :backlinks: none
-   :depth: 2
-   :class: singlecol
-
 Apply When Expressions
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/triggers/trigger-snippets.txt
+++ b/source/triggers/trigger-snippets.txt
@@ -22,12 +22,6 @@ The code snippets in this section cover common use cases for
 :doc:`database Triggers </triggers/database-triggers>`. All of the
 snippets require a linked :doc:`MongoDB cluster </mongodb>`.
 
-.. contents:: Database Trigger Snippets
-   :local:
-   :backlinks: none
-   :depth: 1
-   :class: singlecol
-
 Send an SMS On New Document Inserts
 -----------------------------------
 
@@ -112,12 +106,6 @@ The code snippets in this section cover common use cases for
 :doc:`authentication Triggers </triggers/authentication-triggers>`. All
 of the snippets require you to have enabled one or more
 :doc:`authentication providers </authentication/providers>`.
-
-.. contents:: Authentication Trigger Snippets
-   :local:
-   :backlinks: none
-   :depth: 1
-   :class: singlecol
 
 Store New Users in MongoDB
 --------------------------


### PR DESCRIPTION
## Pull Request Info
- snooty started to yell at us about duplicate contents directives on pages
- I removed the duplicates to stop the yelling

Errors:
ERROR(mongodb/query-roles.txt:56ish): Directive "contents" should only appear once per page
ERROR(triggers/trigger-snippets.txt:24ish): Directive "contents" should only appear once per page
ERROR(triggers/trigger-snippets.txt:115ish): Directive "contents" should only appear once per page
ERROR(graphql/custom-resolvers.txt:31ish): Directive "contents" should only appear once per page
ERROR(admin/api/v3.txt:166ish): Directive "contents" should only appear once per page

### Staged Changes (Requires MongoDB Corp SSO)

- [multiple pages](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/oneContentsDirPerPage/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
