### PR TITLE
(DOCSP-17063): [iOS] Remove beta designation from 10.8.0 versions, add beta callouts

### DIFF
--- a/source/sdk/ios/data-types.txt
+++ b/source/sdk/ios/data-types.txt
@@ -7,15 +7,15 @@ Realm Data Types - iOS SDK
    
    Supported Property Types </sdk/ios/data-types/supported-property-types>
    Collections </sdk/ios/data-types/collections>
-   Maps </sdk/ios/data-types/map>
-   MutableSets </sdk/ios/data-types/mutablesets>
-   AnyRealmValue </sdk/ios/data-types/anyrealmvalue>
+   Maps (beta) </sdk/ios/data-types/map>
+   MutableSets (beta) </sdk/ios/data-types/mutablesets>
+   AnyRealmValue (beta) </sdk/ios/data-types/anyrealmvalue>
    Embedded Objects </sdk/ios/data-types/embedded-objects>
 
 
 - :doc:`Supported Property Types </sdk/ios/data-types/supported-property-types>`
 - :doc:`Collections </sdk/ios/data-types/collections>`
-- :doc:`Maps </sdk/ios/data-types/map>`
-- :doc:`MutableSets </sdk/ios/data-types/mutablesets>`
-- :doc:`AnyRealmValue </sdk/ios/data-types/anyrealmvalue>`
+- :doc:`Maps (beta) </sdk/ios/data-types/map>`
+- :doc:`MutableSets (beta) </sdk/ios/data-types/mutablesets>`
+- :doc:`AnyRealmValue (beta) </sdk/ios/data-types/anyrealmvalue>`
 - :doc:`Embedded Objects </sdk/ios/data-types/embedded-objects>`

--- a/source/sdk/ios/data-types/anyrealmvalue.txt
+++ b/source/sdk/ios/data-types/anyrealmvalue.txt
@@ -1,9 +1,9 @@
 .. _ios-mixed-data-type:
 .. _ios-anyrealmvalue-data-type:
 
-=======================
-AnyRealmValue - iOS SDK
-=======================
+==============================
+AnyRealmValue (beta) - iOS SDK
+==============================
 
 .. default-domain:: mongodb
 
@@ -14,7 +14,7 @@ AnyRealmValue - iOS SDK
    :class: singlecol
 
 
-.. versionadded:: 10.8.0-beta.0
+.. versionadded:: 10.8.0
    ``AnyRealmValue`` type
 
 .. include:: /includes/note-beta-feature.rst
@@ -36,7 +36,7 @@ data types. Supported ``AnyRealmValue`` data types include:
 - String
 - Object
 
-This `mixed data type <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Enums/AnyRealmValue.html>`_ 
+This :swift-sdk:`mixed data type <Enums/AnyRealmValue.html>` 
 is :ref:`indexable <ios-index-a-property>`, but you can't use it as a 
 :ref:`primary key <ios-specify-a-primary-key>`. Because ``null`` is a 
 permitted value, you can't declare an ``AnyRealmValue`` as optional.

--- a/source/sdk/ios/data-types/map.txt
+++ b/source/sdk/ios/data-types/map.txt
@@ -1,8 +1,8 @@
 .. _ios-map:
 
-=============
-Map - iOS SDK
-=============
+====================
+Map (beta) - iOS SDK
+====================
 
 .. default-domain:: mongodb
 
@@ -12,8 +12,10 @@ Map - iOS SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.8.0-beta.2
+.. versionadded:: 10.8.0
    ``Map``
+
+.. include:: /includes/note-beta-feature.rst
 
 Overview
 --------

--- a/source/sdk/ios/data-types/mutablesets.txt
+++ b/source/sdk/ios/data-types/mutablesets.txt
@@ -1,8 +1,8 @@
 .. _ios-mutableset-data-type:
 
-====================
-MutableSet - iOS SDK
-====================
+===========================
+MutableSet (beta) - iOS SDK
+===========================
 
 .. default-domain:: mongodb
 
@@ -12,7 +12,7 @@ MutableSet - iOS SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.8.0-beta.0
+.. versionadded:: 10.8.0
    ``MutableSet`` type
 
 .. include:: /includes/note-beta-feature.rst
@@ -20,7 +20,7 @@ MutableSet - iOS SDK
 Overview
 --------
 
