### PR TITLE
(DOCSP-16089): Draft section for running a password reset func, add Bluehawked example

### DIFF
--- a/examples/ios/Examples/ManageEmailPasswordUsers.m
+++ b/examples/ios/Examples/ManageEmailPasswordUsers.m
@@ -65,7 +65,7 @@
     }];
 }
 
-- (void)testResetPassword {
+- (void)testResetPasswordObjc {
     XCTestExpectation *expectation = [self expectationWithDescription:@"send reset email completes"];
 
     // :code-block-start: reset-password-objc

--- a/examples/ios/Examples/ManageEmailPasswordUsers.swift
+++ b/examples/ios/Examples/ManageEmailPasswordUsers.swift
@@ -106,20 +106,26 @@ class ManageEmailPasswordUsers: XCTestCase {
     }
 
     func testPasswordResetFunc() {
-        var expectation = XCTestExpectation()
+        let expectation = XCTestExpectation()
         // :code-block-start: password-reset-function
         let app = App(id: YOUR_REALM_APP_ID)
         let client = app.emailPasswordAuth
 
         let email = "forgot.my.password@example.com"
         let newPassword = "mynewpassword12345"
+        // The password reset function takes any number of
+        // arguments. You might ask the user to provide answers to
+        // security questions, for example, to verify the user
+        // should be able to complete the password reset.
         let args: [AnyBSON] = []
 
+        // This SDK call maps to the custom password reset
+        // function that you define in the backend
         client.callResetPasswordFunction(email: email, password: newPassword, args: args) { (error) in
             guard error == nil else {
                 print("Password reset failed: \(error!.localizedDescription)")
                 // :hide-start:
-                XCTAssertEqual(error!.localizedDescription, "failed to reset password for user")
+                XCTAssertEqual(error!.localizedDescription, "user not found")
                 expectation.fulfill()
                 // :hide-end:
                 return

--- a/examples/ios/Examples/ManageEmailPasswordUsers.swift
+++ b/examples/ios/Examples/ManageEmailPasswordUsers.swift
@@ -104,4 +104,29 @@ class ManageEmailPasswordUsers: XCTestCase {
         // :code-block-end:
         wait(for: [expectation], timeout: 10)
     }
+
+    func testPasswordResetFunc() {
+        var expectation = XCTestExpectation()
+        // :code-block-start: password-reset-function
+        let app = App(id: YOUR_REALM_APP_ID)
+        let client = app.emailPasswordAuth
+
+        let email = "forgot.my.password@example.com"
+        let newPassword = "mynewpassword12345"
+        let args: [AnyBSON] = []
+
+        client.callResetPasswordFunction(email: email, password: newPassword, args: args) { (error) in
+            guard error == nil else {
+                print("Password reset failed: \(error!.localizedDescription)")
+                // :hide-start:
+                XCTAssertEqual(error!.localizedDescription, "failed to reset password for user")
+                expectation.fulfill()
+                // :hide-end:
+                return
+            }
+            print("Password reset successful!")
+        }
+        // :code-block-end:
+        wait(for: [expectation], timeout: 10)
+    }
 }

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '13.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', '=10.8.0-beta.0'
-  pod 'RealmSwift', '=10.8.0-beta.0'
+  pod 'Realm', '=10.8.0-beta.1'
+  pod 'RealmSwift', '=10.8.0-beta.1'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,5 +13,5 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '=10.8.0-beta.0'
+  pod 'RealmSwift', '=10.8.0-beta.1'
 end

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -18,24 +18,22 @@ PODS:
     - AppAuth (~> 1.2)
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - GTMAppAuth (1.2.1):
+  - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - GTMSessionFetcher/Full (1.5.0):
-    - GTMSessionFetcher/Core (= 1.5.0)
-  - Realm (10.8.0-beta.0):
-    - Realm/Headers (= 10.8.0-beta.0)
-  - Realm/Headers (10.8.0-beta.0)
-  - RealmSwift (10.8.0-beta.0):
-    - Realm (= 10.8.0-beta.0)
-  - SwiftLint (0.42.0)
+  - Realm (10.8.0-beta.1):
+    - Realm/Headers (= 10.8.0-beta.1)
+  - Realm/Headers (10.8.0-beta.1)
+  - RealmSwift (10.8.0-beta.1):
+    - Realm (= 10.8.0-beta.1)
+  - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (= 10.8.0-beta.0)
-  - RealmSwift (= 10.8.0-beta.0)
+  - Realm (= 10.8.0-beta.1)
+  - RealmSwift (= 10.8.0-beta.1)
   - SwiftLint
 
 SPEC REPOS:
@@ -55,13 +53,12 @@ SPEC CHECKSUMS:
   FBSDKCoreKit: b3ca27e124dae67122d3bb47c8f96800b39986a6
   FBSDKLoginKit: a3a92ba9380759cd0c1aa8319465fb5f2857c602
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
-  GTMAppAuth: 5b53231ef6920f149ab84b2969cb0ab572da3077
+  GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: 317f5e9de56991399afc312cc90f08ca112f7294
-  RealmSwift: e2c2c8c78832addb0cf8ef1b5eb532ec40fdc915
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
+  Realm: e4c38b8ed379532209b3222ef4a58214ce9bb1f3
+  RealmSwift: d50e02ae49c16fe78c8a617f0ffbbfafcf3dc7b7
+  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: e7de491ae8cf7b4de810ec91dd6fa00e1da17f46
-
+PODFILE CHECKSUM: f531966431d451e5e7c82800787ef9d7c9e4ef16
 
 COCOAPODS: 1.10.1

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -7,9 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0090B72CEE8344EEB081EB2B /* Pods_RealmExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D4D3FCB7A0EB5AE975DF2B1 /* Pods_RealmExamples.framework */; };
 		228B6F9226166ED10075A6E0 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228B6F9026166ED10075A6E0 /* Errors.swift */; };
 		228B6F9326166ED10075A6E0 /* Errors.m in Sources */ = {isa = PBXBuildFile; fileRef = 228B6F9126166ED10075A6E0 /* Errors.m */; };
-		3AFEF991672127C4DF1EBBD0 /* Pods_RealmExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78B1427059BC0AF19714E831 /* Pods_RealmExamples.framework */; };
+		39DFFABB984AFC2A4429C5D7 /* Pods_QuickStartSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF587332A902F1BFC06AA9C /* Pods_QuickStartSwiftUI.framework */; };
+		3AFEF991672127C4DF1EBBD0 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		4803B327251068F800CCAF97 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4803B326251068F800CCAF97 /* AppDelegate.swift */; };
 		4803B329251068F800CCAF97 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4803B328251068F800CCAF97 /* SceneDelegate.swift */; };
 		4803B32B251068F800CCAF97 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4803B32A251068F800CCAF97 /* ContentView.swift */; };
