### PR TITLE
Fix typo in create-realm-app

### DIFF
--- a/source/get-started/create-realm-app.txt
+++ b/source/get-started/create-realm-app.txt
@@ -88,10 +88,10 @@ C. Add a Realm App
 
    .. include:: /includes/note-app-name-limitations.rst
 
-#. Select a cluster in your project in your project from the
-   :guilabel:`Link your Database` dropdown. {+service+} will automatically
-   create a :ref:`MongoDB service <mongodb-service>` linked to this
-   cluster with the name "mongodb-atlas".
+#. Select a cluster in your project from the :guilabel:`Link your
+   Database` dropdown. {+service+} will automatically create a
+   :ref:`MongoDB service <mongodb-service>` linked to this cluster with
+   the name "mongodb-atlas".
 
    .. include:: /includes/mongodb-4.4-required-for-sync-admonition.rst
 


### PR DESCRIPTION
"in your project" was repeated twice. Per feedback widget.
