### PR TITLE
(DOCSP-17990): Remove beta suffixes from versionadded directives

### DIFF
--- a/source/sdk/dotnet/data-types.txt
+++ b/source/sdk/dotnet/data-types.txt
@@ -18,16 +18,16 @@ Realm Data Types - .NET SDK
 
    Field Types </sdk/dotnet/data-types/field-types>
    Collections </sdk/dotnet/data-types/collections>
-   Dictionaries </sdk/dotnet/data-types/dictionaries>
-   Sets </sdk/dotnet/data-types/sets>
+   Dictionaries (beta) </sdk/dotnet/data-types/dictionaries>
+   Sets (beta) </sdk/dotnet/data-types/sets>
+   RealmValue (beta) </sdk/dotnet/data-types/realm-value>
    RealmInteger </sdk/dotnet/data-types/realm-integer>
-   RealmValue </sdk/dotnet/data-types/realm-value>
    Embedded Objects </sdk/dotnet/data-types/embedded-objects>
 
 - :doc:`Field Types </sdk/dotnet/data-types/field-types>`
 - :doc:`Collections </sdk/dotnet/data-types/collections>`
-- :doc:`Dictionaries </sdk/dotnet/data-types/dictionaries>`
-- :doc:`Sets </sdk/dotnet/data-types/sets>`
+- :doc:`Dictionaries (beta) </sdk/dotnet/data-types/dictionaries>`
+- :doc:`Sets (beta) </sdk/dotnet/data-types/sets>`
+- :doc:`RealmValue (bet) </sdk/dotnet/data-types/realm-value>`
 - :doc:`RealmInteger </sdk/dotnet/data-types/realm-integer>`
-- :doc:`RealmValue </sdk/dotnet/data-types/realm-value>`
 - :doc:`Embedded Objects </sdk/dotnet/data-types/embedded-objects>`

--- a/source/sdk/dotnet/data-types/dictionaries.txt
+++ b/source/sdk/dotnet/data-types/dictionaries.txt
@@ -12,7 +12,7 @@ Dictionaries (Beta) - .NET SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.2.0-beta.1
+.. versionadded:: 10.2.0
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/dotnet/data-types/dictionaries.txt
+++ b/source/sdk/dotnet/data-types/dictionaries.txt
@@ -1,7 +1,7 @@
 .. _dotnet-client-dictionaries:
 
 ==============================
-Dictionaries (Beta) - .NET SDK
+Dictionaries (beta) - .NET SDK
 ==============================
 
 .. default-domain:: mongodb

--- a/source/sdk/dotnet/data-types/realm-integer.txt
+++ b/source/sdk/dotnet/data-types/realm-integer.txt
@@ -1,8 +1,8 @@
 .. _realminteger:
 
-==============================
-RealmInteger (Beta) - .NET SDK
-==============================
+=======================
+RealmInteger - .NET SDK
+=======================
 
 .. default-domain:: mongodb
 
@@ -14,9 +14,6 @@ RealmInteger (Beta) - .NET SDK
 
 Overview
 --------
-.. versionadded:: 10.2.0
-
-.. include:: /includes/note-beta-feature.rst
 
 Realm offers 
 :dotnet-sdk:`RealmInteger <reference/Realms.RealmInteger-1.html>` as a 

--- a/source/sdk/dotnet/data-types/realm-integer.txt
+++ b/source/sdk/dotnet/data-types/realm-integer.txt
@@ -19,7 +19,7 @@ Overview
 .. include:: /includes/note-beta-feature.rst
 
 Realm offers 
-:dotnet-sdk:`RealmInteger<T> <reference/Realms.RealmInteger-1.html>` as a 
+:dotnet-sdk:`RealmInteger <reference/Realms.RealmInteger-1.html>` as a 
 special integer type you can use as a logical counter. ``RealmInteger<T>`` 
 exposes an additional API that can more clearly express intent and generate 
 better conflict resolution steps when using Synchronized Realms. The type 