@@ -18,8 +20,8 @@
 		4803B333251068F900CCAF97 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4803B331251068F900CCAF97 /* LaunchScreen.storyboard */; };
 		48087CA2258800A600E19363 /* ReadWriteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48087CA1258800A600E19363 /* ReadWriteData.swift */; };
 		4813483025C21948006209FC /* Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 4813482F25C21948006209FC /* Notifications.m */; };
-		4813483B25C244CA006209FC /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		4815C5FD25C324F20014538D /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		4813483B25C244CA006209FC /* (null) in Sources */ = {isa = PBXBuildFile; };
+		4815C5FD25C324F20014538D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		482A85942576DC3400BA8700 /* QueryEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482A85932576DC3400BA8700 /* QueryEngine.swift */; };
 		482A859C2576E34300BA8700 /* QueryEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 482A859B2576E34300BA8700 /* QueryEngine.m */; };
 		4834235C25D6E0CB002CE6B0 /* Functions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4834235B25D6E0CB002CE6B0 /* Functions.m */; };
@@ -70,7 +72,6 @@
 		91CEF5FE260E308100A029E0 /* Compacting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CEF5FD260E308100A029E0 /* Compacting.swift */; };
 		91CEF606260E325000A029E0 /* Compacting.m in Sources */ = {isa = PBXBuildFile; fileRef = 91CEF605260E325000A029E0 /* Compacting.m */; };
 		91FDC13B261E5DE3006A6E13 /* MutableSetExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FDC13A261E5DE3006A6E13 /* MutableSetExample.swift */; };
