### PR TITLE
realm-cli version fix -- tutorial backend setup

### DIFF
--- a/source/tutorial/realm-app.txt
+++ b/source/tutorial/realm-app.txt
@@ -148,13 +148,19 @@ app configuration faster. Follow the instructions below to install
 the Realm CLI in your development environment using either a package
 manager or the ``realm-cli`` binary:
 
-.. include:: /includes/install-realm-cli.rst
+{+cli+} is available on ``npm``. To install it on your system, ensure that you
+have `Node.js <https://nodejs.org/en/download/>`_ installed and then run the
+following command in your shell:
+
+.. code-block:: shell
+
+  npm install -g mongodb-realm-cli@1.3.4
 
 .. note:: Realm CLI Version Compatibility
 
-   This tutorial is compatible with version ``1.1.0`` of ``realm-cli``.
+   This tutorial is compatible with version ``1.3.4`` of ``realm-cli``.
    If you encounter an error importing this app, try switching to
-   version ``1.1.0``.
+   version ``1.3.4``. The above command installs version ``1.3.4``.
 
 After installing the ``realm-cli``, you can run the
 following command to confirm that your installation was successful:
@@ -163,7 +169,7 @@ following command to confirm that your installation was successful:
 
    realm-cli --version
 
-If you see output containing a version number such as ``1.1.0``, your
+If you see output containing a version number such as ``1.3.4``, your
 ``realm-cli`` installation was successful.
 
 .. see::

--- a/source/tutorial/realm-app.txt
+++ b/source/tutorial/realm-app.txt
@@ -154,7 +154,7 @@ following command in your shell:
 
 .. code-block:: shell
 
-  npm install -g mongodb-realm-cli@1.3.4
+   npm install -g mongodb-realm-cli@1.3.4
 
 .. note:: Realm CLI Version Compatibility
 


### PR DESCRIPTION
CLI v2 errors out and creates the app but doesn't create all the other app content
CLI 1.1.0 silently fails but has the same end result
CLI 1.3.4 is the way

## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-NNNNN

### Staged Changes (Requires MongoDB Corp SSO)

- [backend app tutorial -- install realm cli](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cli-that-actually-works-tutorial/tutorial/realm-app/#c.-install-the-realm-cli)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
