### PR TITLE
Fix for deprecated ListItem title

### DIFF
--- a/tutorial/rn/components/ActionSheet.js
+++ b/tutorial/rn/components/ActionSheet.js
@@ -18,16 +18,21 @@ export function ActionSheet({ actions, visible, closeOverlay }) {
       onBackdropPress={closeOverlay}
     >
       <>
-        {[...actions, cancelAction].map(({ title, action }) => (
-          <ListItem
-            key={title}
-            title={title}
-            onPress={() => {
-              closeOverlay();
-              action();
-            }}
-          />
-        ))}
+        <ListItem>
+          <ListItem.Content>
+            {[...actions, cancelAction].map(({ title, action }) => (
+              <ListItem.Title            
+                key={title}
+                onPress={() => {
+                  closeOverlay();
+                  action();
+                }}
+              >
+                {title}
+              </ListItem.Title>
+            ))}
+          </ListItem.Content> 
+        </ListItem>
       </>
     </Overlay>
   );

--- a/tutorial/rn/components/ActionSheet.js
+++ b/tutorial/rn/components/ActionSheet.js
@@ -18,21 +18,20 @@ export function ActionSheet({ actions, visible, closeOverlay }) {
       onBackdropPress={closeOverlay}
     >
       <>
-        <ListItem>
-          <ListItem.Content>
-            {[...actions, cancelAction].map(({ title, action }) => (
-              <ListItem.Title            
-                key={title}
-                onPress={() => {
-                  closeOverlay();
-                  action();
-                }}
-              >
-                {title}
-              </ListItem.Title>
-            ))}
-          </ListItem.Content> 
-        </ListItem>
+        {[...actions, cancelAction].map(({ title, action }) => (
+          <ListItem
+            key={title}
+            onPress={() => {
+              closeOverlay();
+              action();
+            }}>
+            <ListItem.Content>
+                <ListItem.Title>
+                  {title}
+                </ListItem.Title>
+            </ListItem.Content> 
+          </ListItem>
+        ))}
       </>
     </Overlay>
   );

