### PR TITLE
(DOCSP-17829): Add services to config file structure

### DIFF
--- a/source/config.txt
+++ b/source/config.txt
@@ -62,6 +62,7 @@ and directories:
    ├── graphql/
    ├── hosting/
    ├── http_endpoints/
+   ├── services/
    ├── sync/
    ├── triggers/
    └── values/
@@ -72,11 +73,12 @@ and source code files, refer to the type's page in this section:
 - :doc:`Realm App </config/app>`
 - :doc:`Users & Authentication Providers </config/auth>`
 - :doc:`MongoDB Data Sources </config/data_sources>`
-- :doc:`Realm Sync </config/sync>`
+- :doc:`Environment Values </config/environments>`
 - :doc:`Functions </config/functions>`
 - :doc:`GraphQL </config/graphql>`
-- :doc:`HTTP Endpoints </config/http_endpoints>`
 - :doc:`Static Hosting </config/hosting>`
+- :doc:`HTTP Endpoints </config/http_endpoints>`
+- :doc:`Third-Party Services </config/services>`
+- :doc:`Realm Sync </config/sync>`
 - :doc:`Triggers </config/triggers>`
 - :doc:`Values </config/values>`
-- :doc:`Environment Values </config/environments>`


### PR DESCRIPTION
## Pull Request Info

* Adds `services` to the config file directory tree example on the root page
* Re-arranges the corresponding links to match the order of their counterparts in the example

### Jira

- (DOCSP-17829): Add services to config file structure

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm App Configuration](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/config-fix/config)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
