### PR TITLE
Android Tutorial: Failing Upwards

### DIFF
--- a/source/includes/steps-tutorial-android-kotlin.yaml
+++ b/source/includes/steps-tutorial-android-kotlin.yaml
@@ -292,9 +292,9 @@ content: |
   logged in user. An :ref:`authentication trigger
   <authentication-triggers>` automatically creates and initializes this
   object when the user creates an account. Add the code that queries for
-  the user object:
+  the user object in ``getProjects()``:
 
-  .. literalinclude:: /tutorial/generated/code/final/ProjectActivity.codeblock.user-init-change-listener.kt
+  .. literalinclude:: /tutorial/generated/code/final/ProjectActivity.codeblock.fetch-synced-user-safely.kt
      :language: kotlin
 
   Because it can take a few seconds for the trigger to create this
@@ -304,8 +304,20 @@ content: |
   watch the {+realm+} for changes and only set up the project's Recycler
   View once the trigger runs:
 
-  .. literalinclude:: /tutorial/generated/code/final/ProjectActivity.codeblock.fetch-synced-user-safely.kt
+  .. literalinclude:: /tutorial/generated/code/final/ProjectActivity.codeblock.user-init-change-listener.kt
      :language: kotlin
+
+  .. note:: Always Enabling the User's Personal Project
+
+     Users shouldn't have to wait for a Trigger to complete just to
+     write tasks to their personal project. But Task Tracker doesn't
+     display any projects until the user's custom user data object has
+     been initialized by a Trigger. To work around this, we automatically
+     create a temporary fake custom user data object whenever custom
+     user data isn't yet available, so the Recycler View has something
+     to display. Since tasks are written to a separate {+realm+}, using
+     an in-memory {+realm+} for the fake custom user data doesn't impact
+     creating and syncing tasks.
 
   Finally, we need to guarantee that ``ProjectActivity`` always closes
   the user {+realm+} when the app closes or the user logs out. To

--- a/source/tutorial/generated/code/final/ProjectActivity.codeblock.fetch-synced-user-safely.kt
+++ b/source/tutorial/generated/code/final/ProjectActivity.codeblock.fetch-synced-user-safely.kt
@@ -1,3 +1,2 @@
-val syncedUsers : RealmResults<User> = realm.where<User>().sort("_id").findAll()
+val syncedUsers : RealmResults<User> = realm.where<User>().sort("id").findAll()
 val syncedUser : User? = syncedUsers.getOrNull(0) // since there might be no user objects in the results, default to "null"
-Log.v(TAG(), "Synced users length: ${syncedUsers.size}")

--- a/source/tutorial/generated/code/final/ProjectActivity.codeblock.set-up-user-realm.kt
+++ b/source/tutorial/generated/code/final/ProjectActivity.codeblock.set-up-user-realm.kt
@@ -7,6 +7,6 @@ Realm.getInstanceAsync(config, object: Realm.Callback() {
     override fun onSuccess(realm: Realm) {
         // since this realm should live exactly as long as this activity, assign the realm to a member variable
         this@ProjectActivity.userRealm = realm
-        setUpRecyclerView(realm)
+        setUpRecyclerView(getProjects(realm))
     }
 })

--- a/source/tutorial/generated/code/final/ProjectActivity.codeblock.user-init-change-listener.kt
+++ b/source/tutorial/generated/code/final/ProjectActivity.codeblock.user-init-change-listener.kt
@@ -1,5 +1,6 @@
-val changeListener = OrderedRealmCollectionChangeListener<RealmResults<User>> { results, changeSet ->
-    Log.i(TAG(), "User object initialized, displaying project list.")
-    setUpRecyclerView(realm)
-}
+val changeListener =
+    OrderedRealmCollectionChangeListener<RealmResults<User>> { results, changeSet ->
+        Log.i(TAG(), "User object initialized, displaying project list.")
+        setUpRecyclerView(getProjects(realm))
+    }
 syncedUsers.addChangeListener(changeListener)

