### PR TITLE
(DOCSP-16234): Warn against using cryptographically-weak hashes on SDK encryption pages

### DIFF
--- a/source/includes/encrypt-use-strong-cryptographic-hash.rst
+++ b/source/includes/encrypt-use-strong-cryptographic-hash.rst
@@ -1,5 +1,5 @@
 .. warning::
 
-   Do not use cryptographically weak hashes for the encryption key. For 
+   Do not use cryptographically-weak hashes for the encryption key. For 
    optimal security, we recommend generating random rather than derived 
    encryption keys.

--- a/source/includes/encrypt-use-strong-cryptographic-hash.rst
+++ b/source/includes/encrypt-use-strong-cryptographic-hash.rst
@@ -1,5 +1,5 @@
 .. warning::
 
-   Do not use cryptographically-weak hashes for the encryption key. For 
-   optimal security, we recommend generating random rather than derived 
+   Do not use cryptographically-weak hashes for {+realm+} encryption keys. 
+   For optimal security, we recommend generating random rather than derived 
    encryption keys.

--- a/source/includes/encrypt-use-strong-cryptographic-hash.rst
+++ b/source/includes/encrypt-use-strong-cryptographic-hash.rst
@@ -1,0 +1,5 @@
+.. warning::
+
+   Do not use cryptographically weak hashes for the encryption key. For 
+   optimal security, we recommend generating random rather than derived 
+   encryption keys.

--- a/source/sdk/android/advanced-guides/encryption.txt
+++ b/source/sdk/android/advanced-guides/encryption.txt
@@ -23,6 +23,8 @@ uses the other 256 bits of the 512-bit encryption key to validate
 integrity using a :wikipedia:`hash-based message authentication code
 (HMAC) <HMAC>`.
 
+.. include:: /includes/encrypt-use-strong-cryptographic-hash.rst
+
 Considerations
 --------------
 

--- a/source/sdk/dotnet/examples/encrypt-a-realm.txt
+++ b/source/sdk/dotnet/examples/encrypt-a-realm.txt
@@ -29,6 +29,8 @@ see :ref:`dotnet-realm-encryption`.
 Example
 -------
 
+.. include:: /includes/encrypt-use-strong-cryptographic-hash.rst
+
 The following code demonstrates how to generate an encryption key and
 open an encrypted {+realm+}:
 

--- a/source/sdk/ios/advanced-guides/encrypt-a-realm.txt
+++ b/source/sdk/ios/advanced-guides/encrypt-a-realm.txt
@@ -26,6 +26,8 @@ uses the other 256 bits of the 512-bit encryption key to validate
 integrity using a :wikipedia:`hash-based message authentication code
 (HMAC) <HMAC>`.
 
+.. include:: /includes/encrypt-use-strong-cryptographic-hash.rst
+
 Considerations
 --------------
 

--- a/source/sdk/node/advanced/encrypt.txt
+++ b/source/sdk/node/advanced/encrypt.txt
@@ -26,6 +26,8 @@ uses the other 256 bits of the 512-bit encryption key to validate
 integrity using a :wikipedia:`hash-based message authentication code
 (HMAC) <HMAC>`.
 
+.. include:: /includes/encrypt-use-strong-cryptographic-hash.rst
+
 Considerations
 --------------
 

--- a/source/sdk/react-native/advanced/encrypt.txt
+++ b/source/sdk/react-native/advanced/encrypt.txt
@@ -26,6 +26,8 @@ uses the other 256 bits of the 512-bit encryption key to validate
 integrity using a :wikipedia:`hash-based message authentication code
 (HMAC) <HMAC>`.
 
+.. include:: /includes/encrypt-use-strong-cryptographic-hash.rst
+
 Considerations
 --------------
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-16234

### Staged Changes (Requires MongoDB Corp SSO)

This is one new warning inserted as an include on all of the SDK encryption pages:

- [Encrypt a Realm - Android](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16234/sdk/android/advanced-guides/encryption/)
- [Encrypt a Realm - iOS](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16234/sdk/ios/advanced-guides/encrypt-a-realm/)
- [Encrypt a Realm - .Net](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16234/sdk/dotnet/examples/encrypt-a-realm/)
- [Encrypt a Realm - Node.js](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16234/sdk/node/)
- [Encrypt a Realm - React Native](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16234/sdk/react-native/advanced/encrypt/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
