### PR TITLE
(DOCSP-13175): Update Apple ID Authentication walkthrough, add tip to SDKs

### DIFF
--- a/source/authentication/apple.txt
+++ b/source/authentication/apple.txt
@@ -30,9 +30,10 @@ object may also include the user's name and email address.
 For additional information on how to implement Sign in with Apple, check
 out:
 
-- The official :apple:`Sign in with Apple documentation <sign-in-with-apple/>` on Apple's Developer Portal
-- The `Introducing Sign In with Apple <https://developer.apple.com/videos/play/wwdc2019/706>`_ session from
-WWDC 2019
+- The official :apple:`Sign in with Apple documentation <sign-in-with-apple/>` 
+  on Apple's Developer Portal
+- The `Introducing Sign In with Apple <https://developer.apple.com/videos/play/wwdc2019/706>`_ 
+  session from WWDC 2019
 - The associated `reference application <https://developer.apple.com/documentation/authenticationservices/adding_the_sign_in_with_apple_flow_to_your_app>`_.
 
 .. note::

--- a/source/authentication/apple.txt
+++ b/source/authentication/apple.txt
@@ -28,10 +28,12 @@ user. If the user has granted permissions to your app, the credential
 object may also include the user's name and email address.
 
 For additional information on how to implement Sign in with Apple, check
-out the `Introducing Sign In with Apple
-<https://developer.apple.com/videos/play/wwdc2019/706>`_ session from
-WWDC 2019 and the associated `reference application
-<https://developer.apple.com/documentation/authenticationservices/adding_the_sign_in_with_apple_flow_to_your_app>`_.
+out:
+
+- The official :apple:`Sign in with Apple documentation <sign-in-with-apple/>` on Apple's Developer Portal
+- The `Introducing Sign In with Apple <https://developer.apple.com/videos/play/wwdc2019/706>`_ session from
+WWDC 2019
+- The associated `reference application <https://developer.apple.com/documentation/authenticationservices/adding_the_sign_in_with_apple_flow_to_your_app>`_.
 
 .. note::
    

--- a/source/includes/authorization-appleidcredential-string.rst
+++ b/source/includes/authorization-appleidcredential-string.rst
@@ -1,0 +1,5 @@
+.. tip::
+   
+   If you get a ``Login failed`` error saying that the ``token contains 
+   an invalid number of segments``, verify that you're passing a UTF-8-encoded 
+   string version of the JWT.

--- a/source/includes/steps-apple-auth-configure.yaml
+++ b/source/includes/steps-apple-auth-configure.yaml
@@ -24,6 +24,10 @@ content: |
    6. Scroll down the :guilabel:`Register an App ID` page until you see
       the :guilabel:`Sign in with Apple` capability. Check the checkbox
       to enable the capability.
+
+   7. Press the :guilabel:`Continue` button at the top of the page. Complete
+      any other setup steps that apply to your app, and then press the 
+      :guilabel:`Register` button.
 ---
 title: Create a Services ID
 ref: create-a-services-id
@@ -49,11 +53,17 @@ content: |
          application's :guilabel:`Client ID`. You will need this value
          later to configure the Apple ID provider in {+service-short+}.
 
-   5. Check the checkbox to enable :guilabel:`Sign in with Apple` and
-      then click :guilabel:`Configure`. Select the App ID that you
-      created as the :guilabel:`Primary App ID`.
+      Press the :guilabel:`Continue` button. Confirm the details, and
+      then press :guilabel:`Register`.
+
+   5. Click into the service you just created. Check the checkbox to enable 
+      :guilabel:`Sign in with Apple` and then click :guilabel:`Configure`. 
+      Select the App ID that you created as the :guilabel:`Primary App ID`.
+
+   6. Enter your domains, subdomains, and return URLs for the Services ID.
+      Press the :guilabel:`Next` button.  
    
-   6. Click :guilabel:`Save` and then click :guilabel:`Continue`.
+   6. Click :guilabel:`Continue` and then click :guilabel:`Save` .
       Confirm that you have correctly configured the Services ID and
       then click :guilabel:`Register`.
 ---
@@ -196,8 +206,9 @@ content: |
          
          2. Turn on the :guilabel:`Provider Enabled` toggle.
          
-         3. For :guilabel:`Client ID`, enter the :guilabel:`Services ID`
-            that you created.
+         3. For the {+service-short+} :guilabel:`Client ID`, enter the 
+            Apple :guilabel:`Services ID` you got when you created a
+            Services ID in step 2.
          
          4. For :guilabel:`Client Secret`, create a new :ref:`secret
             <app-secret>` with a descriptive name and set the
@@ -255,7 +266,8 @@ content: |
          
                 | *config.clientId*
          
-              - Required. The :guilabel:`Services ID` that you created.
+              - Required. The Apple :guilabel:`Services ID` that you created
+                when you completed step 2 above.
          
             * - :guilabel:`Client Secret`
          

