### PR TITLE
enable offline-first in TaskProvider, syncing changes in the background

### DIFF
--- a/tutorial/rn/providers/TasksProvider.js
+++ b/tutorial/rn/providers/TasksProvider.js
@@ -15,7 +15,8 @@ const TasksProvider = ({ children, projectPartition }) => {
   const realmRef = useRef(null);
 
   useEffect(() => {
-    // enable offline-first, syncing changes in the background
+    // Enables offline-first: opens a local realm immediately without waiting 
+    // for the download of a synchronized realm to be completed.
     const OpenRealmBehaviorConfiguration = {
       type: 'openImmediately',
     };

--- a/tutorial/rn/providers/TasksProvider.js
+++ b/tutorial/rn/providers/TasksProvider.js
@@ -15,11 +15,17 @@ const TasksProvider = ({ children, projectPartition }) => {
   const realmRef = useRef(null);
 
   useEffect(() => {
+    // enable offline-first, syncing changes in the background
+    const OpenRealmBehaviorConfiguration = {
+      type: 'openImmediately',
+    };
     // :code-block-start: open-project-realm
     const config = {
       sync: {
         user: user,
         partitionValue: projectPartition,
+        newRealmFileBehavior: OpenRealmBehaviorConfiguration,
+        existingRealmFileBehavior: OpenRealmBehaviorConfiguration,
       },
     };
     // :state-start: final


### PR DESCRIPTION
## Pull Request Info

### What Issue does this address?

The example app in the MongoDB Realm documentation implements Sync, but is not really offline capable. The example app using Realm Sync does not actually illustrate offline-first: Once offline no tasks will be loaded, and even online the unmodified app took between 1000 and 4000 ms (depending on server region) to load a handful of tasks, which shows it is loading these from the MongoDB Atlas server first.

I have tested both the iOS Swift and the React Native 'Task Tracker' app and they are for the most part not offline-first capable as currently implemented.

### How to reproduce

Try to disconnect from the network while in the 'Projects' view of the app. Then click on 'My Project' which is supposed to display a list of tasks. In React Native it will show an empty list while the iOS Swift implementation will just stop responding while offline.

### Fix

This PR will enable proper offline-first behaviour in TaskProvider.js on React Native, syncing changes in the background. It also improves online responsiveness as the visible delay of loading the tasks is alleviated.

### New behaviour

Try to disconnect from the network while in the 'Projects' view of the app. Then click on 'My Project' which is supposed to display a list of tasks. In React Native it will now show a the list of tasks offline, being fully editable as to Task status. Also switching back and forth to the Project View and Task View is possible. While still in the app, the other team members' Projects with tasks will also be accessible.

### Limitations

More testing is recommended, as the new code may require additional code changes elsewhere in the app.

Editing the Team Members list is not possible, as this depends on backend server functions. More code changes are required to get some of this working smoothly in an offline-first scenario.

Also logging out and logging back in is not possible while offline, as authentication happens on the server.

### Relevant Documentation

[Sync Changes Between Devices - React Native SDK — MongoDB Realm](https://docs.mongodb.com/realm/sdk/react-native/examples/sync-changes-between-devices/#sync-changes-in-the-background)

> You may want to sync changes in the background to display partial data to
> the user while the synced realm downloads data from the server, preventing
> the user experience from being blocked. We recommend syncing changes in the
> background for applications in which the user's device may go offline.
> To sync changes in the background, *open a synced realm synchronously*.

> Create a Configuration object, which must include the sync property defining
> a SyncConfiguration object. Set this OpenRealmBehaviorConfiguration object as
> the value for the newRealmFileBehavior and existingRealmFileBehavior fields of
> the SyncConfiguration.

