### PR TITLE
Docsp 18713: add infobox about pausing syncing

### DIFF
--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -106,7 +106,6 @@ Glossary
       using the client's native query language.
 
    compaction
-      .. _glossary-compaction-definition:
       Allocation and deallocation of data within a :term:`{+client-database+}`
       and/or exceeding the size of physical memory can lead to
       fragmentation on disk. Calling the ``compact`` method

--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -104,8 +104,9 @@ Glossary
       GraphQL supports reading and writing data as well as subscribing
       to data changes. An alternative to :term:`{+client-database+}` queries
       using the client's native query language.
-
+   
    compaction
+      .. _glossary-compaction-definition:
       Allocation and deallocation of data within a :term:`{+client-database+}`
       and/or exceeding the size of physical memory can lead to
       fragmentation on disk. Calling the ``compact`` method

--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -105,9 +105,8 @@ Glossary
       to data changes. An alternative to :term:`{+client-database+}` queries
       using the client's native query language.
 
-      .. _glossary-compaction-definition:
-      
    compaction
+      .. _glossary-compaction-definition:
       Allocation and deallocation of data within a :term:`{+client-database+}`
       and/or exceeding the size of physical memory can lead to
       fragmentation on disk. Calling the ``compact`` method

--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -105,8 +105,7 @@ Glossary
       to data changes. An alternative to :term:`{+client-database+}` queries
       using the client's native query language.
    
-   compaction
-      .. _glossary-compaction-definition:
+   compaction .. _glossary-compaction-definition:
       Allocation and deallocation of data within a :term:`{+client-database+}`
       and/or exceeding the size of physical memory can lead to
       fragmentation on disk. Calling the ``compact`` method

--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -104,8 +104,10 @@ Glossary
       GraphQL supports reading and writing data as well as subscribing
       to data changes. An alternative to :term:`{+client-database+}` queries
       using the client's native query language.
-   
-   compaction .. _glossary-compaction-definition:
+
+      .. _glossary-compaction-definition:
+      
+   compaction
       Allocation and deallocation of data within a :term:`{+client-database+}`
       and/or exceeding the size of physical memory can lead to
       fragmentation on disk. Calling the ``compact`` method

--- a/source/includes/note-details-about-pause.rst
+++ b/source/includes/note-details-about-pause.rst
@@ -1,0 +1,33 @@
+.. note::
+   The ``pause`` function is designed for controlling when devices sync. 
+   
+   Examples of when to use ``pause`` include: 
+   -  Syncing only in the evening
+   - Spreading the sync load out across different times
+   - Conserving battery
+   
+   ## is there an upper bound of how long the sync should take?
+   ## even a general rule of thumb would be OK 
+   ##
+   ## my $.02 is that we should not say more that whatever the general rule of thumb is 
+   ## here, and then put any further discussion in a different page, as this seems like a 
+   ## fairly complex topic. 
+   The ``pause`` function is not intended to determine if a Realm should never sync. 
+   As a general principle, Realm sync pauses should not excede XXX_UNIT_OF_TIME. 
+   Pauses that exceed this much time can cause unexpected issues.  
+
+   ## probable scraps 
+   ## what type of storage issues would these be? 
+   For instance, you use ``pause`` for a prolonged period of time, you could encounter
+   issues with storage when you do attempt to sync because the synced Realm 
+   also stores the operations that created the change. These operations can excede 
+   4x the storage of the actual data stored in the Realm. 
+   These operations get pruned from the Realm after they sync. 
+   
+   Another issue you could run into if you sync a Realm after a long pause is there is a server-side feature know as compaction 
+   which prunes the operations from the server-side partitions. After a set amount of 
+   time it starts pruning old operations if the serverside prunes operations from the 
+   partition which is paused then a client could experience a client reset. This will 
+   probably not be an issue if the partition you are running is a per-user private realm. 
+   It is more of an issue with shared realms.
+

--- a/source/includes/note-details-about-pause.rst
+++ b/source/includes/note-details-about-pause.rst
@@ -15,4 +15,4 @@
 
    - Syncing stores the operations that create the changes, which can quickly grow to 
      become much larger than the actual state
-   - Issues related to :ref:`compaction <glossary-compaction-definition>` of data
+   - :ref:`Compaction <glossary-compaction-definition>` of data

