### PR TITLE
(DOCSP-16339): Java SDK 'new' data type notifications

### DIFF
--- a/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/java/DataTypesTest.java
+++ b/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/java/DataTypesTest.java
@@ -98,7 +98,8 @@ public class DataTypesTest extends RealmTest {
                 persons.getPeople().add("Mat");
 
                 frog.setBestFriend(RealmAny.valueOf(persons));
-                Log.v("EXAMPLE", "Best friend: " + frog.getBestFriend().asRealmModel(GroupOfPeople.class).getPeople().toString());
+                Log.v("EXAMPLE", "Best friend: " +
+                        frog.getBestFriend().asRealmModel(GroupOfPeople.class).getPeople().toString());
                 // :code-block-end:
                 // :replace-end:
                 expectation.fulfill();
@@ -157,7 +158,7 @@ public class DataTypesTest extends RealmTest {
                 // set RealmAny field to a string with RealmAny.valueOf a string value
                 frog.get().setBestFriend(RealmAny.valueOf("Greg"));
 
-                expectation.fulfill();
+                expectation.fulfill(); // :hide
             });
             // :code-block-end:
             // :replace-end:
@@ -281,7 +282,7 @@ public class DataTypesTest extends RealmTest {
                 verySmallRocks.setName("verySmallRocks");
                 set.addAll(Arrays.asList(water, verySmallRocks));
 
-                expectation.fulfill();
+                expectation.fulfill(); // :hide
             });
             // :code-block-end:
             // :replace-end:
@@ -408,7 +409,7 @@ public class DataTypesTest extends RealmTest {
                 beatrice.setName("Beatrice");
                 dictionary.putAll(Map.of("small frog", greg, "feathered frog", beatrice));
 
-                expectation.fulfill();
+                expectation.fulfill(); // :hide
             });
             // :code-block-end:
             // :replace-end:

--- a/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/java/DataTypesTest.java
+++ b/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/java/DataTypesTest.java
@@ -158,7 +158,7 @@ public class DataTypesTest extends RealmTest {
                 // set RealmAny field to a string with RealmAny.valueOf a string value
                 frog.get().setBestFriend(RealmAny.valueOf("Greg"));
 
-                expectation.fulfill(); // :hide
+                expectation.fulfill(); // :hide:
             });
             // :code-block-end:
             // :replace-end:
@@ -282,7 +282,7 @@ public class DataTypesTest extends RealmTest {
                 verySmallRocks.setName("verySmallRocks");
                 set.addAll(Arrays.asList(water, verySmallRocks));
 
-                expectation.fulfill(); // :hide
+                expectation.fulfill(); // :hide:
             });
             // :code-block-end:
             // :replace-end:
@@ -409,7 +409,7 @@ public class DataTypesTest extends RealmTest {
                 beatrice.setName("Beatrice");
                 dictionary.putAll(Map.of("small frog", greg, "feathered frog", beatrice));
 
-                expectation.fulfill(); // :hide
+                expectation.fulfill(); // :hide:
             });
             // :code-block-end:
             // :replace-end:

--- a/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/DataTypesTest.kt
+++ b/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/DataTypesTest.kt
@@ -129,7 +129,7 @@ class DataTypesTest : RealmTest() {
 
                 // set RealmAny field to a string with RealmAny.valueOf a string value
                 frog?.bestFriend = RealmAny.valueOf("Greg")
-                expectation.fulfill() // :hide
+                expectation.fulfill() // :hide:
             }
             // :code-block-end:
             // :replace-end:
@@ -226,6 +226,7 @@ class DataTypesTest : RealmTest() {
                 frog = realm.createObject(FrogSetKt::class.java)
                 frog?.name = "Jonathan Livingston Applesauce"
             }
