### PR TITLE
Bullet point-ify seealso

### DIFF
--- a/source/sdk/android/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/android/fundamentals/object-models-and-schemas.txt
@@ -193,8 +193,8 @@ nullable, and cannot be made required.
 
 .. seealso::
 
-   :ref:`Usage Example: Required Fields <android-required-field>`
-   :ref:`Usage Example: Optional Fields <android-optional-field>`
+   - :ref:`Usage Example: Required Fields <android-required-field>`
+   - :ref:`Usage Example: Optional Fields <android-optional-field>`
 
 .. _android-relationships-fundamentals:
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-16060

### Staged Changes (Requires MongoDB Corp SSO)

"See also" links on the "fundamentals" Object Models and Schemas page don't link to the correct location in the "examples" Define a Realm Object Model page.
- [All "See also" links on this page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16060/sdk/android/fundamentals/object-models-and-schemas/#primary-keys)
- [anchors on this page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16060/sdk/android/examples/define-a-realm-object-model/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
