### PR TITLE
(DOCSP-10137): Clarify that wire protocol is for languages without SDKs

### DIFF
--- a/source/mongodb/connect-over-the-wire-protocol.txt
+++ b/source/mongodb/connect-over-the-wire-protocol.txt
@@ -27,7 +27,7 @@ data access rules <mongodb-rules>`, :doc:`functions </functions>`, and
 
 This is a good choice for languages that do not currently have a {+service-short+} 
 SDK. The examples here are for Python, C++11, and the Mongo Shell. Any 
-:driver:`MongoDB driver` that supports the ``appName`` connection 
+:driver:`MongoDB driver <>` that supports the ``appName`` connection 
 string parameter can use the wire protocol to connect to {+service+}.
 
 Prerequisites

--- a/source/mongodb/connect-over-the-wire-protocol.txt
+++ b/source/mongodb/connect-over-the-wire-protocol.txt
@@ -27,8 +27,9 @@ data access rules <mongodb-rules>`, :doc:`functions </functions>`, and
 
 This is a good choice for languages that do not currently have a {+service-short+} 
 SDK. The examples here are for Python, C++11, and the Mongo Shell. Any 
-:driver:`MongoDB driver <>` that supports the ``appName`` connection 
-string parameter can use the wire protocol to connect to {+service+}.
+`MongoDB driver <https://docs.mongodb.com/drivers/>`_ that supports the 
+``appName`` connection string parameter can use the wire protocol to 
+connect to {+service+}.
 
 Prerequisites
 ~~~~~~~~~~~~~

--- a/source/mongodb/connect-over-the-wire-protocol.txt
+++ b/source/mongodb/connect-over-the-wire-protocol.txt
@@ -25,6 +25,11 @@ most client features over the wire protocol, including :ref:`role-based
 data access rules <mongodb-rules>`, :doc:`functions </functions>`, and
 :ref:`service actions <service-actions>`.
 
+This is a good choice for languages that do not currently have a {+service-short+} 
+SDK. The examples here are for Python, C++11, and the Mongo Shell. Any 
+:driver:`MongoDB driver` that supports the ``appName`` connection 
+string parameter can use the wire protocol to connect to {+service+}.
+
 Prerequisites
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-10137

### Staged Changes (Requires MongoDB Corp SSO)

- [Connect Over the Wire Protocol](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-10137/mongodb/connect-over-the-wire-protocol/): Second paragraph in the overview is new

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
