### PR TITLE
[Webhooks] Application User Settings

### DIFF
--- a/source/config/http_endpoints.txt
+++ b/source/config/http_endpoints.txt
@@ -112,9 +112,9 @@ Configuration
      "run_as_authed_user": <Boolean>,
      "run_as_user_id": "<Realm User ID>",
      "run_as_user_id_script_source": "<Function Source Code>",
-     "respond_result": <Boolean>,
      "fetch_custom_user_data": <Boolean>,
      "create_user_on_auth": <Boolean>,
+     "respond_result": <Boolean>,
      "options": {
        "httpMethod": "<HTTP Method>",
        "validationMethod": "<Webhook Validation Method>",
@@ -176,6 +176,16 @@ Configuration
      - If ``true``, {+service-short+} includes the webhook function return value as
        the body of the HTTP response it sends to the client that initiated the
        webhook request.
+   
+   * - | ``fetch_custom_user_data``
+       | Boolean
+     - If ``true``, {+service-short+} queries the requesting user's :ref:`custom
+       user data <custom-user-data>` and, if it exists, exposes the data as an
+       object on the ``context.user.custom_data`` property.
+       
+       This option is only available if ``run_as_authed_user`` is set to
+       ``true``.
+
    
    * - | ``options``
        | Document

--- a/source/config/http_endpoints.txt
+++ b/source/config/http_endpoints.txt
@@ -190,8 +190,9 @@ Configuration
        | Boolean
      - If ``true``, {+service-short+} automatically creates a new user based
        on the provided user credentials if they don't match an already existing
-       user. The authentication provider that corresponds to the credentials
-       must be enabled at the time of the request to create a new user.
+       user (e.g. no other user has the specified email address). The
+       authentication provider that corresponds to the credentials must be
+       enabled at the time of the request to create a new user.
        
        This option is only available if ``run_as_authed_user`` is set to
        ``true``.

--- a/source/config/http_endpoints.txt
+++ b/source/config/http_endpoints.txt
@@ -185,7 +185,16 @@ Configuration
        
        This option is only available if ``run_as_authed_user`` is set to
        ``true``.
-
+   
+   * - | ``create_user_on_auth``
+       | Boolean
+     - If ``true``, {+service-short+} automatically creates a new user based
+       on the provided user credentials if they don't match an already existing
+       user. The authentication provider that corresponds to the credentials
+       must be enabled at the time of the request to create a new user.
+       
+       This option is only available if ``run_as_authed_user`` is set to
+       ``true``.
    
    * - | ``options``
        | Document

--- a/source/includes/steps-create-a-service-webhook-ui.yaml
+++ b/source/includes/steps-create-a-service-webhook-ui.yaml
@@ -78,12 +78,29 @@ content: |
                   {
                     "jwtTokenString": "<User's JWT Token>"
                   }
-     
+         
          .. important:: Do Not Use Both Headers and Body Fields
             
             If a request includes credentials in both the request
             headers and the request body, then Realm throws an error
             and does not execute the function.
+         
+         .. note:: Application Users
+            
+            You can configure a webhook that uses application authentication to
+            perform additional user-related work for each request:
+            
+            - If you enable :guilabel:`Fetch Custom User Data`,
+              {+service-short+} queries the requesting user's :ref:`custom user
+              data <custom-user-data>` and, if it exists, exposes the data as an
+              object on the ``context.user.custom_data`` property.
+            
+            - If you enable :guilabel:`Create User Upon Authentication`,
+              {+service-short+} automatically creates a new user based on the
+              provided user credentials if they don't match an already existing
+              user. The authentication provider that corresponds to the
+              credentials must be enabled at the time of the request to create a
+              new user.
      
      * - System
        - This type of authentication configures a webhook to run as the


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-10284): Webhook settings option for fetching custom user data
- (DOCSP-10285): Webhook settings option for creating a user with application auth

### Staged Changes (Requires MongoDB Corp SSO)

- [Config > HTTP Endpoints > Incoming Webhooks](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/webhooks/config/http_endpoints/#incoming-webhooks)

- [Create a Service Webhook > Configure User Authentication](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/webhooks/services/configure/service-webhooks/#configure-user-authentication-1)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
