### PR TITLE
(DOCSP-16460): Add examples for retrying confirmation methods

### DIFF
--- a/examples/ios/Examples/ManageEmailPasswordUsers.swift
+++ b/examples/ios/Examples/ManageEmailPasswordUsers.swift
@@ -30,6 +30,58 @@ class ManageEmailPasswordUsers: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
+    func testResendConfirmationEmail() {
+        let expectation = XCTestExpectation(description: "Confirmation email resent")
+
+        // :code-block-start: resend-confirmation-email
+        let app = App(id: YOUR_REALM_APP_ID)
+        let client = app.emailPasswordAuth
+        let email = "skroob@example.com"
+        // If Realm is set to send a confirmation email, we can
+        // send the confirmation email again here.
+        client.resendConfirmationEmail(email) { (error) in
+            guard error == nil else {
+                print("Failed to resend confirmation email: \(error!.localizedDescription)")
+                // :hide-start:
+                XCTAssertEqual(error!.localizedDescription, "already confirmed")
+                expectation.fulfill()
+                // :hide-end:
+                return
+            }
+            // The confirmation email has been sent
+            // to the user again.
+            print("Confirmation email resent")
+        }
+        // :code-block-end:
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func testRetryConfirmationFunction() {
+        let expectation = XCTestExpectation(description: "Custom confirmation retriggered")
+
+        // :code-block-start: retry-confirmation-function
+        let app = App(id: YOUR_REALM_APP_ID)
+        let client = app.emailPasswordAuth
+        let email = "skroob@example.com"
+        // If Realm is set to run a custom confirmation function,
+        // we can trigger that function to run again here.
+        client.retryCustomConfirmation(email) { (error) in
+            guard error == nil else {
+                print("Failed to retry custom confirmation: \(error!.localizedDescription)")
+                // :hide-start:
+                XCTAssertEqual(error!.localizedDescription, "cannot run confirmation for skroob@example.com: automatic confirmation is enabled")
+                expectation.fulfill()
+                // :hide-end:
+                return
+            }
+            // The custom confirmation function has been
+            // triggered to run again for the user.
+            print("Custom confirmation retriggered")
+        }
+        // :code-block-end:
+        wait(for: [expectation], timeout: 10)
+    }
+
     func testConfirmNewUserEmail() {
         let expectation = XCTestExpectation(description: "Confirmation continues")
         // :code-block-start: confirm-new-user-email 

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '13.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', '~>10.8.0-beta.2'
-  pod 'RealmSwift', '~>10.8.0-beta.2'
+  pod 'Realm', '~>10.9.0'
+  pod 'RealmSwift', '~>10.9.0'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,5 +13,5 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '~>10.8.0-beta.2'
+  pod 'RealmSwift', '~>10.9.0'
 end

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Realm (10.8.0-beta.1):
-    - Realm/Headers (= 10.8.0-beta.1)
-  - Realm/Headers (10.8.0-beta.1)
-  - RealmSwift (10.8.0-beta.1):
-    - Realm (= 10.8.0-beta.1)
+  - Realm (10.9.0):
+    - Realm/Headers (= 10.9.0)
+  - Realm/Headers (10.9.0)
+  - RealmSwift (10.9.0):
+    - Realm (= 10.9.0)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (from `https://github.com/realm/realm-cocoa`, branch `py/dictionary`)
-  - RealmSwift (from `https://github.com/realm/realm-cocoa`, branch `py/dictionary`)
+  - Realm (~> 10.9.0)
+  - RealmSwift (~> 10.9.0)
   - SwiftLint
 
 SPEC REPOS:
@@ -44,23 +44,9 @@ SPEC REPOS:
     - GoogleSignIn
     - GTMAppAuth
     - GTMSessionFetcher
+    - Realm
+    - RealmSwift
     - SwiftLint
-
-EXTERNAL SOURCES:
-  Realm:
-    :branch: py/dictionary
-    :git: https://github.com/realm/realm-cocoa
-  RealmSwift:
-    :branch: py/dictionary
-    :git: https://github.com/realm/realm-cocoa
-
-CHECKOUT OPTIONS:
-  Realm:
-    :commit: 060730333ffa736b97ece326c401adcbbf59c3b1
-    :git: https://github.com/realm/realm-cocoa
-  RealmSwift:
-    :commit: 060730333ffa736b97ece326c401adcbbf59c3b1
-    :git: https://github.com/realm/realm-cocoa
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
@@ -69,10 +55,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: 6bc0a74e52ce6cf6626479b29f23f85204911417
-  RealmSwift: 0d1bfae191c637683948c74b5e5fa2cd94e5e0e7
+  Realm: 9feef41ab8230ed706c4dc503fc292594915bf9a
+  RealmSwift: 91246183b772e0ea1bf777116c4b8d9939f983b3
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 05ac07d0379c42f8f02a349f60750d77c201ab98
+PODFILE CHECKSUM: 47c2b935c4f0d5228a8fd01244199d1e89628091
 
 COCOAPODS: 1.10.1

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.resend-confirmation-email.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.resend-confirmation-email.swift
@@ -1,0 +1,14 @@
+let app = App(id: YOUR_REALM_APP_ID)
+let client = app.emailPasswordAuth
+let email = "skroob@example.com"
+// If Realm is set to send a confirmation email, we can
+// send the confirmation email again here.
+client.resendConfirmationEmail(email) { (error) in
+    guard error == nil else {
+        print("Failed to resend confirmation email: \(error!.localizedDescription)")
+        return
+    }
+    // The confirmation email has been sent
+    // to the user again.
+    print("Confirmation email resent")
+}

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.retry-confirmation-function.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.retry-confirmation-function.swift
@@ -1,0 +1,14 @@
+let app = App(id: YOUR_REALM_APP_ID)
+let client = app.emailPasswordAuth
+let email = "skroob@example.com"
+// If Realm is set to run a custom confirmation function,
+// we can trigger that function to run again here.
+client.retryCustomConfirmation(email) { (error) in
+    guard error == nil else {
+        print("Failed to retry custom confirmation: \(error!.localizedDescription)")
+        return
+    }
+    // The custom confirmation function has been
+    // triggered to run again for the user.
+    print("Custom confirmation retriggered")
+}

--- a/source/sdk/ios/examples/manage-email-password-users.txt
+++ b/source/sdk/ios/examples/manage-email-password-users.txt
@@ -59,7 +59,6 @@ Retry a User Confirmation Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 10.9.0
-   ``retryCustomConfirmation(email: String)``
 
 Retry a :ref:`custom user confirmation function <auth-run-a-confirmation-function>`. 
 

--- a/source/sdk/ios/examples/manage-email-password-users.txt
+++ b/source/sdk/ios/examples/manage-email-password-users.txt
@@ -37,6 +37,31 @@ Register a New User Account
       .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.register-email-objc.m
          :language: objectivec
 
+.. _ios-retry-user-confirmation:
+
+Retry User Confirmation Methods
+-------------------------------
+
+The SDK provides methods to resend user confirmation emails, or retry custom 
+confirmation methods.
+
+Resend a User Confirmation Email
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Resend a :ref:`confirmation email <auth-send-a-confirmation-email>`. Email/password 
+URLs expire after 30 minutes, so users who do not visit within that period 
+will need new emails to confirm their accounts.
+
+.. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.resend-confirmation-email.swift
+   :language: swift
+
+Retry a User Confirmation Function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Retry a :ref:`custom user confirmation function <auth-run-a-confirmation-function>`. 
+
+.. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.retry-confirmation-function.swift
+   :language: swift
 
 .. _ios-confirm-a-new-users-email-address:
 

--- a/source/sdk/ios/examples/manage-email-password-users.txt
+++ b/source/sdk/ios/examples/manage-email-password-users.txt
@@ -42,7 +42,7 @@ Register a New User Account
 Retry User Confirmation Methods
 -------------------------------
 
-The SDK provides methods to resend user confirmation emails, or retry custom 
+The SDK provides methods to resend user confirmation emails or retry custom 
 confirmation methods.
 
 Resend a User Confirmation Email

--- a/source/sdk/ios/examples/manage-email-password-users.txt
+++ b/source/sdk/ios/examples/manage-email-password-users.txt
@@ -58,6 +58,9 @@ will need new emails to confirm their accounts.
 Retry a User Confirmation Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 10.9.0
+   ``retryCustomConfirmation(email: String)``
+
 Retry a :ref:`custom user confirmation function <auth-run-a-confirmation-function>`. 
 
 .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.retry-confirmation-function.swift


### PR DESCRIPTION
## Pull Request Info

The linked Jira ticket here is just to add an example of the new `retryCustomConfirmation` API, but I realized we don't have the send email method documented either, so I added both.

### Jira

- https://jira.mongodb.org/browse/DOCSP-16460

### Staged Changes (Requires MongoDB Corp SSO)

- [Manage Email/Password Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16460/sdk/ios/examples/manage-email-password-users/#retry-user-confirmation-methods): added the  Retry User Confirmations section, with examples

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
