### PR TITLE
Update Android card on SDK landing page

### DIFF
--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -27,7 +27,7 @@ Realm has open-source SDKs available for most popular languages, frameworks, and
       :icon: /images/icons/android_sdk.svg
       :icon-alt: Android SDK icon
 
-      Build applications for Android. Realm data maps directly to the classes in your app.
+      Build applications for Android in Java or Kotlin. Realm data maps directly to the classes in your app.
 
    .. card::
       :headline: iOS SDK

--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -27,7 +27,7 @@ Realm has open-source SDKs available for most popular languages, frameworks, and
       :icon: /images/icons/android_sdk.svg
       :icon-alt: Android SDK icon
 
-      Build applications for Android in Java or Kotlin. Realm data maps directly to the classes in your app.
+      Build Android applications in Java or Kotlin. Realm data maps directly to the classes in your app.
 
    .. card::
       :headline: iOS SDK


### PR DESCRIPTION
## Pull Request Info

I noticed the Android card on the new SDK landing page is the only one that doesn't mention the SDK's languages. This PR adds Java and Kotlin to the Android card.

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm SDKs](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/update-sdk-lp/sdk/): Update the Android card

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
