### PR TITLE
(DOCSP-16146): Add run a password reset function to Android

### DIFF
--- a/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/ManageEmailPasswordTest.java
+++ b/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/ManageEmailPasswordTest.java
@@ -5,6 +5,8 @@ import android.util.Log;
 import com.mongodb.realm.examples.Expectation;
 import com.mongodb.realm.examples.RealmTest;
 
+import org.bson.BSONObject;
+import org.bson.BsonArray;
 import org.junit.Test;
 
 import java.util.Random;
@@ -78,7 +80,7 @@ public class ManageEmailPasswordTest extends RealmTest {
     }
 
     @Test
-    public void resetAUsersPassword() {
+    public void runAPasswordResetFunc() {
         Random random = new Random();
         String email = "test" + random.nextInt(100000);
         String password = "testtest";
@@ -89,29 +91,16 @@ public class ManageEmailPasswordTest extends RealmTest {
             String appID = YOUR_APP_ID; // replace this with your App ID
             App app = new App(new AppConfiguration.Builder(appID).build());
 
-
-            String token = "token-fake";
-            String tokenId = "token-id-fake";
             String newPassword = "newFakePassword";
 
-            // :code-block-start: send-reset-password-email
-            app.getEmailPassword().sendResetPasswordEmailAsync(email, it -> {
-                if (it.isSuccess()) {
-                    Log.i("EXAMPLE", "Successfully sent the user a reset password link to " + email);
-                } else {
-                    Log.e("EXAMPLE", "Failed to send the user a reset password link to " + email + ": " + it.getError().getErrorMessage());
-                }
-            });
-            // :code-block-end:
+            String[] args = {"security answer 1", "security answer 2"};
 
-            // :code-block-start: reset-password
-            // token and tokenId are query parameters in the confirmation
-            // link sent in the password reset email.
-            app.getEmailPassword().resetPasswordAsync(token, tokenId, newPassword, it -> {
+            // :code-block-start: run-password-reset-func
+            app.getEmailPassword().callResetPasswordFunctionAsync(email, newPassword, args, it -> {
                 if (it.isSuccess()) {
-                    Log.i("EXAMPLE", "Successfully updated password for user.");
+                    Log.i("EXAMPLE", "Successfully reset the password for" + email);
                 } else {
-                    Log.e("EXAMPLE", "Failed to reset user's password: " + it.getError().getErrorMessage());
+                    Log.e("EXAMPLE", "Failed to reset the password for" + email + ": " + it.getError().getErrorMessage());
                     // :hide-start:
                     expectation.fulfill();
                     // :hide-end:
@@ -121,6 +110,7 @@ public class ManageEmailPasswordTest extends RealmTest {
         });
         expectation.await();
     }
+
 
 
 }

--- a/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/ManageEmailPasswordTest.java
+++ b/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/ManageEmailPasswordTest.java
@@ -15,6 +15,7 @@ import io.realm.mongodb.App;
 import io.realm.mongodb.AppConfiguration;
 
 import static com.mongodb.realm.examples.RealmTestKt.YOUR_APP_ID;
+import static com.mongodb.realm.examples.RealmTestKt.getRandomPartition;
 
 public class ManageEmailPasswordTest extends RealmTest {
 
@@ -126,9 +127,7 @@ public class ManageEmailPasswordTest extends RealmTest {
 
     @Test
     public void runAPasswordResetFunc() {
-        Random random = new Random();
-        String email = "test" + random.nextInt(100000);
-        String password = "testtest";
+        String email = getRandomPartition();
 
         Expectation expectation = new Expectation();
         activity.runOnUiThread(() -> {
@@ -136,11 +135,10 @@ public class ManageEmailPasswordTest extends RealmTest {
             String appID = YOUR_APP_ID; // replace this with your App ID
             App app = new App(new AppConfiguration.Builder(appID).build());
 
+            // :code-block-start: run-password-reset-func
             String newPassword = "newFakePassword";
-
             String[] args = {"security answer 1", "security answer 2"};
 
-            // :code-block-start: run-password-reset-func
             app.getEmailPassword().callResetPasswordFunctionAsync(email, newPassword, args, it -> {
                 if (it.isSuccess()) {
                     Log.i("EXAMPLE", "Successfully reset the password for" + email);

--- a/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/ManageEmailPasswordTest.java
+++ b/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/ManageEmailPasswordTest.java
@@ -80,6 +80,51 @@ public class ManageEmailPasswordTest extends RealmTest {
     }
 
     @Test
+    public void resetAUsersPassword() {
+        Random random = new Random();
+        String email = "test" + random.nextInt(100000);
+        String password = "testtest";
+
+        Expectation expectation = new Expectation();
+        activity.runOnUiThread(() -> {
+
+            String appID = YOUR_APP_ID; // replace this with your App ID
+            App app = new App(new AppConfiguration.Builder(appID).build());
+
+
+            String token = "token-fake";
+            String tokenId = "token-id-fake";
+            String newPassword = "newFakePassword";
+
+            // :code-block-start: send-reset-password-email
+            app.getEmailPassword().sendResetPasswordEmailAsync(email, it -> {
+                if (it.isSuccess()) {
+                    Log.i("EXAMPLE", "Successfully sent the user a reset password link to " + email);
+                } else {
+                    Log.e("EXAMPLE", "Failed to send the user a reset password link to " + email + ": " + it.getError().getErrorMessage());
+                }
+            });
+            // :code-block-end:
+
+            // :code-block-start: reset-password
+            // token and tokenId are query parameters in the confirmation
+            // link sent in the password reset email.
+            app.getEmailPassword().resetPasswordAsync(token, tokenId, newPassword, it -> {
+                if (it.isSuccess()) {
+                    Log.i("EXAMPLE", "Successfully updated password for user.");
+                } else {
+                    Log.e("EXAMPLE", "Failed to reset user's password: " + it.getError().getErrorMessage());
+                    // :hide-start:
+                    expectation.fulfill();
+                    // :hide-end:
+                }
+            });
+            // :code-block-end:
+        });
+        expectation.await();
+    }
+
+    @Test
     public void runAPasswordResetFunc() {
         Random random = new Random();
         String email = "test" + random.nextInt(100000);

--- a/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/ManageEmailPasswordTest.kt
+++ b/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/ManageEmailPasswordTest.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import com.mongodb.realm.examples.Expectation
 import com.mongodb.realm.examples.RealmTest
 import com.mongodb.realm.examples.YOUR_APP_ID
+import com.mongodb.realm.examples.getRandomPartition
+
 import io.realm.mongodb.App
 import io.realm.mongodb.AppConfiguration
 import org.junit.Test
@@ -109,17 +111,16 @@ class ManageEmailPasswordTest : RealmTest() {
 
     @Test
     fun runAPasswordResetFunc() {
-        val random = Random()
-        val email = "test" + random.nextInt(100000)
-        val password = "testtest"
+        val email = getRandomPartition()
         val expectation = Expectation()
         activity!!.runOnUiThread {
             val appID: String = YOUR_APP_ID // replace this with your App ID
             val app = App(AppConfiguration.Builder(appID).build())
+
+            // :code-block-start: run-password-reset-func
             val newPassword = "newFakePassword"
             val args = arrayOf("security answer 1", "security answer 2")
 
-            // :code-block-start: run-password-reset-func
             app.emailPassword.callResetPasswordFunctionAsync(email, newPassword, args) {
                 if (it.isSuccess) {
                     Log.i("EXAMPLE", "Successfully reset the password for $email")

--- a/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/ManageEmailPasswordTest.kt
+++ b/examples/android/sync/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/ManageEmailPasswordTest.kt
@@ -106,4 +106,32 @@ class ManageEmailPasswordTest : RealmTest() {
         }
         expectation.await()
     }
+
+    @Test
+    fun runAPasswordResetFunc() {
+        val random = Random()
+        val email = "test" + random.nextInt(100000)
+        val password = "testtest"
+        val expectation = Expectation()
+        activity!!.runOnUiThread {
+            val appID: String = YOUR_APP_ID // replace this with your App ID
+            val app = App(AppConfiguration.Builder(appID).build())
+            val newPassword = "newFakePassword"
+            val args = arrayOf("security answer 1", "security answer 2")
+
+            // :code-block-start: run-password-reset-func
+            app.emailPassword.callResetPasswordFunctionAsync(email, newPassword, args) {
+                if (it.isSuccess) {
+                    Log.i("EXAMPLE", "Successfully reset the password for $email")
+                } else {
+                    Log.e("EXAMPLE", "Failed to reset the password for $email: $it.error")
+                    // :hide-start:
+                    expectation.fulfill()
+                    // :hide-end:
+                }
+            }
+            // :code-block-end:
+        }
+        expectation.await()
+    }
 }

--- a/source/examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.java
+++ b/source/examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.java
@@ -1,3 +1,6 @@
+String newPassword = "newFakePassword";
+String[] args = {"security answer 1", "security answer 2"};
+
 app.getEmailPassword().callResetPasswordFunctionAsync(email, newPassword, args, it -> {
     if (it.isSuccess()) {
         Log.i("EXAMPLE", "Successfully reset the password for" + email);

--- a/source/examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.java
+++ b/source/examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.java
@@ -1,0 +1,7 @@
+app.getEmailPassword().callResetPasswordFunctionAsync(email, newPassword, args, it -> {
+    if (it.isSuccess()) {
+        Log.i("EXAMPLE", "Successfully reset the password for" + email);
+    } else {
+        Log.e("EXAMPLE", "Failed to reset the password for" + email + ": " + it.getError().getErrorMessage());
+    }
+});

--- a/source/examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.kt
+++ b/source/examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.kt
@@ -1,0 +1,7 @@
+app.emailPassword.callResetPasswordFunctionAsync(email, newPassword, args) {
+    if (it.isSuccess) {
+        Log.i("EXAMPLE", "Successfully reset the password for $email")
+    } else {
+        Log.e("EXAMPLE", "Failed to reset the password for $email: $it.error")
+    }
+}

--- a/source/examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.kt
+++ b/source/examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.kt
@@ -1,3 +1,6 @@
+val newPassword = "newFakePassword"
+val args = arrayOf("security answer 1", "security answer 2")
+
 app.emailPassword.callResetPasswordFunctionAsync(email, newPassword, args) {
     if (it.isSuccess) {
         Log.i("EXAMPLE", "Successfully reset the password for $email")

--- a/source/sdk/android/examples/email-password-users.txt
+++ b/source/sdk/android/examples/email-password-users.txt
@@ -149,8 +149,8 @@ Run a Password Reset Function
 
 When you configure your app to :ref:`run a password reset function 
 <auth-run-a-password-reset-function>`, you'll define the function that 
-should run when you call :java-sdk:`callResetPasswordFunction() <io/realm/mongodb/auth/EmailPasswordAuth.html#callResetPasswordFunction-java.lang.String->` 
-or :java-sdk:`callResetPasswordFunctionAsync() <io/realm/mongodb/auth/EmailPasswordAuth.html#callResetPasswordFunctionAsync-java.lang.String->`
+should run when you call :java-sdk:`callResetPasswordFunction() <io/realm/mongodb/auth/EmailPasswordAuth.html#callResetPasswordFunction-java.lang.String-java.lang.String-java.lang.Object...->` 
+or :java-sdk:`callResetPasswordFunctionAsync() <io/realm/mongodb/auth/EmailPasswordAuth.html#callResetPasswordFunctionAsync-java.lang.String-java.lang.String-java.lang.Object:A-io.realm.mongodb.App.Callback->`
 from the SDK. This function can take a username, a password, and any number 
 of additional arguments. You can use these arguments to specify details 
 like security question answers or other challenges that the user should 

--- a/source/sdk/android/examples/email-password-users.txt
+++ b/source/sdk/android/examples/email-password-users.txt
@@ -80,6 +80,21 @@ instance:
 Reset a User's Password
 -----------------------
 
+To reset a user password in {+sync+}, you can either:
+
+- Send a password reset email
+- Run a password reset function
+
+Select your preferred password reset method by going to:
+
+1. Your {+app+}
+#. :guilabel:`Authentication`
+#. :guilabel:`Authentication Providers`
+#. :guilabel:`Email/Password` - and press the :guilabel:`EDIT` button
+
+Send a Password Reset Email
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 To reset a user's password, first send the user a password reset email with
 :java-sdk:`sendResetPasswordEmail() <io/realm/mongodb/auth/EmailPasswordAuth.html#sendResetPasswordEmail-java.lang.String->`
 or :java-sdk:`sendResetPasswordEmailAsync() <io/realm/mongodb/auth/EmailPasswordAuth.html#sendResetPasswordEmailAsync-java.lang.String-io.realm.mongodb.App.Callback->`:
@@ -128,3 +143,41 @@ methods:
    reset email, you can use a :ref:`custom password reset email subject
    <auth-send-a-password-reset-email>` containing a `deep link
    <https://developer.android.com/training/app-links/deep-linking>`__.
+
+Run a Password Reset Function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you configure your app to :ref:`run a password reset function 
+<auth-run-a-password-reset-function>`, you'll define the function that 
+should run when you call :java-sdk:`callResetPasswordFunction() <io/realm/mongodb/auth/EmailPasswordAuth.html#callResetPasswordFunction-java.lang.String->` 
+or :java-sdk:`callResetPasswordFunctionAsync() <io/realm/mongodb/auth/EmailPasswordAuth.html#callResetPasswordFunctionAsync-java.lang.String->`
+from the SDK. This function can take a username, a password, and any number 
+of additional arguments. You can use these arguments to specify details 
+like security question answers or other challenges that the user should 
+pass to successfully complete a password reset.
+
+You might prefer to use a custom password reset function when you want to
+define your own password reset flows. For example, you might send a custom 
+password reset email from a specific domain, or through a service other 
+than email.
+
+.. seealso::
+
+   For more information on how to define a custom password reset function
+   in the {+sync+} backend, including how to structure it and examples 
+   of implementing custom flows, see: :ref:`Run a Password Reset Function 
+   <auth-run-a-password-reset-function>`.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+       :tabid: kotlin
+
+       .. literalinclude:: /examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.kt
+         :language: kotlin
+
+   .. tab::
+       :tabid: java
+
+       .. literalinclude:: /examples/generated/android/sync/ManageEmailPasswordTest.codeblock.run-password-reset-func.java
+         :language: java


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-16146

### Staged Changes (Requires MongoDB Corp SSO)

- [Manage Email/Password Users -> Run a Password Reset Function](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16146/sdk/android/examples/email-password-users/#run-a-password-reset-function):  new section
- [Manage Email/Password Users -> Reset a User's Password](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16146/sdk/android/examples/email-password-users/#reset-a-user-s-password): new verbiage before email reset section

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
