### PR TITLE
Add caret to make sidebar navigable

### DIFF
--- a/source/sdk/android.txt
+++ b/source/sdk/android.txt
@@ -11,10 +11,10 @@ MongoDB Realm Android SDK
    Quick Start </sdk/android/quick-start-local>
    Quick Start with Sync </sdk/android/quick-start-sync>
    Quick Start with LiveData </sdk/android/livedata>
-   Fundamentals </sdk/android/fundamentals>
-   Data Types </sdk/android/data-types>
-   Usage Examples </sdk/android/examples>
-   Advanced Guides </sdk/android/advanced-guides>
+   ˇ Fundamentals </sdk/android/fundamentals>
+   ˇ Data Types </sdk/android/data-types>
+   ˇ Usage Examples </sdk/android/examples>
+   ˇ Advanced Guides </sdk/android/advanced-guides>
    Troubleshooting </sdk/android/troubleshooting>
    Java Reference Manual (Javadoc) <https://docs.mongodb.com/realm-sdks/java/latest/>
    Kotlin Extensions Reference Manual <https://docs.mongodb.com/realm-sdks/java/latest/kotlin-extensions/>

--- a/source/sdk/dotnet.txt
+++ b/source/sdk/dotnet.txt
@@ -13,10 +13,10 @@ MongoDB Realm .NET SDK
    Quick Start with Sync </sdk/dotnet/quick-start-with-sync>
    Compatibility </sdk/dotnet/compatibility>
    Use Realm in a Console App </sdk/dotnet/async-console>
-   Fundamentals </sdk/dotnet/fundamentals>
-   Data Types </sdk/dotnet/data-types>
-   Usage Examples </sdk/dotnet/examples>
-   Advanced Guides </sdk/dotnet/advanced-guides>
+   ⎀ Fundamentals </sdk/dotnet/fundamentals>
+   ⎀ Data Types </sdk/dotnet/data-types>
+   ⎀ Usage Examples </sdk/dotnet/examples>
+   ⎀ Advanced Guides </sdk/dotnet/advanced-guides>
    Troubleshooting </sdk/dotnet/troubleshooting>
    .NET SDK Reference Manual <https://docs.mongodb.com/realm-sdks/dotnet/latest>
    Release Notes <https://github.com/realm/realm-dotnet/releases>

--- a/source/sdk/ios.txt
+++ b/source/sdk/ios.txt
@@ -10,11 +10,11 @@ MongoDB Realm iOS SDK
    Install Realm for iOS, macOS, tvOS, and watchOS </sdk/ios/install>
    Quick Start </sdk/ios/quick-start>
    Quick Start with Sync </sdk/ios/quick-start-with-sync>
-   Fundamentals </sdk/ios/fundamentals>
-   Data Types </sdk/ios/data-types>
-   Usage Examples </sdk/ios/examples>
-   Advanced Guides </sdk/ios/advanced-guides>
-   Integration Guides </sdk/ios/integrations>
+   • Fundamentals </sdk/ios/fundamentals>
+   • Data Types </sdk/ios/data-types>
+   • Usage Examples </sdk/ios/examples>
+   • Advanced Guides </sdk/ios/advanced-guides>
+   • Integration Guides </sdk/ios/integrations>
    Test and Debug </sdk/ios/test-and-debug>
    Upgrade from Stitch to Realm </sdk/ios/upgrade-from-stitch-to-realm>
    Objective-C Reference Manual <https://docs.mongodb.com/realm-sdks/objc/latest>

--- a/source/sdk/node.txt
+++ b/source/sdk/node.txt
@@ -11,10 +11,10 @@ MongoDB Realm Node.js SDK
    Install Realm for Node.js </sdk/node/install>
    Quick Start </sdk/node/quick-start-local>
    Quick Start with Sync </sdk/node/quick-start>
-   ├──Fundamentals </sdk/node/fundamentals>
-   ├──Data Types </sdk/node/data-types>
-   ├──Usage Examples </sdk/node/examples>
-   ├──Integration Guides </sdk/node/integrations>
+   ├Fundamentals </sdk/node/fundamentals>
+   ├Data Types </sdk/node/data-types>
+   ├Usage Examples </sdk/node/examples>
+   ├Integration Guides </sdk/node/integrations>
    Advanced Guides </sdk/node/advanced>
    
    Javascript SDK Reference Manual <https://docs.mongodb.com/realm-sdks/js/latest/>

--- a/source/sdk/node.txt
+++ b/source/sdk/node.txt
@@ -11,10 +11,10 @@ MongoDB Realm Node.js SDK
    Install Realm for Node.js </sdk/node/install>
    Quick Start </sdk/node/quick-start-local>
    Quick Start with Sync </sdk/node/quick-start>
-   Fundamentals </sdk/node/fundamentals>
-   Data Types </sdk/node/data-types>
-   Usage Examples </sdk/node/examples>
-   Integration Guides </sdk/node/integrations>
+   ├──Fundamentals </sdk/node/fundamentals>
+   ├──Data Types </sdk/node/data-types>
+   ├──Usage Examples </sdk/node/examples>
+   ├──Integration Guides </sdk/node/integrations>
    Advanced Guides </sdk/node/advanced>
    
    Javascript SDK Reference Manual <https://docs.mongodb.com/realm-sdks/js/latest/>

--- a/source/sdk/react-native.txt
+++ b/source/sdk/react-native.txt
@@ -11,11 +11,11 @@ MongoDB Realm React Native SDK
    Install Realm for React Native </sdk/react-native/install>
    Quick Start </sdk/react-native/quick-start-local>
    Quick Start with Sync </sdk/react-native/quick-start>
-   Fundamentals </sdk/react-native/fundamentals>
-   Data Types </sdk/react-native/data-types>
-   Usage Examples </sdk/react-native/examples>
-   Integration Guides </sdk/react-native/integrations>
-   Advanced Guides </sdk/react-native/advanced>
+   📁 Fundamentals </sdk/react-native/fundamentals>
+   📁 Data Types </sdk/react-native/data-types>
+   📁 Usage Examples </sdk/react-native/examples>
+   📁 Integration Guides </sdk/react-native/integrations>
+   📁 Advanced Guides </sdk/react-native/advanced>
    
    Javascript SDK Reference Manual <https://docs.mongodb.com/realm-sdks/js/latest/>
    Upgrade from Stitch to Realm </sdk/react-native/migrate>


### PR DESCRIPTION
## Pull Request Info

### Issue Description
- Old side nav: https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/triggers-ia-redirects/sdk/android/ (note the carets that display next to folders, and the animation when you click on them to explore their contents)
- New side nav: https://docs.mongodb.com/realm/sdk/android/ (note that there is no distinction whatsoever between pages and folders)
- Attempting to brainstorm/trial some in-text solutions to make folders more discoverable in our SDKs, which I feel is very difficult/non-discoverable with the new side nav.

### Staged Changes (Requires MongoDB Corp SSO)

- [Android SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/caret/sdk/android/) - upside-down caret
- [.NET SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/caret/sdk/dotnet/) - weird larger upside-down caret that contains an "a"
- [iOS SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/caret/sdk/ios/) - bullet
- [Node SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/caret/sdk/node/) - `tree`-style bars
- [RN SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/caret/sdk/react-native/) - unicode folder

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
