### PR TITLE
(DOCSP-18744): Make docs reference TLS 1.3

### DIFF
--- a/source/security.txt
+++ b/source/security.txt
@@ -43,7 +43,7 @@ project role:
 Network Security
 ----------------
 
-MongoDB Realm uses `TLS 1.2 <https://tools.ietf.org/html/rfc5246>`__ to secure
+MongoDB Realm uses `TLS 1.3 <https://datatracker.ietf.org/doc/html/rfc8446>`__ to secure
 all network requests to and from your application, including apps that connect
 from a Realm SDK as well as queries and operations on a linked :term:`MongoDB
 Atlas data source <linked cluster>`. The TLS certificate is pre-defined and

--- a/source/sync/protocol.txt
+++ b/source/sync/protocol.txt
@@ -102,6 +102,15 @@ integer strictly less than 2^63.
    free to generate identical identifiers for two client files if they are
    associated with different server files.
 
+.. _network-security: 
+
+Network Security
+~~~~~~~~~~~~~~~~
+
+The SDK syncs with the application server over a WebSocket connection secured by
+HTTPS using `TLS 1.3 <https://datatracker.ietf.org/doc/html/rfc8446>`__.
+
+
 .. _sync-session-process:
 
 Sync Session Process
@@ -114,7 +123,6 @@ protocol-specific requests.
 The SDK negotiates a WebSocket connection over HTTP and then establishes a sync
 session by sending :sync-client-message:`BIND` and :sync-client-message:`IDENT`
 requests to the server over the WebSocket connection. 
-The connection is encrypted with `TLS 1.3 <https://datatracker.ietf.org/doc/html/rfc8446>`__.
 Once the session is established, the SDK and server send synced changesets for a given
 {+service-short+} file to each other via :sync-client-message:`UPLOAD` and
 :sync-server-message:`DOWNLOAD` messages. To end the session, the SDK sends an

--- a/source/sync/protocol.txt
+++ b/source/sync/protocol.txt
@@ -113,8 +113,9 @@ protocol-specific requests.
 
 The SDK negotiates a WebSocket connection over HTTP and then establishes a sync
 session by sending :sync-client-message:`BIND` and :sync-client-message:`IDENT`
-requests to the server over the WebSocket connections. Once the session is
-established, the SDK and server send synced changesets for a given
+requests to the server over the WebSocket connection. 
+The connection is encrypted with `TLS 1.3 <https://datatracker.ietf.org/doc/html/rfc8446>`__.
+Once the session is established, the SDK and server send synced changesets for a given
 {+service-short+} file to each other via :sync-client-message:`UPLOAD` and
 :sync-server-message:`DOWNLOAD` messages. To end the session, the SDK sends an
 :sync-client-message:`UNBIND` request.

--- a/source/sync/protocol.txt
+++ b/source/sync/protocol.txt
@@ -107,7 +107,7 @@ integer strictly less than 2^63.
 Network Security
 ~~~~~~~~~~~~~~~~
 
-The SDK syncs with the application server over a WebSocket connection secured by
+The SDK synchronizes with the application server over a WebSocket connection secured by
 HTTPS using `TLS 1.3 <https://datatracker.ietf.org/doc/html/rfc8446>`__.
 
 


### PR DESCRIPTION
## Pull Request Info
added info about TLS 1.3 and network security to Realm Sync docs. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-18744

### Staged Changes (Requires MongoDB Corp SSO)

- [Security](https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18744/security)
- [Sync Protocol](https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18744/sync/protocol/#network-security)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
