### PR TITLE
(DOCS-14165): Add Atlas Project Owner requirement to create/import Realm App procedures

### DIFF
--- a/source/deploy/create-with-cli.txt
+++ b/source/deploy/create-with-cli.txt
@@ -30,7 +30,8 @@ Prerequisites
     <https://docs.atlas.mongodb.com/tutorial/manage-project-settings/>`_.
 
 - A `{+atlas+} <https://www.mongodb.com/realm?tck=realm-docs#atlas-form-container>`_ :atlas:`programmatic API key </configure-api-access/#programmatic-api-keys>` for the MongoDB Cloud
-  account you wish to log in with.
+  account you wish to log in with. You must be a :atlas:`Project Owner <reference/user-roles/#project-roles>` 
+  to create a {+app+}.
 
 Procedure
 ---------

--- a/source/deploy/create-with-cli.txt
+++ b/source/deploy/create-with-cli.txt
@@ -30,7 +30,7 @@ Prerequisites
     <https://docs.atlas.mongodb.com/tutorial/manage-project-settings/>`_.
 
 - A `{+atlas+} <https://www.mongodb.com/realm?tck=realm-docs#atlas-form-container>`_ :atlas:`programmatic API key </configure-api-access/#programmatic-api-keys>` for the MongoDB Cloud
-  account you wish to log in with. You must be a :atlas:`Project Owner <reference/user-roles/#project-roles>` 
+  account you wish to log in with. You must be a :atlas:`Project Owner </reference/user-roles/#project-roles>` 
   to create a {+app+}.
 
 Procedure

--- a/source/deploy/realm-cli-reference.txt
+++ b/source/deploy/realm-cli-reference.txt
@@ -176,6 +176,11 @@ hosted {+app+}. If you import a directory into an application
 that doesn't exist, {+cli-bin+} can :doc:`create the application
 </deploy/create-with-cli>` for you.
 
+.. tip::
+
+   You must be a ``Project Owner`` to import a {+app+}. For more info, 
+   see: :atlas:`Atlas User Roles <reference/user-roles/#project-roles>`.
+
 .. code-block:: shell
 
    realm-cli import \

--- a/source/deploy/realm-cli-reference.txt
+++ b/source/deploy/realm-cli-reference.txt
@@ -179,7 +179,7 @@ that doesn't exist, {+cli-bin+} can :doc:`create the application
 .. tip::
 
    You must be a ``Project Owner`` to import a {+app+}. For more info, 
-   see: :atlas:`Atlas User Roles <reference/user-roles/#project-roles>`.
+   see: :atlas:`Atlas User Roles </reference/user-roles/#project-roles>`.
 
 .. code-block:: shell
 

--- a/source/get-started/create-realm-app.txt
+++ b/source/get-started/create-realm-app.txt
@@ -21,7 +21,7 @@ backend instance for your mobile or web application.
 
 Prerequisites
 -------------
-Before you begin, you will need a
+Before you begin, you must be a ``Project Owner`` in a 
 `{+atlas+} <https://cloud.mongodb.com/user/register?tck=docs_realm>`_ account.
 You can learn more about creating an |atlas| account in the
 :atlas:`Atlas Getting Started </getting-started>`


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCS-14165

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm CLI Reference -> Import an Application](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCS-14165/deploy/realm-cli-reference/#import-an-application): Added a tip with Project Owner requirement and a link to Atlas docs
- [Create a Realm App with Realm CLI](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCS-14165/deploy/create-with-cli/): Added a "Project Owner" requirement line to the prerequisite about having a programmatic API key, with a link to the Atlas docs
- [Create a Realm App (Realm UI)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCS-14165/get-started/create-realm-app/) Added "Project Owner" requirement to the prerequisites

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
