### PR TITLE
(DOCSP-15057): Indicate punycode support in built-in modules

### DIFF
--- a/source/functions/built-in-module-support.txt
+++ b/source/functions/built-in-module-support.txt
@@ -39,6 +39,19 @@ Fully Supported Modules
 - :nodejs:`os <docs/v10.18.1/api/os.html>`
 - :nodejs:`path <docs/v10.18.1/api/path.html>`
 - :github:`punycode <bestiejs/punycode.js>`
+
+  .. note::
+  
+    The built-in :nodejs:`punycode module is deprecated
+    <docs/v10.18.1/api/punycode.html>`. However, {+service-short+}
+    provides the :github:`userland punycode module
+    <bestiejs/punycode.js>` automatically. You can import the module
+    with:
+    
+    .. code-block:: javascript
+    
+       const punycode = require("punycode");
+
 - :nodejs:`querystring <docs/v10.18.1/api/querystring.html>`
 - :nodejs:`stream <docs/v10.18.1/api/stream.html>`
 - :nodejs:`string_decoder <docs/v10.18.1/api/string_decoder.html>`

--- a/source/functions/built-in-module-support.txt
+++ b/source/functions/built-in-module-support.txt
@@ -38,6 +38,7 @@ Fully Supported Modules
 - :nodejs:`net <docs/v10.18.1/api/net.html>`
 - :nodejs:`os <docs/v10.18.1/api/os.html>`
 - :nodejs:`path <docs/v10.18.1/api/path.html>`
+- :github:`punycode <bestiejs/punycode.js>`
 - :nodejs:`querystring <docs/v10.18.1/api/querystring.html>`
 - :nodejs:`stream <docs/v10.18.1/api/stream.html>`
 - :nodejs:`string_decoder <docs/v10.18.1/api/string_decoder.html>`
@@ -150,7 +151,6 @@ modules:
 - ``child_process``
 - ``cluster``
 - ``domain``
-- ``punycode``
 - ``readline``
 - ``v8``
 - ``vm``


### PR DESCRIPTION
- Note: built-in punycode is actually deprecated in node (see https://nodejs.org/docs/v10.18.1/api/punycode.html)
- Confirmed in realm-users that the userland version is supported

## Pull Request Info

### Jira

https://jira.mongodb.org/browse/DOCSP-15057

### Staged Changes (Requires MongoDB Corp SSO)

https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/punycode/functions/built-in-module-support/#fully-supported-modules

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