--- a/source/tutorial/generated/code/final/TaskActivity.codeblock.fetch-tasks-for-project-sorted-by-id.kt
+++ b/source/tutorial/generated/code/final/TaskActivity.codeblock.fetch-tasks-for-project-sorted-by-id.kt
@@ -1,1 +1,1 @@
-adapter = TaskAdapter(realm.where<Task>().sort("_id").findAll(), user!!, partition)
+adapter = TaskAdapter(realm.where<Task>().sort("id").findAll(), user!!, partition)

--- a/source/tutorial/generated/code/final/TaskAdapter.codeblock.change-task-status.kt
+++ b/source/tutorial/generated/code/final/TaskAdapter.codeblock.change-task-status.kt
@@ -9,7 +9,7 @@ val realm: Realm = Realm.getInstance(config)
 // execute Transaction asynchronously to avoid blocking the UI thread
 realm.executeTransactionAsync {
     // using our thread-local new realm instance, query for and update the task status
-    val item = it.where<Task>().equalTo("_id", _id).findFirst()
+    val item = it.where<Task>().equalTo("id", id).findFirst()
     item?.statusEnum = status
 }
 // always close realms when you are done with them!

--- a/source/tutorial/generated/code/final/TaskAdapter.codeblock.delete-task.kt
+++ b/source/tutorial/generated/code/final/TaskAdapter.codeblock.delete-task.kt
@@ -8,7 +8,7 @@ val realm: Realm = Realm.getInstance(config)
 // execute Transaction asynchronously to avoid blocking the UI thread
 realm.executeTransactionAsync {
     // using our thread-local new realm instance, query for and delete the task
-    val item = it.where<Task>().equalTo("_id", id).findFirst()
+    val item = it.where<Task>().equalTo("id", id).findFirst()
     item?.deleteFromRealm()
 }
 // always close realms when you are done with them!

--- a/source/tutorial/generated/code/final/TaskTracker.codeblock.initialize-realm-and-create-app.kt
+++ b/source/tutorial/generated/code/final/TaskTracker.codeblock.initialize-realm-and-create-app.kt
@@ -1,3 +1,6 @@
 taskApp = App(
     AppConfiguration.Builder(BuildConfig.MONGODB_REALM_APP_ID)
+        .defaultSyncErrorHandler { session, error ->
+            Log.e(TAG(), "Sync error: ${error.errorMessage}")
+        }
     .build())

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/LoginActivity.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/LoginActivity.kt
@@ -103,6 +103,7 @@ class LoginActivity : AppCompatActivity() {
             }
             // :state-end: :state-uncomment-start: start
             //// TODO: Log in with the supplied username and password when the "Log in" button is pressed.
+            //onLoginFailed("Couldn't log in. Configure your App ID and login handler.")
             // :state-uncomment-end:
             // :code-block-end:
         }

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/MemberActivity.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/MemberActivity.kt
@@ -111,16 +111,9 @@ class MemberActivity : AppCompatActivity() {
                 Log.e(TAG(), "failed to get team members with: " + result.error)
             }
         }
