### PR TITLE
remove flipper

### DIFF
--- a/tutorial/rn/ios/Podfile
+++ b/tutorial/rn/ios/Podfile
@@ -17,10 +17,10 @@ target 'rn' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
-  post_install do |installer|
-    flipper_post_install(installer)
-  end
+ # use_flipper!
+ # post_install do |installer|
+ #   flipper_post_install(installer)
+ #  end
 end
 
 target 'rn-tvOS' do


### PR DESCRIPTION
## Pull Request Info

why are we making our docs users go through an extra step to run the app? the final app should be as close to clone and go as possible - it seems odd to include this since we do not support flpper 

### Jira

- https://jira.mongodb.org/browse/DOCSP-NNNNN

### Staged Changes (Requires MongoDB Corp SSO)

- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/BRANCH_NAME/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
