### PR TITLE
Fruit Day: Add more SDK docs to landing page to improve user journey/discoverability

### DIFF
--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -136,7 +136,7 @@ platform:
 
      - :doc:`Read and Write Data </sdk/node/examples/read-and-write-data>`
 
-       :doc:`Filter Data </sdk/node/advanced-guides/query-engine>`
+       :doc:`Filter Data </sdk/node/advanced/query-engine>`
 
        :doc:`Query MongoDB </sdk/node/examples/query-mongodb>`
 
@@ -219,7 +219,7 @@ out more about how to implement common user patterns with your SDK:
 
        :doc:`Multi-User Applications </sdk/react-native/advanced/multi-user-applications>`
 
-       :doc:`Link User Identities </sdk/react-native/advanced/link-user-identities>`
+       :doc:`Link User Identities </sdk/react-native/advanced/link-identities>`
 
      - :doc:`Authenticate Users </web/authenticate>`
 

--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -130,13 +130,13 @@ platform:
 
      - :doc:`Read and Write Data </sdk/dotnet/examples/read-and-write-data>`
 
-       :doc:`Filter Data </sdk/dotnet/examples/filter-data>`
+       :doc:`Filter Data </sdk/dotnet/fundamentals/query-engine>`
 
        :doc:`Query MongoDB </sdk/dotnet/examples/mongodb-remote-access>`
 
      - :doc:`Read and Write Data </sdk/node/examples/read-and-write-data>`
 
-       :doc:`Filter Data </sdk/node/examples/filter-data>`
+       :doc:`Filter Data </sdk/node/advanced-guides/query-engine>`
 
        :doc:`Query MongoDB </sdk/node/examples/query-mongodb>`
 
@@ -203,11 +203,11 @@ out more about how to implement common user patterns with your SDK:
 
        :doc:`Create and Manage User API Keys </sdk/node/examples/manage-user-api-keys>`
 
-       :doc:`Custom User Data </sdk/node/advanced-guides/access-custom-user-data>`
+       :doc:`Custom User Data </sdk/node/advanced/access-custom-user-data>`
 
-       :doc:`Multi-User Applications </sdk/node/advanced-guides/multi-user-applications>`
+       :doc:`Multi-User Applications </sdk/node/advanced/multi-user-applications>`
 
-       :doc:`Link User Identities </sdk/node/advanced-guides/link-identities>`
+       :doc:`Link User Identities </sdk/node/advanced/link-identities>`
 
      - :doc:`Authenticate Users </sdk/react-native/examples/authenticate-users>`
 
@@ -215,11 +215,11 @@ out more about how to implement common user patterns with your SDK:
 
        :doc:`Create and Manage User API Keys </sdk/react-native/examples/manage-user-api-keys>`
 
-       :doc:`Custom User Data </sdk/react-native/advanced-guides/access-custom-user-data>`
+       :doc:`Custom User Data </sdk/react-native/advanced/access-custom-user-data>`
 
-       :doc:`Multi-User Applications </sdk/react-native/advanced-guides/multi-user-applications>`
+       :doc:`Multi-User Applications </sdk/react-native/advanced/multi-user-applications>`
 
-       :doc:`Link User Identities </sdk/react-native/advanced-guides/link-identities>`
+       :doc:`Link User Identities </sdk/react-native/advanced/link-user-identities>`
 
      - :doc:`Authenticate Users </web/authenticate>`
 
@@ -260,7 +260,7 @@ about the application lifecycle with {+client-database+}:
 
      - :doc:`Threading </sdk/ios/advanced-guides/threading>`
 
-       :doc:`Client Resets </sdk/ios/advanced-guides/client-resets>`
+       :doc:`Client Resets </sdk/ios/advanced-guides/client-reset>`
 
        :doc:`React to Changes </sdk/ios/examples/react-to-changes>`
 
@@ -276,7 +276,7 @@ about the application lifecycle with {+client-database+}:
 
      - :doc:`Client Resets </sdk/node/advanced/client-reset>`
 
-       :doc:`React to Changes </sdk/node/advanced/react-to-changes>`
+       :doc:`React to Changes </sdk/node/examples/react-to-changes>`
 
      - :doc:`Client Resets </sdk/react-native/advanced/client-reset>`
 