--- a/source/includes/steps-apple-auth-configure.yaml
+++ b/source/includes/steps-apple-auth-configure.yaml
@@ -9,23 +9,23 @@ content: |
       page of the `Apple Developer Portal
       <https://developer.apple.com/account>`_.
 
-   2. Click :guilabel:`Identifiers` in the {+leftnav+}.
+   #. Click :guilabel:`Identifiers` in the {+leftnav+}.
 
-   3. Click the blue plus icon next to :guilabel:`Identifiers`.
+   #. Click the blue plus icon next to :guilabel:`Identifiers`.
 
-   4. On the :guilabel:`Register a New Identifier` page, select
+   #. On the :guilabel:`Register a New Identifier` page, select
       :guilabel:`App IDs` and then click :guilabel:`Continue`.
 
-   5. On the :guilabel:`Register an App ID` page, select
+   #. On the :guilabel:`Register an App ID` page, select
       the :guilabel:`Platform` that your app runs on and then enter a
       brief :guilabel:`Description` and a :wikipedia:`reverse-dns
       notation <Reverse_domain_name_notation>` :guilabel:`Bundle ID`.
    
-   6. Scroll down the :guilabel:`Register an App ID` page until you see
+   #. Scroll down the :guilabel:`Register an App ID` page until you see
       the :guilabel:`Sign in with Apple` capability. Check the checkbox
       to enable the capability.
 
-   7. Press the :guilabel:`Continue` button at the top of the page. Complete
+   #. Press the :guilabel:`Continue` button at the top of the page. Complete
       any other setup steps that apply to your app, and then press the 
       :guilabel:`Register` button.
 ---
@@ -38,12 +38,12 @@ content: |
 
    1. Click :guilabel:`Identifiers` in the {+leftnav+}.
 
-   2. Click the blue plus icon next to :guilabel:`Identifiers`.
+   #. Click the blue plus icon next to :guilabel:`Identifiers`.
 
-   3. On the :guilabel:`Register a New Identifier` page, select
+   #. On the :guilabel:`Register a New Identifier` page, select
       :guilabel:`Services IDs` and then click :guilabel:`Continue`.
 
-   4. On the :guilabel:`Register a Services ID` page, enter a brief
+   #. On the :guilabel:`Register a Services ID` page, enter a brief
       :guilabel:`Description` and a :wikipedia:`reverse-dns notation
       <Reverse_domain_name_notation>` :guilabel:`Identifier`.
 
@@ -56,14 +56,14 @@ content: |
       Press the :guilabel:`Continue` button. Confirm the details, and
       then press :guilabel:`Register`.
 
-   5. Click into the service you just created. Check the checkbox to enable 
+   #. Click into the service you just created. Check the checkbox to enable 
       :guilabel:`Sign in with Apple` and then click :guilabel:`Configure`. 
       Select the App ID that you created as the :guilabel:`Primary App ID`.
 
-   6. Enter your domains, subdomains, and return URLs for the Services ID.
+   #. Enter your domains, subdomains, and return URLs for the Services ID.
       Press the :guilabel:`Next` button.  
    
-   6. Click :guilabel:`Continue` and then click :guilabel:`Save` .
+   #. Click :guilabel:`Continue` and then click :guilabel:`Save`.
       Confirm that you have correctly configured the Services ID and
       then click :guilabel:`Register`.
 ---
@@ -76,25 +76,25 @@ content: |
    
    1. Click :guilabel:`Keys` in the {+leftnav+}.
    
-   2. Click the blue plus icon next to :guilabel:`Keys`.
+   #. Click the blue plus icon next to :guilabel:`Keys`.
    
-   3. On the :guilabel:`Register a New Key` page, enter a descriptive
+   #. On the :guilabel:`Register a New Key` page, enter a descriptive
       :guilabel:`Key Name` and then scroll down to find the
       :guilabel:`Sign in with Apple` row. Check the checkbox to enable
       Sign in with Apple and then click :guilabel:`Configure`.
    
-   4. On the :guilabel:`Configure Key` page, select the App ID that you
+   #. On the :guilabel:`Configure Key` page, select the App ID that you
       created as the :guilabel:`Primary App ID` and then click
       :guilabel:`Save`.
       
       .. figure:: /images/apple-auth-configure-key.png
          :alt: The Configure Key page in the Apple Developer Portal
    
-   5. Click :guilabel:`Continue` to review your key configuration. When
+   #. Click :guilabel:`Continue` to review your key configuration. When
       you're sure that you've configured the key correctly, click
       :guilabel:`Register`.
    
-   6. Copy the :guilabel:`Key ID` value somewhere that you can access it
+   #. Copy the :guilabel:`Key ID` value somewhere that you can access it
       later and then click :guilabel:`Download` to download the key as a
       ``.p8`` text file. You will use these to generate the client
       secret.
@@ -204,26 +204,26 @@ content: |
          1. Click :guilabel:`Authentication` in the {+leftnav+} and
             then click :guilabel:`Apple ID`.
          
