### PR TITLE
(DOCSP-17278): Scope pausing and resuming sync to a realm's sync session

### DIFF
--- a/source/sdk/ios/examples/sync-changes-between-devices.txt
+++ b/source/sdk/ios/examples/sync-changes-between-devices.txt
@@ -532,6 +532,12 @@ file protection settings. See
 Suspend or Resume a Sync Session
 --------------------------------
 
+Opening a synced {+realm+} starts a :swift-sdk:`SyncSession <Extensions/SyncSession.html>`
+for that {+realm+}. You can suspend and resume the sync session on the {+realm+}.
+Pausing a sync session only suspends that {+realm+}'s sync session. If you have
+more than one open {+realm+}, suspend does not affect the sync sessions for 
+other {+realms+}.
+
 .. tabs-realm-languages::
 
    .. tab::

--- a/source/sdk/node/examples/sync-changes-between-devices.txt
+++ b/source/sdk/node/examples/sync-changes-between-devices.txt
@@ -79,9 +79,14 @@ downloading any existing data from the server in the background.
 
 Pause or Resume a Sync Session
 ------------------------------
-You can pause synchronization using the :js-sdk:`syncSession.pause()
+Opening a synced {+realm+} starts a :js-sdk:`sync session <Realm.App.Sync.Session.html>`.
+You can pause and resume the sync session on the {+realm+}. Pausing a sync 
+session only pauses that {+realm+}'s sync session. If you have more than one 
+open {+realm+}, pause does not affect the sync sessions for other {+realms+}.
+
+To pause synchronization, use the :js-sdk:`syncSession.pause()
 <Realm.App.Sync.Session.html#~pause>` method. To resume synchronization, use the
-:js-sdk:`syncSession.resume() <Realm.App.Sync.Session.html#~resume>` method
+:js-sdk:`syncSession.resume() <Realm.App.Sync.Session.html#~resume>` method.
 
 .. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-pause-or-resume-sync-session.js
    :language: javascript

--- a/source/sdk/react-native/examples/sync-changes-between-devices.txt
+++ b/source/sdk/react-native/examples/sync-changes-between-devices.txt
@@ -80,9 +80,14 @@ downloading any existing data from the server in the background.
 
 Pause or Resume a Sync Session
 ------------------------------
-You can pause synchronization using the :js-sdk:`syncSession.pause()
+Opening a synced {+realm+} starts a :js-sdk:`sync session <Realm.App.Sync.Session.html>`.
+You can pause and resume the sync session on the {+realm+}. Pausing a sync 
+session only pauses that {+realm+}'s sync session. If you have more than one 
+open {+realm+}, pause does not affect the sync sessions for other {+realms+}.
+
+To pause synchronization, use the :js-sdk:`syncSession.pause()
 <Realm.App.Sync.Session.html#~pause>` method. To resume synchronization, use the
-:js-sdk:`syncSession.resume() <Realm.App.Sync.Session.html#~resume>` method
+:js-sdk:`syncSession.resume() <Realm.App.Sync.Session.html#~resume>` method.
 
 .. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-pause-or-resume-sync-session.js
    :language: javascript


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-17278

### Staged Changes (Requires MongoDB Corp SSO)

- [iOS SDK - Sync Changes Between Devices](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17278/sdk/ios/examples/sync-changes-between-devices/#suspend-or-resume-a-sync-session)
- [Node.js SDK - Sync Changes Between Devices](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17278/sdk/node/examples/sync-changes-between-devices/#pause-or-resume-a-sync-session)
- [React Native SDK - Sync Changes Between Devices](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17278/sdk/react-native/examples/sync-changes-between-devices/#pause-or-resume-a-sync-session)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
