### PR TITLE
(DOCSP-17883): [iOS] Async-await doc updates and code examples for 10.16.0 release

### DIFF
--- a/examples/ios/Examples/Functions.swift
+++ b/examples/ios/Examples/Functions.swift
@@ -37,4 +37,25 @@ class Functions: AnonymouslyLoggedInTestCase {
         // :code-block-end:
         wait(for: [expectation], timeout: 10)
     }
+    // :code-block-start: async-call-a-function
+    func testAsyncCallFunction() async {
+        let app = App(id: YOUR_REALM_APP_ID)
+
+        // ... log in ...
+
+        let user = app.currentUser!
+
+        do {
+            // The dynamic member name `concatenate` is directly associated with the
+            // function name. The first argument is the `BSONArray` of arguments to be
+            // provided to the function - in this case, a string that represents a
+            // username and a string that represents an email domain.
+            let concatenatedString = try await user.functions.concatenate([AnyBSON("john.smith"), AnyBSON("@companyemail.com")])
+            print("Called function 'concatenate' and got result: \(concatenatedString)")
+            assert(concatenatedString == "john.smith@companyemail.com")
+        } catch {
+            print("Function call failed: \(error.localizedDescription)")
+        }
+    }
+    // :code-block-end:
 }

--- a/examples/ios/Examples/MongoDBRemoteAccess.swift
+++ b/examples/ios/Examples/MongoDBRemoteAccess.swift
@@ -60,6 +60,41 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
+    func testAsyncAwaitInsert() async {
+        do {
+            // Use the async method to login
+            let user = try await app.login(credentials: Credentials.anonymous)
+            print("Login as \(user) succeeded!")
+        } catch {
+            print("Login failed: \(error.localizedDescription)")
+        }
+
+        // mongodb-atlas is the cluster service name
+        let client = app.currentUser!.mongoClient("mongodb-atlas")
+
+        // Select the database
+        let database = client.database(named: "ios")
+
+        // Select the collection
+        let collection = database.collection(withName: "CoffeeDrinks")
+
+        // :code-block-start: async-await-insert
+        // This document represents a CoffeeDrink object
+        let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "partition": "Store 43"]
+
+        do {
+            // Use the async collection method to insert the document
+            let objectId = try await collection.insertOne(drink)
+            // :hide-start:
+            XCTAssertNotNil(objectId)
+            // :hide-end:
+            print("Successfully inserted a document with id: \(objectId)")
+        } catch {
+            print("Call to MongoDB failed: \(error.localizedDescription)")
+        }
+        // :code-block-end:
+    }
+
     func testInsertMany() {
         let expectation = XCTestExpectation(description: "Multiple documents are inserted")
 

--- a/examples/ios/Examples/MultipleUsers.swift
+++ b/examples/ios/Examples/MultipleUsers.swift
@@ -164,4 +164,42 @@ class MultipleUsers: XCTestCase {
         // :code-block-end:
         wait(for: [expectation], timeout: 10)
     }
+
+    func testAsyncLinkIdentities() async {
+        // :code-block-start: async-link-identity
+        let app = App(id: YOUR_REALM_APP_ID)
+
+        func logInAnonymously() async throws -> User {
+            let anonymousUser = try await app.login(credentials: Credentials.anonymous)
+            // User uses app, then later registers an account
+            let newAccountLinkedUser = try await registerNewAccount(anonymousUser: anonymousUser)
+            return newAccountLinkedUser
+        }
+
+        func registerNewAccount(anonymousUser: User) async throws -> User {
+            let email = "swift-async-link@example.com"
+            let password = "ganondorf"
+
+            try await app.emailPasswordAuth.registerUser(email: email, password: password)
+            // Successfully created account, now link it
+            // with the existing anon user
+            let linkedUser = try await link(user: anonymousUser, with: Credentials.emailPassword(email: email, password: password))
+            return linkedUser
+        }
+
+        func link(user: User, with credentials: Credentials) async throws -> User {
+            try await user.linkUser(credentials: credentials)
+        }
+
+        do {
+            let linkedUser = try await logInAnonymously()
+            print("Successfully linked user async: \(linkedUser)")
+            // :hide-start:
+            XCTAssertNotNil(linkedUser)
+            // :hide-end:
+        } catch {
+            print("Failed to link user: \(error.localizedDescription)")
+        }
+        // :code-block-end:
+    }
 }

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '15.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', '~>10.15.1'
-  pod 'RealmSwift', '~>10.15.1'
+  pod 'Realm', :git => 'https://github.com/realm/realm-cocoa.git', :branch => 'master'
+  pod 'RealmSwift', :git => 'https://github.com/realm/realm-cocoa.git', :branch => 'master'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,5 +13,5 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '~>10.15.1'
+  pod 'RealmSwift', :git => 'https://github.com/realm/realm-cocoa.git', :branch => 'master'
 end

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '15.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', :git => 'https://github.com/realm/realm-cocoa.git', :branch => 'master'
-  pod 'RealmSwift', :git => 'https://github.com/realm/realm-cocoa.git', :branch => 'master'
+  pod 'Realm', '=10.16.0'
+  pod 'RealmSwift', '=10.16.0'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,5 +13,5 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', :git => 'https://github.com/realm/realm-cocoa.git', :branch => 'master'
+  pod 'RealmSwift', '=10.16.0'
 end

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Realm (10.15.1):
-    - Realm/Headers (= 10.15.1)
-  - Realm/Headers (10.15.1)
-  - RealmSwift (10.15.1):
-    - Realm (= 10.15.1)
+  - Realm (10.16.0):
+    - Realm/Headers (= 10.16.0)
+  - Realm/Headers (10.16.0)
+  - RealmSwift (10.16.0):
+    - Realm (= 10.16.0)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (from `https://github.com/realm/realm-cocoa.git`, branch `master`)
-  - RealmSwift (from `https://github.com/realm/realm-cocoa.git`, branch `master`)
+  - Realm (= 10.16.0)
+  - RealmSwift (= 10.16.0)
   - SwiftLint
 
 SPEC REPOS:
