### PR TITLE
(DOCSP-16175): Android tutorial maintenance - minor tweaks and fixes

### DIFF
--- a/source/includes/steps-tutorial-android-kotlin.yaml
+++ b/source/includes/steps-tutorial-android-kotlin.yaml
@@ -56,8 +56,14 @@ ref: explore-the-app-structure
 content: |
 
   In the Android Studio Project view, you can see the source files of the task
-  tracker application in the ``app`` folder and its subfolders. The
-  relevant files are as follows:
+  tracker application in the ``app`` folder and its subfolders. 
+  
+  TaskTracker stores files that describe the UI logic for Android
+  views in the ``app/java/com/mongodb/tasktracker`` directory. Files
+  that describe data models or how those data models relate to the UI
+  belong in the ``app/java/com/mongodb/tasktracker/model`` directory.
+  
+  The relevant files are as follows:
 
   .. cssclass:: config-table
   .. list-table::
@@ -135,11 +141,6 @@ content: |
      * - User
        - Model describing in-app user data, including the list of
          projects to which that user belongs.
-
-  TaskTracker stores files that describe the UI logic for Android
-  views in the ``app/java/com/mongodb/tasktracker`` directory. Files
-  that describe data models or how those data models relate to the UI
-  belong in the ``app/java/com/mongodb/tasktracker/models`` directory.
 
 ---
 title: Connect to Your MongoDB Realm App
@@ -322,12 +323,12 @@ content: |
   Finally, we need to guarantee that ``ProjectActivity`` always closes
   the user {+realm+} when the app closes or the user logs out. To
   accomplish this, add logic that calls the ``realm.close()`` method
-  when ``ProjectActivity`` finishes or stops:
-
-  .. literalinclude:: /tutorial/generated/code/final/ProjectActivity.codeblock.on-destroy-close-realm.kt
-     :language: kotlin
+  when ``ProjectActivity`` stops or finishes:
 
   .. literalinclude:: /tutorial/generated/code/final/ProjectActivity.codeblock.on-stop-close-realm.kt
+     :language: kotlin
+
+  .. literalinclude:: /tutorial/generated/code/final/ProjectActivity.codeblock.on-destroy-close-realm.kt
      :language: kotlin
 
 ---
@@ -427,7 +428,7 @@ content: |
   Navigate to ``MemberActivity``, which defines the view
   that pops up when a user clicks the "options" action on their project
   in ``ProjectActivity``. Just like ``ProjectActivity`` and
-  ``ProjectActivity``, ``MemberActivity`` fetches the data for the
+  ``TaskActivity``, ``MemberActivity`` fetches the data for the
   Recycler View in the ``setUpRecyclerView`` method. However, instead of
   querying against a realm, we'll instead use a call to the
   ``getMyTeamMembers`` function. This function returns a list of team


### PR DESCRIPTION
## Pull Request Info

Few more minor tweaks:
- Move a paragraph describing where logic is stored to above the list of files, so users have a bit more orientation as to what's where in the project structure _before_ they start going through the files. Change `models` to `model` to match the project structure
- The todos in the `ProjectActivity.kt` for `onStop()` and `onDestroy()` are in the opposite order as they're listed here in the tutorial doc. Swapping stop/destroy code snippets here in the tutorial doc so they're in the same order in both places.
- `ProjectActivity` was listed twice in one section, but I think one of them was supposed to be `TaskActivity` so I've swapped it here

### Jira

- https://jira.mongodb.org/browse/DOCSP-16175

### Staged Changes (Requires MongoDB Corp SSO)

- [Android Kotlin Tutorial](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16175/tutorial/android-kotlin/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