--- a/source/includes/note-details-about-pause.rst
+++ b/source/includes/note-details-about-pause.rst
@@ -3,14 +3,16 @@
    It is designed and tested with temporary use cases in mind.
 
    Examples of when to use |pause_func_name| include: 
-   * Syncing only in the evening
-   * Spreading the sync load out across different times
-   * Conserving battery
+
+   - Syncing only in the evening
+   - Spreading the sync load out across different times
+   - Conserving battery
    
    The |pause_func_name| function is not intended to determine if a Realm should sync for
    indefinite periods of time, or time ranges in months and years. The functionality
    is not tested for these use cases, and you could encounter a range of issues
    when using it this way. These issues can relate to:  
-   * Syncing stores the operations that create the changes, which can quickly grow to 
+   
+   - Syncing stores the operations that create the changes, which can quickly grow to 
    become much larger than the actual state
-   * Issues related to :ref:`compaction <glossary-compaction-definition>` of data
+   - Issues related to :ref:`compaction <glossary-compaction-definition>` of data

--- a/source/includes/note-details-about-pause.rst
+++ b/source/includes/note-details-about-pause.rst
@@ -1,17 +1,16 @@
 .. note::
-   The ``.|pause_func_name|()`` method gives developers control over what time of day the device sync. 
+   The .|pause_func_name|() method gives developers control over what time of day the device sync. 
    It is designed and tested with temporary use cases in mind.
 
-   Examples of when to use ``|pause_func_name|`` include: 
+   Examples of when to use |pause_func_name| include: 
    -  Syncing only in the evening
    - Spreading the sync load out across different times
    - Conserving battery
    
-   The ``|pause_func_name|`` function is not intended to determine if a Realm should sync for
+   The |pause_func_name| function is not intended to determine if a Realm should sync for
    indefinite periods of time, or time ranges in months and years. The functionality
    is not tested for these use cases, and you could encounter a range of issues
    when using it this way. These issues can relate to:  
    - Syncing stores the operations that create the changes, which can quickly grow to 
    become much larger than the actual state
-   ## TODO make a ref to the compaction section of https://docs.mongodb.com/realm/get-started/glossary/
    - Issues related to :ref:`compaction <glossary-compaction-definition>` of data

--- a/source/includes/note-details-about-pause.rst
+++ b/source/includes/note-details-about-pause.rst
@@ -12,7 +12,7 @@
    indefinite periods of time, or time ranges in months and years. The functionality
    is not tested for these use cases, and you could encounter a range of issues
    when using it this way. These issues can relate to:  
-   
+
    - Syncing stores the operations that create the changes, which can quickly grow to 
-   become much larger than the actual state
+     become much larger than the actual state
    - Issues related to :ref:`compaction <glossary-compaction-definition>` of data

--- a/source/includes/note-details-about-pause.rst
+++ b/source/includes/note-details-about-pause.rst
@@ -1,13 +1,13 @@
 .. note::
-   The ``.pause()`` method gives developers control over what time of day the device sync. 
+   The ``.|pause_func_name|()`` method gives developers control over what time of day the device sync. 
    It is designed and tested with temporary use cases in mind.
 
-   Examples of when to use ``pause`` include: 
+   Examples of when to use ``|pause_func_name|`` include: 
    -  Syncing only in the evening
    - Spreading the sync load out across different times
    - Conserving battery
    
-   The ``pause`` function is not intended to determine if a Realm should sync for
+   The ``|pause_func_name|`` function is not intended to determine if a Realm should sync for
    indefinite periods of time, or time ranges in months and years. The functionality
    is not tested for these use cases, and you could encounter a range of issues
    when using it this way. These issues can relate to:  

--- a/source/includes/note-details-about-pause.rst
+++ b/source/includes/note-details-about-pause.rst
@@ -1,33 +1,17 @@
 .. note::
-   The ``pause`` function is designed for controlling when devices sync. 
-   
+   The ``.pause()`` method gives developers control over what time of day the device sync. 
+   It is designed and tested with temporary use cases in mind.
+
    Examples of when to use ``pause`` include: 
    -  Syncing only in the evening
    - Spreading the sync load out across different times
    - Conserving battery
    
