### PR TITLE
(DOCSP-17333): [Realm Admin API] Use App._id not App.client_app_id

### DIFF
--- a/source/admin/api/v3.txt
+++ b/source/admin/api/v3.txt
@@ -102,11 +102,30 @@ described in :ref:`realm-api-authentication`:
      --header 'Authorization: Bearer <access_token>' \
      https://realm.mongodb.com/api/admin/v3.0/groups/{groupId}/apps
 
-This will return a list of objects describing each {+app+}
-in the provided group. The ``_id`` field contains the
-Application ID.
+This will return a list of objects describing each {+app+} in the provided
+group. For Admin API requests, your Application ID is the ObjectId value in the
+``_id`` field, *not* the ``client_app_id``.
 
-.. include:: /includes/note-find-app-id.rst
+.. example::
+
+   .. code-block:: json
+      :emphasize-lines: 3
+      
+      [
+        {
+            "_id": "5997529e46224c6e42gb6dd9",
+            "group_id": "57879f6cc4b32dbe440bb8c5",
+            "domain_id": "5886619e46124e4c42fb5dd8",
+            "client_app_id": "myapp-abcde",
+            "name": "myapp",
+            "location": "US-VA",
+            "deployment_model": "GLOBAL",
+            "last_used": 1615153544,
+            "last_modified": 0,
+            "product": "standard",
+            "environment": ""
+        }
+      ]
 
 Example
 -------


### PR DESCRIPTION


## Pull Request Info

### Jira

- (DOCSP-17333): [Realm Admin API] Use App._id not App.client_app_id

### Staged Changes (Requires MongoDB Corp SSO)

- [Admin API > Project & Application IDs](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/apifix/admin/api/v3/#std-label-realm-api-project-and-application-ids)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
