### PR TITLE
(DOCSP-16244): [iOS] Key path filtering for change notifications

### DIFF
--- a/examples/ios/Examples/Notifications.swift
+++ b/examples/ios/Examples/Notifications.swift
@@ -1,6 +1,10 @@
 // :replace-start: {
 //   "terms": {
-//     "NotificationExample_": ""
+//     "NotificationExample_": "",
+//     "NotificationExampleKeyPath_": "",
+//     "AlternateNotificationExampleKeyPath_": "",
+//     "keyPath_": "",
+//     "additional": ""
 //   }
 // }
 import RealmSwift
@@ -44,6 +48,66 @@ func objectNotificationExample() {
     try! realm.write {
         dog.name = "Wolfie"
     }
+}
+// :code-block-end:
+
+// Note: the following is not really tested but it makes for a convenient
+// full program example.
+// :code-block-start: register-a-keypath-change-listener
+// Define the dog class.
+class NotificationExampleKeyPath_Dog: Object {
+    @Persisted var name = ""
+    @Persisted var favoriteToy = ""
+    @Persisted var age: Int?
+}
+
+var additionalObjectNotificationToken: NotificationToken?
+
+func keyPath_objectNotificationExample() {
+    let dog = NotificationExampleKeyPath_Dog()
+    dog.name = "Max"
+    dog.favoriteToy = "Ball"
+    dog.age = 2
+
+    // Open the default realm.
+    let realm = try! Realm()
+    try! realm.write {
+        realm.add(dog)
+    }
+    // Observe notifications on some of the object's key paths. Keep a strong
+    // reference to the notification token or the observation will stop.
+    // Invalidate the token when done observing.
+    objectNotificationToken = dog.observe(keyPaths: ["favoriteToy", "age"], { change in // :emphasize:
+        switch change {
+        case .change(let object, let properties):
+            for property in properties {
+                print("Property '\(property.name)' of object \(object) changed to '\(property.newValue!)'")
+            }
+        case .error(let error):
+            print("An error occurred: \(error)")
+        case .deleted:
+            print("The object was deleted.")
+        }
+    })
+
+    // Now update to trigger the notification
+    try! realm.write {
+        dog.favoriteToy = "Frisbee"
+    }
+    // When one or more keypaths is specified, changes to other properties
+    // do not trigger notifications. In this example, changing the "name"
+    // property does not trigger a notification.
+    try! realm.write {
+        dog.name = "Maxamillion"
+    }
+}
+// :code-block-end:
+
+// :code-block-start: alternate-dog-class-for-keypaths
+class AlternateNotificationExampleKeyPath_Dog: Object {
+    @Persisted var name = ""
+    @Persisted var siblings: List<AlternateNotificationExampleKeyPath_Dog> // :emphasize:
+    @Persisted var age: Int?
 }
 // :code-block-end:
 

--- a/examples/ios/Examples/Notifications.swift
+++ b/examples/ios/Examples/Notifications.swift
@@ -4,7 +4,7 @@
 //     "NotificationExampleKeyPath_": "",
 //     "AlternateNotificationExampleKeyPath_": "",
 //     "keyPath_": "",
-//     "additional": ""
+//     "additionalObjectNotificationToken": "objectNotificationToken"
 //   }
 // }
 import RealmSwift

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '13.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', '~>10.10.0'
-  pod 'RealmSwift', '~>10.10.0'
+  pod 'Realm', '~>10.12.0'
+  pod 'RealmSwift', '~>10.12.0'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,5 +13,5 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '~>10.10.0'
+  pod 'RealmSwift', '~>10.12.0'
 end

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Realm (10.10.0):
-    - Realm/Headers (= 10.10.0)
-  - Realm/Headers (10.10.0)
-  - RealmSwift (10.10.0):
-    - Realm (= 10.10.0)
+  - Realm (10.12.0):
+    - Realm/Headers (= 10.12.0)
+  - Realm/Headers (10.12.0)
+  - RealmSwift (10.12.0):
+    - Realm (= 10.12.0)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (~> 10.10.0)
-  - RealmSwift (~> 10.10.0)
+  - Realm (~> 10.12.0)
+  - RealmSwift (~> 10.12.0)
   - SwiftLint
 
 SPEC REPOS:
@@ -55,10 +55,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: f501df41a4222c67850c77cf135d472192ecf294
-  RealmSwift: c69aadfc7db0d60075178d037c2f34ada73d5201
+  Realm: 32488213acb44660539c619d620cec1bac046166
+  RealmSwift: 0abdca6231d5ff8a4f84cef9c1121ef95a483faf
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 9c2b754df215e1c112701b32faed47f18cc2a454
+PODFILE CHECKSUM: 449069f49075ed37d3af8c7afd6a191193cca77b
 
 COCOAPODS: 1.10.1