-   ## is there an upper bound of how long the sync should take?
-   ## even a general rule of thumb would be OK 
-   ##
-   ## my $.02 is that we should not say more that whatever the general rule of thumb is 
-   ## here, and then put any further discussion in a different page, as this seems like a 
-   ## fairly complex topic. 
-   The ``pause`` function is not intended to determine if a Realm should never sync. 
-   As a general principle, Realm sync pauses should not excede XXX_UNIT_OF_TIME. 
-   Pauses that exceed this much time can cause unexpected issues.  
-
-   ## probable scraps 
-   ## what type of storage issues would these be? 
-   For instance, you use ``pause`` for a prolonged period of time, you could encounter
-   issues with storage when you do attempt to sync because the synced Realm 
-   also stores the operations that created the change. These operations can excede 
-   4x the storage of the actual data stored in the Realm. 
-   These operations get pruned from the Realm after they sync. 
-   
-   Another issue you could run into if you sync a Realm after a long pause is there is a server-side feature know as compaction 
-   which prunes the operations from the server-side partitions. After a set amount of 
-   time it starts pruning old operations if the serverside prunes operations from the 
-   partition which is paused then a client could experience a client reset. This will 
-   probably not be an issue if the partition you are running is a per-user private realm. 
-   It is more of an issue with shared realms.
-
+   The ``pause`` function is not intended to determine if a Realm should sync for
+   indefinite periods of time, or time ranges in months and years. The functionality
+   is not tested for these use cases, and you could encounter a range of issues
+   when using it this way. These issues can relate to:  
+   - Syncing stores the operations that create the changes, which can quickly grow to 
+   become much larger than the actual state
+   ## TODO make a ref to the compaction section of https://docs.mongodb.com/realm/get-started/glossary/
+   - Issues related to :ref:`compaction <glossary-compaction-definition>` of data

--- a/source/includes/note-details-about-pause.rst
+++ b/source/includes/note-details-about-pause.rst
@@ -1,18 +1,13 @@
 .. note::
-   The |pause_func_name| method gives developers control over what time of day the device sync. 
-   It is designed and tested with temporary use cases in mind.
+   Use the |pause_func_name| method to control when a device syncs. 
+   You should only use it for temporary and short-term pauses of syncing.
 
    Examples of when to use |pause_func_name| include: 
 
-   - Syncing only in the evening
-   - Spreading the sync load out across different times
-   - Conserving battery
+   - Syncing data only at specified time of day
+   - Conserving device battery use
    
-   The |pause_func_name| function is not intended to determine if a Realm should sync for
-   indefinite periods of time, or time ranges in months and years. The functionality
-   is not tested for these use cases, and you could encounter a range of issues
-   when using it this way. These issues can relate to:  
-
-   - Syncing stores the operations that create the changes, which can quickly grow to 
-     become much larger than the actual state
-   - :ref:`Compaction <glossary-compaction-definition>` of data
+   Don't use the |pause_func_name| method to stop syncing for
+   indefinite time periods or time ranges in months and years. The functionality
+   is not designed or tested for these use cases, and you could encounter a range of issues
+   when using it this way.

--- a/source/includes/note-details-about-pause.rst
+++ b/source/includes/note-details-about-pause.rst
@@ -1,16 +1,16 @@
 .. note::
-   The .|pause_func_name|() method gives developers control over what time of day the device sync. 
+   The |pause_func_name| method gives developers control over what time of day the device sync. 
    It is designed and tested with temporary use cases in mind.
 
    Examples of when to use |pause_func_name| include: 
-   -  Syncing only in the evening
-   - Spreading the sync load out across different times
-   - Conserving battery
+   * Syncing only in the evening
+   * Spreading the sync load out across different times
+   * Conserving battery
    
    The |pause_func_name| function is not intended to determine if a Realm should sync for
    indefinite periods of time, or time ranges in months and years. The functionality
    is not tested for these use cases, and you could encounter a range of issues
    when using it this way. These issues can relate to:  
-   - Syncing stores the operations that create the changes, which can quickly grow to 
+   * Syncing stores the operations that create the changes, which can quickly grow to 
    become much larger than the actual state
-   - Issues related to :ref:`compaction <glossary-compaction-definition>` of data
+   * Issues related to :ref:`compaction <glossary-compaction-definition>` of data

