### PR TITLE
DOCSP-13423 changed the min Node version to 12 instead of 10

### DIFF
--- a/source/sdk/node/install.txt
+++ b/source/sdk/node/install.txt
@@ -36,7 +36,7 @@ Prerequisites
 Before getting started, ensure your environment meets the
 following prerequisites:
 
-- `Node.js <https://nodejs.org/en/>`__ version 10.x or later (including Node version 14) 
+- `Node.js <https://nodejs.org/en/>`__ version 12.x or later (including Node version 14) 
 - Linux, macOS 10.8 (or later), or Windows 8 (or later)
 
 Installation


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-13423

### Staged Changes (Requires MongoDB Corp SSO)

- [Install Realm for Node.js](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-13423/sdk/node/install/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