@@ -44,23 +44,9 @@ SPEC REPOS:
     - GoogleSignIn
     - GTMAppAuth
     - GTMSessionFetcher
+    - Realm
+    - RealmSwift
     - SwiftLint
-
-EXTERNAL SOURCES:
-  Realm:
-    :branch: master
-    :git: https://github.com/realm/realm-cocoa.git
-  RealmSwift:
-    :branch: master
-    :git: https://github.com/realm/realm-cocoa.git
-
-CHECKOUT OPTIONS:
-  Realm:
-    :commit: 9831f0d4dbcc48f508a55ac81a5f7574840190d2
-    :git: https://github.com/realm/realm-cocoa.git
-  RealmSwift:
-    :commit: 9831f0d4dbcc48f508a55ac81a5f7574840190d2
-    :git: https://github.com/realm/realm-cocoa.git
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
@@ -69,10 +55,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: fbcbde2620d51623cc5b18e28f5b165c39abef52
-  RealmSwift: e4bea8e42efad3d543aea23b56504069c6faaea2
+  Realm: b6027801398f3743fc222f096faa85281b506e6c
+  RealmSwift: b02a3d0e4947955da960b642c98ad3a461fc4e70
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: ea852532a48dc93d11fe2f5170dd25415ca00531
+PODFILE CHECKSUM: 985c0e0d258843d6c751bcec0ea843f8668e368d
 
 COCOAPODS: 1.10.1

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -32,8 +32,8 @@ PODS:
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (~> 10.15.1)
-  - RealmSwift (~> 10.15.1)
+  - Realm (from `https://github.com/realm/realm-cocoa.git`, branch `master`)
+  - RealmSwift (from `https://github.com/realm/realm-cocoa.git`, branch `master`)
   - SwiftLint
 
 SPEC REPOS:
@@ -44,9 +44,23 @@ SPEC REPOS:
     - GoogleSignIn
     - GTMAppAuth
     - GTMSessionFetcher
-    - Realm
-    - RealmSwift
     - SwiftLint
