### PR TITLE
(DOCSP-16043): [iOS] Update documentation and code examples for new property declaration syntax

### DIFF
--- a/examples/ios/Examples/AnyRealmValue.swift
+++ b/examples/ios/Examples/AnyRealmValue.swift
@@ -7,9 +7,9 @@ import XCTest
 import RealmSwift
 
 class AnyRealmValueExample_Dog: Object {
-    @objc dynamic var name = ""
-    let age = RealmProperty<AnyRealmValue>()
-    let companion = RealmProperty<AnyRealmValue>()
+    @Persisted var name = ""
+    @Persisted var age: AnyRealmValue
+    @Persisted var companion: AnyRealmValue
 }
 
 class AnyRealmValueTestCase: XCTestCase {
@@ -28,28 +28,28 @@ class AnyRealmValueTestCase: XCTestCase {
     func testAnyRealmValue() {
         // :code-block-start: mixed-data-type
         // Create a AnyRealmValueExample_Dog object and then set its properties
+        // In this case, the dog's age is an int
         let myDog = AnyRealmValueExample_Dog()
         myDog.name = "Rex"
-        // Because we declared age as a `RealmProperty`, we must mutate its `value` property
-        myDog.age.value = .int(5)
+        myDog.age = .int(5)
         // This dog has no companion.
         // You can set the field's type to "none", which represents `nil`
-        myDog.companion.value = .none
+        myDog.companion = .none
 
         // Create another AnyRealmValueExample_Dog object whose age is a float
         let myOtherDog = AnyRealmValueExample_Dog()
         myOtherDog.name = "Spot"
-        myOtherDog.age.value = .float(2.5)
+        myOtherDog.age = .float(2.5)
         // This dog's companion is a cat named Fluffy, represented by a string here
-        myOtherDog.companion.value = .string("Fluffy the Cat")
+        myOtherDog.companion = .string("Fluffy the Cat")
 
         // Create a third AnyRealmValueExample_Dog object whose age is a string
         let myThirdDog = AnyRealmValueExample_Dog()
         myThirdDog.name = "Fido"
-        myThirdDog.age.value = .string("3 months")
+        myThirdDog.age = .string("3 months")
         // This dog's companion is a Person, which is an object that has a
         // string name, an optional string address, and an int age
-        myThirdDog.companion.value = .object(Person(value: ["name": "Sylvia", "age": 12]))
+        myThirdDog.companion = .object(Person(value: ["name": "Sylvia", "age": 12]))
 
         // Get the default realm. You only need to do this once per thread.
         let realm = try! Realm()
@@ -63,19 +63,19 @@ class AnyRealmValueTestCase: XCTestCase {
 
         // Verify the type of the ``AnyRealmProperty`` when attempting to get it. This
         // returns an object whose property contains the matched type.
-        if case let .int(age) = myDog.age.value {
+        if case let .int(age) = myDog.age {
             print(age)  // Prints 5
         }
 
         // In this example, "myOtherDog"'s age is a float type, so checking the type
         // before trying to use it avoids an exception
-        if case let .int(age) = myOtherDog.age.value {
+        if case let .int(age) = myOtherDog.age {
             print(age)  // Doesn't print anything
         }
 
         // Retreiving an object stored as an ``AnyRealmProperty`` gives you
         // the complete object, containing all of the object's properties
-        if case let .object(companion) = myThirdDog.companion.value {
+        if case let .object(companion) = myThirdDog.companion {
             print(companion)
             // Prints all the details of the Person object:
             // {name = Sylvia; address = null; age = 12;}

--- a/examples/ios/Examples/CompleteQuickStart.swift
+++ b/examples/ios/Examples/CompleteQuickStart.swift
@@ -12,13 +12,10 @@ import RealmSwift
 // :code-block-start: model
 // QsTask is the Task model for this QuickStart
 class QsTask: Object {
-    @objc dynamic var _id: ObjectId = ObjectId.generate()
-    @objc dynamic var name: String = ""
-    @objc dynamic var owner: String?
-    @objc dynamic var status: String = ""
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
+    @Persisted var status: String = ""
 
     convenience init(name: String) {
         self.init()

--- a/examples/ios/Examples/EmbeddedObjects.swift
+++ b/examples/ios/Examples/EmbeddedObjects.swift
@@ -9,24 +9,20 @@ import RealmSwift
 // :code-block-start: models
 // Define an embedded object
 class EmbeddedObjectExamples_Address: EmbeddedObject {
-    @objc dynamic var street: String?
-    @objc dynamic var city: String?
-    @objc dynamic var country: String?
-    @objc dynamic var postalCode: String?
+    @Persisted var street: String?
+    @Persisted var city: String?
+    @Persisted var country: String?
+    @Persisted var postalCode: String?
 }
 
 // Define an object with one embedded object
 class EmbeddedObjectExamples_Contact: Object {
-    @objc dynamic var _id = ObjectId.generate()
-    @objc dynamic var name = ""
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name = ""
 
     // Embed a single object.
     // Embedded object properties must be marked optional.
-    @objc dynamic var address: EmbeddedObjectExamples_Address?
-
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted var address: EmbeddedObjectExamples_Address?
 
     convenience init(name: String, address: EmbeddedObjectExamples_Address) {
         self.init()
@@ -37,8 +33,8 @@ class EmbeddedObjectExamples_Contact: Object {
 
 // Define an object with an array of embedded objects
 class EmbeddedObjectExamples_Business: Object {
-    @objc dynamic var name = ""
-    let addresses = List<EmbeddedObjectExamples_Address>() // Embed an array of objects
+    @Persisted var name = ""
+    @Persisted var addresses: List<EmbeddedObjectExamples_Address> // Embed an array of objects
 
     convenience init(name: String, addresses: [EmbeddedObjectExamples_Address]) {
         self.init()

--- a/examples/ios/Examples/LandingPageCodeExamples.swift
+++ b/examples/ios/Examples/LandingPageCodeExamples.swift
@@ -11,16 +11,16 @@ import RealmSwift
 
 // :code-block-start: coffee-drink-object
 class LandingPageExamples_CoffeeDrink: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var hotOrCold: String?
-    @objc dynamic var rating = 0
+    @Persisted var name = ""
+    @Persisted var hotOrCold: String?
+    @Persisted var rating = 0
 }
 // :code-block-end:
 
 class LandingPageExamples_CoffeeShop: Object {
     // Required string property
-    @objc dynamic var name = ""
-    let drinks = List<LandingPageExamples_CoffeeDrink>()
+    @Persisted var name = ""
+    @Persisted var drinks: List<LandingPageExamples_CoffeeDrink>
 }
 
 // MARK: Query Realm Database

--- a/examples/ios/Examples/LocalOnlyCompleteQuickStart.swift
+++ b/examples/ios/Examples/LocalOnlyCompleteQuickStart.swift
@@ -10,9 +10,9 @@ import RealmSwift
 // :code-block-start: quick-start-local-define-object-model
 // LocalOnlyQsTask is the Task model for this QuickStart
 class LocalOnlyQsTask: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var owner: String?
-    @objc dynamic var status: String = ""
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
+    @Persisted var status: String = ""
 
     convenience init(name: String) {
         self.init()

--- a/examples/ios/Examples/MapExample.swift
+++ b/examples/ios/Examples/MapExample.swift
@@ -9,11 +9,11 @@ import RealmSwift
 
 // :code-block-start: models
 class MapExamples_Dog: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var currentCity = ""
+    @Persisted var name = ""
+    @Persisted var currentCity = ""
 
     // Map of city name -> favorite park in that city
-    let favoriteParksByCity = Map<String, String>()
+    @Persisted var favoriteParksByCity: Map<String, String>
 }
 // :code-block-end:
 
@@ -21,7 +21,7 @@ class MapExample: XCTestCase {
     override func setUp() {
         Realm.Configuration.defaultConfiguration = Realm.Configuration(inMemoryIdentifier: "MapExample")
     }
-    
+
     override func tearDown() {
         Realm.Configuration.defaultConfiguration = Realm.Configuration(inMemoryIdentifier: nil)
     }

--- a/examples/ios/Examples/Migrations.swift
+++ b/examples/ios/Examples/Migrations.swift
@@ -9,16 +9,16 @@ import XCTest
 import RealmSwift
 
 class MigrationExampleV0_Person: Object {
-    @objc dynamic var yearsSinceBirth = 0
+    @Persisted var yearsSinceBirth = 0
 }
 
 // :code-block-start: model-v1
 // In the first version of the app, the Person model
 // has separate fields for first and last names.
 class MigrationExampleV1_Person: Object {
-    @objc dynamic var firstName = ""
-    @objc dynamic var lastName = ""
-    @objc dynamic var age = 0
+    @Persisted var firstName = ""
+    @Persisted var lastName = ""
+    @Persisted var age = 0
 }
 // :code-block-end:
 
@@ -27,8 +27,8 @@ class MigrationExampleV1_Person: Object {
 // combined field for the name. A migration will be required
 // to convert from version 1 to version 2.
 class MigrationExampleV2_Person: Object {
-    @objc dynamic var fullName = ""
-    @objc dynamic var age = 0
+    @Persisted var fullName = ""
+    @Persisted var age = 0
 }
 // :code-block-end:
 

--- a/examples/ios/Examples/Models.swift
+++ b/examples/ios/Examples/Models.swift
@@ -3,12 +3,12 @@ import RealmSwift
 // :code-block-start: person-model
 class Person: Object {
     // Required string property
-    @objc dynamic var name: String = ""
+    @Persisted var name: String = ""
 
     // Optional string property
-    @objc dynamic var address: String?
+    @Persisted var address: String?
 
     // Optional integral type property
-    let age = RealmProperty<Int?>()
+    @Persisted var age: Int?
 }
 // :code-block-end:

--- a/examples/ios/Examples/MutableSetExample.swift
+++ b/examples/ios/Examples/MutableSetExample.swift
@@ -9,9 +9,9 @@ import RealmSwift
 
 // :code-block-start: set-collections-model
 class MutableSetExamples_Dog: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var currentCity = ""
-    let citiesVisited = MutableSet<String>()
+    @Persisted var name = ""
+    @Persisted var currentCity = ""
+    @Persisted var citiesVisited: MutableSet<String>
 }
 // :code-block-end:
 

--- a/examples/ios/Examples/Notifications.swift
+++ b/examples/ios/Examples/Notifications.swift
@@ -11,7 +11,7 @@ import XCTest
 // :code-block-start: register-an-object-change-listener
 // Define the dog class.
 class NotificationExample_Dog: Object {
-    @objc dynamic var name = ""
+    @Persisted var name = ""
 }
 
 var objectNotificationToken: NotificationToken?

--- a/examples/ios/Examples/ObjectModels.swift
+++ b/examples/ios/Examples/ObjectModels.swift
@@ -1,7 +1,9 @@
 // :replace-start: {
 //   "terms": {
 //     "ObjectModelsExamples_": "",
-//     "OptionalRequiredPropertyExample_": ""
+//     "ObjectModelsObjcDynamicExamples_": "",
+//     "OptionalRequiredPropertyExample_": "",
+//     "OptionalRequiredPropertyObjcDynamicExample_": ""
 //   }
 // }
 import XCTest
@@ -34,6 +36,22 @@ class OptionalRequiredPropertyExample_Person: Object {
 }
 // :code-block-end:
 
+// :code-block-start: optional-required-properties-objc-dynamic
+class OptionalRequiredPropertyObjcDynamicExample_Person: Object {
+    // Required string property
+    @objc dynamic var name = ""
+
+    // Optional string property
+    @objc dynamic var address: String?
+
+    // Required numeric property
+    @objc dynamic var ageYears = 0
+
+    // Optional numeric property
+    let heightCm = RealmProperty<Float?>()
+}
+// :code-block-end:
+
 // :code-block-start: specify-a-primary-key
 class ObjectModelsExamples_Project: Object {
     @Persisted(primaryKey: true) var id = 0
@@ -41,10 +59,34 @@ class ObjectModelsExamples_Project: Object {
 }
 // :code-block-end:
 
+// :code-block-start: specify-a-primary-key-objc-dynamic
+class ObjectModelsObjcDynamicExamples_Project: Object {
+    @objc dynamic var id = 0
+    @objc dynamic var name = ""
+
+    // Return the name of the primary key property
+    override static func primaryKey() -> String? {
+        return "id"
+    }
+}
+// :code-block-end:
+
 // :code-block-start: index-a-property
 class ObjectModelsExamples_Book: Object {
     @Persisted var priceCents = 0
     @Persisted(indexed: true) var title = ""
+}
+// :code-block-end:
+
+// :code-block-start: index-a-property-objc-dynamic
+class ObjectModelsObjcDynamicExamples_Book: Object {
+    @objc dynamic var priceCents = 0
+    @objc dynamic var title = ""
+
+    // Return a list of indexed property names
+    override static func indexedProperties() -> [String] {
+        return ["title"]
+    }
 }
 // :code-block-end:
 
@@ -72,6 +114,24 @@ class ObjectModelsExamples_Person: Object {
 }
 // :code-block-end:
 
+// :code-block-start: ignore-a-property-objc-dynamic
+class ObjectModelsObjcDynamicExamples_Person: Object {
+    @objc dynamic var tmpId = 0
+    @objc dynamic var firstName = ""
+    @objc dynamic var lastName = ""
+
+    // Read-only properties are automatically ignored
+    var name: String {
+        return "\(firstName) \(lastName)"
+    }
+
+    // Return a list of ignored property names
+    override static func ignoredProperties() -> [String] {
+        return ["tmpId"]
+    }
+}
+// :code-block-end:
+
 // :code-block-start: realm-object-enum
 // Define the enum
 enum ObjectModelsExamples_TaskStatusEnum: String, PersistableEnum {
@@ -90,6 +150,26 @@ class ObjectModelsExamples_Task: Object {
 
     // Optional enum property
     @Persisted var optionalTaskStatusEnumProperty: ObjectModelsExamples_TaskStatusEnum? // :emphasize:
+}
+// :code-block-end:
+
+// :code-block-start: realm-object-enum-objc-dynamic
+// Define the enum
+@objc enum ObjectModelsObjcDynamicExamples_TaskStatusEnum: Int, RealmEnum {
+    case notStarted = 1
+    case inProgress = 2
+    case complete = 3
+}
+
+// To use the enum:
+class ObjectModelsObjcDynamicExamples_Task: Object {
+    @objc dynamic var name: String = ""
+    @objc dynamic var owner: String?
+
+    // Required enum property
+    @objc dynamic var status = ObjectModelsObjcDynamicExamples_TaskStatusEnum.notStarted // :emphasize:
+    // Optional enum property
+    let optionalTaskStatusEnumProperty = RealmProperty<ObjectModelsObjcDynamicExamples_TaskStatusEnum?>() // :emphasize:
 }
 // :code-block-end:
 

--- a/examples/ios/Examples/ObjectModels.swift
+++ b/examples/ios/Examples/ObjectModels.swift
@@ -11,98 +11,90 @@ import RealmSwift
 // A dog has an _id primary key, a string name, an optional
 // string breed, and a date of birth.
 class ObjectModelsExamples_Dog: Object {
-    @objc dynamic var _id = ObjectId.generate()
-    @objc dynamic var name = ""
-    @objc dynamic var breed: String?
-    @objc dynamic var dateOfBirth = Date()
-
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name = ""
+    @Persisted var breed: String?
+    @Persisted var dateOfBirth = Date()
 }
 // :code-block-end:
 
 // :code-block-start: optional-required-properties
 class OptionalRequiredPropertyExample_Person: Object {
     // Required string property
-    @objc dynamic var name = ""
+    @Persisted var name = ""
 
     // Optional string property
-    @objc dynamic var address: String?
+    @Persisted var address: String?
 
     // Required numeric property
-    @objc dynamic var ageYears = 0
+    @Persisted var ageYears = 0
 
     // Optional numeric property
-    let heightCm = RealmProperty<Float?>()
+    @Persisted var heightCm: Float?
 }
 // :code-block-end:
 
 // :code-block-start: specify-a-primary-key
 class ObjectModelsExamples_Project: Object {
-    @objc dynamic var id = 0
-    @objc dynamic var name = ""
-
-    // Return the name of the primary key property
-    override static func primaryKey() -> String? {
-        return "id"
-    }
+    @Persisted(primaryKey: true) var id = 0
+    @Persisted var name = ""
 }
 // :code-block-end:
 
 // :code-block-start: index-a-property
 class ObjectModelsExamples_Book: Object {
-    @objc dynamic var priceCents = 0
-    @objc dynamic var title = ""
-
-    // Return a list of indexed property names
-    override static func indexedProperties() -> [String] {
-        return ["title"]
-    }
+    @Persisted var priceCents = 0
+    @Persisted(indexed: true) var title = ""
 }
 // :code-block-end:
 
 // :code-block-start: ignore-a-property
 class ObjectModelsExamples_Person: Object {
-    @objc dynamic var tmpId = 0
-    @objc dynamic var firstName = ""
-    @objc dynamic var lastName = ""
+    // If some properties are marked as @Persisted,
+    // any properties that do not have the @Persisted
+    // annotation are automatically ignored.
+    var tmpId = 0
+
+    // The @Persisted properties are managed
+    @Persisted var firstName = ""
+    @Persisted var lastName = ""
 
     // Read-only properties are automatically ignored
     var name: String {
         return "\(firstName) \(lastName)"
     }
 
-    // Return a list of ignored property names
-    override static func ignoredProperties() -> [String] {
-        return ["tmpId"]
-    }
+    // If you mix the pre-10.10 property declaration
+    // syntax `@objc dynamic` with the 10.10+ @Persisted
+    // annotation within a class, `@objc dynamic`
+    // properties are ignored.
+    @objc dynamic var email = ""
 }
 // :code-block-end:
 
 // :code-block-start: realm-object-enum
 // Define the enum
-@objc enum ObjectModelsExamples_TaskStatusEnum: Int, RealmEnum {
-    case notStarted = 1
-    case inProgress = 2
-    case complete = 3
+enum ObjectModelsExamples_TaskStatusEnum: String, PersistableEnum {
+    case notStarted
+    case inProgress
+    case complete
 }
 
 // To use the enum:
 class ObjectModelsExamples_Task: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var owner: String?
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
 
     // Required enum property
-    @objc dynamic var status = ObjectModelsExamples_TaskStatusEnum.notStarted // :emphasize:
+    @Persisted var status = ObjectModelsExamples_TaskStatusEnum.notStarted // :emphasize:
 
     // Optional enum property
-    let optionalTaskStatusEnumProperty = RealmProperty<ObjectModelsExamples_TaskStatusEnum?>() // :emphasize:
+    @Persisted var optionalTaskStatusEnumProperty: ObjectModelsExamples_TaskStatusEnum? // :emphasize:
 }
 // :code-block-end:
 
 class ObjectModelsExamples_MyModel: Object {
-    @objc dynamic var someProperty = 0
+    @Persisted var someProperty = 0
 }
 
 class ObjectModels: XCTestCase {

--- a/examples/ios/Examples/QueryEngine.swift
+++ b/examples/ios/Examples/QueryEngine.swift
@@ -8,16 +8,16 @@ import RealmSwift
 
 // :code-block-start: models
 class QueryEngineExamples_Task: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var isComplete = false
-    @objc dynamic var assignee: String?
-    @objc dynamic var priority = 0
-    @objc dynamic var progressMinutes = 0
+    @Persisted var name = ""
+    @Persisted var isComplete = false
+    @Persisted var assignee: String?
+    @Persisted var priority = 0
+    @Persisted var progressMinutes = 0
 }
 
 class QueryEngineExamples_Project: Object {
-    @objc dynamic var name = ""
-    let tasks = List<QueryEngineExamples_Task>()
+    @Persisted var name = ""
+    @Persisted var tasks: List<QueryEngineExamples_Task>
 }
 // :code-block-end:
 

--- a/examples/ios/Examples/ReadWriteData.swift
+++ b/examples/ios/Examples/ReadWriteData.swift
@@ -8,44 +8,40 @@ import RealmSwift
 
 // :code-block-start: models
 class ReadWriteDataExamples_DogToy: Object {
-    @objc dynamic var name = ""
+    @Persisted var name = ""
 }
 
 class ReadWriteDataExamples_Dog: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var age = 0
-    @objc dynamic var color = ""
-    @objc dynamic var currentCity = ""
+    @Persisted var name = ""
+    @Persisted var age = 0
+    @Persisted var color = ""
+    @Persisted var currentCity = ""
 
     // To-one relationship
-    @objc dynamic var favoriteToy: ReadWriteDataExamples_DogToy?
+    @Persisted var favoriteToy: ReadWriteDataExamples_DogToy?
 }
 
 class ReadWriteDataExamples_Person: Object {
-    @objc dynamic var id = 0
-    @objc dynamic var name = ""
+    @Persisted(primaryKey: true) var id = 0
+    @Persisted var name = ""
 
     // To-many relationship - a person can have many dogs
-    let dogs = List<ReadWriteDataExamples_Dog>()
+    @Persisted var dogs: List<ReadWriteDataExamples_Dog>
 
     // Inverse relationship - a person can be a member of many clubs
-    let clubs = LinkingObjects(fromType: ReadWriteDataExamples_DogClub.self, property: "members")
-
-    override static func primaryKey() -> String? {
-        return "id"
-    }
+    @Persisted(originProperty: "members") var clubs: LinkingObjects<ReadWriteDataExamples_DogClub>
 }
 
 class ReadWriteDataExamples_DogClub: Object {
-    @objc dynamic var name = ""
-    let members = List<ReadWriteDataExamples_Person>()
+    @Persisted var name = ""
+    @Persisted var members: List<ReadWriteDataExamples_Person>
 }
 // :code-block-end:
 
 // :code-block-start: object-id-model
 class ReadWriteDataExamples_User: Object {
-    @objc dynamic var id = ObjectId.generate()
-    @objc dynamic var name = ""
+    @Persisted var id: ObjectId
+    @Persisted var name = ""
 }
 // :code-block-end:
 

--- a/examples/ios/Examples/Relationships.swift
+++ b/examples/ios/Examples/Relationships.swift
@@ -1,6 +1,7 @@
 // :replace-start: {
 //   "terms": {
 //     "InverseRelationshipExample_": "",
+//     "InverseRelationshipObjcDynamicExample_": "",
 //     "ToManyExample_": "",
 //     "ToOneRelationship_": ""
 //   }
@@ -25,6 +26,35 @@ class InverseRelationshipExample_Task: Object {
     // Backlink to the user. This is automatically updated whenever
     // this task is added to or removed from a user's task list.
     @Persisted(originProperty: "tasks") var assignee: LinkingObjects<InverseRelationshipExample_User>
+}
+// :code-block-end:
+
+// :code-block-start: inverse-relationship-objc-dynamic
+class InverseRelationshipObjcDynamicExample_User: Object {
+    @objc dynamic var _id: ObjectId = ObjectId.generate()
+    @objc dynamic var _partition: String = ""
+    @objc dynamic var name: String = ""
+
+    // A user can have many tasks.
+    let tasks = List<InverseRelationshipObjcDynamicExample_Task>()
+
+    override static func primaryKey() -> String? {
+        return "_id"
+    }
+}
+
+class InverseRelationshipObjcDynamicExample_Task: Object {
+    @objc dynamic var _id: ObjectId = ObjectId.generate()
+    @objc dynamic var _partition: String = ""
+    @objc dynamic var text: String = ""
+
+    // Backlink to the user. This is automatically updated whenever
+    // this task is added to or removed from a user's task list.
+    let assignee = LinkingObjects(fromType: InverseRelationshipObjcDynamicExample_User.self, property: "tasks")
+
+    override static func primaryKey() -> String? {
+        return "_id"
+    }
 }
 // :code-block-end:
 

--- a/examples/ios/Examples/Relationships.swift
+++ b/examples/ios/Examples/Relationships.swift
@@ -9,63 +9,55 @@ import RealmSwift
 
 // :code-block-start: inverse-relationship
 class InverseRelationshipExample_User: Object {
-    @objc dynamic var _id: ObjectId = ObjectId.generate()
-    @objc dynamic var _partition: String = ""
-    @objc dynamic var name: String = ""
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var _partition: String = ""
+    @Persisted var name: String = ""
 
     // A user can have many tasks.
-    let tasks = List<InverseRelationshipExample_Task>()
-
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted var tasks: List<InverseRelationshipExample_Task>
 }
 
 class InverseRelationshipExample_Task: Object {
-    @objc dynamic var _id: ObjectId = ObjectId.generate()
-    @objc dynamic var _partition: String = ""
-    @objc dynamic var text: String = ""
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var _partition: String = ""
+    @Persisted var text: String = ""
 
     // Backlink to the user. This is automatically updated whenever
     // this task is added to or removed from a user's task list.
-    let assignee = LinkingObjects(fromType: InverseRelationshipExample_User.self, property: "tasks")
-
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted(originProperty: "tasks") var assignee: LinkingObjects<InverseRelationshipExample_User>
 }
 // :code-block-end:
 
 // :code-block-start: to-many-relationship
 class ToManyExample_Person: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var birthdate: Date = Date(timeIntervalSince1970: 1)
+    @Persisted var name: String = ""
+    @Persisted var birthdate: Date = Date(timeIntervalSince1970: 1)
 
     // A person can have many dogs
-    let dogs = List<ToManyExample_Dog>()
+    @Persisted var dogs: List<ToManyExample_Dog>
 }
 
 class ToManyExample_Dog: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var age: Int = 0
-    @objc dynamic var breed: String?
+    @Persisted var name: String = ""
+    @Persisted var age: Int = 0
+    @Persisted var breed: String?
     // No backlink to person -- one-directional relationship
 }
 // :code-block-end:
 
 // :code-block-start: to-one-relationship
 class ToOneRelationship_Person: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var birthdate: Date = Date(timeIntervalSince1970: 1)
+    @Persisted var name: String = ""
+    @Persisted var birthdate: Date = Date(timeIntervalSince1970: 1)
 
     // A person can have one dog
-    @objc dynamic var dog: ToOneRelationship_Dog?
+    @Persisted var dog: ToOneRelationship_Dog?
 }
 
 class ToOneRelationship_Dog: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var age: Int = 0
-    @objc dynamic var breed: String?
+    @Persisted var name: String = ""
+    @Persisted var age: Int = 0
+    @Persisted var breed: String?
     // No backlink to person -- one-directional relationship
 }
 // :code-block-end:

--- a/examples/ios/Examples/Task.swift
+++ b/examples/ios/Examples/Task.swift
@@ -1,18 +1,15 @@
 import RealmSwift
 
 class Task: Object {
-    @objc dynamic var _id: ObjectId = ObjectId.generate()
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     // When configuring Sync, we selected `_partition` as the partition key.
     // A partition key is only required if you are using Sync.
-    @objc dynamic var _partition: String = ""
+    @Persisted var _partition: String = ""
 
-    @objc dynamic var name: String = ""
-    @objc dynamic var owner: String?
-    @objc dynamic var status: String = ""
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
+    @Persisted var status: String = ""
 
     convenience init(partition: String, name: String) {
         self.init()

--- a/examples/ios/Examples/TestSetup.swift
+++ b/examples/ios/Examples/TestSetup.swift
@@ -62,7 +62,7 @@ class TestSetup: NSObject {
         }
 
         let waiter = XCTWaiter()
-        waiter.wait(for: [expectation], timeout: 10)
+        waiter.wait(for: [expectation], timeout: 20)
         assert(waiter.fulfilledExpectations == [expectation])
 
         // Ensure all users are completely removed and app.currentUser is nil.

--- a/examples/ios/Examples/TestingAndDebugging.swift
+++ b/examples/ios/Examples/TestingAndDebugging.swift
@@ -10,12 +10,8 @@ import XCTest
 import RealmSwift
 
 class Debugging_User: Object {
-    @objc dynamic var _id = ObjectId.generate()
-    @objc dynamic var email: String = ""
-
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var email: String = ""
 }
 
 // :code-block-start: test-base-case

--- a/examples/ios/Examples/Threading.swift
+++ b/examples/ios/Examples/Threading.swift
@@ -8,7 +8,7 @@ import XCTest
 import RealmSwift
 
 class ThreadingExamples_Person: Object {
-    @objc dynamic var name = ""
+    @Persisted var name = ""
 
     convenience init(name: String) {
         self.init()
@@ -17,7 +17,7 @@ class ThreadingExamples_Person: Object {
 }
 
 class ThreadingExamples_Email: Object {
-    @objc dynamic var read = false
+    @Persisted var read = false
 }
 
 // :code-block-start: write-async-extension

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '13.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', '~>10.9.0'
-  pod 'RealmSwift', '~>10.9.0'
+  pod 'Realm', '~>10.10.0'
+  pod 'RealmSwift', '~>10.10.0'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,5 +13,5 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '~>10.9.0'
+  pod 'RealmSwift', '~>10.10.0'
 end

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Realm (10.9.0):
-    - Realm/Headers (= 10.9.0)
-  - Realm/Headers (10.9.0)
-  - RealmSwift (10.9.0):
-    - Realm (= 10.9.0)
+  - Realm (10.10.0):
+    - Realm/Headers (= 10.10.0)
+  - Realm/Headers (10.10.0)
+  - RealmSwift (10.10.0):
+    - Realm (= 10.10.0)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (~> 10.9.0)
-  - RealmSwift (~> 10.9.0)
+  - Realm (~> 10.10.0)
+  - RealmSwift (~> 10.10.0)
   - SwiftLint
 
 SPEC REPOS:
@@ -55,10 +55,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: 9feef41ab8230ed706c4dc503fc292594915bf9a
-  RealmSwift: 91246183b772e0ea1bf777116c4b8d9939f983b3
+  Realm: f501df41a4222c67850c77cf135d472192ecf294
+  RealmSwift: c69aadfc7db0d60075178d037c2f34ada73d5201
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 47c2b935c4f0d5228a8fd01244199d1e89628091
+PODFILE CHECKSUM: 9c2b754df215e1c112701b32faed47f18cc2a454
 
 COCOAPODS: 1.10.1

--- a/source/examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
+++ b/source/examples/generated/code/start/AnyRealmValue.codeblock.mixed-data-type.swift
@@ -1,26 +1,26 @@
 // Create a Dog object and then set its properties
+// In this case, the dog's age is an int
 let myDog = Dog()
 myDog.name = "Rex"
-// Because we declared age as a `RealmProperty`, we must mutate its `value` property
-myDog.age.value = .int(5)
+myDog.age = .int(5)
 // This dog has no companion.
 // You can set the field's type to "none", which represents `nil`
-myDog.companion.value = .none
+myDog.companion = .none
 
 // Create another Dog object whose age is a float
 let myOtherDog = Dog()
 myOtherDog.name = "Spot"
-myOtherDog.age.value = .float(2.5)
+myOtherDog.age = .float(2.5)
 // This dog's companion is a cat named Fluffy, represented by a string here
-myOtherDog.companion.value = .string("Fluffy the Cat")
+myOtherDog.companion = .string("Fluffy the Cat")
 
 // Create a third Dog object whose age is a string
 let myThirdDog = Dog()
 myThirdDog.name = "Fido"
-myThirdDog.age.value = .string("3 months")
+myThirdDog.age = .string("3 months")
 // This dog's companion is a Person, which is an object that has a
 // string name, an optional string address, and an int age
-myThirdDog.companion.value = .object(Person(value: ["name": "Sylvia", "age": 12]))
+myThirdDog.companion = .object(Person(value: ["name": "Sylvia", "age": 12]))
 
 // Get the default realm. You only need to do this once per thread.
 let realm = try! Realm()
@@ -34,19 +34,19 @@ try! realm.write {
 
 // Verify the type of the ``AnyRealmProperty`` when attempting to get it. This
 // returns an object whose property contains the matched type.
-if case let .int(age) = myDog.age.value {
+if case let .int(age) = myDog.age {
     print(age)  // Prints 5
 }
 
 // In this example, "myOtherDog"'s age is a float type, so checking the type
 // before trying to use it avoids an exception
-if case let .int(age) = myOtherDog.age.value {
+if case let .int(age) = myOtherDog.age {
     print(age)  // Doesn't print anything
 }
 
 // Retreiving an object stored as an ``AnyRealmProperty`` gives you
 // the complete object, containing all of the object's properties
-if case let .object(companion) = myThirdDog.companion.value {
+if case let .object(companion) = myThirdDog.companion {
     print(companion)
     // Prints all the details of the Person object:
     // {name = Sylvia; address = null; age = 12;}

--- a/source/examples/generated/code/start/CompleteQuickStart.codeblock.complete-quick-start.swift
+++ b/source/examples/generated/code/start/CompleteQuickStart.codeblock.complete-quick-start.swift
@@ -2,13 +2,10 @@ import RealmSwift
 
 // QsTask is the Task model for this QuickStart
 class QsTask: Object {
-    @objc dynamic var _id: ObjectId = ObjectId.generate()
-    @objc dynamic var name: String = ""
-    @objc dynamic var owner: String?
-    @objc dynamic var status: String = ""
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
+    @Persisted var status: String = ""
 
     convenience init(name: String) {
         self.init()

--- a/source/examples/generated/code/start/CompleteQuickStart.codeblock.model.swift
+++ b/source/examples/generated/code/start/CompleteQuickStart.codeblock.model.swift
@@ -1,12 +1,9 @@
 // QsTask is the Task model for this QuickStart
 class QsTask: Object {
-    @objc dynamic var _id: ObjectId = ObjectId.generate()
-    @objc dynamic var name: String = ""
-    @objc dynamic var owner: String?
-    @objc dynamic var status: String = ""
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
+    @Persisted var status: String = ""
 
     convenience init(name: String) {
         self.init()

--- a/source/examples/generated/code/start/EmbeddedObjects.codeblock.models.swift
+++ b/source/examples/generated/code/start/EmbeddedObjects.codeblock.models.swift
@@ -1,23 +1,19 @@
 // Define an embedded object
 class Address: EmbeddedObject {
-    @objc dynamic var street: String?
-    @objc dynamic var city: String?
-    @objc dynamic var country: String?
-    @objc dynamic var postalCode: String?
+    @Persisted var street: String?
+    @Persisted var city: String?
+    @Persisted var country: String?
+    @Persisted var postalCode: String?
 }
 
 // Define an object with one embedded object
 class Contact: Object {
-    @objc dynamic var _id = ObjectId.generate()
-    @objc dynamic var name = ""
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name = ""
 
     // Embed a single object.
     // Embedded object properties must be marked optional.
-    @objc dynamic var address: Address?
-
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted var address: Address?
 
     convenience init(name: String, address: Address) {
         self.init()
@@ -28,8 +24,8 @@ class Contact: Object {
 
 // Define an object with an array of embedded objects
 class Business: Object {
-    @objc dynamic var name = ""
-    let addresses = List<Address>() // Embed an array of objects
+    @Persisted var name = ""
+    @Persisted var addresses: List<Address> // Embed an array of objects
 
     convenience init(name: String, addresses: [Address]) {
         self.init()

--- a/source/examples/generated/code/start/LandingPageCodeExamples.codeblock.coffee-drink-object.swift
+++ b/source/examples/generated/code/start/LandingPageCodeExamples.codeblock.coffee-drink-object.swift
@@ -1,5 +1,5 @@
 class CoffeeDrink: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var hotOrCold: String?
-    @objc dynamic var rating = 0
+    @Persisted var name = ""
+    @Persisted var hotOrCold: String?
+    @Persisted var rating = 0
 }

--- a/source/examples/generated/code/start/LocalOnlyCompleteQuickStart.codeblock.complete-quick-start-local.swift
+++ b/source/examples/generated/code/start/LocalOnlyCompleteQuickStart.codeblock.complete-quick-start-local.swift
@@ -2,9 +2,9 @@ import RealmSwift
 
 // LocalOnlyQsTask is the Task model for this QuickStart
 class LocalOnlyQsTask: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var owner: String?
-    @objc dynamic var status: String = ""
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
+    @Persisted var status: String = ""
 
     convenience init(name: String) {
         self.init()

--- a/source/examples/generated/code/start/LocalOnlyCompleteQuickStart.codeblock.quick-start-local-define-object-model.swift
+++ b/source/examples/generated/code/start/LocalOnlyCompleteQuickStart.codeblock.quick-start-local-define-object-model.swift
@@ -1,8 +1,8 @@
 // LocalOnlyQsTask is the Task model for this QuickStart
 class LocalOnlyQsTask: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var owner: String?
-    @objc dynamic var status: String = ""
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
+    @Persisted var status: String = ""
 
     convenience init(name: String) {
         self.init()

--- a/source/examples/generated/code/start/MapExample.codeblock.models.swift
+++ b/source/examples/generated/code/start/MapExample.codeblock.models.swift
@@ -1,7 +1,7 @@
 class Dog: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var currentCity = ""
+    @Persisted var name = ""
+    @Persisted var currentCity = ""
 
     // Map of city name -> favorite park in that city
-    let favoriteParksByCity = Map<String, String>()
+    @Persisted var favoriteParksByCity: Map<String, String>
 }

--- a/source/examples/generated/code/start/Migrations.codeblock.model-v1.swift
+++ b/source/examples/generated/code/start/Migrations.codeblock.model-v1.swift
@@ -1,7 +1,7 @@
 // In the first version of the app, the Person model
 // has separate fields for first and last names.
 class Person: Object {
-    @objc dynamic var firstName = ""
-    @objc dynamic var lastName = ""
-    @objc dynamic var age = 0
+    @Persisted var firstName = ""
+    @Persisted var lastName = ""
+    @Persisted var age = 0
 }

--- a/source/examples/generated/code/start/Migrations.codeblock.model-v2.swift
+++ b/source/examples/generated/code/start/Migrations.codeblock.model-v2.swift
@@ -2,6 +2,6 @@
 // combined field for the name. A migration will be required
 // to convert from version 1 to version 2.
 class Person: Object {
-    @objc dynamic var fullName = ""
-    @objc dynamic var age = 0
+    @Persisted var fullName = ""
+    @Persisted var age = 0
 }

--- a/source/examples/generated/code/start/Models.codeblock.person-model.swift
+++ b/source/examples/generated/code/start/Models.codeblock.person-model.swift
@@ -1,10 +1,10 @@
 class Person: Object {
     // Required string property
-    @objc dynamic var name: String = ""
+    @Persisted var name: String = ""
 
     // Optional string property
-    @objc dynamic var address: String?
+    @Persisted var address: String?
 
     // Optional integral type property
-    let age = RealmProperty<Int?>()
+    @Persisted var age: Int?
 }

--- a/source/examples/generated/code/start/MutableSetExample.codeblock.set-collections-model.swift
+++ b/source/examples/generated/code/start/MutableSetExample.codeblock.set-collections-model.swift
@@ -1,5 +1,5 @@
 class Dog: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var currentCity = ""
-    let citiesVisited = MutableSet<String>()
+    @Persisted var name = ""
+    @Persisted var currentCity = ""
+    @Persisted var citiesVisited: MutableSet<String>
 }

--- a/source/examples/generated/code/start/Notifications.codeblock.register-an-object-change-listener.swift
+++ b/source/examples/generated/code/start/Notifications.codeblock.register-an-object-change-listener.swift
@@ -1,6 +1,6 @@
 // Define the dog class.
 class Dog: Object {
-    @objc dynamic var name = ""
+    @Persisted var name = ""
 }
 
 var objectNotificationToken: NotificationToken?

--- a/source/examples/generated/code/start/ObjectModels.codeblock.define-a-model.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.define-a-model.swift
@@ -1,12 +1,8 @@
 // A dog has an _id primary key, a string name, an optional
 // string breed, and a date of birth.
 class Dog: Object {
-    @objc dynamic var _id = ObjectId.generate()
-    @objc dynamic var name = ""
-    @objc dynamic var breed: String?
-    @objc dynamic var dateOfBirth = Date()
-
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name = ""
+    @Persisted var breed: String?
+    @Persisted var dateOfBirth = Date()
 }

--- a/source/examples/generated/code/start/ObjectModels.codeblock.ignore-a-property-objc-dynamic.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.ignore-a-property-objc-dynamic.swift
@@ -1,0 +1,15 @@
+class Person: Object {
+    @objc dynamic var tmpId = 0
+    @objc dynamic var firstName = ""
+    @objc dynamic var lastName = ""
+
+    // Read-only properties are automatically ignored
+    var name: String {
+        return "\(firstName) \(lastName)"
+    }
+
+    // Return a list of ignored property names
+    override static func ignoredProperties() -> [String] {
+        return ["tmpId"]
+    }
+}

--- a/source/examples/generated/code/start/ObjectModels.codeblock.ignore-a-property.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.ignore-a-property.swift
@@ -1,15 +1,21 @@
 class Person: Object {
-    @objc dynamic var tmpId = 0
-    @objc dynamic var firstName = ""
-    @objc dynamic var lastName = ""
+    // If some properties are marked as @Persisted,
+    // any properties that do not have the @Persisted
+    // annotation are automatically ignored.
+    var tmpId = 0
+
+    // The @Persisted properties are managed
+    @Persisted var firstName = ""
+    @Persisted var lastName = ""
 
     // Read-only properties are automatically ignored
     var name: String {
         return "\(firstName) \(lastName)"
     }
 
-    // Return a list of ignored property names
-    override static func ignoredProperties() -> [String] {
-        return ["tmpId"]
-    }
+    // If you mix the pre-10.10 property declaration
+    // syntax `@objc dynamic` with the 10.10+ @Persisted
+    // annotation within a class, `@objc dynamic`
+    // properties are ignored.
+    @objc dynamic var email = ""
 }

--- a/source/examples/generated/code/start/ObjectModels.codeblock.index-a-property-objc-dynamic.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.index-a-property-objc-dynamic.swift
@@ -1,0 +1,9 @@
+class Book: Object {
+    @objc dynamic var priceCents = 0
+    @objc dynamic var title = ""
+
+    // Return a list of indexed property names
+    override static func indexedProperties() -> [String] {
+        return ["title"]
+    }
+}

--- a/source/examples/generated/code/start/ObjectModels.codeblock.index-a-property.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.index-a-property.swift
@@ -1,9 +1,4 @@
 class Book: Object {
-    @objc dynamic var priceCents = 0
-    @objc dynamic var title = ""
-
-    // Return a list of indexed property names
-    override static func indexedProperties() -> [String] {
-        return ["title"]
-    }
+    @Persisted var priceCents = 0
+    @Persisted(indexed: true) var title = ""
 }

--- a/source/examples/generated/code/start/ObjectModels.codeblock.optional-required-properties-objc-dynamic.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.optional-required-properties-objc-dynamic.swift
@@ -1,0 +1,13 @@
+class Person: Object {
+    // Required string property
+    @objc dynamic var name = ""
+
+    // Optional string property
+    @objc dynamic var address: String?
+
+    // Required numeric property
+    @objc dynamic var ageYears = 0
+
+    // Optional numeric property
+    let heightCm = RealmProperty<Float?>()
+}

--- a/source/examples/generated/code/start/ObjectModels.codeblock.optional-required-properties.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.optional-required-properties.swift
@@ -1,13 +1,13 @@
 class Person: Object {
     // Required string property
-    @objc dynamic var name = ""
+    @Persisted var name = ""
 
     // Optional string property
-    @objc dynamic var address: String?
+    @Persisted var address: String?
 
     // Required numeric property
-    @objc dynamic var ageYears = 0
+    @Persisted var ageYears = 0
 
     // Optional numeric property
-    let heightCm = RealmProperty<Float?>()
+    @Persisted var heightCm: Float?
 }

--- a/source/examples/generated/code/start/ObjectModels.codeblock.realm-object-enum-objc-dynamic.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.realm-object-enum-objc-dynamic.swift
@@ -1,0 +1,17 @@
+// Define the enum
+@objc enum TaskStatusEnum: Int, RealmEnum {
+    case notStarted = 1
+    case inProgress = 2
+    case complete = 3
+}
+
+// To use the enum:
+class Task: Object {
+    @objc dynamic var name: String = ""
+    @objc dynamic var owner: String?
+
+    // Required enum property
+    @objc dynamic var status = TaskStatusEnum.notStarted 
+    // Optional enum property
+    let optionalTaskStatusEnumProperty = RealmProperty<TaskStatusEnum?>() 
+}

--- a/source/examples/generated/code/start/ObjectModels.codeblock.realm-object-enum.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.realm-object-enum.swift
@@ -1,18 +1,18 @@
 // Define the enum
-@objc enum TaskStatusEnum: Int, RealmEnum {
-    case notStarted = 1
-    case inProgress = 2
-    case complete = 3
+enum TaskStatusEnum: String, PersistableEnum {
+    case notStarted
+    case inProgress
+    case complete
 }
 
 // To use the enum:
 class Task: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var owner: String?
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
 
     // Required enum property
-    @objc dynamic var status = TaskStatusEnum.notStarted 
+    @Persisted var status = TaskStatusEnum.notStarted 
 
     // Optional enum property
-    let optionalTaskStatusEnumProperty = RealmProperty<TaskStatusEnum?>() 
+    @Persisted var optionalTaskStatusEnumProperty: TaskStatusEnum? 
 }

--- a/source/examples/generated/code/start/ObjectModels.codeblock.specify-a-primary-key-objc-dynamic.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.specify-a-primary-key-objc-dynamic.swift
@@ -1,0 +1,9 @@
+class Project: Object {
+    @objc dynamic var id = 0
+    @objc dynamic var name = ""
+
+    // Return the name of the primary key property
+    override static func primaryKey() -> String? {
+        return "id"
+    }
+}

--- a/source/examples/generated/code/start/ObjectModels.codeblock.specify-a-primary-key.swift
+++ b/source/examples/generated/code/start/ObjectModels.codeblock.specify-a-primary-key.swift
@@ -1,9 +1,4 @@
 class Project: Object {
-    @objc dynamic var id = 0
-    @objc dynamic var name = ""
-
-    // Return the name of the primary key property
-    override static func primaryKey() -> String? {
-        return "id"
-    }
+    @Persisted(primaryKey: true) var id = 0
+    @Persisted var name = ""
 }

--- a/source/examples/generated/code/start/QueryEngine.codeblock.models.swift
+++ b/source/examples/generated/code/start/QueryEngine.codeblock.models.swift
@@ -1,12 +1,12 @@
 class Task: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var isComplete = false
-    @objc dynamic var assignee: String?
-    @objc dynamic var priority = 0
-    @objc dynamic var progressMinutes = 0
+    @Persisted var name = ""
+    @Persisted var isComplete = false
+    @Persisted var assignee: String?
+    @Persisted var priority = 0
+    @Persisted var progressMinutes = 0
 }
 
 class Project: Object {
-    @objc dynamic var name = ""
-    let tasks = List<Task>()
+    @Persisted var name = ""
+    @Persisted var tasks: List<Task>
 }

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.models.swift
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.models.swift
@@ -1,33 +1,29 @@
 class DogToy: Object {
-    @objc dynamic var name = ""
+    @Persisted var name = ""
 }
 
 class Dog: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var age = 0
-    @objc dynamic var color = ""
-    @objc dynamic var currentCity = ""
+    @Persisted var name = ""
+    @Persisted var age = 0
+    @Persisted var color = ""
+    @Persisted var currentCity = ""
 
     // To-one relationship
-    @objc dynamic var favoriteToy: DogToy?
+    @Persisted var favoriteToy: DogToy?
 }
 
 class Person: Object {
-    @objc dynamic var id = 0
-    @objc dynamic var name = ""
+    @Persisted(primaryKey: true) var id = 0
+    @Persisted var name = ""
 
     // To-many relationship - a person can have many dogs
-    let dogs = List<Dog>()
+    @Persisted var dogs: List<Dog>
 
     // Inverse relationship - a person can be a member of many clubs
-    let clubs = LinkingObjects(fromType: DogClub.self, property: "members")
-
-    override static func primaryKey() -> String? {
-        return "id"
-    }
+    @Persisted(originProperty: "members") var clubs: LinkingObjects<DogClub>
 }
 
 class DogClub: Object {
-    @objc dynamic var name = ""
-    let members = List<Person>()
+    @Persisted var name = ""
+    @Persisted var members: List<Person>
 }

--- a/source/examples/generated/code/start/ReadWriteData.codeblock.object-id-model.swift
+++ b/source/examples/generated/code/start/ReadWriteData.codeblock.object-id-model.swift
@@ -1,4 +1,4 @@
 class User: Object {
-    @objc dynamic var id = ObjectId.generate()
-    @objc dynamic var name = ""
+    @Persisted var id: ObjectId
+    @Persisted var name = ""
 }

--- a/source/examples/generated/code/start/Relationships.codeblock.inverse-relationship-objc-dynamic.swift
+++ b/source/examples/generated/code/start/Relationships.codeblock.inverse-relationship-objc-dynamic.swift
@@ -1,0 +1,26 @@
+class User: Object {
+    @objc dynamic var _id: ObjectId = ObjectId.generate()
+    @objc dynamic var _partition: String = ""
+    @objc dynamic var name: String = ""
+
+    // A user can have many tasks.
+    let tasks = List<Task>()
+
+    override static func primaryKey() -> String? {
+        return "_id"
+    }
+}
+
+class Task: Object {
+    @objc dynamic var _id: ObjectId = ObjectId.generate()
+    @objc dynamic var _partition: String = ""
+    @objc dynamic var text: String = ""
+
+    // Backlink to the user. This is automatically updated whenever
+    // this task is added to or removed from a user's task list.
+    let assignee = LinkingObjects(fromType: User.self, property: "tasks")
+
+    override static func primaryKey() -> String? {
+        return "_id"
+    }
+}

--- a/source/examples/generated/code/start/Relationships.codeblock.inverse-relationship.swift
+++ b/source/examples/generated/code/start/Relationships.codeblock.inverse-relationship.swift
@@ -1,26 +1,18 @@
 class User: Object {
-    @objc dynamic var _id: ObjectId = ObjectId.generate()
-    @objc dynamic var _partition: String = ""
-    @objc dynamic var name: String = ""
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var _partition: String = ""
+    @Persisted var name: String = ""
 
     // A user can have many tasks.
-    let tasks = List<Task>()
-
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted var tasks: List<Task>
 }
 
 class Task: Object {
-    @objc dynamic var _id: ObjectId = ObjectId.generate()
-    @objc dynamic var _partition: String = ""
-    @objc dynamic var text: String = ""
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var _partition: String = ""
+    @Persisted var text: String = ""
 
     // Backlink to the user. This is automatically updated whenever
     // this task is added to or removed from a user's task list.
-    let assignee = LinkingObjects(fromType: User.self, property: "tasks")
-
-    override static func primaryKey() -> String? {
-        return "_id"
-    }
+    @Persisted(originProperty: "tasks") var assignee: LinkingObjects<User>
 }

--- a/source/examples/generated/code/start/Relationships.codeblock.to-many-relationship.swift
+++ b/source/examples/generated/code/start/Relationships.codeblock.to-many-relationship.swift
@@ -1,14 +1,14 @@
 class Person: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var birthdate: Date = Date(timeIntervalSince1970: 1)
+    @Persisted var name: String = ""
+    @Persisted var birthdate: Date = Date(timeIntervalSince1970: 1)
 
     // A person can have many dogs
-    let dogs = List<Dog>()
+    @Persisted var dogs: List<Dog>
 }
 
 class Dog: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var age: Int = 0
-    @objc dynamic var breed: String?
+    @Persisted var name: String = ""
+    @Persisted var age: Int = 0
+    @Persisted var breed: String?
     // No backlink to person -- one-directional relationship
 }

--- a/source/examples/generated/code/start/Relationships.codeblock.to-one-relationship.swift
+++ b/source/examples/generated/code/start/Relationships.codeblock.to-one-relationship.swift
@@ -1,14 +1,14 @@
 class Person: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var birthdate: Date = Date(timeIntervalSince1970: 1)
+    @Persisted var name: String = ""
+    @Persisted var birthdate: Date = Date(timeIntervalSince1970: 1)
 
     // A person can have one dog
-    @objc dynamic var dog: Dog?
+    @Persisted var dog: Dog?
 }
 
 class Dog: Object {
-    @objc dynamic var name: String = ""
-    @objc dynamic var age: Int = 0
-    @objc dynamic var breed: String?
+    @Persisted var name: String = ""
+    @Persisted var age: Int = 0
+    @Persisted var breed: String?
     // No backlink to person -- one-directional relationship
 }

--- a/source/sdk/ios/data-types/map.txt
+++ b/source/sdk/ios/data-types/map.txt
@@ -36,6 +36,18 @@ You can declare a Map as a property of an object:
 .. literalinclude:: /examples/generated/code/start/MapExample.codeblock.models.swift
    :language: swift
 
+.. note::
+
+   When declaring default values for ``@Persisted`` Map property attributes, both
+   of these syntax types is valid:
+
+   - ``@Persisted var value: Map<String, String>``
+   - ``@Persisted var value = Map<String, String>()``
+
+   However, the second will result in significantly worse performance. This is
+   because the Map is created when the parent object is created, rather than 
+   lazily as needed.
+
 You can then update, check values, iterate over, and delete from the Map
 as you would a standard :apple:`Dictionary
 <documentation/swift/dictionary>`:

--- a/source/sdk/ios/data-types/mutablesets.txt
+++ b/source/sdk/ios/data-types/mutablesets.txt
@@ -63,7 +63,19 @@ For example, a ``Dog`` class model might contain a ``MutableSet`` for
 .. literalinclude:: /examples/generated/code/start/MutableSetExample.codeblock.set-collections-model.swift
    :language: swift
 
-Which you can then update during write transactions:
+.. note::
+
+   When declaring default values for ``@Persisted`` MutableSet property attributes, 
+   both of these syntax types is valid:
+
+   - ``@Persisted var value: MutableSet<String>``
+   - ``@Persisted var value = MutableSet<String>()``
+
+   However, the second will result in significantly worse performance. This is
+   because the MutableSet is created when the parent object is created, rather than 
+   lazily as needed.
+
+You can then update the ``MutableSet`` during write transactions:
 
 .. literalinclude:: /examples/generated/code/start/MutableSetExample.codeblock.set-collections.swift
    :language: swift

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -256,7 +256,7 @@ both types, and use either as a :ref:`primary key <ios-specify-a-primary-key>`.
 .. note::
 
    When declaring default values for ``@Persisted`` UUID or ObjectId property 
-   attributes, both of these syntax types is valid:
+   attributes, both of these syntax types are valid:
 
    - ``@Persisted var value: UUID``
    - ``@Persisted var value = UUID()``
@@ -265,8 +265,10 @@ both types, and use either as a :ref:`primary key <ios-specify-a-primary-key>`.
    
    Additionally, ``@Persisted var id: ObjectId`` has equivalent behavior to 
    ``@objc dynamic var _id = ObjectId.generate()``, but not ``@objc 
-   dynamic var _id = ObjectId()``. The first syntax provides better performance
-   than ``ObjectId.generate()``.
+   dynamic var _id = ObjectId()``. 
+   
+   Prefer ``Persisted var id: ObjectId`` over ``@objc dynamic var _id = 
+   ObjectId.generate()`` for improved performance.
 
 
 .. _ios-size-limitations:

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -85,28 +85,29 @@ Property Cheat Sheet
       ``CGFloat`` properties are discouraged, as the type is not
       platform independent.
 
-      .. important:
+      Setting Default Values
+      ~~~~~~~~~~~~~~~~~~~~~~
 
-         With the ``@Persisted`` declaration syntax, you may see a performance 
-         impact when setting default values for: 
+      With the ``@Persisted`` property declaration syntax, you may see a 
+      performance impact when setting default values for: 
          
-         - ``List``
-         - ``MutableSet`` 
-         - ``Dictionary``
-         - ``Decimal128``
-         - ``UUID``
-         - ``ObjectId`` 
+      - ``List``
+      - ``MutableSet`` 
+      - ``Dictionary``
+      - ``Decimal128``
+      - ``UUID``
+      - ``ObjectId`` 
          
-         ``@Persisted var listProperty: List<Int>`` and ``@Persisted var 
-         listProperty = List<Int>()`` are both valid, and are functionally 
-         equivalent. However, the second declaration will result in poorer 
-         performance. 
+      ``@Persisted var listProperty: List<Int>`` and ``@Persisted var 
+      listProperty = List<Int>()`` are both valid, and are functionally 
+      equivalent. However, the second declaration will result in poorer 
+      performance. 
          
-         This is because the List is created when the parent object is 
-         created, rather than lazily as needed. For most types, this is 
-         a difference so small you can't measure it. For the types listed 
-         here, you may see a performance impact when using the second 
-         declaration style.
+      This is because the List is created when the parent object is 
+      created, rather than lazily as needed. For most types, this is 
+      a difference so small you can't measure it. For the types listed 
+      here, you may see a performance impact when using the second 
+      declaration style.
 
    .. tab:: Obective C
       :tabid: objective-c

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -15,10 +15,160 @@ Supported Property Types - iOS SDK
 Property Cheat Sheet
 --------------------
 
-.. tabs-realm-languages::
+.. tabs::
 
-   .. tab::
+   .. tab:: Swift
       :tabid: swift
+
+      .. versionchanged:: 10.10.0
+         ``@Persisted`` property declaration syntax
+
+      You can use the following types to define your object model
+      properties:
+
+      .. list-table::
+         :header-rows: 1
+         :stub-columns: 1
+         :widths: 20 40 40
+      
+         * - Type
+           - Required
+           - Optional
+         * - Bool
+           - ``@Persisted var value: Bool``
+           - ``@Persisted var value: Bool?``
+         * - Int, Int8, Int16, Int32, Int64
+           - ``@Persisted var value: Int``
+           - ``@Persisted var value: Int?``
+         * - Float
+           - ``@Persisted var value: Float``
+           - ``@Persisted var value: Float?``
+         * - Double
+           - ``@Persisted var value: Double``
+           - ``@Persisted var value: Double?``
+         * - String
+           - ``@Persisted var value: String``
+           - ``@Persisted var value: String?``
+         * - Data
+           - ``@Persisted var value = Data()``
+           - ``@Persisted var value: Data?``
+         * - Date
+           - ``@Persisted var value = Date()``
+           - ``@Persisted var value: Date?``
+         * - Decimal128
+           - ``@Persisted var decimal: Decimal128``
+           - ``@Persisted var decimal: Decimal128?``
+         * - :swift-sdk:`UUID <Extensions.html#/s:10Foundation4UUIDV>`
+           - ``@Persisted var uuid: UUID``
+           - ``@Persisted var uuidOpt: UUID?``
+         * - :swift-sdk:`ObjectId <Classes/ObjectId.html>`
+           - ``@Persisted var objectId: ObjectId``
+           - ``@Persisted var objectId: ObjectId?``
+         * - :swift-sdk:`List <Classes/List.html>`
+           - ``@Persisted var value: List<Type>``
+           - ``@Persisted var value: List<Type?>``
+         * - :ref:`MutableSet <ios-mutableset-data-type>` 
+           - ``@Persisted var value: MutableSet<Type>``
+           - ``@Persisted var value: MutableSet<Type?>``
+         * - :ref:`Map <ios-map>` 
+           - ``@Persisted var value = Map<String, String>``
+           - N/A
+         * - :ref:`AnyRealmValue <ios-anyrealmvalue-data-type>`
+           - ``@Persisted var value: AnyRealmValue``
+           - N/A
+      
+      Additionally:
+
+      - :swift-sdk:`EmbeddedObject <Extensions/EmbeddedObject.html>`-derived types
+      - :swift-sdk:`Enum <Protocols.html#/s:10RealmSwift0A4EnumP>`
+
+      ``CGFloat`` properties are discouraged, as the type is not
+      platform independent.
+
+      .. important:
+
+         With the ``@Persisted`` declaration syntax, you may see a performance 
+         impact when setting default values for: 
+         
+         - ``List``
+         - ``MutableSet`` 
+         - ``Dictionary``
+         - ``Decimal128``
+         - ``UUID``
+         - ``ObjectId`` 
+         
+         ``@Persisted var listProperty: List<Int>`` and ``@Persisted var 
+         listProperty = List<Int>()`` are both valid, and are functionally 
+         equivalent. However, the second declaration will result in poorer 
+         performance. 
+         
+         This is because the List is created when the parent object is 
+         created, rather than lazily as needed. For most types, this is 
+         a difference so small you can't measure it. For the types listed 
+         here, you may see a performance impact when using the second 
+         declaration style.
+
+   .. tab:: Obective C
+      :tabid: objective-c
+
+      You can use the following types to define your object model
+      properties:
+
+      .. list-table::
+         :header-rows: 1
+         :stub-columns: 1
+         :widths: 20 40 40
+      
+         * - Type
+           - Required
+           - Optional
+         * - Boolean
+           - ``@property BOOL value;``
+           - ``@property NSNumber<RLMBool> *value;``
+         * - Integer
+           - ``@property int value;``
+           - ``@property NSNumber<RLMInt> *value;``
+         * - Float
+           - ``@property float value;``
+           - ``@property NSNumber<RLMFloat> *value;``
+         * - Double
+           - ``@property double value;``
+           - ``@property NSNumber<RLMDouble> *value;``
+         * - String
+           - ``@property NSString *value;``
+           - ``@property NSString *value;``
+         * - Data
+           - ``@property NSData *value;``
+           - ``@property NSData *value;``
+         * - Date
+           - ``@property NSDate *value;``
+           - ``@property NSDate *value;``
+         * - Decimal128
+           - ``@property RLMDecimal128 *value;``
+           - ``@property RLMDecimal128 *value;``
+         * - NSUUID
+           - ``@property NSUUID *uuid;``
+           - 
+         * - :objc-sdk:`RLMObjectId <Classes/RLMObjectId.html>`
+           - ``@property RLMObjectId *objectId;``
+           - ``@property RLMObjectId *objectId;``
+         * - :objc-sdk:`RLMArray <Classes/RLMArray.html>`
+           - ``@property RLMArray<MyClass *><MyClass> *items;``
+           - ``@property RLMArray<MyClass *><MyClass> *items;``
+         * - User-defined :objc-sdk:`RLMObject<Classes/RLMObject.html>`
+           - N/A
+           - ``@property MyClass *value;``
+
+      Additionally:
+
+      - Integral types ``int``, ``NSInteger``, ``long``, ``long long``
+      - :objc-sdk:`RLMEmbeddedObject<Classes/RLMEmbeddedObject.html>`-derived types
+
+      ``CGFloat`` properties are discouraged, as the type is not
+      platform independent.
+
+   .. tab:: Swift pre-10.10.0
+      :tabid: swift-pre-10.10.0
 
       .. versionchanged:: 10.8.0
          ``RealmProperty`` replaces ``RealmOptional``
@@ -29,6 +179,7 @@ Property Cheat Sheet
       .. list-table::
          :header-rows: 1
          :stub-columns: 1
+         :widths: 20 40 40
       
          * - Type
            - Required
@@ -86,64 +237,6 @@ Property Cheat Sheet
 
       You can use ``RealmProperty <T?>`` to
       represent integers, doubles, and other types as optional.
-
-      ``CGFloat`` properties are discouraged, as the type is not
-      platform independent.
-
-   .. tab::
-      :tabid: objective-c
-
-      You can use the following types to define your object model
-      properties:
-
-      .. list-table::
-         :header-rows: 1
-         :stub-columns: 1
-      
-         * - Type
-           - Required
-           - Optional
-         * - Boolean
-           - ``@property BOOL value;``
-           - ``@property NSNumber<RLMBool> *value;``
-         * - Integer
-           - ``@property int value;``
-           - ``@property NSNumber<RLMInt> *value;``
-         * - Float
-           - ``@property float value;``
-           - ``@property NSNumber<RLMFloat> *value;``
-         * - Double
-           - ``@property double value;``
-           - ``@property NSNumber<RLMDouble> *value;``
-         * - String
-           - ``@property NSString *value;``
-           - ``@property NSString *value;``
-         * - Data
-           - ``@property NSData *value;``
-           - ``@property NSData *value;``
-         * - Date
-           - ``@property NSDate *value;``
-           - ``@property NSDate *value;``
-         * - Decimal128
-           - ``@property RLMDecimal128 *value;``
-           - ``@property RLMDecimal128 *value;``
-         * - NSUUID
-           - ``@property NSUUID *uuid;``
-           - 
-         * - :objc-sdk:`RLMObjectId <Classes/RLMObjectId.html>`
-           - ``@property RLMObjectId *objectId;``
-           - ``@property RLMObjectId *objectId;``
-         * - :objc-sdk:`RLMArray <Classes/RLMArray.html>`
-           - ``@property RLMArray<MyClass *><MyClass> *items;``
-           - ``@property RLMArray<MyClass *><MyClass> *items;``
-         * - User-defined :objc-sdk:`RLMObject<Classes/RLMObject.html>`
-           - N/A
-           - ``@property MyClass *value;``
-
-      Additionally:
-
-      - Integral types ``int``, ``NSInteger``, ``long``, ``long long``
-      - :objc-sdk:`RLMEmbeddedObject<Classes/RLMEmbeddedObject.html>`-derived types
 
       ``CGFloat`` properties are discouraged, as the type is not
       platform independent.

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -249,9 +249,24 @@ Unique Identifiers
 .. versionadded:: 10.8.0
    ``UUID`` type
 
-ObjectId is a MongoDB-specific 12-byte unique value. UUID is a 16-byte 
-globally-unique value. You can :ref:`index <ios-index-a-property>` both types,
-and use either as a :ref:`primary key <ios-specify-a-primary-key>`.
+``ObjectId`` is a MongoDB-specific 12-byte unique value. ``UUID`` is a 
+16-byte globally-unique value. You can :ref:`index <ios-index-a-property>` 
+both types, and use either as a :ref:`primary key <ios-specify-a-primary-key>`.
+
+.. note::
+
+   When declaring default values for ``@Persisted`` UUID or ObjectId property 
+   attributes, both of these syntax types is valid:
+
+   - ``@Persisted var value: UUID``
+   - ``@Persisted var value = UUID()``
+
+   However, the second will result in poorer performance. 
+   
+   Additionally, ``@Persisted var id: ObjectId`` has equivalent behavior to 
+   ``@objc dynamic var _id = ObjectId.generate()``, but not ``@objc 
+   dynamic var _id = ObjectId()``. The first syntax provides better performance
+   than ``ObjectId.generate()``.
 
 
 .. _ios-size-limitations:

--- a/source/sdk/ios/data-types/supported-property-types.txt
+++ b/source/sdk/ios/data-types/supported-property-types.txt
@@ -261,14 +261,15 @@ both types, and use either as a :ref:`primary key <ios-specify-a-primary-key>`.
    - ``@Persisted var value: UUID``
    - ``@Persisted var value = UUID()``
 
-   However, the second will result in poorer performance. 
+   However, the second will result in poorer performance. This is because the
+   latter creates a new identifier that is never used any time an object is
+   read from the {+realm+}, while the former only creates them when needed.
+
+   ``@Persisted var id: ObjectId`` has equivalent behavior to ``@objc dynamic 
+   var _id = ObjectId.generate()``. They both make random ObjectIds. 
    
-   Additionally, ``@Persisted var id: ObjectId`` has equivalent behavior to 
-   ``@objc dynamic var _id = ObjectId.generate()``, but not ``@objc 
-   dynamic var _id = ObjectId()``. 
-   
-   Prefer ``Persisted var id: ObjectId`` over ``@objc dynamic var _id = 
-   ObjectId.generate()`` for improved performance.
+   ``@Persisted var _id = ObjectId()`` has equivalent behavior to ``@objc 
+   dynamic var _id = ObjectId()``. They both make zero-initialized ObjectIds.
 
 
 .. _ios-size-limitations:

--- a/source/sdk/ios/examples/define-a-realm-object-model.txt
+++ b/source/sdk/ios/examples/define-a-realm-object-model.txt
@@ -62,24 +62,16 @@ Declare Properties
    For reference on which types {+client-database+} supports for use as
    properties, see :ref:`ios-supported-property-types`.
 
-.. tabs-realm-languages::
+.. tabs::
 
-   .. tab::
+   .. tab:: Swift
       :tabid: swift
 
-      When declaring non-generic properties, use the ``@objc dynamic
-      var`` annotation. The ``@objc dynamic var`` attribute turns Realm
-      model properties into accessors for the underlying database data.
-      If the class is declared as ``@objcMembers`` (Swift 4 or later),
-      you can declare properties as ``dynamic var`` without ``@objc``.
+      When declaring non-generic properties, use the ``@Persisted`` annotation. 
+      The ``@Persisted`` attribute turns Realm model properties into accessors 
+      for the underlying database data.
 
-      To declare properties of generic types ``LinkingObjects``,
-      ``List``, and ``RealmProperty``, use ``let``. Generic properties
-      cannot be represented in the Objective‑C runtime, which
-      {+client-database+} uses for dynamic dispatch of dynamic
-      properties.
-
-   .. tab::
+   .. tab:: Objective C
       :tabid: objective-c
 
       Declare properties on your object type as you would on a normal
@@ -93,6 +85,21 @@ Declare Properties
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.array-declaration.m
          :language: objectivec
+   
+   .. tab:: Swift pre-10.10.0
+      :tabid: swift-pre-10.10.0
+
+      When declaring non-generic properties, use the ``@objc dynamic
+      var`` annotation. The ``@objc dynamic var`` attribute turns Realm
+      model properties into accessors for the underlying database data.
+      If the class is declared as ``@objcMembers`` (Swift 4 or later),
+      you can declare properties as ``dynamic var`` without ``@objc``.
+
+      To declare properties of generic types ``LinkingObjects``,
+      ``List``, and ``RealmProperty``, use ``let``. Generic properties
+      cannot be represented in the Objective‑C runtime, which
+      {+client-database+} uses for dynamic dispatch of dynamic
+      properties.
 
 .. note::
 
@@ -103,29 +110,18 @@ Declare Properties
 Specify an Optional/Required Property
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 10.8.0
-   ``RealmProperty`` replaces ``RealmOptional``
+.. tabs::
 
-.. tabs-realm-languages::
-
-   .. tab::
+   .. tab:: Swift
       :tabid: swift
 
-      You can declare ``String``, ``Date``, ``Data``, and
-      :swift-sdk:`ObjectId <Classes/ObjectId.html>` properties as
-      optional or required (non-optional) using standard Swift syntax.
-      Declare optional numeric types using the :swift-sdk:`RealmProperty
-      <Classes/RealmProperty.html>` 
-      type.
+      You can declare properties as optional or required (non-optional) using 
+      standard Swift syntax.
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.optional-required-properties.swift
          :language: swift
 
-      RealmProperty supports ``Int``, ``Float``, ``Double``, ``Bool``,
-      and all of the sized versions of ``Int`` (``Int8``, ``Int16``,
-      ``Int32``, ``Int64``).
-
-   .. tab::
+   .. tab:: Objective C
       :tabid: objective-c
 
       To declare a given property as required, implement the
@@ -135,6 +131,26 @@ Specify an Optional/Required Property
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.optional-required-properties.m
          :language: objectivec
+   
+   .. tab:: Swift pre-10.10.0
+      :tabid: swift-pre-10.10.0
+
+      .. versionchanged:: 10.8.0
+         ``RealmProperty`` replaces ``RealmOptional``
+
+      You can declare ``String``, ``Date``, ``Data``, and
+      :swift-sdk:`ObjectId <Classes/ObjectId.html>` properties as
+      optional or required (non-optional) using standard Swift syntax.
+      Declare optional numeric types using the :swift-sdk:`RealmProperty
+      <Classes/RealmProperty.html>` 
+      type.
+
+      .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.optional-required-properties-objc-dynamic.swift
+         :language: swift
+
+      RealmProperty supports ``Int``, ``Float``, ``Double``, ``Bool``,
+      and all of the sized versions of ``Int`` (``Int8``, ``Int16``,
+      ``Int32``, ``Int64``).
 
 .. _ios-specify-a-primary-key:
 
@@ -151,19 +167,19 @@ You can efficiently :ref:`find
 As long as an object is managed by a {+realm+}, that object's primary
 key value is immutable.
 
-.. tabs-realm-languages::
+.. tabs::
 
-   .. tab::
+   .. tab:: Swift
       :tabid: swift
 
-      Override :swift-sdk:`Object.primaryKey()
-      <Extensions/Object.html#/c:@CM@RealmSwift@@objc(cs)RealmSwiftObject(cm)primaryKey>`
-      to set the model’s primary key.
+      Declare the property with :swift-sdk:`primaryKey: true
+      <s:10RealmSwift9PersistedVA2A11_PrimaryKeyRzrlE07primaryE0ACyxGSb_tcfc>`
+      on the ``@Persisted`` notation to set the model's primary key.
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.specify-a-primary-key.swift
          :language: swift
 
-   .. tab::
+   .. tab:: Objective C
       :tabid: objective-c
 
       Override :objc-sdk:`+[RLMObject primaryKey]
@@ -173,6 +189,15 @@ key value is immutable.
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.specify-a-primary-key.m
          :language: objectivec
 
+   .. tab:: Swift pre-10.10.0
+      :tabid: swift-pre-10.10.0
+
+      Override `Object.primaryKey()
+      <https://docs.mongodb.com/realm-sdks/swift/10.9.0/Extensions/Object.html#/c:@CM@RealmSwift@@objc(cs)RealmSwiftObject(cm)primaryKey>`_
+      to set the model’s primary key.
+
+      .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.specify-a-primary-key-objc-dynamic.swift
+         :language: swift
 
 .. _ios-index-a-property:
 
@@ -190,20 +215,20 @@ Realm supports indexing for string, integer, boolean, ``Date``, ``UUID``,
 .. versionadded:: 10.8.0
    ``UUID`` and ``AnyRealmValue`` types
 
-.. tabs-realm-languages::
+.. tabs::
 
-   .. tab::
+   .. tab:: Swift
       :tabid: swift
 
-      To index a property, override
-      :swift-sdk:`Object.indexedProperties()
+      To index a property, declare the property with 
+      :swift-sdk:`indexed:true
       <Extensions/Object.html#/c:@CM@RealmSwift@@objc(cs)RealmSwiftObject(cm)indexedProperties>`
-      and return a list of indexed property names.
+      on the ``@Persisted`` notation.
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.index-a-property.swift
          :language: swift
 
-   .. tab::
+   .. tab:: Objective C
       :tabid: objective-c
 
       To index a property, override :objc-sdk:`+[RLMObject
@@ -213,6 +238,17 @@ Realm supports indexing for string, integer, boolean, ``Date``, ``UUID``,
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.index-a-property.m
          :language: objectivec
+
+   .. tab:: Swift pre-10.10.0
+      :tabid: swift-pre-10.10.0
+
+      To index a property, override
+      `Object.indexedProperties()
+      <https://docs.mongodb.com/realm-sdks/swift/10.9.0/Extensions/Object.html#/c:@CM@RealmSwift@@objc(cs)RealmSwiftObject(cm)indexedProperties>`_
+      and return a list of indexed property names.
+
+      .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.index-a-property-objc-dynamic.swift
+         :language: swift
 
 .. _ios-ignore-a-property:
 
@@ -228,20 +264,25 @@ observe them using :apple:`KVO
 
    Realm automatically ignores read-only properties.
 
-.. tabs-realm-languages::
+.. tabs::
 
-   .. tab::
+   .. tab:: Swift
       :tabid: swift
 
+      .. deprecated:: 10.10.0 
+         ``ignoredProperties()``
+
       If you don’t want to save a field in your model to its realm,
-      override :swift-sdk:`Object.ignoredProperties()
-      <Extensions/Object.html#/c:@CM@RealmSwift@@objc(cs)RealmSwiftObject(cm)ignoredProperties>`
-      and return a list of ignored property names.
+      leave the ``@Persisted`` notation off the property attribute.
+
+      Additionally, if you mix ``@Persisted`` and ``@objc dynamic`` 
+      property declarations within a class, the ``@objc dynamic`` 
+      properties will be ignored.
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.ignore-a-property.swift
          :language: swift
 
-   .. tab::
+   .. tab:: Objective C
       :tabid: objective-c
 
       If you don’t want to save a field in your model to its realm,
@@ -252,18 +293,50 @@ observe them using :apple:`KVO
       .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.ignore-a-property.m
          :language: objectivec
 
+   .. tab:: Swift pre-10.10.0
+      :tabid: swift-pre-10.10.0
+
+      If you don’t want to save a field in your model to its realm,
+      override `Object.ignoredProperties()
+      <https://docs.mongodb.com/realm-sdks/swift/10.9.0/Extensions/Object.html#/c:@CM@RealmSwift@@objc(cs)RealmSwiftObject(cm)ignoredProperties>`_
+      and return a list of ignored property names.
+
+      .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.ignore-a-property-objc-dynamic.swift
+         :language: swift
+
 .. _ios-realm-enum:
 
 Declare Enum Properties
 -----------------------
 
-{+service-short+} supports only ``Int``-backed ``@objc`` enums.
+.. tabs::
 
-.. include:: /examples/generated/code/start/ObjectModels.codeblock.realm-object-enum.swift.code-block.rst
+   .. tab:: Swift
+      :tabid: swift
 
-.. seealso::
+      .. versionchanged:: 10.10.0 
+         {+service-short+} supports enums of any RawType. Protocol is now 
+         ``PersistableEnum`` rather than ``RealmEnum``.
 
-   :swift-sdk:`RealmEnum <Protocols.html#/s:10RealmSwift0A4EnumP>`
+      You can use enums with ``@Persisted`` by marking it as complying with the
+      :swift-sdk:`PersistableEnum <Protocols.html#/s:10RealmSwift15PersistableEnumP>` 
+      protocol. {+service-short+} supports enums of any RawType.
+
+      .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.realm-object-enum.swift
+         :language: swift
+
+   .. tab:: Swift pre-10.10.0
+      :tabid: swift-pre-10.10.0
+
+      {+service-short+} supports only ``Int``-backed ``@objc`` enums.
+
+      .. literalinclude:: /examples/generated/code/start/ObjectModels.codeblock.realm-object-enum-objc-dynamic.swift
+         :language: swift
+
+      .. seealso::
+
+         `RealmEnum <https://docs.mongodb.com/realm-sdks/swift/10.9.0/Protocols.html#/s:10RealmSwift0A4EnumP>`_
+
 
 .. _ios-declare-relationship-properties:
 
@@ -339,9 +412,9 @@ relationships whenever an object is added or removed in a corresponding
 to-many list or to-one relationship property. You cannot manually set
 the value of an inverse relationship property.
 
-.. tabs-realm-languages::
+.. tabs::
 
-   .. tab::
+   .. tab:: Swift
       :tabid: swift
 
       To define an inverse relationship, use :swift-sdk:`LinkingObjects
@@ -352,7 +425,7 @@ the value of an inverse relationship property.
       .. literalinclude:: /examples/generated/code/start/Relationships.codeblock.inverse-relationship.swift
          :language: swift
 
-   .. tab::
+   .. tab:: Objective C
       :tabid: objective-c
 
       To define an inverse relationship, use
@@ -365,6 +438,17 @@ the value of an inverse relationship property.
 
       .. literalinclude:: /examples/generated/code/start/Relationships.codeblock.inverse-relationship.m
          :language: objectivec
+
+   .. tab:: Swift pre-10.10.0
+      :tabid: swift-pre-10.10.0
+
+      To define an inverse relationship, use `LinkingObjects
+      <https://docs.mongodb.com/realm-sdks/swift/10.9.0/Structs/LinkingObjects.html>`_ 
+      in your object model. The ``LinkingObjects`` definition specifies 
+      the object type and property name of the relationship that it inverts.
+
+      .. literalinclude:: /examples/generated/code/start/Relationships.codeblock.inverse-relationship-objc-dynamic.swift
+         :language: swift
 
 .. _ios-define-an-embedded-object-property:
 

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -220,7 +220,7 @@ does not allow you to:
    For example, a base class could have a ``@Persisted var foo: Int`` property, 
    and a subclass could have an ``@objc dynamic var bar = 0`` property, with 
    both persisted. However, the ``@objc dynamic`` property would be ignored if
-   the ``@Persisted`` property was within the same base or subclass.
+   the ``@Persisted`` property were within the same base or subclass.
 
 Summary
 -------

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -52,7 +52,7 @@ Persisted Property Attributes
    The ``@Persisted`` declaration style replaces the ``@objc dynamic``, 
    ``RealmOptional``, and ``RealmProperty`` declaration notations from older 
    versions of the SDK. For an older version of the SDK, see: 
-   :ref:`Objective-C Dynamic Property Attributes <objc-dynamic-property-attributes>`
+   :ref:`Objective-C Dynamic Property Attributes <objc-dynamic-property-attributes>`.
 
 Declare model properties that you want to store to the database as 
 ``@Persisted``. This enables them to access the underlying database data.
@@ -216,10 +216,11 @@ does not allow you to:
 
 .. versionadded:: 10.10.0
    While you can't mix ``@Persisted`` and ``@objc dynamic`` property declarations
-   within a class, you can mix the notation styles across parent and subclasses. 
-   For example, a parent class could have a ``@Persisted var foo: Int`` property, 
-   and a child of that class could have an ``@objc dynamic var bar = 0`` property, 
-   and both will be persisted.
+   within a class, you can mix the notation styles across base and subclasses. 
+   For example, a base class could have a ``@Persisted var foo: Int`` property, 
+   and a subclass could have an ``@objc dynamic var bar = 0`` property, with 
+   both persisted. However, the ``@objc dynamic`` property would be ignored if
+   the ``@Persisted`` property was within the same base or subclass.
 
 Summary
 -------

--- a/source/sdk/ios/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/ios/fundamentals/object-models-and-schemas.txt
@@ -34,6 +34,49 @@ object that can be stored in that {+realm+}.
 Property Attributes
 -------------------
 
+When you declare the property attributes of a class, you can specify whether
+or not those properties should be managed by the {+realm+}. Managed properties 
+are stored or updated in the database. Conversely, ignored properties are not
+stored to the database. You can mix managed and ignored properties 
+within a class. 
+
+The syntax to mark properties as managed or ignored varies depending on which
+version of the SDK you use.
+
+.. _persisted-property-attributes:
+
+Persisted Property Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 10.10.0
+   The ``@Persisted`` declaration style replaces the ``@objc dynamic``, 
+   ``RealmOptional``, and ``RealmProperty`` declaration notations from older 
+   versions of the SDK. For an older version of the SDK, see: 
+   :ref:`Objective-C Dynamic Property Attributes <objc-dynamic-property-attributes>`
+
+Declare model properties that you want to store to the database as 
+``@Persisted``. This enables them to access the underlying database data.
+
+When you declare any properties as ``@Persisted`` within a class, the other 
+properties within that class are automatically ignored.
+
+If you mix ``@Persisted`` and ``@objc dynamic`` property declarations within
+a class definition, any property attributes marked as ``@objc dynamic`` will 
+be ignored.
+
+.. seealso::
+
+   Our :ref:`Supported Property Types <ios-supported-property-types>` 
+   page contains a property declaration cheatsheet.
+
+.. _objc-dynamic-property-attributes:
+
+Objective-C Dynamic Property Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. versionchanged:: 10.10.0
+   This property declaration information is for versions of the SDK before 
+   10.10.0. 
+
 Declare dynamic {+backend-short+} model properties in the Objective-C runtime. This 
 enables them to access the underlying database data. 
 
@@ -171,6 +214,13 @@ does not allow you to:
    <realm/realm-cocoa/issues/1109#issuecomment-143834756>` for working
    around these limitations.
 
+.. versionadded:: 10.10.0
+   While you can't mix ``@Persisted`` and ``@objc dynamic`` property declarations
+   within a class, you can mix the notation styles across parent and subclasses. 
+   For example, a parent class could have a ``@Persisted var foo: Int`` property, 
+   and a child of that class could have an ``@objc dynamic var bar = 0`` property, 
+   and both will be persisted.
+
 Summary
 -------
 
@@ -179,7 +229,7 @@ Summary
 
 - The {+service-short+} object's **schema** defines the fields of the object and
   which fields are optional, which fields have a default value,
-  and which fields are indexed.
+  which fields are indexed, and which fields are ignored.
 
 - You can define to-one, to-many, and inverse relationships in your schema.
   Inverse relationships automatically form backlinks.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-16043

### Project Kickoff Doc

- [iOS @Persisted Property Wrapper Docs Project Outline](https://docs.google.com/document/d/1nPr-2qfkJaLnqcdS1EZbo3kF9rHcXd6cwdtLq4bDg3g/edit?usp=sharing)

### Staged Changes (Requires MongoDB Corp SSO)

- [Object Models & Schemas](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/fundamentals/object-models-and-schemas/)
     - Added new sections and descriptions under the [Property Attributes section](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/fundamentals/object-models-and-schemas/#property-attributes)
     - Added a note about [changes to Model Inheritance](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/fundamentals/object-models-and-schemas/#model-inheritance) relative to the new `@Persisted` declaration
- [Supported Property Types](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/data-types/supported-property-types/)
     - Added the new `@Persisted` property declarations to the `Swift` tab
     - Added a note about performance when setting default values for some types using the new `@Persisted` notation under the `Swift` property declaration cheat sheet tab
     - Added a note about performance implications of the new `@Persisted` syntax under the Unique Identifiers section
     - Added a `Swift pre-10.10.10` tab with the old style property declarations 
- [Map](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/data-types/map/)
     - Added a note under usage about performance implications when declaring default values
     - Updated code example to show the `@Persisted` syntax
- [MutableSet](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/data-types/mutablesets/)
     - Added a note under usage about performance implications when declaring default values
     - Updated code example to show the `@Persisted` syntax
- [Define a Realm Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/define-a-realm-object-model/)
     - Update all `Swift` examples for the new `@Persisted` syntax
     - Add a `Swift pre-10.10.10` tab showing the `@objc dynamic` syntax in some places:
          - Declare Properties
          - Specify an Optional/Required Property
          - Specify a Primary Key
          - Index a Property
          - Ignore a Property
          - Declare Enum Properties
          - Define an Inverse Relationship Property
- [Read & Write Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/read-and-write-data/)
     - Update `Swift` examples that show property declarations for the new `@Persisted` syntax
          - The models in [About These Examples](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/read-and-write-data/#about-these-examples)
          - The object in [Filter on Object ID Properties](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/read-and-write-data/#filter-on-object-id-properties)
- [Filter Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/filter-data/)
     - Update the  models in the [About the Examples on This Page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/filter-data/) to show the new `@Persisted` syntax
- [React to Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/react-to-changes/)
     - Update the model in the [Register an Object Change Listener](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/react-to-changes/#register-an-object-change-listener) code example to show the new `@Persisted` syntax
- [Modify an Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/modify-an-object-schema/)
     - Update the model in the [Perform a Schema Migration](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/examples/modify-an-object-schema/#perform-a-schema-migration) code example to show the new `@Persisted` syntax
- [Quick Start](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/quick-start/)
     - Update the code examples to show the new `@Persisted` syntax
- [Quick Start with Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/quick-start-with-sync/)
     - Update the code examples to show the new `@Persisted` syntax

Still to do that is not part of this ticket:
- Update the [SwiftUI & Combine](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/sdk/ios/integrations/swiftui/) Integration Guide to show the new syntax
- Update the [iOS Swift Tutorial](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16043/tutorial/ios-swift/) to show the new syntax

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
