### PR TITLE
(DOCSP-14568): [iOS] Add mixed type to Supported Property Types

### DIFF
--- a/examples/ios/Examples/AnyRealmValue.swift
+++ b/examples/ios/Examples/AnyRealmValue.swift
@@ -1,0 +1,69 @@
+// :replace-start: {
+//   "terms": {
+//     "AnyRealmValueExample_": ""
+//   }
+// }
+import XCTest
+import RealmSwift
+
+class AnyRealmValueExample_Dog: Object {
+    @objc dynamic var name = ""
+    let age = RealmProperty<AnyRealmValue>()
+}
+
+class AnyRealmValueTestCase: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        let realm = try! Realm()
+        try! realm.write {
+            realm.deleteAll()
+        }
+    }
+
+    func testAnyRealmValue() {
+        // :code-block-start: mixed-data-type
+        // Create a AnyRealmValueExample_Dog object and then set its properties
+        let myDog = AnyRealmValueExample_Dog()
+        myDog.name = "Rex"
+        // Because we declared age as a `RealmProperty`, we must mutate its `value` property
+        myDog.age.value = .int(5)
+
+        // Create another AnyRealmValueExample_Dog object whose age is a float
+        let myOtherDog = AnyRealmValueExample_Dog()
+        myOtherDog.name = "Spot"
+        myOtherDog.age.value = .float(2.5)
+
+        // Create a third AnyRealmValueExample_Dog object whose age is a string
+        let myThirdDog = AnyRealmValueExample_Dog()
+        myThirdDog.name = "Fido"
+        myOtherDog.age.value = .string("3 and 3/4")
+
+        // Get the default realm. You only need to do this once per thread.
+        let realm = try! Realm()
+
+        // Add to the realm inside a transaction
+        try! realm.write {
+            realm.add(myDog)
+            realm.add(myOtherDog)
+            realm.add(myThirdDog)
+        }
+
+        // Verify the type of the ``AnyRealmProperty`` when attempting to get it. This
+        // returns an object whose property contains the matched type.
+        if case let .int(age) = myDog.age.value {
+            print(age)  // Prints 5
+        }
+
+        // In this example, "myOtherDog"'s age is a float type, so checking the type
+        // before trying to use it avoids an exception
+        if case let .int(age) = myOtherDog.age.value {
+            print(age)  // Doesn't print anything
+        }
+        // :code-block-end:
+    }
+}
+// :replace-end:

--- a/examples/ios/Examples/AnyRealmValue.swift
+++ b/examples/ios/Examples/AnyRealmValue.swift
@@ -9,6 +9,7 @@ import RealmSwift
 class AnyRealmValueExample_Dog: Object {
     @objc dynamic var name = ""
     let age = RealmProperty<AnyRealmValue>()
+    let companion = RealmProperty<AnyRealmValue>()
 }
 
 class AnyRealmValueTestCase: XCTestCase {
@@ -31,16 +32,24 @@ class AnyRealmValueTestCase: XCTestCase {
         myDog.name = "Rex"
         // Because we declared age as a `RealmProperty`, we must mutate its `value` property
         myDog.age.value = .int(5)
+        // This dog has no companion.
+        // You can set the field's type to "none", which represents `nil`
+        myDog.companion.value = .none
 
         // Create another AnyRealmValueExample_Dog object whose age is a float
         let myOtherDog = AnyRealmValueExample_Dog()
         myOtherDog.name = "Spot"
         myOtherDog.age.value = .float(2.5)
+        // This dog's companion is a cat named Fluffy, represented by a string here
+        myOtherDog.companion.value = .string("Fluffy the Cat")
 
         // Create a third AnyRealmValueExample_Dog object whose age is a string
         let myThirdDog = AnyRealmValueExample_Dog()
         myThirdDog.name = "Fido"
-        myOtherDog.age.value = .string("3 and 3/4")
+        myThirdDog.age.value = .string("3 months")
+        // This dog's companion is a Person, which is an object that has a
+        // string name, an optional string address, and an int age
+        myThirdDog.companion.value = .object(Person(value: ["name": "Sylvia", "age": 12]))
 
         // Get the default realm. You only need to do this once per thread.
         let realm = try! Realm()
@@ -62,6 +71,14 @@ class AnyRealmValueTestCase: XCTestCase {
         // before trying to use it avoids an exception
         if case let .int(age) = myOtherDog.age.value {
             print(age)  // Doesn't print anything
+        }
+
+        // Retreiving an object stored as an ``AnyRealmProperty`` gives you
+        // the complete object, containing all of the object's properties
+        if case let .object(companion) = myThirdDog.companion.value {
+            print(companion)
+            // Prints all the details of the Person object:
+            // {name = Sylvia; address = null; age = 12;}
         }
         // :code-block-end:
     }

--- a/examples/ios/Examples/Models.swift
+++ b/examples/ios/Examples/Models.swift
@@ -9,6 +9,6 @@ class Person: Object {
     @objc dynamic var address: String?
 
     // Optional integral type property
-    let age = RealmOptional<Int>()
+    let age = RealmProperty<Int?>()
 }
 // :code-block-end:

--- a/examples/ios/Examples/ObjectModels.swift
+++ b/examples/ios/Examples/ObjectModels.swift
@@ -34,7 +34,7 @@ class OptionalRequiredPropertyExample_Person: Object {
     @objc dynamic var ageYears = 0
 
     // Optional numeric property
-    let heightCm = RealmOptional<Float>()
+    let heightCm = RealmProperty<Float?>()
 }
 // :code-block-end:
 
@@ -97,7 +97,7 @@ class ObjectModelsExamples_Task: Object {
     @objc dynamic var status = ObjectModelsExamples_TaskStatusEnum.notStarted // :emphasize:
 
     // Optional enum property
-    let optionalTaskStatusEnumProperty = RealmOptional<ObjectModelsExamples_TaskStatusEnum>() // :emphasize:
+    let optionalTaskStatusEnumProperty = RealmProperty<ObjectModelsExamples_TaskStatusEnum?>() // :emphasize:
 }
 // :code-block-end:
 

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -60,10 +60,10 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Realm:
-    :commit: 368a7b6a77a113ef7c5c96c011db0e772300a317
+    :commit: ae6c23a1abdf328e96066fd4d3f864863e0c0837
     :git: https://github.com/realm/realm-cocoa
   RealmSwift:
-    :commit: 368a7b6a77a113ef7c5c96c011db0e772300a317
+    :commit: ae6c23a1abdf328e96066fd4d3f864863e0c0837
     :git: https://github.com/realm/realm-cocoa
 
 SPEC CHECKSUMS:
@@ -73,7 +73,7 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: 197a8dabfea5d665224aa00d17f164fc2248dab9
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: 0b00eec04802f43e307712305f751de140e76b74
+  Realm: c77e784b4d3c0aac17a6e17fe2e0dc4c4690ff29
   RealmSwift: 5e7abc842276d7fabd386e67afbf3efde54eb1c6
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		48F38B58252793F600DDEB65 /* ManageApiKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B57252793F600DDEB65 /* ManageApiKeys.swift */; };
 		48F38B5A252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */; };
 		48F38B5C2527A3FE00DDEB65 /* ManageApiKeys.m in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B5B2527A3FE00DDEB65 /* ManageApiKeys.m */; };
+		9136A4DB26409A7E00FFA03B /* AnyRealmValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9136A4DA26409A7E00FFA03B /* AnyRealmValue.swift */; };
 		915E96A825FAB36500AABC09 /* LandingPageCodeExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915E96A725FAB36500AABC09 /* LandingPageCodeExamples.swift */; };
 		917D8C9F26167B69001B7A61 /* TestingAndDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917D8C9E26167B69001B7A61 /* TestingAndDebugging.swift */; };
 		9185DB1925E82C0300AF1389 /* LocalOnlyCompleteQuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9185DB1825E82C0300AF1389 /* LocalOnlyCompleteQuickStart.swift */; };
