### PR TITLE
Android logOut does not delete synced realms

### DIFF
--- a/source/sdk/android/examples/authenticate-users.txt
+++ b/source/sdk/android/examples/authenticate-users.txt
@@ -317,8 +317,6 @@ methods. Both methods:
 
 - immediately halt any synchronization to and from the user's {+realm+}s
 
-- mark the user's {+realm+}s for deletion the next time the app restarts
-
 Because logging out halts synchronization, you should only log out after
 all local Realm updates have uploaded to the server.
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- came up in the Android roundtable

### Staged Changes (Requires MongoDB Corp SSO)

- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/android-logout-retcon/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