--- a/source/examples/generated/code/start/Notifications.codeblock.alternate-dog-class-for-keypaths.swift.code-block.rst
+++ b/source/examples/generated/code/start/Notifications.codeblock.alternate-dog-class-for-keypaths.swift.code-block.rst
@@ -1,0 +1,8 @@
+.. code-block:: swift
+   :emphasize-lines: 3
+
+   class Dog: Object {
+       @Persisted var name = ""
+       @Persisted var siblings: List<Dog> 
+       @Persisted var age: Int?
+   }

--- a/source/examples/generated/code/start/Notifications.codeblock.register-a-keypath-change-listener.swift.code-block.rst
+++ b/source/examples/generated/code/start/Notifications.codeblock.register-a-keypath-change-listener.swift.code-block.rst
@@ -8,7 +8,7 @@
        @Persisted var age: Int?
    }
 
-   var ObjectNotificationToken: NotificationToken?
+   var objectNotificationToken: NotificationToken?
 
    func objectNotificationExample() {
        let dog = Dog()

--- a/source/examples/generated/code/start/Notifications.codeblock.register-a-keypath-change-listener.swift.code-block.rst
+++ b/source/examples/generated/code/start/Notifications.codeblock.register-a-keypath-change-listener.swift.code-block.rst
@@ -1,0 +1,50 @@
+.. code-block:: swift
+   :emphasize-lines: 24
+
+   // Define the dog class.
+   class Dog: Object {
+       @Persisted var name = ""
+       @Persisted var favoriteToy = ""
+       @Persisted var age: Int?
+   }
+
+   var ObjectNotificationToken: NotificationToken?
+
+   func objectNotificationExample() {
+       let dog = Dog()
+       dog.name = "Max"
+       dog.favoriteToy = "Ball"
+       dog.age = 2
+
+       // Open the default realm.
+       let realm = try! Realm()
+       try! realm.write {
+           realm.add(dog)
+       }
+       // Observe notifications on some of the object's key paths. Keep a strong
+       // reference to the notification token or the observation will stop.
+       // Invalidate the token when done observing.
+       objectNotificationToken = dog.observe(keyPaths: ["favoriteToy", "age"], { change in 
+           switch change {
+           case .change(let object, let properties):
+               for property in properties {
+                   print("Property '\(property.name)' of object \(object) changed to '\(property.newValue!)'")
+               }
+           case .error(let error):
+               print("An error occurred: \(error)")
+           case .deleted:
+               print("The object was deleted.")
+           }
+       })
+
+       // Now update to trigger the notification
+       try! realm.write {
+           dog.favoriteToy = "Frisbee"
+       }
+       // When one or more keypaths is specified, changes to other properties
+       // do not trigger notifications. In this example, changing the "name"
+       // property does not trigger a notification.
+       try! realm.write {
+           dog.name = "Maxamillion"
+       }
+   }

--- a/source/sdk/ios/examples/react-to-changes.txt
+++ b/source/sdk/ios/examples/react-to-changes.txt
@@ -59,6 +59,12 @@ inserted, and modified.
    in the following order: deletions, insertions, then
    modifications. Handling insertions before deletions may
    result in unexpected behavior.
+  
+Collection notifications provide a ``change`` parameter that reports which
+objects are deleted, added, or modified during the write transaction. This
+:swift-sdk:`RealmCollectionChange <Enums/RealmCollectionChange.html>` 
+resolves to an array of index paths that you can pass to a ``UITableView``'s 
+batch update methods.
 
 .. tabs-realm-languages::
 
@@ -101,6 +107,78 @@ and whether the object was deleted.
 
       .. literalinclude:: /examples/generated/code/start/Notifications.codeblock.register-an-object-change-listener.m
         :language: objectivec
+
+.. _ios-register-a-keypath-change-listener:
+
+Register a Key Path Change Listener
+-----------------------------------
+
+.. versionadded:: 10.12.0
+
+In addition to registering a notification handler on an :swift-sdk:`object 
+<Extensions/Object.html#/s:So16RealmSwiftObjectC0aB0E7observe8keyPaths2on_So20RLMNotificationTokenCSaySSGSg_So17OS_dispatch_queueCSgyAC0C6ChangeOyxGctSo13RLMObjectBaseCRbzlF>` 
+or :swift-sdk:`collection <Protocols/RealmCollection.html#/s:10RealmSwift0A10CollectionP7observe8keyPaths2on_So20RLMNotificationTokenCSaySSGSg_So17OS_dispatch_queueCSgyAA0aC6ChangeOyxGctF>`, you can pass an optional ``keyPaths`` parameter to specify the key path or 
+key paths to watch.
+
+.. example::
+
+   .. include:: /examples/generated/code/start/Notifications.codeblock.register-a-keypath-change-listener.swift.code-block.rst
+
+When you specify ``keyPaths``, *only* changes to those
+``keyPaths`` trigger notification blocks. Any other changes do not trigger
+notification blocks.
+
+.. example::
+
+   Consider a ``Dog`` object where one of its properties is a list of 
+   ``siblings``:
+
+   .. include:: /examples/generated/code/start/Notifications.codeblock.alternate-dog-class-for-keypaths.swift.code-block.rst
+
+   If you pass ``siblings`` as a ``keyPath`` to observe, any insertion, 
+   deletion, or modification to the ``siblings`` list would trigger a 
+   notification. However, a change to ``someSibling.name`` would not trigger
+   a notification, unless you explicitly observed ``["siblings.name"]``.
+
+.. note::
+
+   Multiple notification tokens on the same object which filter for
+   separate key paths *do not* filter exclusively. If one key path
+   change is satisfied for one notification token, then all notification
+   token blocks for that object will execute.
+
+Realm Collections
+~~~~~~~~~~~~~~~~~
+
+When you observe key paths on the various collection types, expect these 
+behaviors:
+
+- :swift-sdk:`LinkingObjects: <Structs/LinkingObjects.html#/s:10RealmSwift14LinkingObjectsV7observe8keyPaths2on_So20RLMNotificationTokenCSaySSGSg_So17OS_dispatch_queueCSgyAA0A16CollectionChangeOyACyxGGctF>`:
+  Observing a property of the LinkingObject triggers a notification for a 
+  change to that property, but does not trigger notifications for changes to 
+  its other properties. Insertions or deletions to the list or the object 
+  that the list is on trigger a notification. 
+- :swift-sdk:`Lists <Classes/List.html#/s:10RealmSwift4ListC7observe8keyPaths2on_So20RLMNotificationTokenCSaySSGSg_So17OS_dispatch_queueCSgyAA0A16CollectionChangeOyACyxGGctF>`:
+  Observing a property of the list's object will triggers a notification for 
+  a change to that property, but does not trigger notifications for changes 
+  to its other properties. Insertions or deletions to the list or the object 
+  that the list is on trigger a notification. 
+- :swift-sdk:`Map <Classes/Map.html#/s:10RealmSwift3MapC7observe8keyPaths2on_So20RLMNotificationTokenCSaySSGSg_So17OS_dispatch_queueCSgyAA0aC6ChangeOyACyxq_GGctF>`:
+  Observing a property of the map's object triggers a notification for a change
+  to that property, but does not trigger notifications for changes to its other
+  properties. Insertions or deletions to the Map or the object that the map is
+  on trigger a notification. The ``change`` parameter reports, in the form of 
+  keys within the map, which key-value pairs are added, removed, or modified 
+  during each write transaction. 
+- :swift-sdk:`MutableSet <Classes/MutableSet.html#/s:10RealmSwift10MutableSetC7observe8keyPaths2on_So20RLMNotificationTokenCSaySSGSg_So17OS_dispatch_queueCSgyAA0A16CollectionChangeOyACyxGGctF>`:
+  Observing a property of a MutableSet's object triggers a notification 
+  for a change to that property, but does not trigger notifications for changes 
+  to its other properties. Insertions or deletions to the MutableSet or the 
+  object that the MutableSet is on trigger a notification. 
+- :swift-sdk:`Results <Structs/Results.html#/s:10RealmSwift7ResultsV7observe8keyPaths2on_So20RLMNotificationTokenCSaySSGSg_So17OS_dispatch_queueCSgyAA0A16CollectionChangeOyACyxGGctF>`: 
+  Observing a property of the Result triggers a notification for a change to 
+  that property, but does not trigger notifications for changes to its other 
+  properties. Insertions or deletions to the Result trigger a notification.
 
 .. _ios-write-silently:
 

--- a/source/sdk/ios/integrations/swiftui.txt
+++ b/source/sdk/ios/integrations/swiftui.txt
@@ -117,6 +117,16 @@ displays the ItemsView.
 .. literalinclude:: /examples/generated/swiftui/local/QuickStart.codeblock.local-only-content-view.swift
    :language: swift
 
+.. tip::
+
+   Starting in SDK version 10.12.0, you can use an optional key path parameter
+   with ``@ObservedResults`` to filter change notifications to only those
+   occurring on the provided key path or key paths. For example:
+
+   .. code-block::
+   
+      @ObservedResults(MyObject.self, keyPaths: ["myList.property"])
+
 The ItemsView receives the group from the parent view and stores it in
 an :swift-sdk:`@ObservedRealmObject <Structs/ObservedRealmObject.html>`
 property. This allows the ItemsView to "know" when the object has


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-16244

### Staged Changes (Requires MongoDB Corp SSO)

- [React to Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16244/sdk/ios/examples/react-to-changes/#register-a-key-path-change-listener): new section: "Register a Key Path Change Listener"
- [SwiftUI & Combine](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-16244/sdk/ios/integrations/swiftui/#views-and-observed-objects): "Tip" after the second code example: "Starting in SDK version 10.12.0..."

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