+
+EXTERNAL SOURCES:
+  Realm:
+    :branch: master
+    :git: https://github.com/realm/realm-cocoa.git
+  RealmSwift:
+    :branch: master
+    :git: https://github.com/realm/realm-cocoa.git
+
+CHECKOUT OPTIONS:
+  Realm:
+    :commit: 9831f0d4dbcc48f508a55ac81a5f7574840190d2
+    :git: https://github.com/realm/realm-cocoa.git
+  RealmSwift:
+    :commit: 9831f0d4dbcc48f508a55ac81a5f7574840190d2
+    :git: https://github.com/realm/realm-cocoa.git
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
@@ -59,6 +73,6 @@ SPEC CHECKSUMS:
   RealmSwift: e4bea8e42efad3d543aea23b56504069c6faaea2
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: bd158df104dda4c9a9ec8524bd3402d1aea720f0
+PODFILE CHECKSUM: ea852532a48dc93d11fe2f5170dd25415ca00531
 
 COCOAPODS: 1.10.1

--- a/source/examples/generated/code/start/Functions.codeblock.async-call-a-function.swift
+++ b/source/examples/generated/code/start/Functions.codeblock.async-call-a-function.swift
@@ -1,0 +1,19 @@
+func testAsyncCallFunction() async {
+    let app = App(id: YOUR_REALM_APP_ID)
+
+    // ... log in ...
+
+    let user = app.currentUser!
+
+    do {
+        // The dynamic member name `concatenate` is directly associated with the
+        // function name. The first argument is the `BSONArray` of arguments to be
+        // provided to the function - in this case, a string that represents a
+        // username and a string that represents an email domain.
+        let concatenatedString = try await user.functions.concatenate([AnyBSON("john.smith"), AnyBSON("@companyemail.com")])
+        print("Called function 'concatenate' and got result: \(concatenatedString)")
+        assert(concatenatedString == "john.smith@companyemail.com")
+    } catch {
+        print("Function call failed: \(error.localizedDescription)")
+    }
+}

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.confirm-new-user-email.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.confirm-new-user-email.swift
@@ -5,11 +5,11 @@ let client = app.emailPasswordAuth
 // link sent in the confirmation email.
 let token = "someToken"
 let tokenId = "someTokenId"