-        // :state-end: :state-uncomment-start: start
-        //// TODO: Call the `getMyTeamMembers` function to get a list of team members, then display them in a RecyclerView with the following code:
-        //// The `getMyTeamMembers` function returns team members as Document objects. Convert them into Member objects so the MemberAdapter can display them.
-        //// this.members = ArrayList(result.get().map { item -> Member(item as Document) })
-        //// adapter = MemberAdapter(members, user!!)
-        //// recyclerView.layoutManager = LinearLayoutManager(this)
-        //// recyclerView.adapter = adapter
-        //// recyclerView.setHasFixedSize(true)
-        //// recyclerView.addItemDecoration(DividerItemDecoration(this, DividerItemDecoration.VERTICAL))
-        // :state-uncomment-end:
+        // :state-end: :state-start: start
+        // TODO: Call the `getMyTeamMembers` function to get a list of team members, then display them in a RecyclerView
+        // :state-end:
         // :code-block-end:
     }
 }

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/ProjectActivity.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/ProjectActivity.kt
@@ -146,7 +146,10 @@ class ProjectActivity : AppCompatActivity() {
             // :code-block-end:
 
             // user should have a personal project no matter what, so create it if it doesn't already exist
-            // RealmRecyclerAdapters only work on managed objects, so create an in-memory realm to manage our fake custom user data object
+            // RealmRecyclerAdapters only work on managed objects,
+            // so create a realm to manage a fake custom user data object
+            // offline, in-memory because this data does not need to be persistent or synced:
+            // the object is only used to determine the partition for storing tasks
             val fakeRealm = Realm.getInstance(
                 RealmConfiguration.Builder()
                     .allowWritesOnUiThread(true)

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/ProjectActivity.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/ProjectActivity.kt
@@ -12,13 +12,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.mongodb.tasktracker.model.Project
 import com.mongodb.tasktracker.model.ProjectAdapter
 import com.mongodb.tasktracker.model.User
-import io.realm.OrderedRealmCollection
-import io.realm.OrderedRealmCollectionChangeListener
-import io.realm.Realm
-import io.realm.RealmList
-import io.realm.RealmResults
+import io.realm.*
 import io.realm.kotlin.where
 import io.realm.mongodb.sync.SyncConfiguration
+import org.bson.types.ObjectId
 
 /*
 * ProjectActivity: allows a user to view a collection of Projects. Clicking on a project launches a
@@ -50,7 +47,7 @@ class ProjectActivity : AppCompatActivity() {
                 override fun onSuccess(realm: Realm) {
                     // since this realm should live exactly as long as this activity, assign the realm to a member variable
                     this@ProjectActivity.userRealm = realm
-                    setUpRecyclerView(realm)
+                    setUpRecyclerView(getProjects(realm))
                 }
             })
             // :state-end: :state-uncomment-start: start
@@ -116,48 +113,73 @@ class ProjectActivity : AppCompatActivity() {
         }
     }
 
-    private fun setUpRecyclerView(realm: Realm) {
+    private fun getProjects(realm: Realm): RealmList<Project> {
         // query for a user object in our user realm, which should only contain our user object
         // :code-block-start: fetch-synced-user-safely
         // :state-start: final
-        val syncedUsers : RealmResults<User> = realm.where<User>().sort("_id").findAll()
+        val syncedUsers : RealmResults<User> = realm.where<User>().sort("id").findAll()
         val syncedUser : User? = syncedUsers.getOrNull(0) // since there might be no user objects in the results, default to "null"
-        Log.v(TAG(), "Synced users length: ${syncedUsers.size}")
         // :state-end: :state-uncomment-start: start
         //// TODO: query the realm to get a copy of the currently logged in user's User object (or null, if the trigger didn't create it yet)
         //var syncedUser : User? = null
         // :state-uncomment-end:
         // :code-block-end:
-
         // if a user object exists, create the recycler view and the corresponding adapter
         if (syncedUser != null) {
-            val projectsList = syncedUser.memberOf
-            adapter = ProjectAdapter(projectsList, user!!)
-            recyclerView.layoutManager = LinearLayoutManager(this)
-            recyclerView.adapter = adapter
-            recyclerView.setHasFixedSize(true)
-            recyclerView.addItemDecoration(
-                DividerItemDecoration(
-                    this,
-                    DividerItemDecoration.VERTICAL
-                )
-            )
+            return syncedUser.memberOf
         } else {
             // since a trigger creates our user object after initial signup, the object might not exist immediately upon first login.
             // if the user object doesn't yet exist (that is, if there are no users in the user realm), call this function again when it is created
-            Log.i(TAG(), "User object not yet initialized, waiting for initialization via Trigger before displaying projects.")
+            Log.i(
+                TAG(),
+                "User object not yet initialized, only showing default user project until initialization."
+            )
             // change listener on a query for our user object lets us know when the user object has been created by the auth trigger
             // :code-block-start: user-init-change-listener
             // :state-start: final
-            val changeListener = OrderedRealmCollectionChangeListener<RealmResults<User>> { results, changeSet ->
-                Log.i(TAG(), "User object initialized, displaying project list.")
-                setUpRecyclerView(realm)
-            }
+            val changeListener =
+                OrderedRealmCollectionChangeListener<RealmResults<User>> { results, changeSet ->
+                    Log.i(TAG(), "User object initialized, displaying project list.")
+                    setUpRecyclerView(getProjects(realm))
+                }
             syncedUsers.addChangeListener(changeListener)
             // :state-end: :state-uncomment-start: start
             //// TODO: set up a change listener that will set up the recycler view once our trigger initializes the user's User object
             // :state-uncomment-end:
             // :code-block-end:
+
+            // use should have a personal project no matter what, so create it if it doesn't already exist
+            // RealmRecyclerAdapters only work on managed objects, so create an in-memory realm to manage our fake custom user data object
+            val fakeRealm = Realm.getInstance(
+                RealmConfiguration.Builder()
+                    .allowWritesOnUiThread(true)
+                    .inMemory().build())
+            var projectsList: RealmList<Project>? = null
+            var fakeCustomUserData = fakeRealm.where(User::class.java).findFirst()
+            if (fakeCustomUserData == null) {
+                fakeRealm.executeTransaction {
+                    fakeCustomUserData = it.createObject(User::class.java, user?.id)
+                    projectsList = fakeCustomUserData?.memberOf!!
+                    projectsList?.add(Project("My Project", "project=${user?.id}"))
+                }
+            } else {
+                projectsList = fakeCustomUserData?.memberOf
+            }
+
+            return projectsList!!
         }
+    }
+
+    private fun setUpRecyclerView(projectsList: RealmList<Project>) {
+        adapter = ProjectAdapter(projectsList, user!!)
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = adapter
+        recyclerView.setHasFixedSize(true)
+        recyclerView.addItemDecoration(
+            DividerItemDecoration(
+                this,
+                DividerItemDecoration.VERTICAL
+            )
+        )
     }
 }

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/ProjectActivity.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/ProjectActivity.kt
@@ -130,10 +130,7 @@ class ProjectActivity : AppCompatActivity() {
         } else {
             // since a trigger creates our user object after initial signup, the object might not exist immediately upon first login.
             // if the user object doesn't yet exist (that is, if there are no users in the user realm), call this function again when it is created
-            Log.i(
-                TAG(),
-                "User object not yet initialized, only showing default user project until initialization."
-            )
+            Log.i(TAG(), "User object not yet initialized, only showing default user project until initialization.")
             // change listener on a query for our user object lets us know when the user object has been created by the auth trigger
             // :code-block-start: user-init-change-listener
             // :state-start: final

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/ProjectActivity.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/ProjectActivity.kt
@@ -148,7 +148,7 @@ class ProjectActivity : AppCompatActivity() {
             // :state-uncomment-end:
             // :code-block-end:
 
-            // use should have a personal project no matter what, so create it if it doesn't already exist
+            // user should have a personal project no matter what, so create it if it doesn't already exist
             // RealmRecyclerAdapters only work on managed objects, so create an in-memory realm to manage our fake custom user data object
             val fakeRealm = Realm.getInstance(
                 RealmConfiguration.Builder()

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/TaskActivity.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/TaskActivity.kt
@@ -139,7 +139,7 @@ class TaskActivity : AppCompatActivity() {
         // sort this collection so that the displayed order of Tasks remains stable across updates
         // :code-block-start: fetch-tasks-for-project-sorted-by-id
         // :state-start: final
-        adapter = TaskAdapter(realm.where<Task>().sort("_id").findAll(), user!!, partition)
+        adapter = TaskAdapter(realm.where<Task>().sort("id").findAll(), user!!, partition)
         // :state-end: :state-uncomment-start: start
         //// TODO: Query the realm for Task objects, sorted by a stable order that remains consistent between runs.
         // :state-uncomment-end:

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/TaskTracker.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/TaskTracker.kt
@@ -2,6 +2,8 @@ package com.mongodb.tasktracker
 
 import android.app.Application
 import android.util.Log
+import android.widget.Toast
+import androidx.core.content.ContextCompat
 
 import io.realm.Realm
 import io.realm.log.LogLevel
@@ -29,6 +31,9 @@ class TaskTracker : Application() {
         // :code-block-start: initialize-realm-and-create-app
         taskApp = App(
             AppConfiguration.Builder(BuildConfig.MONGODB_REALM_APP_ID)
+                .defaultSyncErrorHandler { session, error ->
+                    Log.e(TAG(), "Sync error: ${error.errorMessage}")
+                }
             .build())
         // :code-block-end:
 
@@ -40,3 +45,4 @@ class TaskTracker : Application() {
         Log.v(TAG(), "Initialized the Realm App configuration for: ${taskApp.configuration.appId}")
     }
 }
+

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/model/Project.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/model/Project.kt
@@ -7,4 +7,4 @@ import io.realm.annotations.RealmClass
 open class Project(
     var name: String? = null,
     var partition: String? = null
-): RealmObject() {}
+): RealmObject()

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/model/Task.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/model/Task.kt
@@ -2,12 +2,13 @@ package com.mongodb.tasktracker.model
 
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
+import io.realm.annotations.RealmField
 import io.realm.annotations.Required
 import org.bson.types.ObjectId
 
 
 open class Task(_name: String = "Task") : RealmObject() {
-    @PrimaryKey var _id: ObjectId = ObjectId()
+    @PrimaryKey @RealmField("_id") var id: ObjectId = ObjectId()
     var name: String = _name
     var owner: String? = null
 

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/model/TaskAdapter.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/model/TaskAdapter.kt
@@ -66,14 +66,14 @@ internal class TaskAdapter(data: OrderedRealmCollection<Task>, val user: io.real
                             status = TaskStatus.Complete
                         }
                         deleteCode -> {
-                            removeAt(holder.data?._id!!)
+                            removeAt(holder.data?.id!!)
                         }
                     }
 
                     // if the status variable has a new value, update the status of the task in realm
                     if (status != null) {
-                        Log.v(TAG(), "Changing status of ${holder.data?.name} (${holder.data?._id}) to $status")
-                        changeStatus(status!!, holder.data?._id)
+                        Log.v(TAG(), "Changing status of ${holder.data?.name} (${holder.data?.id}) to $status")
+                        changeStatus(status, holder.data?.id!!)
                     }
                     true
                 }
@@ -82,7 +82,7 @@ internal class TaskAdapter(data: OrderedRealmCollection<Task>, val user: io.real
         }
     }
 
-    private fun changeStatus(status: TaskStatus, _id: ObjectId?) {
+    private fun changeStatus(status: TaskStatus, id: ObjectId) {
         // :code-block-start: change-task-status
         // :state-start: final
         // need to create a separate instance of realm to issue an update
@@ -96,7 +96,7 @@ internal class TaskAdapter(data: OrderedRealmCollection<Task>, val user: io.real
         // execute Transaction asynchronously to avoid blocking the UI thread
         realm.executeTransactionAsync {
             // using our thread-local new realm instance, query for and update the task status
-            val item = it.where<Task>().equalTo("_id", _id).findFirst()
+            val item = it.where<Task>().equalTo("id", id).findFirst()
             item?.statusEnum = status
         }
         // always close realms when you are done with them!
@@ -123,7 +123,7 @@ internal class TaskAdapter(data: OrderedRealmCollection<Task>, val user: io.real
         // execute Transaction asynchronously to avoid blocking the UI thread
         realm.executeTransactionAsync {
             // using our thread-local new realm instance, query for and delete the task
-            val item = it.where<Task>().equalTo("_id", id).findFirst()
+            val item = it.where<Task>().equalTo("id", id).findFirst()
             item?.deleteFromRealm()
         }
         // always close realms when you are done with them!

--- a/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/model/User.kt
+++ b/tutorial/kotlin-android/app/src/main/java/com/mongodb/tasktracker/model/User.kt
@@ -3,11 +3,12 @@ package com.mongodb.tasktracker.model
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey
+import io.realm.annotations.RealmField
 import io.realm.annotations.Required
 
 open class User(
-    @PrimaryKey var _id: String = "",
+    @PrimaryKey @RealmField("_id") var id: String = "",
     var _partition: String = "",
     var memberOf: RealmList<Project> = RealmList(),
     var name: String = ""
-): RealmObject() {}
+): RealmObject()


### PR DESCRIPTION
## Pull Request Info
- Enables personal project writes in the Android tutorial even when permissions/functions/triggers have not been set up.
- Still requires email/password auth (with automatic confirmation) and Sync enabled with a required String partition key named `_partition`.

### Staged Changes (Requires MongoDB Corp SSO)

- [Android Tutorial - Implement the Projects List](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/android-tutorial-ian-fix/tutorial/android-kotlin/#implement-the-projects-list)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
