### PR TITLE
Fix android install steps - jcenter block

### DIFF
--- a/source/includes/steps-install-android.yaml
+++ b/source/includes/steps-install-android.yaml
@@ -20,7 +20,7 @@ content: |
       .. tab:: Version 10.4.0 and up
          :tabid: gte-10-4-0
 
-         In ``buildscript.dependencies``, add the following:
+         In ``buildscript.repositories``, add the following:
 
          .. code-block:: groovy
 


### PR DESCRIPTION
In android install documentation, jcenter() needs to be added into the repositories block, not dependencies block.

## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-NNNNN

### Staged Changes (Requires MongoDB Corp SSO)

- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/BRANCH_NAME/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