@@ -157,6 +158,7 @@
 		756197CA73FF09331F7ED204 /* Pods-RealmSwiftExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmSwiftExampleTests.release.xcconfig"; path = "Target Support Files/Pods-RealmSwiftExampleTests/Pods-RealmSwiftExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		7D033479B74D15FCF29CFE1B /* Pods_RealmExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82A9EC393EF912515E8527A0 /* Pods-RealmObjcExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmObjcExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-RealmObjcExampleTests/Pods-RealmObjcExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		9136A4DA26409A7E00FFA03B /* AnyRealmValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyRealmValue.swift; sourceTree = "<group>"; };
 		915E96A725FAB36500AABC09 /* LandingPageCodeExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LandingPageCodeExamples.swift; sourceTree = "<group>"; };
 		917D8C9E26167B69001B7A61 /* TestingAndDebugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestingAndDebugging.swift; sourceTree = "<group>"; };
 		9185DB1825E82C0300AF1389 /* LocalOnlyCompleteQuickStart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalOnlyCompleteQuickStart.swift; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 				48BD8FF025800B4D009DE2E6 /* AnonymouslyLoggedInTestCase.h */,
 				48BD8FEB25800AA3009DE2E6 /* AnonymouslyLoggedInTestCase.m */,
 				48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */,
+				9136A4DA26409A7E00FFA03B /* AnyRealmValue.swift */,
 				48E63FB7252646A700F883B1 /* Authenticate.swift */,
 				91CEF605260E325000A029E0 /* Compacting.m */,
 				91CEF5FD260E308100A029E0 /* Compacting.swift */,
@@ -661,6 +664,7 @@
 				4870F8A52593EE91004FF76D /* Relationships.swift in Sources */,
 				48C5BC3225A4CDE70004DA3D /* Migrations.swift in Sources */,
 				917D8C9F26167B69001B7A61 /* TestingAndDebugging.swift in Sources */,
+				9136A4DB26409A7E00FFA03B /* AnyRealmValue.swift in Sources */,
 				48944D8B25BF7BCA0092B8AC /* ObjectModels.swift in Sources */,
 				48BF341D25111194004139AF /* Task.swift in Sources */,
 				48E63FB8252646A700F883B1 /* Authenticate.swift in Sources */,

--- a/source/examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
+++ b/source/examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
@@ -3,16 +3,24 @@ let myDog = Dog()
 myDog.name = "Rex"
 // Because we declared age as a `RealmProperty`, we must mutate its `value` property
 myDog.age.value = .int(5)
+// This dog has no companion.
+// You can set the field's type to "none", which represents `nil`
+myDog.companion.value = .none
 
 // Create another Dog object whose age is a float
 let myOtherDog = Dog()
 myOtherDog.name = "Spot"
 myOtherDog.age.value = .float(2.5)
+// This dog's companion is a cat named Fluffy, represented by a string here
+myOtherDog.companion.value = .string("Fluffy the Cat")
 
 // Create a third Dog object whose age is a string
 let myThirdDog = Dog()
 myThirdDog.name = "Fido"
-myOtherDog.age.value = .string("3 and 3/4")
+myThirdDog.age.value = .string("3 months")
+// This dog's companion is a Person, which is an object that has a
+// string name, an optional string address, and an int age
+myThirdDog.companion.value = .object(Person(value: ["name": "Sylvia", "age": 12]))
 
 // Get the default realm. You only need to do this once per thread.
 let realm = try! Realm()
