### PR TITLE
Change nonsensical version added to note

### DIFF
--- a/source/sdk/android/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/android/fundamentals/object-models-and-schemas.txt
@@ -50,7 +50,7 @@ created, modified, or deleted.
 Primary Keys
 ------------
 
-.. versionadded:: Since version 10.6.0, {+client-database+} automatically indexes primary keys.
+.. note:: Since version 10.6.0, {+client-database+} automatically indexes primary keys.
 
 {+service-short+} treats fields marked with the
 :java-sdk:`@PrimaryKey <io/realm/annotations/PrimaryKey.html>` annotation

--- a/source/sdk/android/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/android/fundamentals/object-models-and-schemas.txt
@@ -52,7 +52,8 @@ Primary Keys
 
 .. versionadded:: 10.6.0
 
-   Since version 10.6.0, {+client-database+} automatically indexes primary keys.
+   {+client-database+} automatically :ref:`indexes <android-indexes-fundamentals>`
+   primary key fields.
 
 {+service-short+} treats fields marked with the
 :java-sdk:`@PrimaryKey <io/realm/annotations/PrimaryKey.html>` annotation
@@ -82,9 +83,6 @@ You can create a primary key with any of the following types:
 - ``Long`` or ``long``
 - ``Short`` or ``short``
 - ``Byte`` or ``byte[]``
-
-Using a ``String`` as a primary key implicitly
-:ref:`indexes <android-indexes-fundamentals>` the field.
 
 Non-primitive types can contain a value of ``null`` as a primary key
 value, but only for one object of a particular type, since each primary

--- a/source/sdk/android/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/android/fundamentals/object-models-and-schemas.txt
@@ -50,7 +50,9 @@ created, modified, or deleted.
 Primary Keys
 ------------
 
-.. note:: Since version 10.6.0, {+client-database+} automatically indexes primary keys.
+.. versionadded:: 10.6.0
+
+   Since version 10.6.0, {+client-database+} automatically indexes primary keys.
 
 {+service-short+} treats fields marked with the
 :java-sdk:`@PrimaryKey <io/realm/annotations/PrimaryKey.html>` annotation

--- a/source/sdk/android/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/android/fundamentals/object-models-and-schemas.txt
@@ -53,7 +53,7 @@ Primary Keys
 .. versionadded:: 10.6.0
 
    {+client-database+} automatically :ref:`indexes <android-indexes-fundamentals>`
-   primary key fields.
+   primary key fields. Previously, only ``String`` fields were automatically indexed.
 
 {+service-short+} treats fields marked with the
 :java-sdk:`@PrimaryKey <io/realm/annotations/PrimaryKey.html>` annotation


### PR DESCRIPTION
The [current documentation](https://docs.mongodb.com/realm/sdk/android/fundamentals/object-models-and-schemas/#primary-keys), which uses the `versionadded` directive, currently displays the following nonsensical text:

*New in version Since*: version 10.6.0, Realm Database automatically indexes primary keys.

Changed to a note to make this clearly not broken for readers.

[Staging Build](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/version-added-to-note/sdk/android/fundamentals/object-models-and-schemas/#primary-keys)