-client.confirmUser(token, tokenId: tokenId) { (error) in
-    guard error == nil else {
-        print("User confirmation failed: \(error!.localizedDescription)")
-        return
-    }
+
+do {
+    try await client.confirmUser(token, tokenId: tokenId)
     // User email address confirmed.
     print("Successfully confirmed user.")
+} catch {
+    print("User confirmation failed: \(error.localizedDescription)")
 }

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.password-reset-function.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.password-reset-function.swift
@@ -11,10 +11,9 @@ let args: [AnyBSON] = []
 
 // This SDK call maps to the custom password reset
 // function that you define in the backend
-client.callResetPasswordFunction(email: email, password: newPassword, args: args) { (error) in
-    guard error == nil else {
-        print("Password reset failed: \(error!.localizedDescription)")
-        return
-    }
+do {
+    try await client.callResetPasswordFunction(email: email, password: newPassword, args: args)
     print("Password reset successful!")
+} catch {
+    print("Password reset failed: \(error.localizedDescription)")
 }

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.register-email-completion-handler.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.register-email-completion-handler.swift
@@ -2,11 +2,11 @@ let app = App(id: YOUR_REALM_APP_ID)
 let client = app.emailPasswordAuth
 let email = "skroob@example.com"
 let password = "password12345"
-
-do {
-    try await client.registerUser(email: email, password: password)
+client.registerUser(email: email, password: password) { (error) in
+    guard error == nil else {
+        print("Failed to register: \(error!.localizedDescription)")
+        return
+    }
     // Registering just registers. You can now log in.
     print("Successfully registered user.")
-} catch {
-    print("Failed to register: \(error.localizedDescription)")
 }

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.resend-confirmation-email.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.resend-confirmation-email.swift
@@ -3,12 +3,11 @@ let client = app.emailPasswordAuth
 let email = "skroob@example.com"
 // If Realm is set to send a confirmation email, we can
 // send the confirmation email again here.
-client.resendConfirmationEmail(email) { (error) in
-    guard error == nil else {
-        print("Failed to resend confirmation email: \(error!.localizedDescription)")
-        return
-    }
+do {
+    try await client.resendConfirmationEmail(email)
     // The confirmation email has been sent
     // to the user again.
     print("Confirmation email resent")
+} catch {
+    print("Failed to resend confirmation email: \(error.localizedDescription)")
 }

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.reset-password.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.reset-password.swift
@@ -4,13 +4,12 @@ let client = app.emailPasswordAuth
 let email = "forgot.my.password@example.com"
 // If Realm app password reset mode is "Send a password reset email",
 // we can do so here:
-client.sendResetPasswordEmail(email, completion: {(error) in
-    guard error == nil else {
-        print("Reset password email not sent: \(error!.localizedDescription)")
-        return
-    }
+do {
+    try await client.sendResetPasswordEmail(email)
     print("Password reset email sent.")
-})
+} catch {
+    print("Reset password email not sent: \(error.localizedDescription)")
+}
 
 // Later...
 
@@ -20,11 +19,10 @@ let newPassword = "mynewpassword12345"
 // link sent in the reset password email.
 let token = "someToken"
 let tokenId = "someTokenId"
-client.resetPassword(to: newPassword, token: token, tokenId: tokenId) { (error) in
-    guard error == nil else {
-        print("Failed to reset password: \(error!.localizedDescription)")
-        return
-    }
-    // Password reset successful.
+
+do {
+    try await client.resetPassword(to: newPassword, token: token, tokenId: tokenId)
     print("Password reset successful.")
+} catch {
+    print("Failed to reset password: \(error.localizedDescription)")
 }

--- a/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.retry-confirmation-function.swift
+++ b/source/examples/generated/code/start/ManageEmailPasswordUsers.codeblock.retry-confirmation-function.swift
@@ -3,12 +3,11 @@ let client = app.emailPasswordAuth
 let email = "skroob@example.com"
 // If Realm is set to run a custom confirmation function,
 // we can trigger that function to run again here.
-client.retryCustomConfirmation(email) { (error) in
-    guard error == nil else {
-        print("Failed to retry custom confirmation: \(error!.localizedDescription)")
-        return
-    }
+do {
+    try await client.retryCustomConfirmation(email)
     // The custom confirmation function has been
     // triggered to run again for the user.
     print("Custom confirmation retriggered")
+} catch {
+    print("Failed to retry custom confirmation: \(error.localizedDescription)")
 }

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.codeblock.async-await-insert.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.codeblock.async-await-insert.swift
@@ -1,0 +1,10 @@
+// This document represents a CoffeeDrink object
+let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "partition": "Store 43"]
+
+do {
+    // Use the async collection method to insert the document
+    let objectId = try await collection.insertOne(drink)
+    print("Successfully inserted a document with id: \(objectId)")
+} catch {
+    print("Call to MongoDB failed: \(error.localizedDescription)")
+}

--- a/source/examples/generated/code/start/MultipleUsers.codeblock.async-link-identity.swift
+++ b/source/examples/generated/code/start/MultipleUsers.codeblock.async-link-identity.swift
@@ -1,0 +1,30 @@
+let app = App(id: YOUR_REALM_APP_ID)
+
+func logInAnonymously() async throws -> User {
+    let anonymousUser = try await app.login(credentials: Credentials.anonymous)
+    // User uses app, then later registers an account
+    let newAccountLinkedUser = try await registerNewAccount(anonymousUser: anonymousUser)
+    return newAccountLinkedUser
+}
+
+func registerNewAccount(anonymousUser: User) async throws -> User {
+    let email = "swift-async-link@example.com"
+    let password = "ganondorf"
+
+    try await app.emailPasswordAuth.registerUser(email: email, password: password)
+    // Successfully created account, now link it
+    // with the existing anon user
+    let linkedUser = try await link(user: anonymousUser, with: Credentials.emailPassword(email: email, password: password))
+    return linkedUser
+}
+
+func link(user: User, with credentials: Credentials) async throws -> User {
+    try await user.linkUser(credentials: credentials)
+}
+
+do {
+    let linkedUser = try await logInAnonymously()
+    print("Successfully linked user async: \(linkedUser)")
+} catch {
+    print("Failed to link user: \(error.localizedDescription)")
+}

--- a/source/sdk/ios/advanced-guides/link-user-identities.txt
+++ b/source/sdk/ios/advanced-guides/link-user-identities.txt
@@ -4,6 +4,12 @@
 Link User Identities - iOS SDK
 ==============================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
 Overview
 --------
 
@@ -38,3 +44,16 @@ of the ``User`` object of a logged in User.
 
       .. literalinclude:: /examples/generated/code/start/MultipleUsers.codeblock.link-identity-objc.m
          :language: objectivec
+
+.. _ios-async-await-link-user-identities:
+
+Async/Await Example
+-------------------
+
+.. versionadded:: 10.15.x
+
+If you're using Swift 5.5 with an iOS target of 15.0 or higher, you can use 
+the :swift-sdk:`async/await version of User.linkUser<UPDATE LINK>`.
+
+.. literalinclude:: /examples/generated/code/start/MultipleUsers.codeblock.async-link-identity.swift
+   :language: swift

--- a/source/sdk/ios/advanced-guides/link-user-identities.txt
+++ b/source/sdk/ios/advanced-guides/link-user-identities.txt
@@ -50,10 +50,10 @@ of the ``User`` object of a logged in User.
 Async/Await Example
 -------------------
 
-.. versionadded:: 10.15.x
+.. versionadded:: 10.16.0
 
 If you're using Swift 5.5 with an iOS target of 15.0 or higher, you can use 
-the :swift-sdk:`async/await version of User.linkUser<UPDATE LINK>`.
+the :swift-sdk:`async/await version of User.linkUser<Extensions/User.html#/s:So7RLMUserC10RealmSwiftE8linkUser11credentials7Combine6FutureCyABs5Error_pGAC11CredentialsO_tF>`.
 
 .. literalinclude:: /examples/generated/code/start/MultipleUsers.codeblock.async-link-identity.swift
    :language: swift

--- a/source/sdk/ios/examples/call-a-function.txt
+++ b/source/sdk/ios/examples/call-a-function.txt
@@ -49,3 +49,14 @@ is executed on a non-main global ``DispatchQueue``.
 
       .. literalinclude:: /examples/generated/code/start/Functions.codeblock.call-a-function.m
          :language: objectivec
+
+Async/Await Call a Function
+---------------------------
+
+.. versionadded:: 10.15.x
+
+If you're using Swift 5.5 with an iOS target of 15.0 or higher, you can use 
+the :swift-sdk:`async/await versions of the User.function methods<UPDATE LINK>`.
+
+.. literalinclude:: /examples/generated/code/start/Functions.codeblock.async-call-a-function.swift
+   :language: swift

--- a/source/sdk/ios/examples/call-a-function.txt
+++ b/source/sdk/ios/examples/call-a-function.txt
@@ -53,10 +53,10 @@ is executed on a non-main global ``DispatchQueue``.
 Async/Await Call a Function
 ---------------------------
 
-.. versionadded:: 10.15.x
+.. versionadded:: 10.16.0
 
 If you're using Swift 5.5 with an iOS target of 15.0 or higher, you can use 
-the :swift-sdk:`async/await versions of the User.function methods<UPDATE LINK>`.
+the async/await versions of the ``User.function`` methods.
 
 .. literalinclude:: /examples/generated/code/start/Functions.codeblock.async-call-a-function.swift
    :language: swift

--- a/source/sdk/ios/examples/manage-email-password-users.txt
+++ b/source/sdk/ios/examples/manage-email-password-users.txt
@@ -18,7 +18,7 @@ When you have enabled the :ref:`email/password provider
 account, confirm an email address, and reset a user's password from
 client code.
 
-.. versionchanged:: 10.15.x
+.. versionchanged:: 10.16.0
  
    Email/password user APIs add async/await support. Code examples on 
    this page updated to async/await syntax. For an example of the older

--- a/source/sdk/ios/examples/manage-email-password-users.txt
+++ b/source/sdk/ios/examples/manage-email-password-users.txt
@@ -18,6 +18,13 @@ When you have enabled the :ref:`email/password provider
 account, confirm an email address, and reset a user's password from
 client code.
 
+.. versionchanged:: 10.15.x
+ 
+   Email/password user APIs add async/await support. Code examples on 
+   this page updated to async/await syntax. For an example of the older
+   syntax, see: :ref:`Email/Password User Examples with Completion Handlers 
+   <ios-manage-users-completion-handler-example>`.
+
 .. _ios-register-a-new-user-account:
 
 Register a New User Account
@@ -149,4 +156,18 @@ than email.
    <auth-run-a-password-reset-function>`.
  
 .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.password-reset-function.swift
+   :language: swift
+
+.. _ios-manage-users-completion-handler-example:
+
+Email/Password User Methods with Completion Handlers
+----------------------------------------------------
+
+If you're not using :apple:`Apple's async/await syntax
+<documentation/swift/swift_standard_library/concurrency/updating_an_app_to_use_swift_concurrency>`, 
+all of these methods are available with completion handlers. This example 
+shows :ref:`registering a user <ios-register-a-new-user-account>` with the 
+completion handler syntax.
+
+.. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.register-email-completion-handler.swift
    :language: swift

--- a/source/sdk/ios/examples/mongodb-remote-access.txt
+++ b/source/sdk/ios/examples/mongodb-remote-access.txt
@@ -56,10 +56,10 @@ example looks like this:
 Async/Await Query MongoDB
 -------------------------
 
-.. versionadded:: 10.15.x
+.. versionadded:: 10.16.0
 
 If you're using Swift 5.5 with an iOS target of 15.0 or higher, you can use 
-the :swift-sdk:`async/await versions of the MongoCollection methods<UPDATE LINK>`.
+the :swift-sdk:`async/await versions of the MongoCollection methods<Extensions/MongoCollection.html>`.
 
 All of the methods on this page are compatible with the async/await syntax.
 This example illustrates that syntax for the ``collection.insertOne()`` method. 

--- a/source/sdk/ios/examples/mongodb-remote-access.txt
+++ b/source/sdk/ios/examples/mongodb-remote-access.txt
@@ -51,6 +51,24 @@ example looks like this:
 
 .. include:: /examples/generated/code/start/MongoDBRemoteAccess.codeblock.insert-sample-data.swift.code-block.rst
 
+.. _ios-mongodb-async-await-query:
+
+Async/Await Query MongoDB
+-------------------------
+
+.. versionadded:: 10.15.x
+
+If you're using Swift 5.5 with an iOS target of 15.0 or higher, you can use 
+the :swift-sdk:`async/await versions of the MongoCollection methods<UPDATE LINK>`.
+
+All of the methods on this page are compatible with the async/await syntax.
+This example illustrates that syntax for the ``collection.insertOne()`` method. 
+You can see the completion handler version in :ref:`Insert a Single Document 
+<ios-mongodb-insertOne>`.
+
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.codeblock.async-await-insert.swift
+   :language: swift
+
 .. _ios-mongodb-create-documents:
 
 Create Documents


### PR DESCRIPTION
## Pull Request Info

UPDATE: These updates have been released as 10.16.0. I've resolved these todos and this PR is ready for merging after review.

_This update is for a not-yet-released version of the Cocoa SDK_. Prior to merging this PR, but after release, resolve these todos:

- [x]  Update Podfile to point to the release version of the SDK
- [x]  Update "UPDATE LINK" placeholders to point to the actual SDK methods in the Swift API docs
- [x]  Update version directives to list the actual release version

### Jira

- https://jira.mongodb.org/browse/DOCSP-17883
- [Docs Kickoff Outline](https://docs.google.com/document/d/1bXuJz3ggWAI60Bg16PTqWUuQXSf3TYgvH5cA95qETaY/edit?usp=sharing): This PR is for the async methods for: 
  - EmailPasswordAuth
  - User.linkUser
  - MongoCollection
  - User.functions

### Staged Changes (Requires MongoDB Corp SSO)

- [Manage Email/Password Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17883/sdk/ios/examples/manage-email-password-users/): Update all methods on the page for async/await, and add a completion handler example for folks who want to see the older syntax
- [Call a Function](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17883/sdk/ios/examples/call-a-function/#async-await-call-a-function): Add an async/await syntax example
- [Query MongoDB](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17883/sdk/ios/examples/mongodb-remote-access/#async-await-query-mongodb): Add an async/await syntax example
- [Link User Identities](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17883/sdk/ios/advanced-guides/link-user-identities/#async-await-example): Add an async/await syntax example

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
