### PR TITLE
(DOCSP-17462): Add Missing .NET Link in /sync/get-started

### DIFF
--- a/source/includes/steps-enable-sync-ui.yaml
+++ b/source/includes/steps-enable-sync-ui.yaml
@@ -63,5 +63,6 @@ content: |
 
   - :ref:`Sync Data on Android <android-sync-data>`
   - :ref:`Sync Data on iOS, macOS, and tvOS<ios-sync-changes-between-devices>`
+  - :ref:`Sync Data on .NET <dotnet-sync-changes-between-devices>`
   - :ref:`Sync Data on Node.js <node-sync-changes-between-devices>`
   - :ref:`Sync Data with React Native <react-native-sync-changes-between-devices>`


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-17462

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm Sync > Get Started with Sync#Sync Data from a Client](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17462-missing-csharp-syncdata-link/sync/get-started/#sync-data-from-a-client)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
