### PR TITLE
(DOCSP-17493): Update SwiftUI example app for cocoa 10.10.0 syntax

### DIFF
--- a/examples/ios/QuickStartSwiftUI/QuickStart.swift
+++ b/examples/ios/QuickStartSwiftUI/QuickStart.swift
@@ -38,36 +38,28 @@ let randomNouns = [
 
 /// An individual item. Part of a `Group`.
 final class Item: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Item.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Item. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The name of the Item, By default, a random name is generated.
-    @objc dynamic var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
+    @Persisted var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
 
     /// A flag indicating whether the user "favorited" the item.
-    @objc dynamic var isFavorite = false
+    @Persisted var isFavorite = false
 
     /// The backlink to the `Group` this item is a part of.
-    let group = LinkingObjects(fromType: Group.self, property: "items")
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted(originProperty: "items") var group: LinkingObjects<Group>
 }
 
 /// Represents a collection of items.
 final class Group: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Group.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Group. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The collection of Items in this group.
-    var items = RealmSwift.List<Item>()
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted var items = RealmSwift.List<Item>()
 }
 // :code-block-end:
 

--- a/source/examples/generated/swiftui/local/QuickStart.codeblock.complete-swiftui-combine-quick-start.swift
+++ b/source/examples/generated/swiftui/local/QuickStart.codeblock.complete-swiftui-combine-quick-start.swift
@@ -21,36 +21,28 @@ let randomNouns = [
 
 /// An individual item. Part of a `Group`.
 final class Item: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Item.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Item. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The name of the Item, By default, a random name is generated.
-    @objc dynamic var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
+    @Persisted var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
 
     /// A flag indicating whether the user "favorited" the item.
-    @objc dynamic var isFavorite = false
+    @Persisted var isFavorite = false
 
     /// The backlink to the `Group` this item is a part of.
-    let group = LinkingObjects(fromType: Group.self, property: "items")
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted(originProperty: "items") var group: LinkingObjects<Group>
 }
 
 /// Represents a collection of items.
 final class Group: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Group.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Group. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The collection of Items in this group.
-    var items = RealmSwift.List<Item>()
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted var items = RealmSwift.List<Item>()
 }
 
 // MARK: Views

--- a/source/examples/generated/swiftui/local/QuickStart.codeblock.models.swift
+++ b/source/examples/generated/swiftui/local/QuickStart.codeblock.models.swift
@@ -15,34 +15,26 @@ let randomNouns = [
 
 /// An individual item. Part of a `Group`.
 final class Item: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Item.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Item. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The name of the Item, By default, a random name is generated.
-    @objc dynamic var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
+    @Persisted var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
 
     /// A flag indicating whether the user "favorited" the item.
-    @objc dynamic var isFavorite = false
+    @Persisted var isFavorite = false
 
     /// The backlink to the `Group` this item is a part of.
-    let group = LinkingObjects(fromType: Group.self, property: "items")
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted(originProperty: "items") var group: LinkingObjects<Group>
 }
 
 /// Represents a collection of items.
 final class Group: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Group.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Group. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The collection of Items in this group.
-    var items = RealmSwift.List<Item>()
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted var items = RealmSwift.List<Item>()
 }

--- a/source/examples/generated/swiftui/sync/QuickStart.codeblock.complete-swiftui-combine-quick-start.swift
+++ b/source/examples/generated/swiftui/sync/QuickStart.codeblock.complete-swiftui-combine-quick-start.swift
@@ -28,36 +28,28 @@ let randomNouns = [
 
 /// An individual item. Part of a `Group`.
 final class Item: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Item.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Item. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The name of the Item, By default, a random name is generated.
-    @objc dynamic var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
+    @Persisted var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
 
     /// A flag indicating whether the user "favorited" the item.
-    @objc dynamic var isFavorite = false
+    @Persisted var isFavorite = false
 
     /// The backlink to the `Group` this item is a part of.
-    let group = LinkingObjects(fromType: Group.self, property: "items")
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted(originProperty: "items") var group: LinkingObjects<Group>
 }
 
 /// Represents a collection of items.
 final class Group: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Group.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Group. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The collection of Items in this group.
-    var items = RealmSwift.List<Item>()
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted var items = RealmSwift.List<Item>()
 }
 
 // MARK: Views

--- a/source/examples/generated/swiftui/sync/QuickStart.codeblock.models.swift
+++ b/source/examples/generated/swiftui/sync/QuickStart.codeblock.models.swift
@@ -15,34 +15,26 @@ let randomNouns = [
 
 /// An individual item. Part of a `Group`.
 final class Item: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Item.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Item. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The name of the Item, By default, a random name is generated.
-    @objc dynamic var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
+    @Persisted var name = "\(randomAdjectives.randomElement()!) \(randomNouns.randomElement()!)"
 
     /// A flag indicating whether the user "favorited" the item.
-    @objc dynamic var isFavorite = false
+    @Persisted var isFavorite = false
 
     /// The backlink to the `Group` this item is a part of.
-    let group = LinkingObjects(fromType: Group.self, property: "items")
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted(originProperty: "items") var group: LinkingObjects<Group>
 }
 
 /// Represents a collection of items.
 final class Group: Object, ObjectKeyIdentifiable {
-    /// The unique ID of the Group.
-    @objc dynamic var _id = ObjectId.generate()
+    /// The unique ID of the Group. `primaryKey: true` declares the
+    /// _id member as the primary key to the realm.
+    @Persisted(primaryKey: true) var _id: ObjectId
 
     /// The collection of Items in this group.
-    var items = RealmSwift.List<Item>()
-
-    /// Declares the _id member as the primary key to the realm.
-    override class func primaryKey() -> String? {
-        "_id"
-    }
+    @Persisted var items = RealmSwift.List<Item>()
 }

--- a/source/sdk/ios/integrations/swiftui.txt
+++ b/source/sdk/ios/integrations/swiftui.txt
@@ -17,7 +17,8 @@ Prerequisites
 
 - Have Xcode 12.2 or later (minimum Swift version 5.3.1).
 - Create a new Xcode project using the SwiftUI "App" template with a minimum iOS target of 14.0.
-- :ref:`Install the iOS SDK. <ios-install>`
+- :ref:`Install the iOS SDK. <ios-install>` This SwiftUI app requires a minimum 
+  SDK version of 10.10.0.
 
 Overview
 --------


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-17493

### Staged Changes (Requires MongoDB Corp SSO)

- [Use Realm Database with SwiftUI and Combine](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17493/sdk/ios/integrations/swiftui/): 
     - Added SDK version requirement to Prerequisites section
     - Updated code examples to show: 
          - `@Persisted` syntax
          - New way of declaring `primaryKey` 
          - More performant `ObjectId`
          - New way of declaring `LinkingObjects`

Note for @cbush: when I updated the `LinkingObjects` syntax, I got an error message until I added `@Persisted` to the `var items` in line 62. It was _not_ declared as `@objc dynamic` in the pre-10.10.0 version of this app. Confirmed the app works with this syntax, but am wondering if I'm missing some reason to have not done it this way. 

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