-         2. Turn on the :guilabel:`Provider Enabled` toggle.
+         #. Turn on the :guilabel:`Provider Enabled` toggle.
          
-         3. For the {+service-short+} :guilabel:`Client ID`, enter the 
+         #. For the {+service-short+} :guilabel:`Client ID`, enter the 
             Apple :guilabel:`Services ID` you got when you created a
-            Services ID in step 2.
+            :guilabel:`Services ID` in step 2 above.
          
-         4. For :guilabel:`Client Secret`, create a new :ref:`secret
+         #. For :guilabel:`Client Secret`, create a new :ref:`secret
             <app-secret>` with a descriptive name and set the
             :guilabel:`Client Secret Value` to the JWT string that you
             generated. Alternatively, you can select a pre-existing
             secret that contains the JWT.
          
-         5. For :guilabel:`Redirect URIs`, click :guilabel:`Add Redirect
+         #. For :guilabel:`Redirect URIs`, click :guilabel:`Add Redirect
             URI` and enter the URL that {+service-short+} should redirect to once
             the OAuth process is complete. Provide a URL for a domain
             that you control and then use a `universal link
             <https://developer.apple.com/library/content/documentation/General/Conceptual/AppSearch/UniversalLinks.html>`_
             to redirect the user back to your app.
 
-         6. Click :guilabel:`Save` to finish configuring the provider.
+         #. Click :guilabel:`Save` to finish configuring the provider.
             To make the provider available to client applications, you
             need to deploy your changes. Click :guilabel:`Review &
             Deploy Changes` and then click :guilabel:`Deploy`.

--- a/source/sdk/android/examples/authenticate-users.txt
+++ b/source/sdk/android/examples/authenticate-users.txt
@@ -302,6 +302,8 @@ to ``app.login()`` or ``app.loginAsync()``.
       .. literalinclude:: /examples/generated/android/sync/AuthenticationTest.codeblock.apple.kt
          :language: kotlin
 
+.. include:: /includes/authorization-appleidcredential-string.rst
+
 .. _android-logout:
 
 Log a User Out

--- a/source/sdk/dotnet/examples/authenticate.txt
+++ b/source/sdk/dotnet/examples/authenticate.txt
@@ -126,6 +126,8 @@ you can log in using the following code:
 .. literalinclude:: /examples/generated/dotnet/Examples.codeblock.logon_apple.cs
    :language: csharp
 
+.. include:: /includes/authorization-appleidcredential-string.rst
+
 .. _dotnet-logout:
 
 Log a User Out

--- a/source/sdk/ios/examples/authenticate-users.txt
+++ b/source/sdk/ios/examples/authenticate-users.txt
@@ -139,6 +139,8 @@ If you have enabled :ref:`Sign-in with Apple authentication
 .. literalinclude:: /examples/generated/code/start/Authenticate.codeblock.apple.swift
    :language: swift
 
+.. include:: /includes/authorization-appleidcredential-string.rst
+
 .. _ios-logout:
 
 Log Out

--- a/source/sdk/node/examples/authenticate-users.txt
+++ b/source/sdk/node/examples/authenticate-users.txt
@@ -301,6 +301,8 @@ use to finish logging the user in to your app.
            console.log(`Logged in with id: ${user.id}`);
          });
 
+.. include:: /includes/authorization-appleidcredential-string.rst
+
 .. _node-logout:
 
 Log a User Out

--- a/source/sdk/react-native/examples/authenticate-users.txt
+++ b/source/sdk/react-native/examples/authenticate-users.txt
@@ -301,6 +301,8 @@ use to finish logging the user in to your app.
            console.log(`Logged in with id: ${user.id}`);
          });
 
+.. include:: /includes/authorization-appleidcredential-string.rst
+
 .. _react-native-logout:
 
 Log a User Out

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -729,6 +729,8 @@ an ID token that you can use to finish logging the user in to your app.
              console.log(`Logged in with id: ${user.id}`);
            });
 
+.. include:: /includes/authorization-appleidcredential-string.rst
+
 .. _web-logout:
 
 Log Out


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-13175

### Staged Changes (Requires MongoDB Corp SSO)

- [Apple ID Authentication](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13175/authentication/apple/)

New tip added to all of the SDK authentication pages:
- [Authenticate Users - Android SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13175/sdk/android/examples/authenticate-users/#apple-user)
- [Authenticate Users - iOS SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13175/sdk/ios/examples/authenticate-users/#apple-user)
- [Authenticate Users - .Net SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13175/sdk/dotnet/examples/authenticate/#apple-user)
- [Authenticate Users - Node SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13175/sdk/node/examples/authenticate-users/#apple-user)
- [Authenticate Users - React Native SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13175/sdk/react-native/examples/authenticate-users/#apple-user)
- [Authenticate Users - Web SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13175/web/authenticate/#authenticate-with-the-apple-sdk)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