--- a/source/sdk/dotnet/data-types/realm-integer.txt
+++ b/source/sdk/dotnet/data-types/realm-integer.txt
@@ -14,7 +14,7 @@ RealmInteger (Beta) - .NET SDK
 
 Overview
 --------
-.. versionadded:: 10.2.0-beta.1
+.. versionadded:: 10.2.0
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/dotnet/data-types/realm-value.txt
+++ b/source/sdk/dotnet/data-types/realm-value.txt
@@ -1,7 +1,7 @@
 .. _realmvalue:
 
 ============================
-RealmValue (Beta) - .NET SDK
+RealmValue (beta) - .NET SDK
 ============================
 
 .. default-domain:: mongodb

--- a/source/sdk/dotnet/data-types/sets.txt
+++ b/source/sdk/dotnet/data-types/sets.txt
@@ -12,7 +12,7 @@ Sets (Beta) - .NET SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.2.0-beta.1
+.. versionadded:: 10.2.0
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/dotnet/data-types/sets.txt
+++ b/source/sdk/dotnet/data-types/sets.txt
@@ -1,7 +1,7 @@
 .. _dotnet-client-sets:
 
 ======================
-Sets (Beta) - .NET SDK
+Sets (beta) - .NET SDK
 ======================
 
 .. default-domain:: mongodb

--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -11,11 +11,9 @@ Flutter SDK (Preview)
    Realm SDK for Flutter APIs <https://pub.dev/documentation/realm/latest/realm/realm-library.html>
    Realm SDK for Dart APIs <https://pub.dev/documentation/realm_dart/latest/realm/realm-library.html>
 
-.. versionadded:: 0.1.0+preview
-
 The {+service+} Flutter SDK enables client applications written in 
 `Dart <https://dart.dev/>`__ for the `Flutter <https://flutter.dev/>`__ 
-platform to access data stored in local {+realms+}. 
+platform to access data stored in local {+realm+}s. 
 
 .. include:: /includes/note-preview-sdk.rst
 

--- a/source/sdk/ios/data-types/anyrealmvalue.txt
+++ b/source/sdk/ios/data-types/anyrealmvalue.txt
@@ -15,7 +15,6 @@ AnyRealmValue (beta) - iOS SDK
 
 
 .. versionadded:: 10.8.0
-   ``AnyRealmValue`` type
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/ios/data-types/map.txt
+++ b/source/sdk/ios/data-types/map.txt
@@ -13,7 +13,6 @@ Map (beta) - iOS SDK
    :class: singlecol
 
 .. versionadded:: 10.8.0
-   ``Map``
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/ios/data-types/mutablesets.txt
+++ b/source/sdk/ios/data-types/mutablesets.txt
@@ -13,7 +13,6 @@ MutableSet (beta) - iOS SDK
    :class: singlecol
 
 .. versionadded:: 10.8.0
-   ``MutableSet`` type
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/node/data-types.txt
+++ b/source/sdk/node/data-types.txt
@@ -17,16 +17,16 @@ Realm Data Types - Node.js SDK
 
    Field Types </sdk/node/data-types/field-types>
    Collections </sdk/node/data-types/collections>
-   Dictionaries </sdk/node/data-types/dictionaries>
-   Sets </sdk/node/data-types/sets>
-   Mixed </sdk/node/data-types/mixed>
+   Dictionaries (beta) </sdk/node/data-types/dictionaries>
+   Sets (beta) </sdk/node/data-types/sets>
+   Mixed (beta) </sdk/node/data-types/mixed>
    UUID </sdk/node/data-types/uuid>
    Embedded Objects </sdk/node/data-types/embedded-objects>
 
 - :doc:`Field Types </sdk/node/data-types/field-types>`
 - :doc:`Collections </sdk/node/data-types/collections>`
-- :doc:`Dictionaries </sdk/node/data-types/dictionaries>`
-- :doc:`Sets </sdk/node/data-types/sets>`
-- :doc:`Mixed </sdk/node/data-types/mixed>`
+- :doc:`Dictionaries (beta) </sdk/node/data-types/dictionaries>`
+- :doc:`Sets (beta) </sdk/node/data-types/sets>`
+- :doc:`Mixed (beta) </sdk/node/data-types/mixed>`
 - :doc:`UUID </sdk/node/data-types/uuid>`
 - :doc:`Embedded Objects </sdk/node/data-types/embedded-objects>`