+
             val setChangeListener: SetChangeListener<SnackKt>
                     = SetChangeListener<SnackKt> { set, changes ->
                 Log.v("EXAMPLE", "Set changed: " +
@@ -233,6 +234,7 @@ class DataTypesTest : RealmTest() {
                         changes.numberOfDeletions + " items removed.")
             }
             frog?.favoriteSnacks?.addChangeListener(setChangeListener)
+
             realm.executeTransaction { r: Realm? ->
                 // get the RealmSet field from the object we just created
                 val set = frog!!.favoriteSnacks
@@ -377,7 +379,7 @@ class DataTypesTest : RealmTest() {
                 dictionary.putAll(mapOf<String, FrogDictionaryKt>(
                         Pair("small frog", greg),
                         Pair("feathered frog", beatrice)))
-                expectation.fulfill() // :hide
+                expectation.fulfill() // :hide:
             }
             // :code-block-end:
             // :replace-end:

--- a/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/DataTypesTest.kt
+++ b/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/DataTypesTest.kt
@@ -3,11 +3,10 @@ package com.mongodb.realm.examples.kotlin
 import android.util.Log
 import com.mongodb.realm.examples.Expectation
 import com.mongodb.realm.examples.RealmTest
+import com.mongodb.realm.examples.model.java.FrogAny
 import com.mongodb.realm.examples.model.java.GroupOfPeople
 import com.mongodb.realm.examples.model.kotlin.*
-import io.realm.Realm
-import io.realm.RealmAny
-import io.realm.RealmConfiguration
+import io.realm.*
 import org.junit.Assert
 import org.junit.Test
 import java.util.*
@@ -84,6 +83,59 @@ class DataTypesTest : RealmTest() {
         expectation.await()
     }
 
+    @Test
+    fun testRealmAnyNotifications() {
+        val expectation = Expectation()
+        activity!!.runOnUiThread {
+            val config = RealmConfiguration.Builder()
+                    .inMemory()
+                    .name("realmany-notification-test-java")
+                    .allowQueriesOnUiThread(true)
+                    .allowWritesOnUiThread(true)
+                    .build()
+            val realm = Realm.getInstance(config)
+
+            // :replace-start: {
+            //    "terms": {
+            //       "FrogAnyKt": "Frog"
+            //    }
+            // }
+            // :code-block-start: realmany-notifications
+            var frog: FrogAnyKt? = null
+
+            realm.executeTransaction { r: Realm? ->
+                frog = realm.createObject(FrogAnyKt::class.java)
+                frog?.name = "Jonathan Livingston Applesauce"
+            }
+
+            val objectChangeListener = RealmObjectChangeListener<FrogAnyKt> { frog, changeSet ->
+                if (changeSet != null) {
+                    Log.v("EXAMPLE", "Changes to fields: " +
+                            changeSet.changedFields)
+                    if (changeSet.isFieldChanged("best_friend")) {
+                        Log.v("EXAMPLE", "RealmAny best friend field changed to : " +
+                                frog.bestFriendToString())
+                    }
+                }
+            }
+
+            frog?.addChangeListener(objectChangeListener)
+
+            realm.executeTransaction { r: Realm? ->
+                // set RealmAny field to a null value
+                frog?.bestFriend = RealmAny.nullValue()
+                Log.v("EXAMPLE", "Best friend: " + frog?.bestFriendToString())
+
+                // set RealmAny field to a string with RealmAny.valueOf a string value
+                frog?.bestFriend = RealmAny.valueOf("Greg")
+                // :code-block-end:
+                // :replace-end:
+                expectation.fulfill()
+            }
+        }
+        expectation.await()
+    }
+
 
     @Test
     fun testRealmSet() {
@@ -141,6 +193,59 @@ class DataTypesTest : RealmTest() {
                 flies.deleteFromRealm()
                 // deleting flies object reduced the size of the set by one
                 Assert.assertTrue(sizeOfSetBeforeDelete == set.size + 1)
+                // :code-block-end:
+                // :replace-end:
+                expectation.fulfill()
+            }
+        }
+        expectation.await()
+    }
+
+    @Test
+    fun testRealmSetNotifications() {
+        val expectation = Expectation()
+        activity!!.runOnUiThread {
+            val config = RealmConfiguration.Builder()
+                    .inMemory()
+                    .name("realmset-test-java")
+                    .allowQueriesOnUiThread(true)
+                    .allowWritesOnUiThread(true)
+                    .build()
+            val realm = Realm.getInstance(config)
+
+            // :replace-start: {
+            //    "terms": {
+            //       "FrogSetKt": "Frog",
+            //       "SnackKt": "Snack"
+            //    }
+            // }
+            // :code-block-start: realmset-notifications
+            var frog :FrogSetKt? = null
+            realm.executeTransaction { r: Realm? ->
+                frog = realm.createObject(FrogSetKt::class.java)
+                frog?.name = "Jonathan Livingston Applesauce"
+            }
+            val setChangeListener: SetChangeListener<SnackKt> = SetChangeListener<SnackKt> { set, changes ->
+                Log.v("EXAMPLE", "Set changed: " +
+                        changes.numberOfInsertions + " new items, " +
+                        changes.numberOfDeletions + " items removed.")
+            }
+            frog?.favoriteSnacks?.addChangeListener(setChangeListener)
+            realm.executeTransaction { r: Realm? ->
+                // get the RealmSet field from the object we just created
+                val set = frog!!.favoriteSnacks
+
+                // add value to the RealmSet
+                val flies = realm.createObject(SnackKt::class.java)
+                flies.name = "flies"
+                set.add(flies)
+
+                // add multiple values to the RealmSet
+                val water = realm.createObject(SnackKt::class.java)
+                water.name = "water"
+                val verySmallRocks = realm.createObject(SnackKt::class.java)
+                verySmallRocks.name = "verySmallRocks"
+                set.addAll(Arrays.asList(water, verySmallRocks))
                 // :code-block-end:
                 // :replace-end:
                 expectation.fulfill()
@@ -211,6 +316,65 @@ class DataTypesTest : RealmTest() {
                 )
                 // but greg object IS now null:
                 Assert.assertEquals(dictionary["small frog"], null)
+                // :code-block-end:
+                // :replace-end:
+                expectation.fulfill()
+            }
+        }
+        expectation.await()
+    }
+
+    @Test
+    fun testRealmDictionaryNotifications() {
+        val expectation = Expectation()
+        activity!!.runOnUiThread {
+            val config = RealmConfiguration.Builder()
+                    .inMemory()
+                    .name("realmdictionary-test-java")
+                    .allowQueriesOnUiThread(true)
+                    .allowWritesOnUiThread(true)
+                    .build()
+            val realm = Realm.getInstance(config)
+
+            // :replace-start: {
+            //    "terms": {
+            //       "FrogDictionaryKt": "Frog"
+            //    }
+            // }
+            // :code-block-start: realmdictionary-notifications
+            var frog: FrogDictionaryKt? = null
+            realm.executeTransaction { r: Realm? ->
+                frog = realm.createObject(FrogDictionaryKt::class.java)
+                frog?.name = "Jonathan Livingston Applesauce"
+            }
+
+            val mapChangeListener: MapChangeListener<String, FrogDictionaryKt> = MapChangeListener<String, FrogDictionaryKt> { map, changes ->
+                for (insertion in changes.insertions) {
+                    Log.v("EXAMPLE",
+                            "Inserted key:  " + insertion +
+                                    ", Inserted value: " + map[insertion]!!.name)
+                }
+            }
+
+            frog?.nicknamesToFriends?.addChangeListener(mapChangeListener)
+
+            realm.executeTransaction { r: Realm? ->
+                // get the RealmDictionary field from the object we just created
+                val dictionary = frog!!.nicknamesToFriends
+
+                // add key/value to the dictionary
+                val wirt = realm.createObject(FrogDictionaryKt::class.java)
+                wirt.name = "Wirt"
+                dictionary["tall frog"] = wirt
+
+                // add multiple keys/values to the dictionary
+                val greg = realm.createObject(FrogDictionaryKt::class.java)
+                greg.name = "Greg"
+                val beatrice = realm.createObject(FrogDictionaryKt::class.java)
+                beatrice.name = "Beatrice"
+                dictionary.putAll(mapOf<String, FrogDictionaryKt>(
+                        Pair("small frog", greg),
+                        Pair("feathered frog", beatrice)))
                 // :code-block-end:
                 // :replace-end:
                 expectation.fulfill()

--- a/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/DataTypesTest.kt
+++ b/examples/android/local/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/DataTypesTest.kt
@@ -108,7 +108,8 @@ class DataTypesTest : RealmTest() {
                 frog?.name = "Jonathan Livingston Applesauce"
             }
 
-            val objectChangeListener = RealmObjectChangeListener<FrogAnyKt> { frog, changeSet ->
+            val objectChangeListener
+                    = RealmObjectChangeListener<FrogAnyKt> { frog, changeSet ->
                 if (changeSet != null) {
                     Log.v("EXAMPLE", "Changes to fields: " +
                             changeSet.changedFields)
@@ -128,10 +129,10 @@ class DataTypesTest : RealmTest() {
 
                 // set RealmAny field to a string with RealmAny.valueOf a string value
                 frog?.bestFriend = RealmAny.valueOf("Greg")
-                // :code-block-end:
-                // :replace-end:
-                expectation.fulfill()
+                expectation.fulfill() // :hide
             }
+            // :code-block-end:
+            // :replace-end:
         }
         expectation.await()
     }
@@ -225,7 +226,8 @@ class DataTypesTest : RealmTest() {
                 frog = realm.createObject(FrogSetKt::class.java)
                 frog?.name = "Jonathan Livingston Applesauce"
             }
-            val setChangeListener: SetChangeListener<SnackKt> = SetChangeListener<SnackKt> { set, changes ->
+            val setChangeListener: SetChangeListener<SnackKt>
+                    = SetChangeListener<SnackKt> { set, changes ->
                 Log.v("EXAMPLE", "Set changed: " +
                         changes.numberOfInsertions + " new items, " +
                         changes.numberOfDeletions + " items removed.")
@@ -246,10 +248,10 @@ class DataTypesTest : RealmTest() {
                 val verySmallRocks = realm.createObject(SnackKt::class.java)
                 verySmallRocks.name = "verySmallRocks"
                 set.addAll(Arrays.asList(water, verySmallRocks))
-                // :code-block-end:
-                // :replace-end:
-                expectation.fulfill()
+                expectation.fulfill() // :hide
             }
+            // :code-block-end:
+            // :replace-end:
         }
         expectation.await()
     }
@@ -348,11 +350,11 @@ class DataTypesTest : RealmTest() {
                 frog?.name = "Jonathan Livingston Applesauce"
             }
 
-            val mapChangeListener: MapChangeListener<String, FrogDictionaryKt> = MapChangeListener<String, FrogDictionaryKt> { map, changes ->
+            val mapChangeListener: MapChangeListener<String, FrogDictionaryKt>
+                    = MapChangeListener<String, FrogDictionaryKt> { map, changes ->
                 for (insertion in changes.insertions) {
                     Log.v("EXAMPLE",
-                            "Inserted key:  " + insertion +
-                                    ", Inserted value: " + map[insertion]!!.name)
+                            "Inserted key:  $insertion, Inserted value: ${map[insertion]!!.name}")
                 }
             }
 
@@ -375,10 +377,10 @@ class DataTypesTest : RealmTest() {
                 dictionary.putAll(mapOf<String, FrogDictionaryKt>(
                         Pair("small frog", greg),
                         Pair("feathered frog", beatrice)))
-                // :code-block-end:
-                // :replace-end:
-                expectation.fulfill()
+                expectation.fulfill() // :hide
             }
+            // :code-block-end:
+            // :replace-end:
         }
         expectation.await()
     }

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.java
@@ -1,0 +1,33 @@
+AtomicReference<Frog> frog = new AtomicReference<Frog>();
+realm.executeTransaction(r -> {
+        frog.set(realm.createObject(Frog.class));
+        frog.get().setName("Jonathan Livingston Applesauce");
+});
+
+RealmObjectChangeListener<Frog> objectChangeListener =
+        new RealmObjectChangeListener<Frog>() {
+    @Override
+    public void onChange(@NotNull Frog frog, @Nullable ObjectChangeSet changeSet) {
+        if (changeSet != null) {
+            Log.v("EXAMPLE", "Changes to fields: " +
+                    Arrays.toString(changeSet.getChangedFields()));
+            if (changeSet.isFieldChanged("best_friend")) {
+                Log.v("EXAMPLE", "RealmAny best friend field changed to : " +
+                        frog.bestFriendToString());
+            }
+        }
+    }
+};
+
+frog.get().addChangeListener(objectChangeListener);
+
+realm.executeTransaction(r -> {
+    // set RealmAny field to a null value
+    frog.get().setBestFriend(RealmAny.nullValue());
+    Log.v("EXAMPLE", "Best friend: " + frog.get().bestFriendToString());
+
+    // set RealmAny field to a string with RealmAny.valueOf a string value
+    frog.get().setBestFriend(RealmAny.valueOf("Greg"));
+
+    expectation.fulfill();
+});

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.java
@@ -29,5 +29,4 @@ realm.executeTransaction(r -> {
     // set RealmAny field to a string with RealmAny.valueOf a string value
     frog.get().setBestFriend(RealmAny.valueOf("Greg"));
 
-    expectation.fulfill(); // :hide
 });

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.java
@@ -29,5 +29,5 @@ realm.executeTransaction(r -> {
     // set RealmAny field to a string with RealmAny.valueOf a string value
     frog.get().setBestFriend(RealmAny.valueOf("Greg"));
 
-    expectation.fulfill();
+    expectation.fulfill(); // :hide
 });

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.kt
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.kt
@@ -1,0 +1,27 @@
+var frog: Frog? = null
+
+realm.executeTransaction { r: Realm? ->
+    frog = realm.createObject(Frog::class.java)
+    frog?.name = "Jonathan Livingston Applesauce"
+}
+
+val objectChangeListener = RealmObjectChangeListener<Frog> { frog, changeSet ->
+    if (changeSet != null) {
+        Log.v("EXAMPLE", "Changes to fields: " +
+                changeSet.changedFields)
+        if (changeSet.isFieldChanged("best_friend")) {
+            Log.v("EXAMPLE", "RealmAny best friend field changed to : " +
+                    frog.bestFriendToString())
+        }
+    }
+}
+
+frog?.addChangeListener(objectChangeListener)
+
+realm.executeTransaction { r: Realm? ->
+    // set RealmAny field to a null value
+    frog?.bestFriend = RealmAny.nullValue()
+    Log.v("EXAMPLE", "Best friend: " + frog?.bestFriendToString())
+
+    // set RealmAny field to a string with RealmAny.valueOf a string value
+    frog?.bestFriend = RealmAny.valueOf("Greg")

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.kt
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.kt
@@ -5,7 +5,8 @@ realm.executeTransaction { r: Realm? ->
     frog?.name = "Jonathan Livingston Applesauce"
 }
 
-val objectChangeListener = RealmObjectChangeListener<Frog> { frog, changeSet ->
+val objectChangeListener
+        = RealmObjectChangeListener<Frog> { frog, changeSet ->
     if (changeSet != null) {
         Log.v("EXAMPLE", "Changes to fields: " +
                 changeSet.changedFields)
@@ -25,3 +26,5 @@ realm.executeTransaction { r: Realm? ->
 
     // set RealmAny field to a string with RealmAny.valueOf a string value
     frog?.bestFriend = RealmAny.valueOf("Greg")
+    expectation.fulfill() // :hide
+}

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.kt
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.kt
@@ -26,5 +26,4 @@ realm.executeTransaction { r: Realm? ->
 
     // set RealmAny field to a string with RealmAny.valueOf a string value
     frog?.bestFriend = RealmAny.valueOf("Greg")
-    expectation.fulfill() // :hide
 }

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmany.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmany.java
@@ -37,4 +37,5 @@
   persons.getPeople().add("Mat");
 
   frog.setBestFriend(RealmAny.valueOf(persons));
-  Log.v("EXAMPLE", "Best friend: " + frog.getBestFriend().asRealmModel(GroupOfPeople.class).getPeople().toString());
+  Log.v("EXAMPLE", "Best friend: " +
+          frog.getBestFriend().asRealmModel(GroupOfPeople.class).getPeople().toString());

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.java
@@ -35,5 +35,4 @@ realm.executeTransaction(r -> {
     beatrice.setName("Beatrice");
     dictionary.putAll(Map.of("small frog", greg, "feathered frog", beatrice));
 
-    expectation.fulfill(); // :hide
 });

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.java
@@ -35,5 +35,5 @@ realm.executeTransaction(r -> {
     beatrice.setName("Beatrice");
     dictionary.putAll(Map.of("small frog", greg, "feathered frog", beatrice));
 
-    expectation.fulfill();
+    expectation.fulfill(); // :hide
 });

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.java
@@ -1,0 +1,39 @@
+AtomicReference<Frog> frog = new AtomicReference<Frog>();
+realm.executeTransaction(r -> {
+    frog.set(realm.createObject(Frog.class));
+    frog.get().setName("Jonathan Livingston Applesauce");
+});
+
+MapChangeListener<String, Frog> mapChangeListener =
+    new MapChangeListener<String, Frog>() {
+        @Override
+        public void onChange(RealmMap<String, Frog> map,
+                             MapChangeSet<String> changes) {
+            for (String insertion : changes.getInsertions()) {
+                Log.v("EXAMPLE",
+                        "Inserted key:  " + insertion +
+                                ", Inserted value: " + map.get(insertion).getName());
+            }
+        }
+    };
+
+frog.get().getNicknamesToFriends().addChangeListener(mapChangeListener);
+
+realm.executeTransaction(r -> {
+    // get the RealmDictionary field from the object we just created
+    RealmDictionary<Frog> dictionary = frog.get().getNicknamesToFriends();
+
+    // add key/value to the dictionary
+    Frog wirt = realm.createObject(Frog.class);
+    wirt.setName("Wirt");
+    dictionary.put("tall frog", wirt);
+
+    // add multiple keys/values to the dictionary
+    Frog greg = realm.createObject(Frog.class);
+    greg.setName("Greg");
+    Frog beatrice = realm.createObject(Frog.class);
+    beatrice.setName("Beatrice");
+    dictionary.putAll(Map.of("small frog", greg, "feathered frog", beatrice));
+
+    expectation.fulfill();
+});

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.kt
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.kt
@@ -31,5 +31,4 @@ realm.executeTransaction { r: Realm? ->
     dictionary.putAll(mapOf<String, Frog>(
             Pair("small frog", greg),
             Pair("feathered frog", beatrice)))
-    expectation.fulfill() // :hide
 }

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.kt
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.kt
@@ -1,0 +1,33 @@
+var frog: Frog? = null
+realm.executeTransaction { r: Realm? ->
+    frog = realm.createObject(Frog::class.java)
+    frog?.name = "Jonathan Livingston Applesauce"
+}
+
+val mapChangeListener: MapChangeListener<String, Frog> = MapChangeListener<String, Frog> { map, changes ->
+    for (insertion in changes.insertions) {
+        Log.v("EXAMPLE",
+                "Inserted key:  " + insertion +
+                        ", Inserted value: " + map[insertion]!!.name)
+    }
+}
+
+frog?.nicknamesToFriends?.addChangeListener(mapChangeListener)
+
+realm.executeTransaction { r: Realm? ->
+    // get the RealmDictionary field from the object we just created
+    val dictionary = frog!!.nicknamesToFriends
+
+    // add key/value to the dictionary
+    val wirt = realm.createObject(Frog::class.java)
+    wirt.name = "Wirt"
+    dictionary["tall frog"] = wirt
+
+    // add multiple keys/values to the dictionary
+    val greg = realm.createObject(Frog::class.java)
+    greg.name = "Greg"
+    val beatrice = realm.createObject(Frog::class.java)
+    beatrice.name = "Beatrice"
+    dictionary.putAll(mapOf<String, Frog>(
+            Pair("small frog", greg),
+            Pair("feathered frog", beatrice)))

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.kt
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.kt
@@ -4,11 +4,11 @@ realm.executeTransaction { r: Realm? ->
     frog?.name = "Jonathan Livingston Applesauce"
 }
 
-val mapChangeListener: MapChangeListener<String, Frog> = MapChangeListener<String, Frog> { map, changes ->
+val mapChangeListener: MapChangeListener<String, Frog>
+        = MapChangeListener<String, Frog> { map, changes ->
     for (insertion in changes.insertions) {
         Log.v("EXAMPLE",
-                "Inserted key:  " + insertion +
-                        ", Inserted value: " + map[insertion]!!.name)
+                "Inserted key:  $insertion, Inserted value: ${map[insertion]!!.name}")
     }
 }
 
@@ -31,3 +31,5 @@ realm.executeTransaction { r: Realm? ->
     dictionary.putAll(mapOf<String, Frog>(
             Pair("small frog", greg),
             Pair("feathered frog", beatrice)))
+    expectation.fulfill() // :hide
+}

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.java
@@ -30,5 +30,5 @@ realm.executeTransaction(r -> {
     verySmallRocks.setName("verySmallRocks");
     set.addAll(Arrays.asList(water, verySmallRocks));
 
-    expectation.fulfill();
+    expectation.fulfill(); // :hide
 });

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.java
@@ -1,0 +1,34 @@
+AtomicReference<Frog> frog = new AtomicReference<Frog>();
+realm.executeTransaction(r -> {
+    frog.set(realm.createObject(Frog.class));
+    frog.get().setName("Jonathan Livingston Applesauce");
+});
+
+SetChangeListener<Snack> setChangeListener = new SetChangeListener<Snack>() {
+    @Override
+    public void onChange(@NotNull RealmSet<Snack> set, SetChangeSet changes) {
+        Log.v("EXAMPLE", "Set changed: " +
+                changes.getNumberOfInsertions() + " new items, " +
+                changes.getNumberOfDeletions() + " items removed.");
+    }
+};
+frog.get().getFavoriteSnacks().addChangeListener(setChangeListener);
+
+realm.executeTransaction(r -> {
+    // get the RealmSet field from the object we just created
+    RealmSet<Snack> set = frog.get().getFavoriteSnacks();
+
+    // add value to the RealmSet
+    Snack flies = realm.createObject(Snack.class);
+    flies.setName("flies");
+    set.add(flies);
+
+    // add multiple values to the RealmSet
+    Snack water = realm.createObject(Snack.class);
+    water.setName("water");
+    Snack verySmallRocks = realm.createObject(Snack.class);
+    verySmallRocks.setName("verySmallRocks");
+    set.addAll(Arrays.asList(water, verySmallRocks));
+
+    expectation.fulfill();
+});

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.java
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.java
@@ -30,5 +30,4 @@ realm.executeTransaction(r -> {
     verySmallRocks.setName("verySmallRocks");
     set.addAll(Arrays.asList(water, verySmallRocks));
 
-    expectation.fulfill(); // :hide
 });

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.kt
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.kt
@@ -3,7 +3,8 @@ realm.executeTransaction { r: Realm? ->
     frog = realm.createObject(Frog::class.java)
     frog?.name = "Jonathan Livingston Applesauce"
 }
-val setChangeListener: SetChangeListener<Snack> = SetChangeListener<Snack> { set, changes ->
+val setChangeListener: SetChangeListener<Snack>
+        = SetChangeListener<Snack> { set, changes ->
     Log.v("EXAMPLE", "Set changed: " +
             changes.numberOfInsertions + " new items, " +
             changes.numberOfDeletions + " items removed.")
@@ -24,3 +25,5 @@ realm.executeTransaction { r: Realm? ->
     val verySmallRocks = realm.createObject(Snack::class.java)
     verySmallRocks.name = "verySmallRocks"
     set.addAll(Arrays.asList(water, verySmallRocks))
+    expectation.fulfill() // :hide
+}

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.kt
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.kt
@@ -1,0 +1,26 @@
+var frog :Frog? = null
+realm.executeTransaction { r: Realm? ->
+    frog = realm.createObject(Frog::class.java)
+    frog?.name = "Jonathan Livingston Applesauce"
+}
+val setChangeListener: SetChangeListener<Snack> = SetChangeListener<Snack> { set, changes ->
+    Log.v("EXAMPLE", "Set changed: " +
+            changes.numberOfInsertions + " new items, " +
+            changes.numberOfDeletions + " items removed.")
+}
+frog?.favoriteSnacks?.addChangeListener(setChangeListener)
+realm.executeTransaction { r: Realm? ->
+    // get the RealmSet field from the object we just created
+    val set = frog!!.favoriteSnacks
+
+    // add value to the RealmSet
+    val flies = realm.createObject(Snack::class.java)
+    flies.name = "flies"
+    set.add(flies)
+
+    // add multiple values to the RealmSet
+    val water = realm.createObject(Snack::class.java)
+    water.name = "water"
+    val verySmallRocks = realm.createObject(Snack::class.java)
+    verySmallRocks.name = "verySmallRocks"
+    set.addAll(Arrays.asList(water, verySmallRocks))

--- a/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.kt
+++ b/source/examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.kt
@@ -3,6 +3,7 @@ realm.executeTransaction { r: Realm? ->
     frog = realm.createObject(Frog::class.java)
     frog?.name = "Jonathan Livingston Applesauce"
 }
+
 val setChangeListener: SetChangeListener<Snack>
         = SetChangeListener<Snack> { set, changes ->
     Log.v("EXAMPLE", "Set changed: " +
@@ -10,6 +11,7 @@ val setChangeListener: SetChangeListener<Snack>
             changes.numberOfDeletions + " items removed.")
 }
 frog?.favoriteSnacks?.addChangeListener(setChangeListener)
+
 realm.executeTransaction { r: Realm? ->
     // get the RealmSet field from the object we just created
     val set = frog!!.favoriteSnacks

--- a/source/sdk/android/data-types/realmany.txt
+++ b/source/sdk/android/data-types/realmany.txt
@@ -86,11 +86,12 @@ values implicitly to compare across types.
 Notifications
 -------------
 
-To subscribe to changes to a ``RealmAny`` field, subscribe to changes to
-the object that contains the field with :java-sdk:`RealmObject.addChangeListener
-<io/realm/RealmObject.html#addChangeListener-io.realm.RealmChangeListener->`.
-You can use the ``ObjectChangeSet`` parameter to determine if the
-``RealmAny`` field changed.
+To subscribe to changes to a ``RealmAny`` field, use the
+:java-sdk:`RealmObject.addChangeListener
+<io/realm/RealmObject.html#addChangeListener-io.realm.RealmChangeListener->`
+method of the enclosing object. You can use the
+:java-sdk:`ObjectChangeSet <io/realm/ObjectChangeSet.html>`
+parameter to determine if the ``RealmAny`` field changed.
 
 .. tabs-realm-languages::
    

--- a/source/sdk/android/data-types/realmany.txt
+++ b/source/sdk/android/data-types/realmany.txt
@@ -83,3 +83,31 @@ values that do not contain the type. Type queries match the underlying
 type, rather than ``RealmAny``. Arithmetic operators convert numeric
 values implicitly to compare across types.
 
+Notifications
+-------------
+
+To subscribe to changes to a ``RealmAny`` field, subscribe to changes to
+the object that contains the field with :java-sdk:`RealmObject.addChangeListener
+<io/realm/RealmObject.html#addChangeListener-io.realm.RealmChangeListener->`.
+You can use the ``ObjectChangeSet`` parameter to determine if the
+``RealmAny`` field changed.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+       :tabid: kotlin
+
+       .. literalinclude:: /examples/generated/android/local/FrogAnyKt.codeblock.complete.kt
+          :language: kotlin
+
+       .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.kt
+          :language: kotlin
+
+   .. tab::
+       :tabid: java
+
+       .. literalinclude:: /examples/generated/android/local/FrogAny.codeblock.complete.java
+          :language: java
+
+       .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.java
+          :language: java

--- a/source/sdk/android/data-types/realmany.txt
+++ b/source/sdk/android/data-types/realmany.txt
@@ -97,17 +97,11 @@ You can use the ``ObjectChangeSet`` parameter to determine if the
    .. tab::
        :tabid: kotlin
 
-       .. literalinclude:: /examples/generated/android/local/FrogAnyKt.codeblock.complete.kt
-          :language: kotlin
-
        .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.kt
           :language: kotlin
 
    .. tab::
        :tabid: java
-
-       .. literalinclude:: /examples/generated/android/local/FrogAny.codeblock.complete.java
-          :language: java
 
        .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmany-notifications.java
           :language: java

--- a/source/sdk/android/data-types/realmdictionary.txt
+++ b/source/sdk/android/data-types/realmdictionary.txt
@@ -65,3 +65,35 @@ instances can only use keys of type ``String``.
 
        .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmDictionary.java
           :language: java
+
+Notifications
+-------------
+
+To subscribe to changes to a ``RealmDictionary``, pass a
+:java-sdk:`MapChangeListener <io/realm/MapChangeListener.html>`
+implementation to the :java-sdk:`RealmSet.addChangeListener <io/realm/RealmMap.html#addChangeListener-io.realm.MapChangeListener->` method.
+Your ``MapChangeListener`` implementation must define an
+``onChange()`` method, which accepts a reference to the changed ``RealmDictionary``
+and a set of changes as parameters. You can access the keys
+added to the dictionary as well as the keys removed from the dictionary
+through the ``MapChangeSet`` parameter.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+       :tabid: kotlin
+
+       .. literalinclude:: /examples/generated/android/local/FrogDictionaryKt.codeblock.complete.kt
+          :language: kotlin
+
+       .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.kt
+          :language: kotlin
+
+   .. tab::
+       :tabid: java
+
+       .. literalinclude:: /examples/generated/android/local/FrogDictionary.codeblock.complete.java
+          :language: java
+
+       .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.java
+          :language: java

--- a/source/sdk/android/data-types/realmdictionary.txt
+++ b/source/sdk/android/data-types/realmdictionary.txt
@@ -83,17 +83,11 @@ through the ``MapChangeSet`` parameter.
    .. tab::
        :tabid: kotlin
 
-       .. literalinclude:: /examples/generated/android/local/FrogDictionaryKt.codeblock.complete.kt
-          :language: kotlin
-
        .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.kt
           :language: kotlin
 
    .. tab::
        :tabid: java
-
-       .. literalinclude:: /examples/generated/android/local/FrogDictionary.codeblock.complete.java
-          :language: java
 
        .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmdictionary-notifications.java
           :language: java

--- a/source/sdk/android/data-types/realmset.txt
+++ b/source/sdk/android/data-types/realmset.txt
@@ -102,17 +102,11 @@ through the ``SetChangeSet`` parameter.
    .. tab::
        :tabid: kotlin
 
-       .. literalinclude:: /examples/generated/android/local/FrogSetKt.codeblock.complete.kt
-          :language: kotlin
-
        .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.kt
           :language: kotlin
 
    .. tab::
        :tabid: java
-
-       .. literalinclude:: /examples/generated/android/local/FrogSet.codeblock.complete.java
-          :language: java
 
        .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.java
           :language: java

--- a/source/sdk/android/data-types/realmset.txt
+++ b/source/sdk/android/data-types/realmset.txt
@@ -84,3 +84,35 @@ store in your ``RealmSet``.
 
        .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmSet.java
           :language: java
+
+Notifications
+-------------
+
+To subscribe to changes to a ``RealmSet``, pass a
+:java-sdk:`SetChangeListener <io/realm/SetChangeListener.html>`
+implementation to the :java-sdk:`RealmSet.addChangeListener <io/realm/RealmSet.html#addChangeListener-io.realm.SetChangeListener->` method.
+Your ``SetChangeListener`` implementation must define an
+``onChange()`` method, which accepts a reference to the changed ``RealmSet``
+and a set of changes as parameters. You can access the number of items
+added to the set as well as the number of items removed from the set
+through the ``SetChangeSet`` parameter.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+       :tabid: kotlin
+
+       .. literalinclude:: /examples/generated/android/local/FrogSetKt.codeblock.complete.kt
+          :language: kotlin
+
+       .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.kt
+          :language: kotlin
+
+   .. tab::
+       :tabid: java
+
+       .. literalinclude:: /examples/generated/android/local/FrogSet.codeblock.complete.java
+          :language: java
+
+       .. literalinclude:: /examples/generated/android/local/DataTypesTest.codeblock.realmset-notifications.java
+          :language: java


### PR DESCRIPTION
Apologies that the links aren't working -- seems to be a platform issue where anchor links, uh, don't work?

## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-16339

### Staged Changes (Requires MongoDB Corp SSO)

- [RealmAny -- Notifications](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16339/sdk/android/data-types/realmany/#notifications)
- [RealmSet -- Notifications](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16339/sdk/android/data-types/realmset/#notifications)
- [RealmDictionary -- Notifications](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16339/sdk/android/data-types/realmdictionary/#notifications)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