--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -98,3 +98,188 @@ programming languages. Find yours below to start building your Realm app:
        :doc:`Apollo GraphQL Client (React) </web/graphql-apollo-react>`
 
        :js-sdk:`Javascript SDK Reference Manual <>`
+
+CRUD Operations
+---------------
+
+The local-first {+client-database+} offers native, idiomatic SDKs for 
+CRUD operations. Explore common examples for your preferred language or
+platform:
+
+.. list-table::
+   :header-rows: 1
+   :class: index-table
+
+   * - Android SDK
+     - iOS SDK
+     - .NET SDK
+     - Node.js SDK
+     - React Native SDK
+
+   * - :doc:`Read and Write Data </sdk/android/examples/read-and-write-data>`
+
+       :doc:`Filter Data </sdk/android/examples/filter-data>`
+
+       :doc:`Query MongoDB </sdk/android/examples/mongodb-remote-access>`
+
+     - :doc:`Read and Write Data </sdk/ios/examples/read-and-write-data>`
+
+       :doc:`Filter Data </sdk/ios/examples/filter-data>`
+
+       :doc:`Query MongoDB </sdk/ios/examples/mongodb-remote-access>`
+
+     - :doc:`Read and Write Data </sdk/dotnet/examples/read-and-write-data>`
+
+       :doc:`Filter Data </sdk/dotnet/examples/filter-data>`
+
+       :doc:`Query MongoDB </sdk/dotnet/examples/mongodb-remote-access>`
+
+     - :doc:`Read and Write Data </sdk/node/examples/read-and-write-data>`
+
+       :doc:`Filter Data </sdk/node/examples/filter-data>`
+
+       :doc:`Query MongoDB </sdk/node/examples/query-mongodb>`
+
+     - :doc:`Read and Write Data </sdk/react-native/examples/read-and-write-data>`
+
+       :doc:`Query MongoDB </sdk/react-native/examples/query-mongodb>`
+
+User Management
+---------------
+
+Developers using {+sync+} can leverage native SDKs to manage users. Find
+out more about how to implement common user patterns with your SDK: 
+
+.. list-table::
+   :header-rows: 1
+   :class: index-table
+
+   * - Android SDK
+     - iOS SDK
+     - .NET SDK
+     - Node.js SDK
+     - React Native SDK
+     - Web SDK
+
+   * - :doc:`Authenticate Users </sdk/android/examples/authenticate-users>`
+
+       :doc:`Manage Email/Password Users </sdk/android/examples/email-password-users>`
+
+       :doc:`Create and Manage User API Keys </sdk/android/examples/manage-user-api-keys>`
+
+       :doc:`Custom User Data </sdk/android/advanced-guides/custom-user-data>`
+
+       :doc:`Multi-User Applications </sdk/android/advanced-guides/multi-user-applications>`
+
+       :doc:`Link User Identities </sdk/android/advanced-guides/link-user-identities>`
+
+     - :doc:`Authenticate Users </sdk/ios/examples/authenticate-users>`
+
+       :doc:`Manage Email/Password Users </sdk/ios/examples/manage-email-password-users>`
+
+       :doc:`Create and Manage User API Keys </sdk/ios/examples/manage-user-api-keys>`
+
+       :doc:`Custom User Data </sdk/ios/advanced-guides/custom-user-data>`
+
+       :doc:`Multi-User Applications </sdk/ios/advanced-guides/multi-user-applications>`
+
+       :doc:`Link User Identities </sdk/ios/advanced-guides/link-user-identities>`
+
+     - :doc:`Authenticate Users </sdk/dotnet/examples/authenticate>`
+
+       :doc:`Manage Email/Password Users </sdk/dotnet/examples/manage-email-password-users>`
+
+       :doc:`Create and Manage User API Keys </sdk/dotnet/examples/manage-user-api-keys>`
+
+       :doc:`Custom User Data </sdk/dotnet/advanced-guides/custom-user-data>`
+
+       :doc:`Multi-User Applications </sdk/dotnet/advanced-guides/multi-user-applications>`
+
+       :doc:`Link User Identities </sdk/dotnet/advanced-guides/link-user-identities>`
+
+     - :doc:`Authenticate Users </sdk/node/examples/authenticate-users>`
+
+       :doc:`Manage Email/Password Users </sdk/node/examples/manage-email-password-users>`
+
+       :doc:`Create and Manage User API Keys </sdk/node/examples/manage-user-api-keys>`
+
+       :doc:`Custom User Data </sdk/node/advanced-guides/access-custom-user-data>`
+
+       :doc:`Multi-User Applications </sdk/node/advanced-guides/multi-user-applications>`
+
+       :doc:`Link User Identities </sdk/node/advanced-guides/link-identities>`
+
+     - :doc:`Authenticate Users </sdk/react-native/examples/authenticate-users>`
+
+       :doc:`Manage Email/Password Users </sdk/react-native/examples/manage-email-password-users>`
+
+       :doc:`Create and Manage User API Keys </sdk/react-native/examples/manage-user-api-keys>`
+
+       :doc:`Custom User Data </sdk/react-native/advanced-guides/access-custom-user-data>`
+
+       :doc:`Multi-User Applications </sdk/react-native/advanced-guides/multi-user-applications>`
+
+       :doc:`Link User Identities </sdk/react-native/advanced-guides/link-identities>`
+
+     - :doc:`Authenticate Users </web/authenticate>`
+
+       :doc:`Manage Email/Password Users </web/manage-email-password-users>`
+
+       :doc:`Create and Manage User API Keys </web/create-manage-api-keys>`
+
+       :doc:`Custom User Data </web/access-custom-user-data>`
+
+       :doc:`Multi-User Applications </web/work-with-multiple-users>`
+
+       :doc:`Link User Identities </web/link-identities>`
+
+Application Lifecycle
+---------------------
+
+After you've mastered the basics of CRUD and user management, learn more
+about the application lifecycle with {+client-database+}:
+
+.. list-table::
+   :header-rows: 1
+   :class: index-table
+
+   * - Android SDK
+     - iOS SDK
+     - .NET SDK
+     - Node.js SDK
+     - React Native SDK
+     - Web SDK
+
+   * - :doc:`Threading </sdk/android/advanced-guides/threading>`
+
+       :doc:`Client Resets </sdk/android/advanced-guides/client-reset>`
+
+       :doc:`React to Changes </sdk/android/examples/react-to-changes>`
+
+       :doc:`Migrations </sdk/android/advanced-guides/migrations>`
+
+     - :doc:`Threading </sdk/ios/advanced-guides/threading>`
+
+       :doc:`Client Resets </sdk/ios/advanced-guides/client-resets>`
+
+       :doc:`React to Changes </sdk/ios/examples/react-to-changes>`
+
+       :doc:`Compact a Realm </sdk/ios/advanced-guides/compacting>`
+
+     - :doc:`Threading </sdk/dotnet/advanced-guides/threading>`
+
+       :doc:`Client Resets </sdk/dotnet/advanced-guides/client-reset>`
+
+       :doc:`React to Changes </sdk/dotnet/examples/react-to-changes>`
+
+       :doc:`Compact a Realm </sdk/dotnet/advanced-guides/compact-realm>`
+
+     - :doc:`Client Resets </sdk/node/advanced/client-reset>`
+
+       :doc:`React to Changes </sdk/node/advanced/react-to-changes>`
+
+     - :doc:`Client Resets </sdk/react-native/advanced/client-reset>`
+
+       :doc:`React to Changes </sdk/react-native/examples/react-to-changes>`
+
+     - :doc:`Migrate </web/migrate>`


### PR DESCRIPTION
## Pull Request Info

I've been thinking more about the user journey of folks who come to the Realm docs, and some of the discussions we've had about discoverability and IA, and thought this might be a nice quick win for fruit day:

Added three new sections to the Realm SDK landing page:
- CRUD Operations
- User Management
- Application Lifecycle

How do we feel about these buckets? Do we think things are missing/misplaced?

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm SDKs landing page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/improve-sdk-docs-discoverability/sdk/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