--- a/source/sdk/node/data-types/dictionaries.txt
+++ b/source/sdk/node/data-types/dictionaries.txt
@@ -12,7 +12,7 @@ Dictionaries (beta) - Node.js SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.5.0-beta.1
+.. versionadded:: 10.5.0
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/node/data-types/field-types.txt
+++ b/source/sdk/node/data-types/field-types.txt
@@ -23,7 +23,7 @@ Field Types - Node.js SDK
 - ``date`` maps to the JavaScript :mdn:`Date <Web/JavaScript/Reference/Global_Objects/Date>` type.
 - ``list`` maps to the JavaScript :mdn:`Array <Web/JavaScript/Reference/Global_Objects/Array>` type. You can also specify that a field contains a list of primitive value types by appending ``[]`` to the type name.
 - ``linkingObjects`` is a special type used to define an inverse relationship.
-- ``dictionary`` used to manage a collection of unique String keys paired with values. The ``Dictionary`` data type is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
-- ``set`` is based on the JavaScript :mdn:`Set <Web/JavaScript/Reference/Global_Objects/Set>` type. ``{+service-short+} Set`` is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
-- ``mixed`` is a property type that can hold different data types. The ``Mixed`` data type is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
-- ``uuid`` is a universally unique identifier from :js-sdk:`Realm.BSON <Realm.html#.BSON>`. The ``UUID`` data type is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
+- ``dictionary`` used to manage a collection of unique String keys paired with values. The ``Dictionary`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
+- ``set`` is based on the JavaScript :mdn:`Set <Web/JavaScript/Reference/Global_Objects/Set>` type. ``{+service-short+} Set`` is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
+- ``mixed`` is a property type that can hold different data types. The ``Mixed`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
+- ``uuid`` is a universally unique identifier from :js-sdk:`Realm.BSON <Realm.html#.BSON>`. The ``UUID`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.

--- a/source/sdk/node/data-types/mixed.txt
+++ b/source/sdk/node/data-types/mixed.txt
@@ -12,7 +12,7 @@ Mixed (beta) - Node.js SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.5.0-beta.1
+.. versionadded:: 10.5.0
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/node/data-types/sets.txt
+++ b/source/sdk/node/data-types/sets.txt
@@ -12,7 +12,7 @@ Sets (beta) - Node.js SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.5.0-beta.1
+.. versionadded:: 10.5.0
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/node/data-types/uuid.txt
+++ b/source/sdk/node/data-types/uuid.txt
@@ -11,7 +11,7 @@ UUID - Node.js SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.5.0-beta.1
+.. versionadded:: 10.5.0
 
 Overview
 --------

--- a/source/sdk/react-native/data-types.txt
+++ b/source/sdk/react-native/data-types.txt
@@ -17,16 +17,16 @@ Realm Data Types - React Native SDK
 
    Field Types </sdk/react-native/data-types/field-types>
    Collections </sdk/react-native/data-types/collections>
-   Dictionaries </sdk/react-native/data-types/dictionaries>
-   Sets </sdk/react-native/data-types/sets>
-   Mixed </sdk/react-native/data-types/mixed>
+   Dictionaries (beta) </sdk/react-native/data-types/dictionaries>
+   Sets (beta) </sdk/react-native/data-types/sets>
+   Mixed (beta) </sdk/react-native/data-types/mixed>
    UUID </sdk/react-native/data-types/uuid>
    Embedded Objects </sdk/react-native/data-types/embedded-objects>
 
 - :doc:`Field Types </sdk/react-native/data-types/field-types>`
 - :doc:`Collections </sdk/react-native/data-types/collections>`
-- :doc:`Dictionaries </sdk/react-native/data-types/dictionaries>`
-- :doc:`Sets </sdk/react-native/data-types/sets>`
-- :doc:`Mixed </sdk/react-native/data-types/mixed>`
+- :doc:`Dictionaries (beta) </sdk/react-native/data-types/dictionaries>`
+- :doc:`Sets (beta) </sdk/react-native/data-types/sets>`
+- :doc:`Mixed (beta) </sdk/react-native/data-types/mixed>`
 - :doc:`UUID </sdk/react-native/data-types/uuid>`
 - :doc:`Embedded Objects </sdk/react-native/data-types/embedded-objects>`

--- a/source/sdk/react-native/data-types/dictionaries.txt
+++ b/source/sdk/react-native/data-types/dictionaries.txt
@@ -12,7 +12,7 @@ Dictionaries (beta) - React Native SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.5.0-beta.1
+.. versionadded:: 10.5.0
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/react-native/data-types/field-types.txt
+++ b/source/sdk/react-native/data-types/field-types.txt
@@ -23,7 +23,7 @@ Field Types - React Native SDK
 - ``date`` maps to the JavaScript :mdn:`Date <Web/JavaScript/Reference/Global_Objects/Date>` type.
 - ``list`` maps to the JavaScript :mdn:`Array <Web/JavaScript/Reference/Global_Objects/Array>` type. You can also specify that a field contains a list of primitive value type by appending ``[]`` to the type name.
 - ``linkingObjects`` is a special type used to define an inverse relationship.
-- ``dictionary`` used to manage a collection of unique String keys paired with values. The ``Dictionary`` data type is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
-- ``set`` is based on the JavaScript :mdn:`Set <Web/JavaScript/Reference/Global_Objects/Set>` type. ``{+service-short+} Set`` is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
-- ``mixed`` is a property type that can hold different data types. The ``Mixed`` data type is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
-- ``uuid`` is a universally unique identifier from :js-sdk:`Realm.BSON <Realm.html#.BSON>`. The ``UUID`` data type is available in the :github:`realm-js@10.5.0-beta.1 release <realm/realm-js/releases/tag/v10.5.0-beta.1>`.
+- ``dictionary`` used to manage a collection of unique String keys paired with values. The ``Dictionary`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
+- ``set`` is based on the JavaScript :mdn:`Set <Web/JavaScript/Reference/Global_Objects/Set>` type. ``{+service-short+} Set`` is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
+- ``mixed`` is a property type that can hold different data types. The ``Mixed`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
+- ``uuid`` is a universally unique identifier from :js-sdk:`Realm.BSON <Realm.html#.BSON>`. The ``UUID`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.

--- a/source/sdk/react-native/data-types/mixed.txt
+++ b/source/sdk/react-native/data-types/mixed.txt
@@ -11,7 +11,7 @@ Mixed (beta) - React Native SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.5.0-beta.1
+.. versionadded:: 10.5.0
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/react-native/data-types/sets.txt
+++ b/source/sdk/react-native/data-types/sets.txt
@@ -12,7 +12,7 @@ Sets (beta) - React Native SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.5.0-beta.1
+.. versionadded:: 10.5.0
 
 .. include:: /includes/note-beta-feature.rst
 

--- a/source/sdk/react-native/data-types/uuid.txt
+++ b/source/sdk/react-native/data-types/uuid.txt
@@ -11,7 +11,7 @@ UUID - React Native SDK
    :depth: 2
    :class: singlecol
 
-.. versionadded:: 10.5.0-beta.1
+.. versionadded:: 10.5.0
 
 Overview
 --------


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-17990
- Also standardized versionadded directives between SDKs to *only* mention the version, no type reference (since the entire page is about the type)
- Also removed "beta" warnings from the .NET RealmInteger page, because that type isn't in beta and it's been around since 10.0.0.
- And removed direct links to the first beta release that mentioned the new types in the Node and React Native SDKs.
- Fixed broken link to a .NET reference page (link target used <T>, which naturally confused RST mightily)

### Staged Changes (Requires MongoDB Corp SSO)

- [All Data Types Pages in All SDKs](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17990)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
