### PR TITLE
(DOCSP-18233): Provide CLI v2 alternative for deprecated flag when deploying with GitHub

### DIFF
--- a/source/includes/steps-github-deploy.yaml
+++ b/source/includes/steps-github-deploy.yaml
@@ -71,19 +71,24 @@ content: |
   The configured branch and directory must contain an :ref:`application
   directory <app-directory>` with configuration files that define your
   application. You can create the application directory manually or :doc:`export
-  the application directory </deploy/export-realm-app>` of an existing app (using the
-  ``--for-source-control`` option).
+  the application directory </deploy/export-realm-app>` of an existing app.
+  
+  .. important::
+   
+     In order to deploy successfully, your git repository *must not* contain 
+     some fields that are present in your application export. 
 
-  .. important:: Export For Source Control
+     If you are using :ref:`realm-cli v1.x <realm-cli-v1>` for the v1 app
+     structure, use the ``--for-source-control`` flag when you export an app.
+     This flag omits the ``name``, ``app_id``, ``location``, and ``deployment_model`` 
+     fields in the ``config.json`` file, and the ``config.clusterName`` field of 
+     the ``config.json`` of any Atlas :ref:`data sources <link-a-data-source>` 
+     connected to the application.
 
-     {+app+}s deployed via GitHub *must not* specify the ``name``, ``app_id``,
-     ``location``, or ``deployment_model`` fields in the ``config.json`` file.
-     Applications deployed via GitHub must also omit the ``config.clusterName``
-     field of the ``config.json`` of any Atlas :ref:`data sources
-     <link-a-data-source>` connected to the application.
-     
-     Application configurations exported with the ``--for-source-control`` flag
-     omit these fields automatically.
+     If you are using the :ref:`realm-cli v2.x <realm-cli>` for the v2 app
+     structure, ``--for-source-control`` is no longer an available flag. The
+     v2 app structure no longer contains most of those references. The only 
+     field you must remove is the ``app_id`` from the ``realm_config.json`` file.
 
   Add the application directory to the repository and then commit the changes:
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-18233

### Staged Changes (Requires MongoDB Corp SSO)

- [Deploy Automatically with GitHub](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18233/deploy/deploy-automatically-with-github/#initialize-the-repository): "Important" directive in "Step 3: Initialize the Repository"

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