-		B9170656257F9CB924AEBA6F /* Pods_QuickStartSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AF8E651F4F80B36D8C460AF /* Pods_QuickStartSwiftUI.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +85,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1D4D3FCB7A0EB5AE975DF2B1 /* Pods_RealmExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		228B6F9026166ED10075A6E0 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		228B6F9126166ED10075A6E0 /* Errors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Errors.m; sourceTree = "<group>"; };
 		4803B324251068F800CCAF97 /* RealmExamplesHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RealmExamplesHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -145,17 +147,9 @@
 		48F38B57252793F600DDEB65 /* ManageApiKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageApiKeys.swift; sourceTree = "<group>"; };
 		48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymouslyLoggedInTestCase.swift; sourceTree = "<group>"; };
 		48F38B5B2527A3FE00DDEB65 /* ManageApiKeys.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ManageApiKeys.m; sourceTree = "<group>"; };
-
-		4B040991139BCE878C9D6C0A /* Pods-RealmExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExamples.release.xcconfig"; path = "Target Support Files/Pods-RealmExamples/Pods-RealmExamples.release.xcconfig"; sourceTree = "<group>"; };
-		5AF8E651F4F80B36D8C460AF /* Pods_QuickStartSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStartSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		68EA0F823D8002EF83FC15E5 /* Pods_RealmSwiftExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmSwiftExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6C55D4D8147A41A52A10E3EF /* Pods_RealmObjcExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmObjcExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6E69CD87EDE75EB7C847B812 /* Pods-RealmObjcExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmObjcExamples.release.xcconfig"; path = "Target Support Files/Pods-RealmObjcExamples/Pods-RealmObjcExamples.release.xcconfig"; sourceTree = "<group>"; };
-		6EDC925A03B8E45CAD1C5AD8 /* Pods-RealmObjcExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmObjcExamples.debug.xcconfig"; path = "Target Support Files/Pods-RealmObjcExamples/Pods-RealmObjcExamples.debug.xcconfig"; sourceTree = "<group>"; };
-		6F24F5A00336D52B946D9EEF /* Pods-QuickStartSwiftUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartSwiftUI.release.xcconfig"; path = "Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI.release.xcconfig"; sourceTree = "<group>"; };
-		756197CA73FF09331F7ED204 /* Pods-RealmSwiftExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmSwiftExampleTests.release.xcconfig"; path = "Target Support Files/Pods-RealmSwiftExampleTests/Pods-RealmSwiftExampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		7D033479B74D15FCF29CFE1B /* Pods_RealmExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		82A9EC393EF912515E8527A0 /* Pods-RealmObjcExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmObjcExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-RealmObjcExampleTests/Pods-RealmObjcExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		582A61F6F341821B0C632B0C /* Pods-RealmExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExamples.debug.xcconfig"; path = "Target Support Files/Pods-RealmExamples/Pods-RealmExamples.debug.xcconfig"; sourceTree = "<group>"; };
+		5CF772D6D27E64F6EADF7006 /* Pods-RealmExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExamples.release.xcconfig"; path = "Target Support Files/Pods-RealmExamples/Pods-RealmExamples.release.xcconfig"; sourceTree = "<group>"; };
+		613FAD387146D4ABC57E754B /* Pods-QuickStartSwiftUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartSwiftUI.debug.xcconfig"; path = "Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI.debug.xcconfig"; sourceTree = "<group>"; };
 		9136A4DA26409A7E00FFA03B /* AnyRealmValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyRealmValue.swift; sourceTree = "<group>"; };
 		915E96A725FAB36500AABC09 /* LandingPageCodeExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LandingPageCodeExamples.swift; sourceTree = "<group>"; };
 		917D8C9E26167B69001B7A61 /* TestingAndDebugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestingAndDebugging.swift; sourceTree = "<group>"; };
@@ -163,13 +157,8 @@
 		91CEF5FD260E308100A029E0 /* Compacting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compacting.swift; sourceTree = "<group>"; };
 		91CEF605260E325000A029E0 /* Compacting.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Compacting.m; sourceTree = "<group>"; };
 		91FDC13A261E5DE3006A6E13 /* MutableSetExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutableSetExample.swift; sourceTree = "<group>"; };
-		930065835B0988B74FE25746 /* Pods-RealmExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExampleTests.release.xcconfig"; path = "Target Support Files/Pods-RealmExampleTests/Pods-RealmExampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		BE555C3FD2D6ABFD03EF1B48 /* Pods-RealmSwiftExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmSwiftExamples.debug.xcconfig"; path = "Target Support Files/Pods-RealmSwiftExamples/Pods-RealmSwiftExamples.debug.xcconfig"; sourceTree = "<group>"; };
-		D547E1ADA4590104AE4C46DD /* Pods-RealmExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExamples.debug.xcconfig"; path = "Target Support Files/Pods-RealmExamples/Pods-RealmExamples.debug.xcconfig"; sourceTree = "<group>"; };
-		D837B198485E9C7685B900E9 /* Pods-RealmSwiftExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmSwiftExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-RealmSwiftExampleTests/Pods-RealmSwiftExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		D92146F677FB49790F5009B4 /* Pods_RealmObjcExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmObjcExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F85C0C618AC9A207BEE75D23 /* Pods-QuickStartSwiftUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartSwiftUI.debug.xcconfig"; path = "Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI.debug.xcconfig"; sourceTree = "<group>"; };
-		FF33619D749E0545AF025962 /* Pods-RealmObjcExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmObjcExampleTests.release.xcconfig"; path = "Target Support Files/Pods-RealmObjcExampleTests/Pods-RealmObjcExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		9EF587332A902F1BFC06AA9C /* Pods_QuickStartSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStartSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F031E02203B6F069E8E3A216 /* Pods-QuickStartSwiftUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartSwiftUI.release.xcconfig"; path = "Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -184,7 +173,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EB93F4E8E703165355C09E63 /* Pods_QuickStartSwiftUI.framework in Frameworks */,
+				39DFFABB984AFC2A4429C5D7 /* Pods_QuickStartSwiftUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,7 +181,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3AFEF991672127C4DF1EBBD0 /* Pods_RealmExamples.framework in Frameworks */,
+				3AFEF991672127C4DF1EBBD0 /* (null) in Frameworks */,
+				0090B72CEE8344EEB081EB2B /* Pods_RealmExamples.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -202,8 +192,8 @@
 		25659AAC46A872278D314C5C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				D7CECD7871BE62047A2BFC5C /* Pods_QuickStartSwiftUI.framework */,
