### PR TITLE
Add `contextIsolation: false` to node setup to enable `require`

### DIFF
--- a/source/examples/QuickStarts/electron/quickstart-main.js
+++ b/source/examples/QuickStarts/electron/quickstart-main.js
@@ -5,6 +5,7 @@ function createWindow() {
   const mainWindow = new BrowserWindow({
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false
     },
   });
 

--- a/source/examples/QuickStarts/electron/quickstart-setup-main.js
+++ b/source/examples/QuickStarts/electron/quickstart-setup-main.js
@@ -10,6 +10,7 @@ function createWindow() {
     height: 600,
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false
     },
   });
 

--- a/source/includes/steps-realm-with-electron.yaml
+++ b/source/includes/steps-realm-with-electron.yaml
@@ -66,7 +66,8 @@ content: |
          width: 800,
          height: 600,
          webPreferences: {
-           nodeIntegration: true
+           nodeIntegration: true,
+           contextIsolation: false
          }
        })
 


### PR DESCRIPTION
As of Electron v12, `contextIsolation` is enabled by default: https://www.electronjs.org/docs/breaking-changes#default-changed-contextisolation-defaults-to-true. This prevents you from calling `require` in the render process. This quick fix ensures that the Realm quickstart can be built with newer version of Electron - it might make sense to refactor it to work with the default of `contextIsolation` enabled in future.

## Pull Request Info

### Jira

~- https://jira.mongodb.org/browse/DOCSP-NNNNN~

### Staged Changes (Requires MongoDB Corp SSO)

~- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/BRANCH_NAME/)~

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
