### PR TITLE
(DOCSP-15424): Set the Client Log Level move onto a sync-agnostic page

### DIFF
--- a/source/sdk/android/examples/open-and-close-a-local-realm.txt
+++ b/source/sdk/android/examples/open-and-close-a-local-realm.txt
@@ -245,3 +245,26 @@ models. You can selectively include individual modules when opening a
 .. seealso::
 
    :ref:`Fundamentals: Modules <android-modules>`
+
+.. _android-set-the-client-log-level:
+
+Set the Client Log Level
+------------------------
+
+To configure the log level for Realm logs in your application, pass a
+:java-sdk:`LogLevel <io/realm/log/LogLevel.html>` to 
+:java-sdk:`RealmLog.setLevel() <io/realm/log/RealmLog.html#setLevel-int->`:
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
+
+      .. literalinclude:: /examples/generated/android/sync/SyncDataTest.codeblock.set-client-log-level.kt
+         :language: kotlin
+
+   .. tab::
+      :tabid: java
+
+      .. literalinclude:: /examples/generated/android/sync/SyncDataTest.codeblock.set-client-log-level.java
+         :language: java

--- a/source/sdk/android/examples/open-and-close-a-local-realm.txt
+++ b/source/sdk/android/examples/open-and-close-a-local-realm.txt
@@ -268,3 +268,8 @@ To configure the log level for Realm logs in your application, pass a
 
       .. literalinclude:: /examples/generated/android/sync/SyncDataTest.codeblock.set-client-log-level.java
          :language: java
+
+.. note::
+
+   Realm uses the log levels defined by
+   `Log4J <https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Level.html>`.

--- a/source/sdk/android/examples/open-and-close-a-local-realm.txt
+++ b/source/sdk/android/examples/open-and-close-a-local-realm.txt
@@ -272,4 +272,4 @@ To configure the log level for Realm logs in your application, pass a
 .. note::
 
    Realm uses the log levels defined by
-   `Log4J <https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Level.html>`.
+   `Log4J <https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Level.html>`_.

--- a/source/sdk/android/examples/sync-changes-between-devices.txt
+++ b/source/sdk/android/examples/sync-changes-between-devices.txt
@@ -311,26 +311,3 @@ handler:
    To see how to recover unsynced local changes in a client reset, check out
    this :github:`example on GitHub
    <mongodb/realm-practice/blob/main/node/index.js#L49>`.
-
-.. _android-set-the-client-log-level:
-
-Set the Client Log Level
-------------------------
-
-To configure the log level for Realm logs in your application, pass a
-:java-sdk:`LogLevel <io/realm/log/LogLevel.html>` to 
-:java-sdk:`RealmLog.setLevel() <io/realm/log/RealmLog.html#setLevel-int->`:
-
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: kotlin
-
-      .. literalinclude:: /examples/generated/android/sync/SyncDataTest.codeblock.set-client-log-level.kt
-         :language: kotlin
-
-   .. tab::
-      :tabid: java
-
-      .. literalinclude:: /examples/generated/android/sync/SyncDataTest.codeblock.set-client-log-level.java
-         :language: java


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-15424

### Staged Changes (Requires MongoDB Corp SSO)

- [Set the Client Log Level (section)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-15424/sdk/android/examples/open-and-close-a-local-realm/#set-the-client-log-level)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
