### PR TITLE
Quick fix: JS links on field-types page

### DIFF
--- a/source/sdk/node/data-types/field-types.txt
+++ b/source/sdk/node/data-types/field-types.txt
@@ -23,7 +23,7 @@ Field Types - Node.js SDK
 - ``date`` maps to the JavaScript :mdn:`Date <Web/JavaScript/Reference/Global_Objects/Date>` type.
 - ``list`` maps to the JavaScript :mdn:`Array <Web/JavaScript/Reference/Global_Objects/Array>` type. You can also specify that a field contains a list of primitive value types by appending ``[]`` to the type name.
 - ``linkingObjects`` is a special type used to define an inverse relationship.
-- ``uuid`` is a universally unique identifier from :js-sdk:`Realm.BSON <Realm.html#.BSON>`. The ``UUID`` data type is available in the :js-sdk:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
-- ``set`` is based on the JavaScript :mdn:`Set <Web/JavaScript/Reference/Global_Objects/Set>` type. ``{+service-short+} Set`` is available in the :js-sdk:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
-- ``dictionary`` used to manage a collection of unique String keys paired with values. The ``Dictionary`` data type is available in the :js-sdk:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
-- ``mixed`` is a property type that can hold different data types. The ``Mixed`` data type is available in the :js-sdk:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
+- ``uuid`` is a universally unique identifier from :js-sdk:`Realm.BSON <Realm.html#.BSON>`. The ``UUID`` data type is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
+- ``set`` is based on the JavaScript :mdn:`Set <Web/JavaScript/Reference/Global_Objects/Set>` type. ``{+service-short+} Set`` is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
+- ``dictionary`` used to manage a collection of unique String keys paired with values. The ``Dictionary`` data type is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
+- ``mixed`` is a property type that can hold different data types. The ``Mixed`` data type is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.


### PR DESCRIPTION
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/realm-js-link-fix/sdk/node/data-types/field-types/