### PR TITLE
[iOS] Modify a schema: more clearly outline when a migration is required

### DIFF
--- a/source/sdk/ios/examples/modify-an-object-schema.txt
+++ b/source/sdk/ios/examples/modify-an-object-schema.txt
@@ -20,13 +20,17 @@ Overview
 When you update your object schema, you must increment the schema version 
 and perform a migration. 
 
-If your schema update adds or removes properties, {+client-database+} can 
-perform the migration automatically, and you only need to increment the 
-``schemaVersion``. 
+If your schema update adds optional properties or removes properties, 
+{+client-database+} can perform the migration automatically. You only need to 
+increment the ``schemaVersion``. 
 
-For more complex schema updates, such as combining fields, renaming fields, or 
-converting from an object to an embedded object, you must also specify the 
-migration logic in a ``migrationBlock``.
+For more complex schema updates, you must also specify the migration logic 
+in a ``migrationBlock``. This might include changes such as:
+
+- Adding required properties that must be populated with default values
+- Combining fields
+- Renaming fields
+- Converting from an object to an embedded object
 
 Update a Schema Version
 -----------------------
@@ -37,8 +41,11 @@ these changes.
 
 .. note::
 
-   {+client-database+} does not automatically set values for new properties
-   unless the new object schema specifies a default value.
+   {+client-database+} does not automatically set values for new required 
+   properties. You must use a migration block to set default values for
+   new required properties. For new optional properties, existing records 
+   can have null values. This means you don't need a migration block when 
+   adding optional properties.
 
 .. example::
 
@@ -71,8 +78,6 @@ these changes.
    To resolve a migration error in these circumstances, pass 
    ``Realm.Configuration(schemaVersion: <Your Incremented Version>)`` 
    into the ``ObservedResults`` constructor.
-
-      
 
 .. _ios-perform-a-schema-migration:
 


### PR DESCRIPTION
## Pull Request Info

This update is based on discussions in a couple of Slack threads and a DevHub forum question. Clarify that added required fields must have a migration to set default values, while added optional fields can be migrated automatically with just a `schemaVersion` bump.

### Staged Changes (Requires MongoDB Corp SSO)

- [Modify an Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/ios-update-migration-docs/sdk/ios/examples/modify-an-object-schema/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
