### PR TITLE
(DOSCP-12392): [iOS] Clarify when to use init vs. asyncOpen

### DIFF
--- a/source/sdk/ios/examples/sync-changes-between-devices.txt
+++ b/source/sdk/ios/examples/sync-changes-between-devices.txt
@@ -72,6 +72,47 @@ Open a Synced Realm
       .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm-synchronously.m
          :language: objectivec
 
+Decide How to Open the Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When choosing between ``init`` and ``asyncOpen`` to open the {+realm+}, 
+consider these factors:
+ 
+  - When you use ``asyncOpen``, the app attempts to download an up-to-date 
+    {+realm+} before opening it. The user must wait to access the data and 
+    interact with the app. After this download completes, the user has the 
+    most current version of the data.
+
+  - When you open a {+realm+} with ``init``, the client opens immediately. 
+    The app contains stale data - whatever was available the last time the 
+    app was open. The user can access that data and interact with the app 
+    right away.
+
+Which method to choose depends on how important it is for your app to have 
+the most current version of data. 
+
+Consider the example of a note-taking app. You might decide it's most 
+important for your user to be able to quickly jot down a note. The user 
+shouldn't have to wait while downloading changes that a family member made 
+to a shared note. In this case, opening a {+realm+} with ``init`` gets the 
+user to the UI right away.
+
+In a game, though, it might be most important for a user to have current 
+data. Say a theoretical user plays the game on both an iPad and an iPhone. 
+The user progresses three levels on the iPad. Later, the user opens the 
+game on an iPhone. In this case, ``asyncOpen`` is a better way to open the 
+{+realm+}. Loading with stale data might get the user into the game faster, 
+but three levels behind.
+
+A common pattern is to open a {+realm+} with ``asyncOpen``, and then use 
+``init`` for subsequent opens. 
+
+.. tip::
+
+   When you use ``asyncOpen``, :ref:`check first for a network connection 
+   <ios-check-network-connection>`. If the app is offline, ``asyncOpen``
+   leaves your app waiting forever.
+
 
 .. _ios-sync-changes-in-the-background:
 

--- a/source/sdk/ios/examples/sync-changes-between-devices.txt
+++ b/source/sdk/ios/examples/sync-changes-between-devices.txt
@@ -109,7 +109,7 @@ A common pattern is to open a {+realm+} with ``asyncOpen``, and then use
 
 .. tip::
 
-   When you use ``asyncOpen``, :ref:`check first for a network connection 
+   When you use ``asyncOpen``, you should first :ref:`check for a network connection 
    <ios-check-network-connection>`. If the app is offline, ``asyncOpen``
    leaves your app waiting forever.
 

--- a/source/sdk/ios/examples/sync-changes-between-devices.txt
+++ b/source/sdk/ios/examples/sync-changes-between-devices.txt
@@ -78,15 +78,15 @@ Decide How to Open the Realm
 When choosing between ``init`` and ``asyncOpen`` to open the {+realm+}, 
 consider these factors:
  
-  - When you use ``asyncOpen``, the app attempts to download an up-to-date 
-    {+realm+} before opening it. The user must wait to access the data and 
-    interact with the app. After this download completes, the user has the 
-    most current version of the data.
+- When you use ``asyncOpen``, the app attempts to download an up-to-date 
+  {+realm+} before opening it. The user must wait to access the data and 
+  interact with the app. After this download completes, the user has the 
+  most current version of the data.
 
-  - When you open a {+realm+} with ``init``, the client opens immediately. 
-    The app contains stale data - whatever was available the last time the 
-    app was open. The user can access that data and interact with the app 
-    right away.
+- When you open a {+realm+} with ``init``, the client opens immediately. 
+  The app contains stale data - whatever was available the last time the 
+  app was open. The user can access that data and interact with the app 
+  right away.
 
 Which method to choose depends on how important it is for your app to have 
 the most current version of data. 
@@ -98,11 +98,11 @@ to a shared note. In this case, opening a {+realm+} with ``init`` gets the
 user to the UI right away.
 
 In a game, though, it might be most important for a user to have current 
-data. Say a theoretical user plays the game on both an iPad and an iPhone. 
-The user progresses three levels on the iPad. Later, the user opens the 
-game on an iPhone. In this case, ``asyncOpen`` is a better way to open the 
-{+realm+}. Loading with stale data might get the user into the game faster, 
-but three levels behind.
+data. Say a user plays the game on both an iPad and an iPhone. The user 
+progresses three levels on the iPad. Later, the user opens the game on an 
+iPhone. In this case, ``asyncOpen`` is a better way to open the {+realm+}. 
+Loading with stale data might get the user into the game faster, but three 
+levels behind.
 
 A common pattern is to open a {+realm+} with ``asyncOpen``, and then use 
 ``init`` for subsequent opens. 


### PR DESCRIPTION
## Pull Request Info

I've written a new section for this page: "Decide How to Open the Realm." This covers in more detail when to use `init` vs. `asyncOpen` when opening a realm.

### Jira

- https://jira.mongodb.org/browse/DOCSP-12392

### Staged Changes (Requires MongoDB Corp SSO)

- [Sync Changes Between Devices: Decide How to Open the Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-12392/sdk/ios/examples/sync-changes-between-devices/#decide-how-to-open-the-realm)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