-				78B1427059BC0AF19714E831 /* Pods_RealmExamples.framework */,
+				9EF587332A902F1BFC06AA9C /* Pods_QuickStartSwiftUI.framework */,
+				1D4D3FCB7A0EB5AE975DF2B1 /* Pods_RealmExamples.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -335,10 +325,10 @@
 		A485B1FDFCAD54FE9AB803CD /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				5F17CD0CDB067BFF475DEBD0 /* Pods-QuickStartSwiftUI.debug.xcconfig */,
-				98806B88AD589CFB8F86FB77 /* Pods-QuickStartSwiftUI.release.xcconfig */,
-				6E5F8BA3C3EDC8710CEE2037 /* Pods-RealmExamples.debug.xcconfig */,
-				C3DB4DC5EC72FEDC66759793 /* Pods-RealmExamples.release.xcconfig */,
+				613FAD387146D4ABC57E754B /* Pods-QuickStartSwiftUI.debug.xcconfig */,
+				F031E02203B6F069E8E3A216 /* Pods-QuickStartSwiftUI.release.xcconfig */,
+				582A61F6F341821B0C632B0C /* Pods-RealmExamples.debug.xcconfig */,
+				5CF772D6D27E64F6EADF7006 /* Pods-RealmExamples.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -641,7 +631,7 @@
 				4847120225891A3B004BD6EF /* ReadWriteData.m in Sources */,
 				48C072062511B6DB004B02BB /* ManageEmailPasswordUsers.m in Sources */,
 				482A85942576DC3400BA8700 /* QueryEngine.swift in Sources */,