--- a/tutorial/rn/components/ManageTeam.js
+++ b/tutorial/rn/components/ManageTeam.js
@@ -10,38 +10,58 @@ export function ManageTeam() {
   const [newTeamMember, setNewTeamMember] = useState(null);
   const [teamMemberList, setTeamMemberList] = useState([]);
 
+  // :code-block-start: get-team
   // getTeam calls the backend function getMyTeamMembers to retrieve the
   // team members of the logged in user's project
   const getTeam = async () => {
     try {
+      // :state-start: final
       const teamMembers = await user.functions.getMyTeamMembers([]);
       setTeamMemberList(teamMembers);
+      // :state-end: :state-uncomment-start: start
+      //// TODO: Call the getMyTeamMembers Realm function and pass the result to setTeamMemberList().
+      // :state-uncomment-end:
     } catch (err) {
       Alert.alert("An error occurred while getting team members", err);
     }
   };
+  // :code-block-end:
 
+  // :code-block-start: add-team-member
   // addTeamMember calls the backend function addTeamMember to add a
   // team member to the logged in user's project
   const addTeamMember = async () => {
     try {
+       // :state-start: final
       await user.functions.addTeamMember(newTeamMember);
       getTeam();
+      // :state-end: :state-uncomment-start: start
+      //// TODO: Call the addTeamMember Realm function with the given email,
+      //// then call getTeam() to refresh the list.
+      // :state-uncomment-end:
     } catch (err) {
       Alert.alert("An error occurred while adding a team member", err.message);
     }
   };
+  // :code-block-end:
 
+  // :code-block-start: remove-team-member
   // removeTeamMember calls the backend function removeTeamMember to remove a
   // team member from the logged in user's project
   const removeTeamMember = async (email) => {
     try {
+      // :state-start: final
       await user.functions.removeTeamMember(email);
       getTeam();
+      // :state-end: :state-uncomment-start: start
+      //// TODO: Call the removeTeamMember Realm function with the given email,
+      //// then call getTeam() to refresh the list.
+      // :state-uncomment-end:
     } catch (err) {
       Alert.alert("An error occurred while removing a team member", err);
     }
   };
+  // :code-block-end:
 
   const openDeleteDialogue = (member) => {
     Alert.alert("Remove the following member from your team?", member.name, [

--- a/tutorial/rn/components/ManageTeam.js
+++ b/tutorial/rn/components/ManageTeam.js
@@ -10,58 +10,38 @@ export function ManageTeam() {
   const [newTeamMember, setNewTeamMember] = useState(null);
   const [teamMemberList, setTeamMemberList] = useState([]);
 
-  // :code-block-start: get-team
   // getTeam calls the backend function getMyTeamMembers to retrieve the
   // team members of the logged in user's project
   const getTeam = async () => {
     try {
-      // :state-start: final
       const teamMembers = await user.functions.getMyTeamMembers([]);
       setTeamMemberList(teamMembers);
-      // :state-end: :state-uncomment-start: start
-      //// TODO: Call the getMyTeamMembers Realm function and pass the result to setTeamMemberList().
-      // :state-uncomment-end:
     } catch (err) {
       Alert.alert("An error occurred while getting team members", err);
     }
   };
-  // :code-block-end:
 
-  // :code-block-start: add-team-member
   // addTeamMember calls the backend function addTeamMember to add a
   // team member to the logged in user's project
   const addTeamMember = async () => {
     try {
-      // :state-start: final
       await user.functions.addTeamMember(newTeamMember);
       getTeam();
-      // :state-end: :state-uncomment-start: start
-      //// TODO: Call the addTeamMember Realm function with the given email,
-      //// then call getTeam() to refresh the list.
-      // :state-uncomment-end:
     } catch (err) {
       Alert.alert("An error occurred while adding a team member", err.message);
     }
   };
-  // :code-block-end:
 
-  // :code-block-start: remove-team-member
   // removeTeamMember calls the backend function removeTeamMember to remove a
   // team member from the logged in user's project
   const removeTeamMember = async (email) => {
     try {
-      // :state-start: final
       await user.functions.removeTeamMember(email);
       getTeam();
-      // :state-end: :state-uncomment-start: start
-      //// TODO: Call the removeTeamMember Realm function with the given email,
-      //// then call getTeam() to refresh the list.
-      // :state-uncomment-end:
     } catch (err) {
       Alert.alert("An error occurred while removing a team member", err);
     }
   };
-  // :code-block-end:
 
   const openDeleteDialogue = (member) => {
     Alert.alert("Remove the following member from your team?", member.name, [
@@ -85,19 +65,19 @@ export function ManageTeam() {
       <View style={styles.manageTeamTitle}>
         <Text h3>My Team</Text>
       </View>
-      <ListItem>
-        <ListItem.Content>
-          {teamMemberList.map((member) => (
-            <ListItem.Title
-              onPress={() => openDeleteDialogue(member)}
-              bottomDivider
-              key={member.name}
-            >
-              {member.name}
-            </ListItem.Title>
-          ))}
-        </ListItem.Content>
-      </ListItem>
+      {teamMemberList.map((member) => (
+        <ListItem
+          onPress={() => openDeleteDialogue(member)}
+          bottomDivider
+          key={member.name}
+        >
+          <ListItem.Content>
+              <ListItem.Title>
+                {member.name}
+              </ListItem.Title>
+          </ListItem.Content>
+        </ListItem>
+      ))}
 
       <Text h4> Add member:</Text>
       <View style={styles.inputContainer}>

--- a/tutorial/rn/components/ManageTeam.js
+++ b/tutorial/rn/components/ManageTeam.js
@@ -85,14 +85,19 @@ export function ManageTeam() {
       <View style={styles.manageTeamTitle}>
         <Text h3>My Team</Text>
       </View>
-      {teamMemberList.map((member) => (
-        <ListItem
-          title={member.name}
-          onPress={() => openDeleteDialogue(member)}
-          bottomDivider
-          key={member.name}
-        />
-      ))}
+      <ListItem>
+        <ListItem.Content>
+          {teamMemberList.map((member) => (
+            <ListItem.Title
+              onPress={() => openDeleteDialogue(member)}
+              bottomDivider
+              key={member.name}
+            >
+              {member.name}
+            </ListItem.Title>
+          ))}
+        </ListItem.Content>
+      </ListItem>
 
       <Text h4> Add member:</Text>
       <View style={styles.inputContainer}>

--- a/tutorial/rn/components/TaskItem.js
+++ b/tutorial/rn/components/TaskItem.js
@@ -23,6 +23,8 @@ export function TaskItem({ task }) {
   // move the task into that status. Rather than creating a generic method to
   // avoid repetition, we split each status to separate each case in the code
   // below for demonstration purposes.
+  // :code-block-start: define-task-status-actions
+  // :state-start: final
   if (task.status !== "" && task.status !== Task.STATUS_OPEN) {
     actions.push({
       title: "Mark Open",
@@ -47,6 +49,10 @@ export function TaskItem({ task }) {
       },
     });
   }
+  // :state-end: :state-uncomment-start: start
+  //// TODO
+  // :state-uncomment-end:
+  // :code-block-end:
 
   return (
     <>

--- a/tutorial/rn/components/TaskItem.js
+++ b/tutorial/rn/components/TaskItem.js
@@ -63,21 +63,26 @@ export function TaskItem({ task }) {
         }}
         actions={actions}
       />
-      <ListItem
-        key={task.id}
-        onPress={() => {
-          setActionSheetVisible(true);
-        }}
-        title={task.name}
-        bottomDivider
-        checkmark={
-          task.status === Task.STATUS_COMPLETE ? (
-            <Text>&#10004; {/* checkmark */}</Text>
-          ) : task.status === Task.STATUS_IN_PROGRESS ? (
-            <Text>In Progress</Text>
-          ) : null
-        }
-      />
+      <ListItem>
+        <ListItem.Content>
+          <ListItem.Title
+            key={task.id}
+            onPress={() => {
+              setActionSheetVisible(true);
+            }}
+            bottomDivider
+            checkmark={
+              task.status === Task.STATUS_COMPLETE ? (
+                <Text>&#10004; {/* checkmark */}</Text>
+              ) : task.status === Task.STATUS_IN_PROGRESS ? (
+                <Text>In Progress</Text>
+              ) : null
+            }
+          >        
+            {task.name}
+          </ListItem.Title>
+        </ListItem.Content>
+      </ListItem>
     </>
   );
 }

--- a/tutorial/rn/components/TaskItem.js
+++ b/tutorial/rn/components/TaskItem.js
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
-import { Text, ListItem } from "react-native-elements";
+import { ListItem, Text } from "react-native-elements";
 import { useTasks } from "../providers/TasksProvider";
 import { ActionSheet } from "./ActionSheet";
 import { Task } from "../schemas";
+
+import styles from "../stylesheet";
 
 export function TaskItem({ task }) {
   const [actionSheetVisible, setActionSheetVisible] = useState(false);
@@ -21,8 +23,6 @@ export function TaskItem({ task }) {
   // move the task into that status. Rather than creating a generic method to
   // avoid repetition, we split each status to separate each case in the code
   // below for demonstration purposes.
-  // :code-block-start: define-task-status-actions
-  // :state-start: final
   if (task.status !== "" && task.status !== Task.STATUS_OPEN) {
     actions.push({
       title: "Mark Open",
@@ -47,10 +47,6 @@ export function TaskItem({ task }) {
       },
     });
   }
-  // :state-end: :state-uncomment-start: start
-  //// TODO
-  // :state-uncomment-end:
-  // :code-block-end:
 
   return (
     <>
@@ -63,25 +59,24 @@ export function TaskItem({ task }) {
         }}
         actions={actions}
       />
-      <ListItem>
+      <ListItem 
+        key={task.id} 
+        onPress={() => {
+          setActionSheetVisible(true);
+        }}
+        bottomDivider>
         <ListItem.Content>
-          <ListItem.Title
-            key={task.id}
-            onPress={() => {
-              setActionSheetVisible(true);
-            }}
-            bottomDivider
-            checkmark={
-              task.status === Task.STATUS_COMPLETE ? (
-                <Text>&#10004; {/* checkmark */}</Text>
-              ) : task.status === Task.STATUS_IN_PROGRESS ? (
-                <Text>In Progress</Text>
-              ) : null
-            }
-          >        
+          <ListItem.Title>
             {task.name}
-          </ListItem.Title>
+            </ListItem.Title>
         </ListItem.Content>
+        {
+          task.status === Task.STATUS_COMPLETE ? (
+            <Text>&#10004; {/* checkmark */}</Text>
+          ) : task.status === Task.STATUS_IN_PROGRESS ? (
+            <Text>In Progress</Text>
+          ) : null
+        }
       </ListItem>
     </>
   );

--- a/tutorial/rn/package.json
+++ b/tutorial/rn/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/stack": "^5.9.2",
     "react": "16.13.1",
     "react-native": "0.63.2",
-    "react-native-elements": "^2.2.1",
+    "react-native-elements": "^2.3.2",
     "react-native-gesture-handler": "^1.7.0",
     "react-native-reanimated": "^1.13.0",
     "react-native-safe-area-context": "^3.1.6",

--- a/tutorial/rn/views/ProjectsView.js
+++ b/tutorial/rn/views/ProjectsView.js
@@ -19,12 +19,17 @@ export function ProjectsView({ navigation }) {
     <View>
       {projectData.map((project) => (
         <View key={project.name}>
-          <ListItem
-            title={project.name}
-            onPress={() => onClickProject(project)}
-            bottomDivider
-            key={project.name}
-          />
+          <ListItem>
+            <ListItem.Content>
+              <ListItem.Title
+                onPress={() => onClickProject(project)}
+                bottomDivider
+                key={project.name}
+              >
+                {project.name}
+              </ListItem.Title>
+            </ListItem.Content>
+          </ListItem>
         </View>
       ))}
     </View>

--- a/tutorial/rn/views/ProjectsView.js
+++ b/tutorial/rn/views/ProjectsView.js
@@ -19,13 +19,13 @@ export function ProjectsView({ navigation }) {
     <View>
       {projectData.map((project) => (
         <View key={project.name}>
-          <ListItem>
+          <ListItem
+            onPress={() => onClickProject(project)}
+            bottomDivider
+            key={project.name}
+          >
             <ListItem.Content>
-              <ListItem.Title
-                onPress={() => onClickProject(project)}
-                bottomDivider
-                key={project.name}
-              >
+              <ListItem.Title>
                 {project.name}
               </ListItem.Title>
             </ListItem.Content>


### PR DESCRIPTION
Fix for deprecated ListItem title in the RN tutorial.

Reference: https://reactnativeelements.com/blog/2020/08/10/2.3-upgrade-guide/#listitem

## Pull Request Info

Running the RN tutorial throws the following warning.

`[Sat Jun 19 2021 05:03:22.951]  WARN     'ListItem.title' prop has been deprecated and will be removed in the next version. `

This PR updates the `ListItem` code according to the following React Native Elements upgrade guide.

https://reactnativeelements.com/blog/2020/08/10/2.3-upgrade-guide/#listitem

### Jira

N/A

### Staged Changes (Requires MongoDB Corp SSO)

N/A

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
