### PR TITLE
Remove warning about Realm Studio not supporting the new data types

### DIFF
--- a/source/includes/note-beta-feature.rst
+++ b/source/includes/note-beta-feature.rst
@@ -7,8 +7,6 @@
    
    - The API may change.
    - New data types are not backwards compatible. 
-   - Realm Studio version 11.0.0-beta is not compatible with {+realm+} files
-     using this new data type. 
 
    To add new data types via :ref:`development mode <enable-development-mode>`, 
    you must update the client SDK. {+sync+} client applications using older


### PR DESCRIPTION
## Pull Request Info

[Realm Studio 11.0.0 has released](https://github.com/realm/realm-studio/releases/tag/v11.0.0), which supports the new data types. I've removed the warning about the Realm Studio 11.0.0 beta not supporting the data types from the `include` about the beta state of the new types.

### Staged Changes (Requires MongoDB Corp SSO)

- The warning on any page that features the new data types, such as: [Android -> RealmAny(beta)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/remove-studio-warning/sdk/android/data-types/realmany/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
