### PR TITLE
(DOCSP-17068): Change secret link to point to updated path

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -1467,7 +1467,7 @@ paths:
     post:
       tags: ["secrets"]
       operationId: "adminCreateASecret"
-      summary: "Create a new :doc:`Secret </values-and-secrets/define-a-secret>`."
+      summary: "Create a new :doc:`Secret </values-and-secrets/define-and-manage-secrets>`."
       requestBody:
         description: "The Secret to create."
         required: true
@@ -1496,7 +1496,7 @@ paths:
     put:
       tags: ["secrets"]
       operationId: "adminModifyASecret"
-      summary: "Modify a :doc:`Secret </values-and-secrets/define-a-secret>` associated with a Realm app."
+      summary: "Modify a :doc:`Secret </values-and-secrets/define-and-manage-secrets>` associated with a Realm app."
       requestBody:
         description: "The modified value of the Secret."
         required: true
@@ -1514,7 +1514,7 @@ paths:
     delete:
       tags: ["secrets"]
       operationId: "adminDeleteSecret"
-      summary: "Delete a :doc:`Secret </values-and-secrets/define-a-secret>` associated with a Realm app."
+      summary: "Delete a :doc:`Secret </values-and-secrets/define-and-manage-secrets>` associated with a Realm app."
       responses:
         '204':
           description: "The Secret was successfully deleted."


### PR DESCRIPTION
## Pull Request Info

Correcting links related to secrets to point to updated path.

### Jira

- https://jira.mongodb.org/browse/DOCSP-17068

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm Admin API -> Create a new Secret](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17068/admin/api/v3/#post-/groups/%7Bgroupid%7D/apps/%7Bappid%7D/secrets)
- [Realm Admin API -> Modify a Secret](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17068/admin/api/v3/#put-/groups/%7Bgroupid%7D/apps/%7Bappid%7D/secrets/%7Bsecretid%7D)
- [Realm Admin API -> Delete a Secret](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17068/admin/api/v3/#delete-/groups/%7Bgroupid%7D/apps/%7Bappid%7D/secrets/%7Bsecretid%7D)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