-A `MutableSet <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_ 
+A :swift-sdk:`MutableSet <Classes/MutableSet.html>` 
 collection represents a :ref:`to-many relationship <ios-to-many-relationship>` 
 containing distinct values. A ``MutableSet`` supports the following types 
 (and their optional versions): 
@@ -82,5 +82,5 @@ For example, ``MutableSet`` intersection methods:
 
    - For a complete list of methods available, such as ``contains``, 
      ``isSubset``, ``union``, ``subtract``, see: 
-     `MutableSet API reference <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/MutableSet.html>`_
+     :swift-sdk:`MutableSet API reference <Classes/MutableSet.html>`
    - For more info on to-many relationships, see: :ref:`To-Many Relationships <ios-to-many-relationship>`

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -20,7 +20,7 @@ Property Cheat Sheet
    .. tab::
       :tabid: swift
 
-      .. versionchanged:: 10.8.0-beta.0
+      .. versionchanged:: 10.8.0
          ``RealmProperty`` replaces ``RealmOptional``
 
       You can use the following types to define your object model
@@ -57,7 +57,7 @@ Property Cheat Sheet
          * - Decimal128
            - ``@objc dynamic var decimal: Decimal128 = 0``
            - ``@objc dynamic var decimal: Decimal128?``
-         * - `UUID <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Extensions.html#/s:10Foundation4UUIDV>`_
+         * - :swift-sdk:`UUID <Extensions.html#/s:10Foundation4UUIDV>`
            - ``@objc dynamic var uuid = UUID()``
            - ``@objc dynamic var uuidOpt: UUID?``
          * - :swift-sdk:`ObjectId <Classes/ObjectId.html>`
@@ -152,7 +152,7 @@ Property Cheat Sheet
 Unique Identifiers
 ------------------
 
-.. versionadded:: 10.8.0-beta.0
+.. versionadded:: 10.8.0
    ``UUID`` type
 
 ObjectId is a MongoDB-specific 12-byte unique value. UUID is a 16-byte 

--- a/source/sdk/ios/examples/define-a-realm-object-model.txt
+++ b/source/sdk/ios/examples/define-a-realm-object-model.txt
@@ -103,7 +103,7 @@ Declare Properties
 Specify an Optional/Required Property
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 10.8.0-beta.0
+.. versionchanged:: 10.8.0
    ``RealmProperty`` replaces ``RealmOptional``
 
 .. tabs-realm-languages::
@@ -114,8 +114,8 @@ Specify an Optional/Required Property
       You can declare ``String``, ``Date``, ``Data``, and
       :swift-sdk:`ObjectId <Classes/ObjectId.html>` properties as
       optional or required (non-optional) using standard Swift syntax.
-      Declare optional numeric types using the `RealmProperty
-      <https://docs.mongodb.com/realm-sdks/swift/10.8.0-beta.0/Classes/RealmProperty.html>`_ 
+      Declare optional numeric types using the :swift-sdk:`RealmProperty
+      <Classes/RealmProperty.html>` 
       type.
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.optional-required-properties.swift
@@ -187,7 +187,7 @@ for specific situations.
 Realm supports indexing for string, integer, boolean, ``Date``, ``UUID``,
 ``ObjectId``, and ``AnyRealmValue`` properties.
 
-.. versionadded:: 10.8.0-beta.0
+.. versionadded:: 10.8.0
    ``UUID`` and ``AnyRealmValue`` types
 
 .. tabs-realm-languages::

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -47,7 +47,7 @@ Use ``let`` to declare ``LinkingObjects``, ``List``, ``RealmOptional`` and
 ``RealmProperty``. The Objective-C runtime cannot represent these 
 generic properties.
 
-.. versionchanged:: 10.8.0-beta.0
+.. versionchanged:: 10.8.0
    ``RealmProperty`` replaces ``RealmOptional``
 
 .. seealso::


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-17063

### Staged Changes (Requires MongoDB Corp SSO)

- [Maps (beta)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17063/sdk/ios/data-types/map/): Add "(beta)" to title, ToC, remove "beta" from "New in version" directive, add `include` for the beta feature note.
- [MutableSets (beta)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17063/sdk/ios/data-types/mutablesets/): Add "(beta)" to title, ToC, remove "beta" from "New in version" directive
- [AnyRealmValue (beta)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17063/sdk/ios/data-types/anyrealmvalue/): Add "(beta)" to title, ToC, remove "beta" from "New in version" directive, point SDK reference doc link to 'latest' instead of a specific beta version.
- [Supported Property Types](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17063/sdk/ios/data-types/supported-property-types/): Update "Changed in version" and "New in version" directives to remove beta from version number, point `UUID` SDK reference doc link to 'latest' instead of a specific beta version.
- [Define a Realm Object Schema -> Specify an Optional/Required Property section](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17063/sdk/ios/examples/define-a-realm-object-model/#specify-an-optional-required-property): Updated the "Changed in version" to remove beta from the version number, point SDK reference doc link to 'latest' instead of a specific beta version. Also updated the "New in version" in [Index a Property](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17063/sdk/ios/examples/define-a-realm-object-model/#index-a-property) on this page to remove beta designation.
- [Object Models & Schemas -> Property Attributes section](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17063/sdk/ios/fundamentals/object-models-and-schemas/#property-attributes): Updated the "Changed in version" to remove beta from the version number

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
