### PR TITLE
(DOCSP-18707): [iOS] Add async/await methods for App.login and asyncOpen

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,7 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        - uses: actions/checkout@v2
+        - uses: maxim-lobanov/setup-xcode@v1
+          with:
+            xcode-version: latest
       - name: Dependencies
         run: |
           cd examples/ios

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Run iOS Example App Tests
-    runs-on: macos-latest
+    runs-on: macOS-11
 
     steps:
       - name: Checkout

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Force XCode 12.2
-        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
+      - name: Force XCode 13.0
+        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Dependencies
         run: |
           cd examples/ios

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest
+          xcode-version: '13.0'
       - name: Dependencies
         run: |
           cd examples/ios

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -26,11 +26,11 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           cd examples/ios
-          xcodebuild build-for-testing -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=Any iOS Simulator Device"
+          xcodebuild build-for-testing -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 13 Pro"
       - name: Test
         env:
           scheme: ${{ 'default' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
           cd examples/ios
-          xcodebuild test-without-building -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=Any iOS Simulator Device"
+          xcodebuild test-without-building -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 13 Pro"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        - uses: maxim-lobanov/setup-xcode@v1
-          with:
-            xcode-version: latest
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest
       - name: Dependencies
         run: |
           cd examples/ios

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -23,11 +23,11 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           cd examples/ios
-          xcodebuild build-for-testing -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 12 Pro"
+          xcodebuild build-for-testing -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=Any iOS Simulator Device"
       - name: Test
         env:
           scheme: ${{ 'default' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
           cd examples/ios
-          xcodebuild test-without-building -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 12 Pro"
+          xcodebuild test-without-building -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=Any iOS Simulator Device"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        - uses: actions/checkout@v2
+        uses: actions/checkout@v2
         - uses: maxim-lobanov/setup-xcode@v1
           with:
             xcode-version: latest

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Force XCode 13.0
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Dependencies
         run: |
           cd examples/ios

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -23,17 +23,11 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           cd examples/ios
-          device=`instruments -s -devices | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild build-for-testing -scheme "Test Examples" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+          xcodebuild build-for-testing -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 12 Pro"
       - name: Test
         env:
           scheme: ${{ 'default' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
           cd examples/ios
-          device=`instruments -s -devices | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild test-without-building -scheme "Test Examples" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device" || xcodebuild test-without-building -scheme "Test Examples" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+          xcodebuild test-without-building -workspace "RealmExamples.xcworkspace" -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 12 Pro"

--- a/examples/ios/Examples/Authenticate.swift
+++ b/examples/ios/Examples/Authenticate.swift
@@ -187,6 +187,28 @@ class Authenticate: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
+    // :code-block-start: async-await
+    func testAsyncAwaitLogin() async {
+        // :hide-start:
+        let expectation = XCTestExpectation(description: "login completes")
+        // :hide-end:
+        let anonCredentials = Credentials.anonymous
+
+        do {
+            let user = try await app.login(credentials: anonCredentials)
+            // :hide-start:
+            expectation.fulfill()
+            // :hide-end:
+            print("Successfully logged in as user \(user)")
+        } catch {
+            print("Login failed: \(error.localizedDescription)")
+        }
+        // :hide-start:
+        wait(for: [expectation], timeout: 10)
+        // :hide-end:
+    }
+    // :code-block-end:
+
     func testAnonymousCredentials() {
         let expectation = XCTestExpectation(description: "login completes")
 

--- a/examples/ios/Examples/Authenticate.swift
+++ b/examples/ios/Examples/Authenticate.swift
@@ -187,27 +187,32 @@ class Authenticate: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
-    // :code-block-start: async-await
     func testAsyncAwaitLogin() async {
-        // :hide-start:
         let expectation = XCTestExpectation(description: "login completes")
-        // :hide-end:
-        let anonCredentials = Credentials.anonymous
+
+        // :code-block-start: async-await
+        func login() async throws -> User {
+            // Instantiate the app using your Realm app ID
+            let app = App(id: YOUR_REALM_APP_ID)
+            // Authenticate with the instance of the app that points
+            // to your backend. Here, we're using anonymous login.
+            let loggedInUser = try await app.login(credentials: Credentials.anonymous)
+            return loggedInUser
+        }
 
         do {
-            let user = try await app.login(credentials: anonCredentials)
+            let user = try await login()
+            // Do something with user
+            print("Successfully logged in user: \(user)")
             // :hide-start:
             expectation.fulfill()
             // :hide-end:
-            print("Successfully logged in as user \(user)")
         } catch {
-            print("Login failed: \(error.localizedDescription)")
+            print("Failed to log in user: \(error.localizedDescription)")
         }
-        // :hide-start:
+        // :code-block-end:
         wait(for: [expectation], timeout: 10)
-        // :hide-end:
     }
-    // :code-block-end:
 
     func testAnonymousCredentials() {
         let expectation = XCTestExpectation(description: "login completes")

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -1,10 +1,10 @@
-platform :ios, '13.0'
+platform :ios, '15.0'
 
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', '~>10.14.0'
-  pod 'RealmSwift', '~>10.14.0'
+  pod 'Realm', '~>10.15.0'
+  pod 'RealmSwift', '~>10.15.0'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,5 +13,5 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '~>10.14.0'
+  pod 'RealmSwift', '~>10.15.0'
 end

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '15.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', '~>10.15.0'
-  pod 'RealmSwift', '~>10.15.0'
+  pod 'Realm', '~>10.15.1'
+  pod 'RealmSwift', '~>10.15.1'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,5 +13,5 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '~>10.15.0'
+  pod 'RealmSwift', '~>10.15.1'
 end

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Realm (10.15.0):
-    - Realm/Headers (= 10.15.0)
-  - Realm/Headers (10.15.0)
-  - RealmSwift (10.15.0):
-    - Realm (= 10.15.0)
+  - Realm (10.15.1):
+    - Realm/Headers (= 10.15.1)
+  - Realm/Headers (10.15.1)
+  - RealmSwift (10.15.1):
+    - Realm (= 10.15.1)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (~> 10.15.0)
-  - RealmSwift (~> 10.15.0)
+  - Realm (~> 10.15.1)
+  - RealmSwift (~> 10.15.1)
   - SwiftLint
 
 SPEC REPOS:
@@ -55,10 +55,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: 13e805eb23d3eb8d8bb700d9cf9761f4b625b389
-  RealmSwift: 51b29bb4e19fe7322c8a599cf3494b8a08888ef1
+  Realm: fbcbde2620d51623cc5b18e28f5b165c39abef52
+  RealmSwift: e4bea8e42efad3d543aea23b56504069c6faaea2
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: c89b88a0593f86d535dded5f4177305dc73d885b
+PODFILE CHECKSUM: bd158df104dda4c9a9ec8524bd3402d1aea720f0
 
 COCOAPODS: 1.10.1

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Realm (10.14.0):
-    - Realm/Headers (= 10.14.0)
-  - Realm/Headers (10.14.0)
-  - RealmSwift (10.14.0):
-    - Realm (= 10.14.0)
+  - Realm (10.15.0):
+    - Realm/Headers (= 10.15.0)
+  - Realm/Headers (10.15.0)
+  - RealmSwift (10.15.0):
+    - Realm (= 10.15.0)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (~> 10.14.0)
-  - RealmSwift (~> 10.14.0)
+  - Realm (~> 10.15.0)
+  - RealmSwift (~> 10.15.0)
   - SwiftLint
 
 SPEC REPOS:
@@ -55,10 +55,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: 95a120db10fa66d0f1d10bee4ce828177ae00090
-  RealmSwift: 4937e1b6f9b87bc25dc23883198807bf69e8cb76
+  Realm: 13e805eb23d3eb8d8bb700d9cf9761f4b625b389
+  RealmSwift: 51b29bb4e19fe7322c8a599cf3494b8a08888ef1
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 0833954a0ae8b53ef05efaa523c74d81c55d636a
+PODFILE CHECKSUM: c89b88a0593f86d535dded5f4177305dc73d885b
 
 COCOAPODS: 1.10.1

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -802,6 +802,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_EXPAND_BUILD_SETTINGS = YES;
 				INFOPLIST_FILE = Examples/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -826,6 +827,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_EXPAND_BUILD_SETTINGS = YES;
 				INFOPLIST_FILE = Examples/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/examples/ios/RealmExamples.xcodeproj/xcshareddata/xcschemes/Test Examples.xcscheme
+++ b/examples/ios/RealmExamples.xcodeproj/xcshareddata/xcschemes/Test Examples.xcscheme
@@ -45,6 +45,13 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/source/examples/generated/code/start/Authenticate.codeblock.async-await.swift
+++ b/source/examples/generated/code/start/Authenticate.codeblock.async-await.swift
@@ -1,0 +1,10 @@
+func testAsyncAwaitLogin() async {
+    let anonCredentials = Credentials.anonymous
+
+    do {
+        let user = try await app.login(credentials: anonCredentials)
+        print("Successfully logged in as user \(user)")
+    } catch {
+        print("Login failed: \(error.localizedDescription)")
+    }
+}

--- a/source/examples/generated/code/start/Authenticate.codeblock.async-await.swift
+++ b/source/examples/generated/code/start/Authenticate.codeblock.async-await.swift
@@ -1,10 +1,16 @@
-func testAsyncAwaitLogin() async {
-    let anonCredentials = Credentials.anonymous
+func login() async throws -> User {
+    // Instantiate the app using your Realm app ID
+    let app = App(id: YOUR_REALM_APP_ID)
+    // Authenticate with the instance of the app that points
+    // to your backend. Here, we're using anonymous login.
+    let loggedInUser = try await app.login(credentials: Credentials.anonymous)
+    return loggedInUser
+}
 
-    do {
-        let user = try await app.login(credentials: anonCredentials)
-        print("Successfully logged in as user \(user)")
-    } catch {
-        print("Login failed: \(error.localizedDescription)")
-    }
+do {
+    let user = try await login()
+    // Do something with user
+    print("Successfully logged in user: \(user)")
+} catch {
+    print("Failed to log in user: \(error.localizedDescription)")
 }

--- a/source/examples/generated/code/start/Sync.codeblock.async-await-open-synced-realm.swift
+++ b/source/examples/generated/code/start/Sync.codeblock.async-await-open-synced-realm.swift
@@ -1,0 +1,8 @@
+func testAsyncAwaitOpenRealm() async throws {
+    let app = App(id: YOUR_REALM_APP_ID)
+    let user = try await app.login(credentials: Credentials.anonymous)
+    let partitionValue = "some partition value"
+    var configuration = user.configuration(partitionValue: partitionValue)
+    let realm = try await Realm(configuration: configuration)
+    print("Successfully opened realm: \(realm)")
+}

--- a/source/examples/generated/code/start/Sync.codeblock.open-synced-realm.swift
+++ b/source/examples/generated/code/start/Sync.codeblock.open-synced-realm.swift
@@ -1,0 +1,38 @@
+// Get a user. If there is already a logged in user,
+// return that user. If not, log in.
+func getUser() async throws -> User {
+    // Check for a logged-in user
+    if app.currentUser != nil {
+        return app.currentUser!
+    } else {
+        // Instantiate the app using your Realm app ID
+        let app = App(id: YOUR_REALM_APP_ID)
+        // Authenticate with the instance of the app that points
+        // to your backend. Here, we're using anonymous login.
+        let loggedInUser = try await app.login(credentials: Credentials.anonymous)
+        return loggedInUser
+    }
+}
+
+// Establish the user, define the config, and
+// return a realm for that user
+func getRealm() async throws -> Realm {
+    // Get a logged-in app user
+    let user = try await getUser()
+    // Specify which data this authenticated user should
+    // be able to access.
+    let partitionValue = "some partition value"
+    // Store a configuration that consists of the current user,
+    // authenticated to this instance of your app, who should be
+    // able to access this data (partition).
+    var configuration = user.configuration(partitionValue: partitionValue)
+    // Open a Realm with this configuration.
+    let realm = try await Realm(configuration: configuration)
+    print("Successfully opened realm: \(realm)")
+    return realm
+}
+
+// Get a realm
+let realm = try await getRealm()
+// Do something with the realm
+print("The open realm is: \(realm)")

--- a/source/examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift
+++ b/source/examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift
@@ -1,0 +1,8 @@
+func testSpecifyDownloadBehavior() async throws {
+    let app = App(id: YOUR_REALM_APP_ID)
+    let user = try await app.login(credentials: Credentials.anonymous)
+    let partitionValue = "some partition value"
+    var configuration = user.configuration(partitionValue: partitionValue)
+    let realm = try await Realm(configuration: configuration, downloadBeforeOpen: .always) 
+    print("Successfully opened realm after downloading: \(realm)")
+}

--- a/source/examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
+++ b/source/examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
@@ -1,5 +1,5 @@
 .. code-block:: swift
-   :emphasize-lines: 9
+   :emphasize-lines: 6
 
    func testSpecifyDownloadBehavior() async throws {
        let app = App(id: YOUR_REALM_APP_ID)

--- a/source/examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
+++ b/source/examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
@@ -1,0 +1,11 @@
+.. code-block:: swift
+   :emphasize-lines: 9
+
+   func testSpecifyDownloadBehavior() async throws {
+       let app = App(id: YOUR_REALM_APP_ID)
+       let user = try await app.login(credentials: Credentials.anonymous)
+       let partitionValue = "some partition value"
+       var configuration = user.configuration(partitionValue: partitionValue)
+       let realm = try await Realm(configuration: configuration, downloadBeforeOpen: .always) 
+       print("Successfully opened realm after downloading: \(realm)")
+   }

--- a/source/sdk/ios/examples.txt
+++ b/source/sdk/ios/examples.txt
@@ -14,6 +14,7 @@ Usage Examples - iOS SDK
    Connect to a MongoDB Realm Backend App </sdk/ios/examples/connect-to-a-mongodb-realm-backend-app>
    Authenticate Users </sdk/ios/examples/authenticate-users>
    Sync Changes Between Devices </sdk/ios/examples/sync-changes-between-devices>
+   Legacy Realm Sync Open Methods </sdk/ios/examples/sync-realm-open-legacy>
    Call a Function </sdk/ios/examples/call-a-function>
    Manage Email/Password Users </sdk/ios/examples/manage-email-password-users>
    Create & Manage User API Keys </sdk/ios/examples/manage-user-api-keys>

--- a/source/sdk/ios/examples/authenticate-users.txt
+++ b/source/sdk/ios/examples/authenticate-users.txt
@@ -147,7 +147,7 @@ Async/Await Login
 .. versionadded:: 10.15.0
 
 The async/await version of the :swift-sdk:`App.login <Extensions/App.html#/s:So6RLMAppC10RealmSwiftE5login11credentials7Combine6FutureCySo7RLMUserCs5Error_pGAC11CredentialsO_tF>` 
-method returns a publisher that eventually returns a User or Error.
+method asynchronously returns a User or Error.
 
 .. literalinclude:: /examples/generated/code/start/Authenticate.codeblock.async-await.swift
    :language: swift

--- a/source/sdk/ios/examples/authenticate-users.txt
+++ b/source/sdk/ios/examples/authenticate-users.txt
@@ -141,6 +141,17 @@ If you have enabled :ref:`Sign-in with Apple authentication
 
 .. include:: /includes/authorization-appleidcredential-string.rst
 
+Async/Await Login
+~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 10.15.0
+
+The async/await version of the :swift-sdk:`App.login <Extensions/App.html#/s:So6RLMAppC10RealmSwiftE5login11credentials7Combine6FutureCySo7RLMUserCs5Error_pGAC11CredentialsO_tF>` 
+method returns a publisher that eventually returns a User or Error.
+
+.. literalinclude:: /examples/generated/code/start/Authenticate.codeblock.async-await.swift
+   :language: swift
+
 .. _ios-logout:
 
 Log Out

--- a/source/sdk/ios/examples/sync-changes-between-devices.txt
+++ b/source/sdk/ios/examples/sync-changes-between-devices.txt
@@ -97,8 +97,8 @@ Open a Synced Realm
       to :objc-sdk:`+[RLMRealm realmWithConfiguration:error:]
       <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`.
 
-      This opens a synced {+realm+} on the device. The {+realm+} will 
-      attempt to sync with your {+app+} in the background to check for changes 
+      This opens a synced {+realm+} on the device. The {+realm+} 
+      attempts to sync with your {+app+} in the background to check for changes 
       on the server, or upload changes that the user has made.
 
       .. literalinclude:: /examples/generated/code/start/Sync.codeblock.init-synced-realm.m
@@ -123,7 +123,7 @@ accepts a case from the ``OpenBehavior`` enum:
   Requires the user to have an active internet connection.
 - ``once``: Download data before opening a {+realm+} for the first time, but
   open it without downloading changes on subsequent opens. This lets you 
-  populate a {+realm+} with initial data, but enables offline first 
+  populate a {+realm+} with initial data, but enables offline-first 
   functionality on subsequent opens.
 
 .. include:: /examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst

--- a/source/sdk/ios/examples/sync-changes-between-devices.txt
+++ b/source/sdk/ios/examples/sync-changes-between-devices.txt
@@ -14,12 +14,12 @@ Sync Changes Between Devices - iOS SDK
 
 .. _ios-open-a-synced-realm:
 
-Open a Synced Realm
--------------------
+Overview
+--------
 
-The typical flow for opening a synced {+realm+} for the first time involves:
+The typical flow for opening a synced {+realm+} involves:
 
-1. Authenticating the user
+1. :ref:`Authenticating the user <ios-authenticate-users>`
 #. Creating a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`
 #. Opening the user's synced {+realm+} with the configuration.
 
@@ -34,17 +34,8 @@ With cached credentials, you can:
 
 - Open a synced {+realm+} immediately with the data that is on the device.
   You can use this method offline or online.
-- Open a synced {+realm+} after syncing changes with your {+app+}. You can
-  only use this method if the user is online.
-
-Open A Synced Realm Offline
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can work with synced {+realms+} offline if the user credentials are
-cached and you use {+backend-short+} initializers to open the {+realms+}.
-If your app requires that a user always have the most up-to-date data, 
-you'll use ``asyncOpen`` to open the {+realm+}, but that requires a user
-to have a network connection.
+- Open a synced {+realm+} after downloading changes from your {+app+}. 
+  This requires the user to have an active internet connection.
 
 Synced Realms vs Local Realms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -55,47 +46,44 @@ Synced {+realms+} differ from local {+client-database+} in a few ways:
   whereas local {+realms+} do not.
 - Synced {+realms+} can be accessed by authenticated users, while local 
   {+realms+} do not require any concept of users or authentication.
-- Some methods of opening synced {+realms+} require users to be online, 
-  while local {+realms+} can be used entirely offline.
+- With synced {+realms+}, you can :ref:`specify the download behavior 
+  <ios-specify-download-behavior>` to download updates before opening a 
+  {+realm+}. However, this requires users to be online. Local {+realms+} - 
+  with no sync capability - can always be used offline.
 
 You can copy data from a :ref:`local {+client-database+} <ios-open-a-local-realm>` 
 to a synced {+realm+}, but you cannot sync a local {+client-database+}. You
-must initialize a synced {+realm+} with a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`. 
+must initialize a synced {+realm+} with a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`.
 
-Open a Synced Realm for the First Time
---------------------------------------
+.. _ios-login-and-open-realm:
 
-Authenticate a User
-~~~~~~~~~~~~~~~~~~~
-
-The first time a user opens a {+realm+}, you'll need to authenticate the user. 
-Upon this initial login, we cache login credentials. On subsequent opens, you 
-can check for a logged-in user, and then open new {+realms+}. You don't need to
-complete the login flow while you have a logged-in user. 
-
-Depending on your business logic, you may also require the user to download 
-data from {+backend+} before opening a synced {+realm+} on device.
-
-Log In and Open a Synced Realm with Data on the Device
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Open a Synced Realm
+-------------------
 
 .. tabs-realm-languages::
    
    .. tab::
       :tabid: swift
 
-      The first time you log in and open a synced {+realm+}, you'll log in the
-      user, and pass the  user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
-      object with the desired :ref:`partition value <partition-value>` to
-      :swift-sdk:`Realm.asyncOpen(configuration:)
-      <Structs/Realm.html#/s:10RealmSwift0A0V9asyncOpen13configuration13callbackQueue0F0AC05AsyncD4TaskVAC13ConfigurationV_So17OS_dispatch_queueCyACSg_s5Error_pSgtctFZ>`:
+      .. versionchanged:: 10.15.0
 
-      This opens a synced {+realm+} on the device with data that is present
-      on the device. The {+realm+} will attempt to sync with your {+app+} in
-      the background to check for changes on the server, or upload changes 
-      that the user has made.
+      .. seealso::
+         
+         This example uses async/await introduced in Swift 5.5 for iOS 15. If you're
+         using an older version of Swift or need to support older platforms, see:
+         :ref:`Legacy Realm Sync Open Methods <ios-realm-open-legacy>`. 
 
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.login-and-init-synced-realm.swift
+      Pass a logged-in user's :swift-sdk:`configuration <Structs/Realm/Configuration.html>` 
+      object with the desired :ref:`partition value <partition-value>` to 
+      :swift-sdk:`{+realm+} initializers 
+      <Structs/Realm.html#/s:10RealmSwift0A0V13configuration5queueA2C13ConfigurationV_So012OS_dispatch_D0CSgtKcfc>`.
+
+      You can optionally :ref:`specify whether a {+realm+} should download 
+      changes before opening <ios-specify-download-behavior>`. If you do not
+      specify download behavior, this opens a {+realm+} with data that is on
+      the device, and attempts to sync changes in the background.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm.swift
          :language: swift
 
    .. tab::
@@ -109,224 +97,36 @@ Log In and Open a Synced Realm with Data on the Device
       to :objc-sdk:`+[RLMRealm realmWithConfiguration:error:]
       <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`.
 
-      This opens a synced {+realm+} on the device with data that is present
-      on the device. The {+realm+} will attempt to sync with your {+app+} in
-      the background to check for changes on the server, or upload changes 
-      that the user has made.
+      This opens a synced {+realm+} on the device. The {+realm+} will 
+      attempt to sync with your {+app+} in the background to check for changes 
+      on the server, or upload changes that the user has made.
 
       .. literalinclude:: /examples/generated/code/start/Sync.codeblock.init-synced-realm.m
          :language: swift
 
-Log In and Download Changes Before Opening a Realm
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _ios-specify-download-behavior:
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: swift
+Download Changes Before Open
+----------------------------
 
-      If you want to download data from your backend {+app+} before the user 
-      can work with the synced {+realm+}, you'll log in the user, and pass the 
-      user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
-      object with the desired :ref:`partition value <partition-value>` to
-      :swift-sdk:`Realm.asyncOpen(configuration:)
-      <Structs/Realm.html#/s:10RealmSwift0A0V9asyncOpen13configuration13callbackQueue0F0AC05AsyncD4TaskVAC13ConfigurationV_So17OS_dispatch_queueCyACSg_s5Error_pSgtctFZ>`:
+.. versionadded:: 10.15.0
 
-      When this is the first time opening the {+realm+} on the device, ``asyncOpen`` 
-      downloads the entire remote {+realm+} before opening the file on device. 
-      If the synced {+realm+} is already present on the device, ``asyncOpen`` 
-      downloads only the latest changes since the {+realm+} last synced with 
-      the {+app+}.
+When you open a synced {+realm+} with the Swift SDK, you can pass the 
+``downloadBeforeOpen`` parameter to specify whether to download the 
+changeset from your {+app+} before opening the {+realm+}. This parameter 
+accepts a case from the ``OpenBehavior`` enum:
 
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.login-asyncopen-synced-realm.swift
-         :language: swift
+- ``never``: Immediately open the {+realm+} on the device. Download changes 
+  in the background when the user has internet, but don't block opening
+  the {+realm+}.
+- ``always``: Check for changes every time you open the {+realm+}.
+  Requires the user to have an active internet connection.
+- ``once``: Download data before opening a {+realm+} for the first time, but
+  open it without downloading changes on subsequent opens. This lets you 
+  populate a {+realm+} with initial data, but enables offline first 
+  functionality on subsequent opens.
 
-   .. tab::
-      :tabid: objective-c
-
-      To open a synced {+realm+} asynchronously, pass the logged-in user's
-      :objc-sdk:`RLMRealmConfiguration
-      <Classes/RLMRealmConfiguration.html>` object with the desired
-      :ref:`partition value <partition-value>` to :objc-sdk:`+[RLMRealm
-      asyncOpenWithConfiguration:callbackQueue:callback]
-      <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)asyncOpenWithConfiguration:callbackQueue:callback:>`:
-
-      If this is the first time opening the {+realm+} on the device, ``asyncOpen`` 
-      downloads the entire remote {+realm+} before opening the file on device. 
-      If a {+realm+} is already present on the device, ``asyncOpen`` downloads 
-      only the latest changes since the {+realm+} last synced with the {+app+}.
-      
-      A common pattern is to use ``asyncOpen`` during a login 
-      flow, but use ``init`` to open a {+realm+} on subsequent opens.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.asyncopen-synced-realm.m
-         :language: objectivec
-
-Open a Synced Realm with Cached Credentials
--------------------------------------------
-
-After you have authenticated a user and created a sync configuration to 
-open a {+realm+}, you can open the same {+realm+} again using the sync 
-configuration with cached credentials. You can use two different methods to 
-open the synced {+realm+}, depending on your needs:
-
-- :ref:`Open a synced {+realm+} with data that is on the device 
-  <ios-open-synced-realm-with-data-on-device>` immediately. This works regardless 
-  of network status, and enables the user to start working with the {+realm+} 
-  without waiting for changes to download from the server. However, data that 
-  is on the device may be stale. Additionally, this may result in behavior that 
-  seems unexpected or surprising to the user. Data may appear "suddenly" as 
-  it syncs in the background after the user has already begun working with the 
-  {+realm+}. You'll need to account for this in your UI logic.
-- :ref:`Open a synced {+realm+} after syncing changes <ios-open-synced-realm-after-sync>`. 
-  This requires the user to have a network connection, so you should 
-  :ref:`check the network connection <ios-check-network-connection>` before 
-  attempting to open the {+realm+} from the server. This method of opening the 
-  {+realm+} ensures that the user always has the most up-to-date data from the 
-  server. The cost of using this method is an upfront pause while loading, and 
-  being unable to open the {+realm+} offline.
-
-.. _ios-open-synced-realm-with-data-on-device:
-
-Open a Synced Realm with Data on the Device
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can use initializers to open the {+realm+} immediately, using the data
-that is on the device. If you want to open a synced {+realm+} offline, use 
-this method. You must have a cached, logged-in user.
-
-.. example::
-
-   Consider the example of a note-taking app. You might decide it's most 
-   important for your user to be able to quickly jot down a note. The user 
-   shouldn't have to wait while downloading changes that a family member made 
-   to a shared note. In this case, opening a {+realm+} with ``init`` gets the 
-   user to the UI right away, or while the user is offline. When the user has
-   a network connection, changes will sync in the background.
-
-   In contrast, you might want a store inventory app to always check the server 
-   for changes before working with a {+realm+}. If you use stale data from the
-   last time the {+realm+} was open on the device, the app data could reflect 
-   incorrect counts, inaccurate pricing data, or other out-of-date data issues. 
-   In that case, you'd want the app to download changes before letting the user
-   work with the data.
-
-.. note::
-
-   A synced {+realm+} is not interchangeable with a local {+client-database+}.
-   If you want to sync a local {+client-database+}, you'll need to :ref:`copy the
-   content from the local {+realm+} to a synced {+realm+} <copy-local-data-to-synced-realm>`. 
-   A local {+realm+} lives only on the device and never attempts to sync with 
-   the server. A synced {+realm+} contains additional {+sync-short+}-related 
-   metadata, and consistently and persistently attempts to connect and sync 
-   data with the server.
-
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: swift
-
-      To open a synced {+realm+} with data on the device, pass the 
-      logged-in user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
-      object with the desired :ref:`partition value <partition-value>` to
-      :swift-sdk:`Realm() <Structs/Realm.html>` initializers. This opens 
-      the {+realm+} immediately, before downloading changesets from the server.
-      This works if the device is offline, but may lead to temporary data
-      inconsistencies while your app downloads any new remote data. The 
-      {+realm+} will update from the server in the background.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm-offline.swift
-         :language: swift
-
-   .. tab::
-      :tabid: objective-c
-
-      You can open the realm synchronously with the
-      :objc-sdk:`+[RLMRealm realmWithConfiguration:error:]
-      <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`
-      initializers. This opens the {+realm+} immediately, before downloading 
-      changesets from the server. This works if the device is offline, but 
-      may lead to temporary data inconsistencies while your app downloads 
-      any new remote data. The {+realm+} will update from the server in the 
-      background.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm-synchronously.m
-         :language: objectivec
-
-.. _ios-open-synced-realm-after-sync:
-
-Open a Synced Realm After Downloading Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- 
-In some apps, such as games, you might want the user to always have current data. 
-Use ``asyncOpen`` to sync the {+realm+} with the {+app+} before opening it.
-
-.. example::
-
-   Say a user plays a game on both an iPad and an iPhone. The user progresses 
-   three levels on the iPad. Later, the user opens the game on an iPhone. In this 
-   case, ``asyncOpen`` is a better way to open the {+realm+}. Loading with stale 
-   data would get the user into the game faster, but the user's data would be 
-   three levels out of sync.
-
-   In contrast, if you had an app that allowed the user to record and save their
-   favorite recipes, you might want to give them the option to create a new 
-   recipe without waiting to download updates, or even if they're offline. If 
-   you opened a synced realm with data on the device, the user could enter a 
-   new recipe, which would sync with the {+app+} when they next had a network 
-   connection.
-
-A common pattern is to open a {+realm+} with ``asyncOpen`` in the login flow, 
-and then use ``init`` for subsequent opens. If you want users to only interact 
-with the most up-to-date version of your data, you can exclusively use 
-``asyncOpen``. This incurs the cost of additional loading time and prevents 
-users from opening a realm while offline.
-
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: swift
-
-      To open a synced {+realm+} only after it has downloaded changes from your 
-      {+app+}, verify that the user has :ref:`a network connection <ios-check-network-connection>`, 
-      and then pass the logged-in user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
-      object with the desired :ref:`partition value <partition-value>` to
-      :swift-sdk:`Realm.asyncOpen(configuration:)
-      <Structs/Realm.html#/s:10RealmSwift0A0V9asyncOpen13configuration13callbackQueue0F0AC05AsyncD4TaskVAC13ConfigurationV_So17OS_dispatch_queueCyACSg_s5Error_pSgtctFZ>`:
-
-      If this is the first time opening the {+realm+} on the device, ``asyncOpen`` 
-      downloads the entire remote {+realm+} before opening the file on device. 
-      If a {+realm+} is already present on the device, ``asyncOpen`` downloads 
-      only the latest changes since the {+realm+} last synced with the {+app+}.
-      
-      You might use ``asyncOpen`` exclusively to open {+realms+} when you need
-      to ensure that the user always has the latest data from the server.
-      However, if the user is currently offline, the user won't be able to
-      work with the {+realm+}.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.use-async-open-with-cached-credentials.swift
-         :language: swift
-
-   .. tab::
-         :tabid: objective-c
-
-         To open a synced {+realm+} asynchronously, pass the logged-in user's
-         :objc-sdk:`RLMRealmConfiguration
-         <Classes/RLMRealmConfiguration.html>` object with the desired
-         :ref:`partition value <partition-value>` to :objc-sdk:`+[RLMRealm
-         asyncOpenWithConfiguration:callbackQueue:callback]
-         <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)asyncOpenWithConfiguration:callbackQueue:callback:>`:
-
-         If this is the first time opening the {+realm+} on the device, ``asyncOpen`` 
-         downloads the entire remote {+realm+} before opening the file on device. 
-         If a {+realm+} is already present on the device, ``asyncOpen`` downloads 
-         only the latest changes since the {+realm+} last synced with the {+app+}.
-         
-         A common pattern is to use ``asyncOpen`` during a login 
-         flow, but use ``init`` to open a {+realm+} on subsequent opens.
-
-         .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm.m
-            :language: objectivec
+.. include:: /examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
 
 .. _ios-open-synced-realm-swiftui:
 

--- a/source/sdk/ios/examples/sync-realm-open-legacy.txt
+++ b/source/sdk/ios/examples/sync-realm-open-legacy.txt
@@ -40,9 +40,9 @@ Open A Synced Realm Offline
 
 You can work with synced {+realms+} offline if the user credentials are
 cached and you use {+backend-short+} initializers to open the {+realms+}.
-If your app requires that a user always have the most up-to-date data, 
-you'll use ``asyncOpen`` to open the {+realm+}, but that requires a user
-to have a network connection.
+If you use ``asyncOpen`` instead of initializers to open the {+realm+}, 
+the user always has the most up-to-date data, but must have a network 
+connection.
 
 Open a Synced Realm for the First Time
 --------------------------------------
@@ -50,10 +50,10 @@ Open a Synced Realm for the First Time
 Authenticate a User
 ~~~~~~~~~~~~~~~~~~~
 
-The first time a user opens a {+realm+}, you'll need to authenticate the user. 
-Upon this initial login, we cache login credentials. On subsequent opens, you 
-can check for a logged-in user, and then open new {+realms+}. You don't need to
-complete the login flow while you have a logged-in user. 
+The first time a user opens a {+realm+}, you must authenticate the user. 
+Upon this initial login, {+service-short+} caches login credentials. On 
+subsequent opens, check for a logged-in user, and then open new {+realms+}. 
+You can skip the login flow while you have a logged-in user. 
 
 Depending on your business logic, you may also require the user to download 
 data from {+backend+} before opening a synced {+realm+} on device.
@@ -66,14 +66,14 @@ Log In and Open a Synced Realm with Data on the Device
    .. tab::
       :tabid: swift
 
-      The first time you log in and open a synced {+realm+}, you'll log in the
-      user, and pass the  user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
+      The first time you log in and open a synced {+realm+}, you log the
+      user in, and pass the  user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
       object with the desired :ref:`partition value <partition-value>` to
       :swift-sdk:`Realm.asyncOpen(configuration:)
       <Structs/Realm.html#/s:10RealmSwift0A0V9asyncOpen13configuration13callbackQueue0F0AC05AsyncD4TaskVAC13ConfigurationV_So17OS_dispatch_queueCyACSg_s5Error_pSgtctFZ>`:
 
       This opens a synced {+realm+} on the device with data that is present
-      on the device. The {+realm+} will attempt to sync with your {+app+} in
+      on the device. The {+realm+} attempts to sync with your {+app+} in
       the background to check for changes on the server, or upload changes 
       that the user has made.
 
@@ -83,8 +83,8 @@ Log In and Open a Synced Realm with Data on the Device
    .. tab::
       :tabid: objective-c
 
-      The first time you log in and open a synced {+realm+}, you'll log in the
-      user, and pass the user's :objc-sdk:`RLMSyncConfiguration 
+      The first time you log in and open a synced {+realm+}, log the
+      user in, and pass the user's :objc-sdk:`RLMSyncConfiguration 
       <Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)syncConfiguration>` 
       object with the desired :objc-sdk:`partitionValue 
       <Classes/RLMSyncConfiguration.html#/c:objc(cs)RLMSyncConfiguration(py)partitionValue>` 
@@ -92,7 +92,7 @@ Log In and Open a Synced Realm with Data on the Device
       <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`.
 
       This opens a synced {+realm+} on the device with data that is present
-      on the device. The {+realm+} will attempt to sync with your {+app+} in
+      on the device. The {+realm+} attempts to sync with your {+app+} in
       the background to check for changes on the server, or upload changes 
       that the user has made.
 
@@ -108,7 +108,7 @@ Log In and Download Changes Before Opening a Realm
       :tabid: swift
 
       If you want to download data from your backend {+app+} before the user 
-      can work with the synced {+realm+}, you'll log in the user, and pass the 
+      can work with the synced {+realm+}, log the user in, and pass the 
       user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
       object with the desired :ref:`partition value <partition-value>` to
       :swift-sdk:`Realm.asyncOpen(configuration:)
@@ -159,7 +159,7 @@ open the synced {+realm+}, depending on your needs:
   is on the device may be stale. Additionally, this may result in behavior that 
   seems unexpected or surprising to the user. Data may appear "suddenly" as 
   it syncs in the background after the user has already begun working with the 
-  {+realm+}. You'll need to account for this in your UI logic.
+  {+realm+}. You must account for this in your UI logic.
 - :ref:`Open a synced {+realm+} after syncing changes <ios-open-synced-realm-after-sync>`. 
   This requires the user to have a network connection, so you should 
   :ref:`check the network connection <ios-check-network-connection>` before 
@@ -184,7 +184,7 @@ this method. You must have a cached, logged-in user.
    shouldn't have to wait while downloading changes that a family member made 
    to a shared note. In this case, opening a {+realm+} with ``init`` gets the 
    user to the UI right away, or while the user is offline. When the user has
-   a network connection, changes will sync in the background.
+   a network connection, changes sync in the background.
 
    In contrast, you might want a store inventory app to always check the server 
    for changes before working with a {+realm+}. If you use stale data from the
@@ -196,7 +196,7 @@ this method. You must have a cached, logged-in user.
 .. note::
 
    A synced {+realm+} is not interchangeable with a local {+client-database+}.
-   If you want to sync a local {+client-database+}, you'll need to :ref:`copy the
+   If you want to sync a local {+client-database+}, you must :ref:`copy the
    content from the local {+realm+} to a synced {+realm+} <copy-local-data-to-synced-realm>`. 
    A local {+realm+} lives only on the device and never attempts to sync with 
    the server. A synced {+realm+} contains additional {+sync-short+}-related 
@@ -215,7 +215,7 @@ this method. You must have a cached, logged-in user.
       the {+realm+} immediately, before downloading changesets from the server.
       This works if the device is offline, but may lead to temporary data
       inconsistencies while your app downloads any new remote data. The 
-      {+realm+} will update from the server in the background.
+      {+realm+} updates from the server in the background.
 
       .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm-offline.swift
          :language: swift
@@ -229,7 +229,7 @@ this method. You must have a cached, logged-in user.
       initializers. This opens the {+realm+} immediately, before downloading 
       changesets from the server. This works if the device is offline, but 
       may lead to temporary data inconsistencies while your app downloads 
-      any new remote data. The {+realm+} will update from the server in the 
+      any new remote data. The {+realm+} updates from the server in the 
       background.
 
       .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm-synchronously.m

--- a/source/sdk/ios/examples/sync-realm-open-legacy.txt
+++ b/source/sdk/ios/examples/sync-realm-open-legacy.txt
@@ -1,0 +1,311 @@
+.. _ios-realm-open-legacy:
+
+========================================
+Legacy Realm Sync Open Methods - iOS SDK
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+The examples on this page describe how to work with synced {+realms+} in
+iOS SDK versions prior to 10.15.0. Alternately, if you're building apps 
+for iOS targets prior to 15.0, with Swift versions older than 5.5, or with 
+Objective-C, you can use these methods and code examples to work with 
+{+realms+} asynchronously.
+
+.. note::
+  
+   The ``OpenBehavior`` enum, and :ref:`the ability to specify whether to download
+   data before opening a {+realm+}<ios-specify-download-behavior>`, do not 
+   apply to the legacy examples on this page. If you want to require 
+   downloading changes before opening a {+realm+} with this older syntax, 
+   you must use ``asyncOpen``, which :ref:`always downloads changes before 
+   opening a {+realm+}<ios-open-synced-realm-after-sync>`.
+
+.. seealso::
+
+   If you're using Swift SDK 10.15.0 or newer, see the :ref:`Sync Changes 
+   Between Devices page <ios-sync-changes-between-devices>`.
+
+Open A Synced Realm Offline
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can work with synced {+realms+} offline if the user credentials are
+cached and you use {+backend-short+} initializers to open the {+realms+}.
+If your app requires that a user always have the most up-to-date data, 
+you'll use ``asyncOpen`` to open the {+realm+}, but that requires a user
+to have a network connection.
+
+Open a Synced Realm for the First Time
+--------------------------------------
+
+Authenticate a User
+~~~~~~~~~~~~~~~~~~~
+
+The first time a user opens a {+realm+}, you'll need to authenticate the user. 
+Upon this initial login, we cache login credentials. On subsequent opens, you 
+can check for a logged-in user, and then open new {+realms+}. You don't need to
+complete the login flow while you have a logged-in user. 
+
+Depending on your business logic, you may also require the user to download 
+data from {+backend+} before opening a synced {+realm+} on device.
+
+Log In and Open a Synced Realm with Data on the Device
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      The first time you log in and open a synced {+realm+}, you'll log in the
+      user, and pass the  user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
+      object with the desired :ref:`partition value <partition-value>` to
+      :swift-sdk:`Realm.asyncOpen(configuration:)
+      <Structs/Realm.html#/s:10RealmSwift0A0V9asyncOpen13configuration13callbackQueue0F0AC05AsyncD4TaskVAC13ConfigurationV_So17OS_dispatch_queueCyACSg_s5Error_pSgtctFZ>`:
+
+      This opens a synced {+realm+} on the device with data that is present
+      on the device. The {+realm+} will attempt to sync with your {+app+} in
+      the background to check for changes on the server, or upload changes 
+      that the user has made.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.login-and-init-synced-realm.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      The first time you log in and open a synced {+realm+}, you'll log in the
+      user, and pass the user's :objc-sdk:`RLMSyncConfiguration 
+      <Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)syncConfiguration>` 
+      object with the desired :objc-sdk:`partitionValue 
+      <Classes/RLMSyncConfiguration.html#/c:objc(cs)RLMSyncConfiguration(py)partitionValue>` 
+      to :objc-sdk:`+[RLMRealm realmWithConfiguration:error:]
+      <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`.
+
+      This opens a synced {+realm+} on the device with data that is present
+      on the device. The {+realm+} will attempt to sync with your {+app+} in
+      the background to check for changes on the server, or upload changes 
+      that the user has made.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.init-synced-realm.m
+         :language: swift
+
+Log In and Download Changes Before Opening a Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      If you want to download data from your backend {+app+} before the user 
+      can work with the synced {+realm+}, you'll log in the user, and pass the 
+      user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
+      object with the desired :ref:`partition value <partition-value>` to
+      :swift-sdk:`Realm.asyncOpen(configuration:)
+      <Structs/Realm.html#/s:10RealmSwift0A0V9asyncOpen13configuration13callbackQueue0F0AC05AsyncD4TaskVAC13ConfigurationV_So17OS_dispatch_queueCyACSg_s5Error_pSgtctFZ>`:
+
+      When this is the first time opening the {+realm+} on the device, ``asyncOpen`` 
+      downloads the entire remote {+realm+} before opening the file on device. 
+      If the synced {+realm+} is already present on the device, ``asyncOpen`` 
+      downloads only the latest changes since the {+realm+} last synced with 
+      the {+app+}.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.login-asyncopen-synced-realm.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      To open a synced {+realm+} asynchronously, pass the logged-in user's
+      :objc-sdk:`RLMRealmConfiguration
+      <Classes/RLMRealmConfiguration.html>` object with the desired
+      :ref:`partition value <partition-value>` to :objc-sdk:`+[RLMRealm
+      asyncOpenWithConfiguration:callbackQueue:callback]
+      <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)asyncOpenWithConfiguration:callbackQueue:callback:>`:
+
+      If this is the first time opening the {+realm+} on the device, ``asyncOpen`` 
+      downloads the entire remote {+realm+} before opening the file on device. 
+      If a {+realm+} is already present on the device, ``asyncOpen`` downloads 
+      only the latest changes since the {+realm+} last synced with the {+app+}.
+      
+      A common pattern is to use ``asyncOpen`` during a login 
+      flow, but use ``init`` to open a {+realm+} on subsequent opens.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.asyncopen-synced-realm.m
+         :language: objectivec
+
+Open a Synced Realm with Cached Credentials
+-------------------------------------------
+
+After you have authenticated a user and created a sync configuration to 
+open a {+realm+}, you can open the same {+realm+} again using the sync 
+configuration with cached credentials. You can use two different methods to 
+open the synced {+realm+}, depending on your needs:
+
+- :ref:`Open a synced {+realm+} with data that is on the device 
+  <ios-open-synced-realm-with-data-on-device>` immediately. This works regardless 
+  of network status, and enables the user to start working with the {+realm+} 
+  without waiting for changes to download from the server. However, data that 
+  is on the device may be stale. Additionally, this may result in behavior that 
+  seems unexpected or surprising to the user. Data may appear "suddenly" as 
+  it syncs in the background after the user has already begun working with the 
+  {+realm+}. You'll need to account for this in your UI logic.
+- :ref:`Open a synced {+realm+} after syncing changes <ios-open-synced-realm-after-sync>`. 
+  This requires the user to have a network connection, so you should 
+  :ref:`check the network connection <ios-check-network-connection>` before 
+  attempting to open the {+realm+} from the server. This method of opening the 
+  {+realm+} ensures that the user always has the most up-to-date data from the 
+  server. The cost of using this method is an upfront pause while loading, and 
+  being unable to open the {+realm+} offline.
+
+.. _ios-open-synced-realm-with-data-on-device:
+
+Open a Synced Realm with Data on the Device
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use initializers to open the {+realm+} immediately, using the data
+that is on the device. If you want to open a synced {+realm+} offline, use 
+this method. You must have a cached, logged-in user.
+
+.. example::
+
+   Consider the example of a note-taking app. You might decide it's most 
+   important for your user to be able to quickly jot down a note. The user 
+   shouldn't have to wait while downloading changes that a family member made 
+   to a shared note. In this case, opening a {+realm+} with ``init`` gets the 
+   user to the UI right away, or while the user is offline. When the user has
+   a network connection, changes will sync in the background.
+
+   In contrast, you might want a store inventory app to always check the server 
+   for changes before working with a {+realm+}. If you use stale data from the
+   last time the {+realm+} was open on the device, the app data could reflect 
+   incorrect counts, inaccurate pricing data, or other out-of-date data issues. 
+   In that case, you'd want the app to download changes before letting the user
+   work with the data.
+
+.. note::
+
+   A synced {+realm+} is not interchangeable with a local {+client-database+}.
+   If you want to sync a local {+client-database+}, you'll need to :ref:`copy the
+   content from the local {+realm+} to a synced {+realm+} <copy-local-data-to-synced-realm>`. 
+   A local {+realm+} lives only on the device and never attempts to sync with 
+   the server. A synced {+realm+} contains additional {+sync-short+}-related 
+   metadata, and consistently and persistently attempts to connect and sync 
+   data with the server.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      To open a synced {+realm+} with data on the device, pass the 
+      logged-in user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
+      object with the desired :ref:`partition value <partition-value>` to
+      :swift-sdk:`Realm() <Structs/Realm.html>` initializers. This opens 
+      the {+realm+} immediately, before downloading changesets from the server.
+      This works if the device is offline, but may lead to temporary data
+      inconsistencies while your app downloads any new remote data. The 
+      {+realm+} will update from the server in the background.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm-offline.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      You can open the realm synchronously with the
+      :objc-sdk:`+[RLMRealm realmWithConfiguration:error:]
+      <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`
+      initializers. This opens the {+realm+} immediately, before downloading 
+      changesets from the server. This works if the device is offline, but 
+      may lead to temporary data inconsistencies while your app downloads 
+      any new remote data. The {+realm+} will update from the server in the 
+      background.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm-synchronously.m
+         :language: objectivec
+
+.. _ios-open-synced-realm-after-sync:
+
+Open a Synced Realm After Downloading Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ 
+In some apps, such as games, you might want the user to always have current data. 
+Use ``asyncOpen`` to sync the {+realm+} with the {+app+} before opening it.
+
+.. example::
+
+   Say a user plays a game on both an iPad and an iPhone. The user progresses 
+   three levels on the iPad. Later, the user opens the game on an iPhone. In this 
+   case, ``asyncOpen`` is a better way to open the {+realm+}. Loading with stale 
+   data would get the user into the game faster, but the user's data would be 
+   three levels out of sync.
+
+   In contrast, if you had an app that allowed the user to record and save their
+   favorite recipes, you might want to give them the option to create a new 
+   recipe without waiting to download updates, or even if they're offline. If 
+   you opened a synced realm with data on the device, the user could enter a 
+   new recipe, which would sync with the {+app+} when they next had a network 
+   connection.
+
+A common pattern is to open a {+realm+} with ``asyncOpen`` in the login flow, 
+and then use ``init`` for subsequent opens. If you want users to only interact 
+with the most up-to-date version of your data, you can exclusively use 
+``asyncOpen``. This incurs the cost of additional loading time and prevents 
+users from opening a realm while offline.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      To open a synced {+realm+} only after it has downloaded changes from your 
+      {+app+}, verify that the user has :ref:`a network connection <ios-check-network-connection>`, 
+      and then pass the logged-in user's :swift-sdk:`Configuration <Structs/Realm/Configuration.html>` 
+      object with the desired :ref:`partition value <partition-value>` to
+      :swift-sdk:`Realm.asyncOpen(configuration:)
+      <Structs/Realm.html#/s:10RealmSwift0A0V9asyncOpen13configuration13callbackQueue0F0AC05AsyncD4TaskVAC13ConfigurationV_So17OS_dispatch_queueCyACSg_s5Error_pSgtctFZ>`:
+
+      If this is the first time opening the {+realm+} on the device, ``asyncOpen`` 
+      downloads the entire remote {+realm+} before opening the file on device. 
+      If a {+realm+} is already present on the device, ``asyncOpen`` downloads 
+      only the latest changes since the {+realm+} last synced with the {+app+}.
+      
+      You might use ``asyncOpen`` exclusively to open {+realms+} when you need
+      to ensure that the user always has the latest data from the server.
+      However, if the user is currently offline, the user won't be able to
+      work with the {+realm+}.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.use-async-open-with-cached-credentials.swift
+         :language: swift
+
+   .. tab::
+         :tabid: objective-c
+
+         To open a synced {+realm+} asynchronously, pass the logged-in user's
+         :objc-sdk:`RLMRealmConfiguration
+         <Classes/RLMRealmConfiguration.html>` object with the desired
+         :ref:`partition value <partition-value>` to :objc-sdk:`+[RLMRealm
+         asyncOpenWithConfiguration:callbackQueue:callback]
+         <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)asyncOpenWithConfiguration:callbackQueue:callback:>`:
+
+         If this is the first time opening the {+realm+} on the device, ``asyncOpen`` 
+         downloads the entire remote {+realm+} before opening the file on device. 
+         If a {+realm+} is already present on the device, ``asyncOpen`` downloads 
+         only the latest changes since the {+realm+} last synced with the {+app+}.
+         
+         A common pattern is to use ``asyncOpen`` during a login 
+         flow, but use ``init`` to open a {+realm+} on subsequent opens.
+
+         .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm.m
+            :language: objectivec

--- a/source/sdk/ios/examples/sync-realm-open-legacy.txt
+++ b/source/sdk/ios/examples/sync-realm-open-legacy.txt
@@ -32,8 +32,8 @@ Objective-C, you can use these methods and code examples to work with
 
 .. seealso::
 
-   If you're using Swift SDK 10.15.0 or newer, see the :ref:`Sync Changes 
-   Between Devices page <ios-sync-changes-between-devices>`.
+   If you're using Swift 5.5 with iOS SDK 10.15.0 or newer, see the 
+   :ref:`Sync Changes Between Devices page <ios-sync-changes-between-devices>`.
 
 Open A Synced Realm Offline
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

This PR documents the changes that were introduced in [10.15.0](https://github.com/realm/realm-cocoa/releases/tag/v10.15.0) - new async support for `App.login` and `asyncOpen`, and the introduction of `OpenBehavior` and the `downloadBeforeOpen` param. There will be a separate PR for the rest of the async/await changes when they are released.

### Jira

- https://jira.mongodb.org/browse/DOCSP-18707

### Staged Changes (Requires MongoDB Corp SSO)

- [Authenticate Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18707/sdk/ios/examples/authenticate-users/#async-await-login): New section for Async/Await Login
- [Sync Changes Between Devices](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18707/sdk/ios/examples/sync-changes-between-devices)
  - New Swift text and code example: [Open a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18707/sdk/ios/examples/sync-changes-between-devices/#open-a-synced-realm)
  - New section and code example: [Download Changes Before Open](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18707/sdk/ios/examples/sync-changes-between-devices/#download-changes-before-open)
  - [Overview](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18707/sdk/ios/examples/sync-changes-between-devices/#overview): Tweaked this section a little and the "Synced Realms vs Local Realms" verbiage that is a sub-section here to reflect the new download behavior functionality
- [Legacy Realm Sync Open Methods](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18707/sdk/ios/examples/sync-realm-open-legacy/): This page splits off the old open methods which we still need to retain for users who are building for older iOS targets and with older versions of Swift. `asyncOpen` behavior is different enough that it warrants keeping around all the verbiage, etc. The only new content on this page is the `Overview`.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
