### PR TITLE
(DOCSP-18849): Add build and hosting to web tutorial

### DIFF
--- a/source/hosting.txt
+++ b/source/hosting.txt
@@ -1,3 +1,5 @@
+.. _static-hosting:
+
 ==============
 Static Hosting
 ==============

--- a/source/hosting/host-a-single-page-application.txt
+++ b/source/hosting/host-a-single-page-application.txt
@@ -1,3 +1,5 @@
+.. _host-a-single-page-application:
+
 ==============================
 Host a Single-Page Application
 ==============================

--- a/source/tutorial/web-graphql.txt
+++ b/source/tutorial/web-graphql.txt
@@ -346,6 +346,42 @@ look and behave the same as the development version you made in the previous ste
 
 You can find the production bundle's code with your repository in a newly generated folder ``build``.
 
+J. Deploy the App with Realm
+----------------------------
+
+With the production bundle ready, it's time to deploy the app on the web. 
+You're going to deploy the app using :ref:`Realm Static Hosting <static-hosting>` via the Realm UI.
+
+.. note:: Deploying App with Realm CLI
+   You can also :ref:`deploy your app to static hosting using the Realm CLI <host-a-single-page-application>`.
+
+   However, in this tutorial we're just going to explore deployment using the Realm UI. 
+
+First, navigate to the **Hosting** section of the Realm UI. You can find it on the side menu under **Manage**. 
+Once you're on the Hosting page, click the **Enable Hosting** button. 
+
+Now that you have hosting enabled, replace the default ``index.html`` with the production 
+bundle you built in the last step. Delete the ``index.html`` file by clicking the check 
+box next to the file and then **Actions > Delete**. 
+
+To add your app, first open a file browser on your computer, such as Finder on Mac or 
+File Explorer on Windows. Navigate to the ``build`` folder in your app's root folder. 
+Select all the ``build`` folder's contents, and drag it over to the Realm Hosting UI's 
+Files page. Release the mouse to trigger uploading the assets. 
+
+Once the files finish uploading, click the **Review & Deploy** button at the top of the page. 
+A dialog will open with you changes. Review the changes and click the **Deploy** button
+at the bottom of the dialogue to start the deployment of your app.
+
+Realm then will deploy your site to ``<Your-App-Id>.mongodbstitch.com``. 
+Deployment can take up to a few minutes. You can track the status on the Hosting page. 
+
+Once deployment finishes, navigate to your app's new domain. Here you'll find the 
+app with the same backend and data that you were working with before, now live on the internet!
+
+For more detailed information about hosting your web app with Realm, refer to our documentation 
+on :ref:`hosting a single page application <host-a-single-page-application>`.  
+
 What's Next?
 ------------
 
@@ -366,6 +402,8 @@ options to keep practicing and learn more:
   - :doc:`Android (Kotlin) </tutorial/android-kotlin>`
   - :doc:`React Native (JavaScript) </tutorial/react-native>`
   - :doc:`Node.js (JavaScript) CLI </tutorial/nodejs-cli>`
+
+- Use the Realm CLI to automate deploying your frontend application.
 
 - Dive deeper into the docs to learn more about MongoDB Realm. You'll find
   information and guides on features like:

--- a/source/tutorial/web-graphql.txt
+++ b/source/tutorial/web-graphql.txt
@@ -88,7 +88,7 @@ B. Explore the App Structure & Components
 -----------------------------------------
 
 The web client is a standard React web application written in JavaScript and
-scaffolded with `create-react-app
+scaffolded with `Create React App
 <https://facebook.github.io/create-react-app/>`__. We encourage you to explore
 the files in the app for a few minutes before you continue the tutorial. This
 will help you to familiarize yourself with what the app contains and where
@@ -279,8 +279,8 @@ email address and pass it their respective server-side functions:
 .. literalinclude:: /tutorial/generated/code/final/EditPermissionsModal.codeblock.useTeamMembers.js
    :language: javascript
 
-Try It Out
-----------
+H. Try It Out Locally
+---------------------
 
 The task tracker app is now fully configured so you can start it up to start
 tracking tasks.
@@ -323,10 +323,33 @@ If the app builds successfully, here are some things you can try in the app:
 - Navigate to *second@example.com*'s project
 - Collaborate by adding, updating, and removing some new tasks
 
+I. Build the App
+----------------
+
+Now that you've validated that the app is working, it's time to get the app ready for deployment. 
+In this section, you're going to create a production build with `Create React App's build script <https://create-react-app.dev/docs/production-build/>`__.
+
+To create your production bundle, run the command: 
+
+.. code-block:: shell
+   
+   npm run build
+
+Once the build finishes, validate it's working by running:
+
+.. code-block:: shell
+   
+   npx serve -s build
+
+You will see a new browser window pop up running the app on ``localhost:5000``. The app should 
+look and behave the same as the development version you made in the previous step. 
+
+You can find the production bundle's code with your repository in a newly generated folder ``build``.
+
 What's Next?
 ------------
 
-You just built a functional task tracker web application built with MongoDB
+You just built and deployed a functional task tracker web application built with MongoDB
 Realm. Great job!
 
 Now that you have some hands-on experience with MongoDB Realm, consider these


### PR DESCRIPTION
## Pull Request Info

added new sections about building the production bundle and deploying the app. 

i think that section J, about the deployment would benefit from visuals b.c it's all about using the Realm UI, perhaps in the form of animated Gifs. however, i'm not sure what'd be our best practices for including such media. i'd appreciate if the reviewer could provide some feedback on what if any visuals should be included. 

also note that for the tutorial, i just did the deployment using the Realm UI, not the CLI. i did this to keep the tutorial simple, and not make the user have to go back into the realm backend directory. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-18849

### Staged Changes (Requires MongoDB Corp SSO)

- [Web Tutorial](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/tutorial/web-graphql/)
note: added sections I and J in addition to small tweaks throughout. 

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
