### PR TITLE
(DOCSP-16307): Add 'full_document_before_change' to trigger endpoint documentation

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -2732,6 +2732,13 @@ components:
                 If true, indicates that ``UPDATE`` change events should include the most current
                 :manual:`majority-committed </reference/read-concern-majority/>` version of the
                 modified document in the ``fullDocument`` field.
+            full_document_before_change:
+              type: boolean
+              description: >-
+                **Only Available for Database Triggers** --
+                If true, indicates that the ``UPDATE`` change event response should include a copy
+                of the modified document from before the update was applied. :ref:`Preimages <trigger-preimages>` 
+                must be enabled.
             schedule:
               type: string
               description: >-


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-16307

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm Administration API -> Event Trigger APIs (both POST and PUT)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16307/admin/api/v3/#post-/groups/%7Bgroupid%7D/apps/%7Bappid%7D/triggers): Add `full_document_before_change` bool to the request body, with a link to the `Preimages` feature which must be enabled to use this functionality

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