--- a/source/sdk/android/examples/sync-changes-between-devices.txt
+++ b/source/sdk/android/examples/sync-changes-between-devices.txt
@@ -102,6 +102,9 @@ on your :java-sdk:`SyncSession <io/realm/mongodb/sync/SyncSession.html>`:
          :language: java
 
 
+.. |pause_func_name| replace:: stop
+.. include:: /includes/note-details-about-pause.rst
+
 To resume a currently paused sync session, call
 :java-sdk:`start() <io/realm/mongodb/sync/SyncSession.html#start-->`
 on your :java-sdk:`SyncSession <io/realm/mongodb/sync/SyncSession.html>`:

--- a/source/sdk/android/examples/sync-changes-between-devices.txt
+++ b/source/sdk/android/examples/sync-changes-between-devices.txt
@@ -102,7 +102,7 @@ on your :java-sdk:`SyncSession <io/realm/mongodb/sync/SyncSession.html>`:
          :language: java
 
 
-.. |pause_func_name| replace:: stop
+.. |pause_func_name| replace:: ``.stop()``
 .. include:: /includes/note-details-about-pause.rst
 
 To resume a currently paused sync session, call

--- a/source/sdk/dotnet/examples/sync-changes-between-devices.txt
+++ b/source/sdk/dotnet/examples/sync-changes-between-devices.txt
@@ -83,6 +83,8 @@ methods:
 .. literalinclude:: /examples/generated/dotnet/Examples.codeblock.pause-synced-realm.cs
    :language: csharp
 
+.. |pause_func_name| replace:: ``.Stop()``
+.. include:: /includes/note-details-about-pause.rst
 
 .. _dotnet-check-network-connection:
 

--- a/source/sdk/ios/examples/sync-changes-between-devices.txt
+++ b/source/sdk/ios/examples/sync-changes-between-devices.txt
@@ -560,6 +560,8 @@ other {+realms+}.
       .. literalinclude:: /examples/generated/code/start/Sync.codeblock.pause-resume-sync-session.m
          :language: objectivec
 
+.. |pause_func_name| replace:: ``.suspend()``
+.. include:: /includes/note-details-about-pause.rst
 
 .. _ios-check-sync-progress:
 

--- a/source/sdk/node/examples/sync-changes-between-devices.txt
+++ b/source/sdk/node/examples/sync-changes-between-devices.txt
@@ -91,6 +91,9 @@ To pause synchronization, use the :js-sdk:`syncSession.pause()
 .. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-pause-or-resume-sync-session.js
    :language: javascript
 
+.. |pause_func_name| replace:: ``.pause()``
+.. include:: /includes/note-details-about-pause.rst
+
 .. _node-check-sync-progress:
 
 Check Upload & Download Progress for a Sync Session

--- a/source/sdk/react-native/examples/sync-changes-between-devices.txt
+++ b/source/sdk/react-native/examples/sync-changes-between-devices.txt
@@ -92,6 +92,9 @@ To pause synchronization, use the :js-sdk:`syncSession.pause()
 .. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-pause-or-resume-sync-session.js
    :language: javascript
 
+.. |pause_func_name| replace:: ``.pause()``
+.. include:: /includes/note-details-about-pause.rst
+
 .. _react-native-check-sync-progress:
 
 Check Upload & Download Progress for a Sync Session


### PR DESCRIPTION
## Pull Request Info
added information about pausing realm sync to SDK examples pages for Sync Changes Between Devices to clarify how it should be used. 

included for:
- Android
- iOS
- .NET
- Node
- React Native

*note*: not relevant for the other SDKs 

given that the pause method has different names depending on SDK, created reusable note with insertable function name per SDK so general content name could stay same with method name changing. 

also added a ref to link to compaction, which is referenced in the note about pausing. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-18713

### Staged Changes (Requires MongoDB Corp SSO)

- [Android SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18713/sdk/android/examples/sync-changes-between-devices/)
- [iOS SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18713/sdk/ios/examples/sync-changes-between-devices/)
- [.NET SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18713/sdk/dotnet/examples/sync-changes-between-devices/)
- [Node SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18713/sdk/node/examples/sync-changes-between-devices/)
- [React Native SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18713/sdk/react-native/examples/sync-changes-between-devices/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