-				4813483B25C244CA006209FC /* BuildFile in Sources */,
+				4813483B25C244CA006209FC /* (null) in Sources */,
 				48BF34182511095C004139AF /* RealmApp.swift in Sources */,
 				48944D9825C0BD520092B8AC /* Relationships.m in Sources */,
 				91FDC13B261E5DE3006A6E13 /* MutableSetExample.swift in Sources */,
@@ -657,7 +647,7 @@
 				9185DB1925E82C0300AF1389 /* LocalOnlyCompleteQuickStart.swift in Sources */,
 				485C5D0B258A71200069AAE8 /* Encrypt.swift in Sources */,
 				482A859C2576E34300BA8700 /* QueryEngine.m in Sources */,
-				4815C5FD25C324F20014538D /* BuildFile in Sources */,
+				4815C5FD25C324F20014538D /* (null) in Sources */,
 				48924B8A2514EAD900CC9567 /* MultipleUsers.swift in Sources */,
 				48087CA2258800A600E19363 /* ReadWriteData.swift in Sources */,
 				48F38B502527806600DDEB65 /* AccessMongoDB.swift in Sources */,
@@ -743,7 +733,7 @@
 		};
 		4891801A2534E33600D53F19 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5F17CD0CDB067BFF475DEBD0 /* Pods-QuickStartSwiftUI.debug.xcconfig */;
+			baseConfigurationReference = 613FAD387146D4ABC57E754B /* Pods-QuickStartSwiftUI.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -764,7 +754,7 @@
 		};
 		4891801B2534E33600D53F19 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 98806B88AD589CFB8F86FB77 /* Pods-QuickStartSwiftUI.release.xcconfig */;
+			baseConfigurationReference = F031E02203B6F069E8E3A216 /* Pods-QuickStartSwiftUI.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -785,7 +775,7 @@
 		};
 		4896EE522510514B00D1FABF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E5F8BA3C3EDC8710CEE2037 /* Pods-RealmExamples.debug.xcconfig */;
+			baseConfigurationReference = 582A61F6F341821B0C632B0C /* Pods-RealmExamples.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
@@ -809,7 +799,7 @@
 		};
 		4896EE532510514B00D1FABF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C3DB4DC5EC72FEDC66759793 /* Pods-RealmExamples.release.xcconfig */;
