### PR TITLE
(DOCSP-15728): JSON Schema declaration for embedded objects is incorrect

### DIFF
--- a/source/includes/embedded-object-json-schema.rst
+++ b/source/includes/embedded-object-json-schema.rst
@@ -10,16 +10,16 @@ embedded objects map to embedded documents in the parent type's
      "bsonType": "object",
      "required": ["_id"],
      "properties": {
-       "_id": "objectId",
-       "name": "string",
+       "_id": { "bsonType": "objectId" },
+       "name": { "bsonType": "string" },
        "address": {
          "title": "Address",
          "bsonType": "object",
          "properties": {
-           "street": "string",
-           "city": "string",
-           "country": "string",
-           "postalCode": "string"
+           "street": { "bsonType": "string" },
+           "city": { "bsonType": "string" },
+           "country": { "bsonType": "string" },
+           "postalCode": { "bsonType": "string" }
          }
        }
      }
@@ -34,17 +34,17 @@ embedded objects map to embedded documents in the parent type's
      "required": ["_id", "name", "addresses"],
      "properties": {
        "_id": "objectId",
-       "name": "string",
+       "name": { "bsonType": "string" },
        "addresses": {
          "bsonType": "array",
          "items": {
            "title": "Address",
            "bsonType": "object",
            "properties": {
-             "street": "string",
-             "city": "string",
-             "country": "string",
-             "postalCode": "string"
+             "street": { "bsonType": "string" },
+             "city": { "bsonType": "string" },
+             "country": { "bsonType": "string" },
+             "postalCode": { "bsonType": "string" }
            }
          }
        }

--- a/source/sdk/ios/data-types/embedded-objects.txt
+++ b/source/sdk/ios/data-types/embedded-objects.txt
@@ -37,16 +37,20 @@ by a new embedded object instance.
    should use :ref:`relationships <ios-client-relationships>`
    instead.
 
-Embedded object types are reusable and composable. You can use the same
-embedded object type in multiple parent object types and you can embed
-objects inside of other embedded objects.
+Embedded Object Data Models
+---------------------------
 
-Realm Object Models
--------------------
+You can define embedded object types using either Realm object models or
+a server-side document schema. Embedded object types are reusable and
+composable. You can use the same embedded object type in multiple parent
+object types and you can embed objects inside of other embedded objects.
 
 .. important::
    
    Embedded objects cannot have a :ref:`primary key <ios-primary-keys>`.
+
+Realm Object Models
+~~~~~~~~~~~~~~~~~~~
 
 To define an embedded object, derive a class from
 :swift-sdk:`EmbeddedObject <Classes/EmbeddedObject.html>` in Swift or
@@ -67,6 +71,11 @@ object types in the same way as you would define a relationship:
 
       .. literalinclude:: /examples/EmbeddedObjects/DefineEmbeddedObjects.m
          :language: objectivec
+
+JSON Schema
+~~~~~~~~~~~
+
+.. include:: /includes/embedded-object-json-schema.rst
 
 Read and Write Embedded Objects
 -------------------------------


### PR DESCRIPTION
## Pull Request Info

- Fixes embedded object JSON schema type declarations (shared across all SDKs)
- Slightly updates iOS Embedded Objects page to match other SDKs

### Jira

- https://jira.mongodb.org/browse/DOCSP-15728

### Staged Changes (Requires MongoDB Corp SSO)

- [Embedded Objects (iOS)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/schema/sdk/ios/data-types/embedded-objects/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