@@ -34,4 +42,12 @@ if case let .int(age) = myDog.age.value {
 // before trying to use it avoids an exception
 if case let .int(age) = myOtherDog.age.value {
     print(age)  // Doesn't print anything
+}
+
+// Retreiving an object stored as an ``AnyRealmProperty`` gives you
+// the complete object, containing all of the object's properties
+if case let .object(companion) = myThirdDog.companion.value {
+    print(companion)
+    // Prints all the details of the Person object:
+    // {name = Sylvia; address = null; age = 12;}
 }

--- a/source/examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
+++ b/source/examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
@@ -1,0 +1,37 @@
+// Create a Dog object and then set its properties
+let myDog = Dog()
+myDog.name = "Rex"
+// Because we declared age as a `RealmProperty`, we must mutate its `value` property
+myDog.age.value = .int(5)
+
+// Create another Dog object whose age is a float
+let myOtherDog = Dog()
+myOtherDog.name = "Spot"
+myOtherDog.age.value = .float(2.5)
+
+// Create a third Dog object whose age is a string
+let myThirdDog = Dog()
+myThirdDog.name = "Fido"
+myOtherDog.age.value = .string("3 and 3/4")
+
+// Get the default realm. You only need to do this once per thread.
+let realm = try! Realm()
+
+// Add to the realm inside a transaction
+try! realm.write {
+    realm.add(myDog)
+    realm.add(myOtherDog)
+    realm.add(myThirdDog)
+}
+
+// Verify the type of the ``AnyRealmProperty`` when attempting to get it. This
+// returns an object whose property contains the matched type.
+if case let .int(age) = myDog.age.value {
+    print(age)  // Prints 5
+}
+
+// In this example, "myOtherDog"'s age is a float type, so checking the type
+// before trying to use it avoids an exception
+if case let .int(age) = myOtherDog.age.value {
+    print(age)  // Doesn't print anything
+}

--- a/source/examples/generated/code/start/Models.codeblock.person-model.swift
+++ b/source/examples/generated/code/start/Models.codeblock.person-model.swift
@@ -6,5 +6,5 @@ class Person: Object {
     @objc dynamic var address: String?
 
     // Optional integral type property
-    let age = RealmOptional<Int>()
+    let age = RealmProperty<Int?>()
 }

--- a/source/examples/generated/code/start/ObjectModels.codeblock.optional-required-properties.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.optional-required-properties.swift
@@ -9,5 +9,5 @@ class Person: Object {
     @objc dynamic var ageYears = 0
 
     // Optional numeric property
-    let heightCm = RealmOptional<Float>()
+    let heightCm = RealmProperty<Float?>()
 }

--- a/source/examples/generated/code/start/ObjectModels.codeblock.realm-object-enum.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.realm-object-enum.swift
@@ -14,5 +14,5 @@ class Task: Object {
     @objc dynamic var status = TaskStatusEnum.notStarted 
 
     // Optional enum property
-    let optionalTaskStatusEnumProperty = RealmOptional<TaskStatusEnum>() 
+    let optionalTaskStatusEnumProperty = RealmProperty<TaskStatusEnum?>() 
 }

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -183,7 +183,7 @@ permitted value, you can't declare an ``AnyRealmValue`` as optional.
 .. literalinclude:: /examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
    :language: swift
 
-You can compare these mixed value types:
+You can :ref:`compare <ios-filter-data/#operators>` these mixed value types:
 
 - Numeric: int, bool, float, double, decimal
 - Byte-based: string, binary
@@ -191,8 +191,11 @@ You can compare these mixed value types:
 
 When using the ``AnyRealmValue`` mixed data type, keep these things in mind:
 
-- Equals queries match on the value and the type
-- Not equals queries match objects with either different values or 
+- ``equals`` queries match on value and type
+- ``not equals`` queries match objects with either different values or 
   different types
-- Realm converts comparable numeric properties where possible
-- String properties do not match numeric queries.
+- {+realm+} converts comparable numeric properties where possible. For example,
+  in a mixed type field, 1 matches all of 1.0, 1, and true.
+- String properties do not match numeric queries. For example, in a mixed
+  type field, 1 does not match "1". "1" does not match 1, 1.0, or true.
+  

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -66,6 +66,9 @@ Supported Property Types - iOS SDK
          * - :swift-sdk:`MutableSet <Classes/MutableSet.html>`
            - ``let value = MutableSet<Type>()``
            - 
+         * - :swift-sdk:`Mixed Data Type <Enums/AnyRealmValue.html>`
+           - ``let value = RealmProperty<AnyRealmValue>()``
+           - N/A
          * - User-defined :swift-sdk:`Object <Extensions/Object.html>`
            - N/A
            - ``@objc dynamic var value: MyClass?``
@@ -146,3 +149,44 @@ ObjectId is a MongoDB-specific 12-byte unique value. UUID is a 16-byte
 globally-unique value. You can :ref:`index <ios-index-a-property>` both types,
 and use either as a :ref:`primary key <ios-specify-a-primary-key>`.
 
+.. _ios-mixed-data-type:
+
+Mixed Data Type
+---------------
+
+.. versionadded:: 10.?
+   The ``AnyRealmValue`` type is new in this version.
+
+``AnyRealmValue`` is a {+service-short+} property type that can hold different 
+data types. Supported ``AnyRealmValue`` data types include:
+
+- Int
+- Float
+- Double
+- Decimal128
+- ObjectID
+- UUID
+- Bool
+- Date
+- Data
+- String
+- Object
+
+This mixed data type is indexable, but you can't use it as a primary key. 
+Because ``null`` is a permitted value, you can't declare an ``AnyRealmValue`` 
+as optional.
+
+You can compare these mixed value types:
+- Numeric: int, bool, float, double, decimal
+- Byte-based: string, binary
+- Time-based: timestamp, objectId
+
+When using the ``AnyRealmValue`` mixed data type, keep these things in mind:
+
+- Equals queries match on the value and the type
+- Not equals queries match objects with either different values or different types
+- Realm converts comparable numeric properties where possible
+- String properties do not match numeric queries.
+
+.. literalinclude:: /examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
+   :language: swift

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -183,7 +183,7 @@ permitted value, you can't declare an ``AnyRealmValue`` as optional.
 .. literalinclude:: /examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
    :language: swift
 
-You can :ref:`compare <ios-filter-data/#operators>` these mixed value types:
+You can :ref:`compare <ios-filter-data-operators>` these mixed value types:
 
 - Numeric: int, bool, float, double, decimal
 - Byte-based: string, binary

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -12,6 +12,9 @@ Supported Property Types - iOS SDK
    :depth: 2
    :class: singlecol
 
+Property Cheat Sheet
+--------------------
+
 .. tabs-realm-languages::
 
    .. tab::
@@ -172,11 +175,16 @@ data types. Supported ``AnyRealmValue`` data types include:
 - String
 - Object
 
-This mixed data type is indexable, but you can't use it as a primary key. 
-Because ``null`` is a permitted value, you can't declare an ``AnyRealmValue`` 
-as optional.
+This :swift-sdk:`mixed data type <Enums/AnyRealmValue.html>` is 
+:ref:`indexable <ios-index-a-property>`, but you can't use it as a 
+:ref:`primary key <ios-specify-a-primary-key>`. Because ``null`` is a 
+permitted value, you can't declare an ``AnyRealmValue`` as optional.
+
+.. literalinclude:: /examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
+   :language: swift
 
 You can compare these mixed value types:
+
 - Numeric: int, bool, float, double, decimal
 - Byte-based: string, binary
 - Time-based: timestamp, objectId
@@ -184,9 +192,7 @@ You can compare these mixed value types:
 When using the ``AnyRealmValue`` mixed data type, keep these things in mind:
 
 - Equals queries match on the value and the type
-- Not equals queries match objects with either different values or different types
+- Not equals queries match objects with either different values or 
+  different types
 - Realm converts comparable numeric properties where possible
 - String properties do not match numeric queries.
-
-.. literalinclude:: /examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
-   :language: swift

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -17,6 +17,9 @@ Supported Property Types - iOS SDK
    .. tab::
       :tabid: swift
 
+      .. versionchanged:: 10.?
+         ``RealmProperty`` replaces ``RealmOptional`` in this version.
+
       You can use the following types to define your object model
       properties:
 
@@ -29,16 +32,16 @@ Supported Property Types - iOS SDK
            - Optional
          * - Bool
            - ``@objc dynamic var value = false``
-           - ``let value = RealmOptional<Bool>()``
+           - ``let value = RealmProperty<Bool?>()``
          * - Int, Int8, Int16, Int32, Int64
            - ``@objc dynamic var value = 0``
-           - ``let value = RealmOptional<Int>()``
+           - ``let value = RealmProperty<Int?>()``
          * - Float
            - ``@objc dynamic var value: Float = 0.0``
-           - ``let value = RealmOptional<Float>()``
+           - ``let value = RealmProperty<Float?>()``
          * - Double
            - ``@objc dynamic var value: Double = 0.0``
-           - ``let value = RealmOptional<Double>()``
+           - ``let value = RealmProperty<Double?>()``
          * - String
            - ``@objc dynamic var value = ""``
            - ``@objc dynamic var value: String? = nil``
@@ -53,7 +56,7 @@ Supported Property Types - iOS SDK
            - ``@objc dynamic var decimal: Decimal128?``
          * - UUID
            - ``@objc dynamic var uuid = UUID()``
-           - 
+           - ``@objc dynamic var uuidOpt: UUID?``
          * - :swift-sdk:`ObjectId <Classes/ObjectId.html>`
            - ``@objc dynamic var objectId = ObjectId.generate()``
            - ``@objc dynamic var objectId: ObjectId?``
@@ -72,7 +75,7 @@ Supported Property Types - iOS SDK
       - :swift-sdk:`EmbeddedObject <Extensions/EmbeddedObject.html>`-derived types
       - :swift-sdk:`Enum <Protocols.html#/s:10RealmSwift0A4EnumP>`
 
-      You can use :swift-sdk:`RealmOptional <Classes/RealmOptional.html>` to
+      You can use ``RealmProperty <T?>`` to
       represent integers, doubles, and other types as optional.
 
       ``CGFloat`` properties are discouraged, as the type is not

--- a/source/sdk/ios/examples/define-a-realm-object-model.txt
+++ b/source/sdk/ios/examples/define-a-realm-object-model.txt
@@ -70,7 +70,7 @@ Declare Properties
       you can declare properties as ``dynamic var`` without ``@objc``.
 
       To declare properties of generic types ``LinkingObjects``,
-      ``List``, and ``RealmOptional``, use ``let``. Generic properties
+      ``List``, and ``RealmProperty``, use ``let``. Generic properties
       cannot be represented in the Objective‑C runtime, which
       {+client-database+} uses for dynamic dispatch of dynamic
       properties.
@@ -103,13 +103,13 @@ Specify an Optional/Required Property
       You can declare ``String``, ``Date``, ``Data``, and
       :swift-sdk:`ObjectId <Classes/ObjectId.html>` properties as
       optional or required (non-optional) using standard Swift syntax.
-      Declare optional numeric types using the :swift-sdk:`RealmOptional
-      <Classes/RealmOptional.html>` type.
+      Declare optional numeric types using the :swift-sdk:`RealmProperty
+      <Classes/RealmProperty.html>` type.
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.optional-required-properties.swift
          :language: swift
 
-      RealmOptional supports ``Int``, ``Float``, ``Double``, ``Bool``,
+      RealmProperty supports ``Int``, ``Float``, ``Double``, ``Bool``,
       and all of the sized versions of ``Int`` (``Int8``, ``Int16``,
       ``Int32``, ``Int64``).
 

--- a/source/sdk/ios/examples/define-a-realm-object-model.txt
+++ b/source/sdk/ios/examples/define-a-realm-object-model.txt
@@ -169,8 +169,8 @@ for slightly slower writes. Indexes take up more space in the realm
 file. It’s best to only add indexes when optimizing the read performance
 for specific situations.
 
-Realm supports indexing for string, integer, boolean, ``Date``, and
-``ObjectId`` properties.
+Realm supports indexing for string, integer, boolean, ``Date``, ``UUID``,
+``ObjectId``, and ``AnyRealmValue`` properties.
 
 .. tabs-realm-languages::
 

--- a/source/sdk/ios/examples/filter-data.txt
+++ b/source/sdk/ios/examples/filter-data.txt
@@ -173,7 +173,7 @@ You can iterate through a collection property with another query using the
          .. literalinclude:: /examples/generated/code/start/QueryEngine.codeblock.subquery.m
              :language: objectivec
 
-
+.. _ios-filter-data-operators:
 
 Operators
 ---------

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -44,7 +44,7 @@ You can either:
   properties with ``dynamic var``. 
 
 Use ``let`` to declare ``LinkingObjects``, ``List``, and 
-``RealmOptional``. The Objective-C runtime cannot represent these 
+``RealmProperty``. The Objective-C runtime cannot represent these 
 generic properties.
 
 .. seealso::


### PR DESCRIPTION
## Pull Request Info

The links to Jazzy docs for `RealmProperty` and `AnyRealmValue` are broken currently, but I believe they'll be valid once the auto-generated docs are updated.

As part of this work, I updated the docs where `RealmOptional` was specified. In most instances where, I replaced `RealmOptional` with `RealmProperty`, but on the Supported Properties page, I also added directives about the version in which this change occurred. I don't know the version number yet; I'll update that before I publish the docs.

I also updated the code examples that used `RealmOptional` to use `RealmProperty` and generated updated snippets with Bluehawk.

### Jira

- https://jira.mongodb.org/browse/DOCSP-14568

### Staged Changes (Requires MongoDB Corp SSO)

- [Supported Property Types](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14568/sdk/ios/data-types/supported-property-types/#mixed-data-type): Add Mixed Data Type section
- [Define a Realm Object Model](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14568/sdk/ios/examples/define-a-realm-object-model/#specify-an-optional-required-property): Update "Specify an Optional/Required Property" section to use `RealmProperty`
- [Object models & Schemas](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-14568/sdk/ios/fundamentals/object-models-and-schemas/): Update "Property Attributes" section to use `RealmProperty`

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