+			baseConfigurationReference = 5CF772D6D27E64F6EADF7006 /* Pods-RealmExamples.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.password-reset-function.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.password-reset-function.swift
@@ -3,8 +3,14 @@ let client = app.emailPasswordAuth
 
 let email = "forgot.my.password@example.com"
 let newPassword = "mynewpassword12345"
+// The password reset function takes any number of
+// arguments. You might ask the user to provide answers to
+// security questions, for example, to verify the user
+// should be able to complete the password reset.
 let args: [AnyBSON] = []
 
+// This SDK call maps to the custom password reset
+// function that you define in the backend
 client.callResetPasswordFunction(email: email, password: newPassword, args: args) { (error) in
     guard error == nil else {
         print("Password reset failed: \(error!.localizedDescription)")

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.password-reset-function.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.password-reset-function.swift
@@ -1,0 +1,14 @@
+let app = App(id: YOUR_REALM_APP_ID)
+let client = app.emailPasswordAuth
+
+let email = "forgot.my.password@example.com"
+let newPassword = "mynewpassword12345"
+let args: [AnyBSON] = []
+
+client.callResetPasswordFunction(email: email, password: newPassword, args: args) { (error) in
+    guard error == nil else {
+        print("Password reset failed: \(error!.localizedDescription)")
+        return
+    }
+    print("Password reset successful!")
+}

--- a/source/sdk/ios/examples/manage-email-password-users.txt
+++ b/source/sdk/ios/examples/manage-email-password-users.txt
@@ -70,17 +70,17 @@ To reset a user password in {+sync+}, you can either:
 
 Select your preferred password reset method by going to:
 
-- Your {+app+}
-- :guilabel:`Authentication`
-- :guilabel:`Authentication Providers`
-- :guilabel:`Email/Password` - and press the :guilabel:`EDIT` button
+1. Your {+app+}
+#. :guilabel:`Authentication`
+#. :guilabel:`Authentication Providers`
+#. :guilabel:`Email/Password` - and press the :guilabel:`EDIT` button
 
 Send a Password Reset Email
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After you configure your {+app+} to :ref:`send a password reset email 
 <auth-send-a-password-reset-email>`, you can call ``sendResetPasswordEmail`` 
-with the user's email. {+backend+} sends an email to the user containing 
+with the user's email. {+backend+} sends an email to the user that contains 
 a unique URL. The user must visit this URL within 30 minutes to confirm 
 the reset.
  
@@ -103,16 +103,16 @@ Run a Password Reset Function
 
 When you configure your app to :ref:`run a password reset function 
 <auth-run-a-password-reset-function>`, you'll define the function that 
-should run when you call ``callResetPasswordFunction()`` from the SDK. 
-This function can take a username, a password, and any number of 
-additional arguments. You can use these arguments to specify things like 
-security question answers or other challenges that the user should pass 
-to successfully complete a password reset.
+should run when you call :swift-sdk:`callResetPasswordFunction() <Extensions/EmailPasswordAuth.html#/s:So20RLMEmailPasswordAuthC10RealmSwiftE09callResetB8Function5email8password4args7Combine6FutureCyyts5Error_pGSS_SSSayAC7AnyBSONOGtF>` 
+from the SDK. This function can take a username, a password, and any number 
+of additional arguments. You can use these arguments to specify details 
+like security question answers or other challenges that the user should 
+pass to successfully complete a password reset.
 
 You might prefer to use a custom password reset function when you want to
-define your own password reset flows. This might include things like 
-sending a custom password reset email from a specific domain, or sending 
-password reset messages through a service other than email.
+define your own password reset flows. For example, you might send a custom 
+password reset email from a specific domain, or through a service other 
+than email.
 
 .. seealso::
 

--- a/source/sdk/ios/examples/manage-email-password-users.txt
+++ b/source/sdk/ios/examples/manage-email-password-users.txt
@@ -63,6 +63,27 @@ Confirm a New User's Email Address
 Reset a User's Password
 -----------------------
 
+To reset a user password in {+sync+}, you can either:
+
+- Send a password reset email
+- Run a password reset function
+
+Select your preferred password reset method by going to:
+
+- Your {+app+}
+- :guilabel:`Authentication`
+- :guilabel:`Authentication Providers`
+- :guilabel:`Email/Password` - and press the :guilabel:`EDIT` button
+
+Send a Password Reset Email
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After you configure your {+app+} to :ref:`send a password reset email 
+<auth-send-a-password-reset-email>`, you can call ``sendResetPasswordEmail`` 
+with the user's email. {+backend+} sends an email to the user containing 
+a unique URL. The user must visit this URL within 30 minutes to confirm 
+the reset.
+ 
 .. tabs-realm-languages::
    
    .. tab::
@@ -76,3 +97,29 @@ Reset a User's Password
 
       .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.reset-password-objc.m
          :language: objectivec
+
+Run a Password Reset Function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you configure your app to :ref:`run a password reset function 
+<auth-run-a-password-reset-function>`, you'll define the function that 
+should run when you call ``callResetPasswordFunction()`` from the SDK. 
+This function can take a username, a password, and any number of 
+additional arguments. You can use these arguments to specify things like 
+security question answers or other challenges that the user should pass 
+to successfully complete a password reset.
+
+You might prefer to use a custom password reset function when you want to
+define your own password reset flows. This might include things like 
+sending a custom password reset email from a specific domain, or sending 
+password reset messages through a service other than email.
+
+.. seealso::
+
+   For more information on how to define a custom password reset function
+   in the {+sync+} backend, including how to structure it and examples 
+   of implementing custom flows, see: :ref:`Run a Password Reset Function 
+   <auth-run-a-password-reset-function>`.
+ 
+.. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.password-reset-function.swift
+   :language: swift


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-16089

### Staged Changes (Requires MongoDB Corp SSO)

- [Manage Email Password Users -> Run a Password Reset Function (New section)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16089/sdk/ios/examples/manage-email-password-users/#run-a-password-reset-function)
- [Manage Email Password Users -> Reset a User's Password (new verbiage above code examples)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16089/sdk/ios/examples/manage-email-password-users/#reset-a-user-s-password)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
