### PR TITLE
(DOCSP-13154): Cascading deletes don't really cascade, so rename

### DIFF
--- a/source/sdk/android/examples/read-and-write-data.txt
+++ b/source/sdk/android/examples/read-and-write-data.txt
@@ -662,7 +662,7 @@ Delete an Object and its Dependent Objects
 
 Sometimes, you have :ref:`dependent objects
 <android-client-relationships>` that you want to delete when
-you delete the parent object. We call this a **cascading
+you delete the parent object. We call this a **chaining
 delete**. {+client-database+} does not delete the dependent
 objects for you. If you do not delete the objects yourself,
 they will remain orphaned in your {+realm+}. Whether or not
@@ -675,7 +675,7 @@ deleting the parent object.
 .. example::
 
    The following code demonstrates how to perform a
-   cascading delete by first deleting all of Ali's turtles,
+   chaining delete by first deleting all of Ali's turtles,
    then deleting Ali:
 
    .. tabs-realm-languages::


### PR DESCRIPTION
## Pull Request Info
Known issue: the anchor link doesn't work right, so you'll have to ctrl+f for "dependent objects" on the page. DOP issue: https://jira.mongodb.org/browse/DOP-2232

### Jira

- https://jira.mongodb.org/browse/DOCSP-13154

### Staged Changes (Requires MongoDB Corp SSO)

- [Delete an Object and its Dependent Objects](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13154/sdk/android/examples/read-and-write-data/#delete-an-object-and-its-dependent-objects)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
