### PR TITLE
(DOCSP-16164): Add info about set methods where applicable

### DIFF
--- a/source/sdk/android/data-types/realmset.txt
+++ b/source/sdk/android/data-types/realmset.txt
@@ -25,8 +25,8 @@ any ``RealmSet`` instances that contain the object.
 
 Because ``RealmSet`` implements ``RealmCollection``, it has some useful
 mathematical methods, such as ``sum``, ``min``, and ``max``. For a complete
-list of available ``RealmSet`` methods, see: :java-sdk:`the RealmSet 
-reference documentation<io/realm/RealmSet.html>`.
+list of available ``RealmSet`` methods, see: :java-sdk:`the RealmSet API 
+reference <io/realm/RealmSet.html>`.
 
 .. note:: ``RealmSet`` Limitations
 

--- a/source/sdk/android/data-types/realmset.txt
+++ b/source/sdk/android/data-types/realmset.txt
@@ -23,6 +23,11 @@ actually only store references to those objects, so deleting a
 {+service-short+} object from a {+realm+} also deletes that object from
 any ``RealmSet`` instances that contain the object.
 
+Because ``RealmSet`` implements ``RealmCollection``, it has some useful
+mathematical methods, such as ``sum``, ``min``, and ``max``. For a complete
+list of available ``RealmSet`` methods, see: :java-sdk:`the RealmSet 
+reference documentation<io/realm/RealmSet.html>`.
+
 .. note:: ``RealmSet`` Limitations
 
    Objects containing ``RealmSet`` fields currently cannot use the

--- a/source/sdk/ios/data-types/collections.txt
+++ b/source/sdk/ios/data-types/collections.txt
@@ -97,6 +97,14 @@ You can filter and sort a ``MutableSet`` with the :ref:`same predicates
 {+service-short+} collections, you can :ref:`register a change listener 
 <ios-register-a-collection-change-listener>` on a ``MutableSet``.
 
+.. seealso::
+
+   ``MutableSet`` implements many of the :apple:`operations available to 
+   Swift sets </documentation/swift/set#Set%20Operations>`, such as: 
+   ``contains``, ``isSubset``, ``union``, ``intersection``, ``subtract``, 
+   and more. For a complete list of methods available on ``MutableSet``, 
+   see: `RealmSwift SDK reference documentation<https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_.  
+
 MutableSet as a Property
 ````````````````````````
 

--- a/source/sdk/ios/data-types/collections.txt
+++ b/source/sdk/ios/data-types/collections.txt
@@ -97,14 +97,6 @@ You can filter and sort a ``MutableSet`` with the :ref:`same predicates
 {+service-short+} collections, you can :ref:`register a change listener 
 <ios-register-a-collection-change-listener>` on a ``MutableSet``.
 
-.. seealso::
-
-   ``MutableSet`` implements many of the :apple:`operations available to 
-   Swift sets </documentation/swift/set#Set%20Operations>`, such as: 
-   ``contains``, ``isSubset``, ``union``, ``intersection``, ``subtract``, 
-   and more. For a complete list of methods available on ``MutableSet``, 
-   see: `RealmSwift SDK reference documentation <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_.  
-
 MutableSet as a Property
 ````````````````````````
 
@@ -131,7 +123,9 @@ For example, ``MutableSet`` intersection methods:
 
 .. seealso::
 
-   - For a complete list of methods available, see: `MutableSet reference documentation <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_
+   - For a complete list of methods available, such as ``contains``, 
+     ``isSubset``, ``union``, ``subtract``, and more see: 
+     `MutableSet reference documentation <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_
    - For more info on to-many relationships, see: :ref:`To-Many Relationships <ios-to-many-relationship>`
 
 .. _ios-linking-objects:

--- a/source/sdk/ios/data-types/collections.txt
+++ b/source/sdk/ios/data-types/collections.txt
@@ -103,7 +103,7 @@ You can filter and sort a ``MutableSet`` with the :ref:`same predicates
    Swift sets </documentation/swift/set#Set%20Operations>`, such as: 
    ``contains``, ``isSubset``, ``union``, ``intersection``, ``subtract``, 
    and more. For a complete list of methods available on ``MutableSet``, 
-   see: `RealmSwift SDK reference documentation<https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_.  
+   see: `RealmSwift SDK reference documentation <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_.  
 
 MutableSet as a Property
 ````````````````````````

--- a/source/sdk/ios/data-types/collections.txt
+++ b/source/sdk/ios/data-types/collections.txt
@@ -124,8 +124,8 @@ For example, ``MutableSet`` intersection methods:
 .. seealso::
 
    - For a complete list of methods available, such as ``contains``, 
-     ``isSubset``, ``union``, ``subtract``, and more see: 
-     `MutableSet reference documentation <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_
+     ``isSubset``, ``union``, ``subtract``, see: 
+     `MutableSet API reference <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_
    - For more info on to-many relationships, see: :ref:`To-Many Relationships <ios-to-many-relationship>`
 
 .. _ios-linking-objects:


### PR DESCRIPTION
## Pull Request Info

For the reviewer: this ended up being minor. I already had info about it in a `See also` on the iOS page, so I added some more method names there. Android doesn't really have the set-specific methods that we were requested to highlight. And [.Net already links to HashSet](https://docs.mongodb.com/realm/sdk/dotnet/data-types/sets/) where those methods are documented. So I think this is mostly taken care of already, and has just involved some minor tweaks.

### Jira

- https://jira.mongodb.org/browse/DOCSP-16164

### Staged Changes (Requires MongoDB Corp SSO)

- [Collections (iOS)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16164/sdk/ios/data-types/collections/#mutableset): Updated `See also` at the bottom of the MutableSet section
- [RealmSet (Android)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16164/sdk/android/data-types/realmset/): Added a paragraph above the "Note" (didn't want to do a `See also` there because there was already a `Note` in that position)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
