### PR TITLE
(DOCSP-18595): Add guide to disable deployment drafts

### DIFF
--- a/source/includes/steps-deploy-draft-ui-changes.yaml
+++ b/source/includes/steps-deploy-draft-ui-changes.yaml
@@ -5,6 +5,10 @@ content: |
   want to include in the deployment through the {+ui+}.
   If you have drafts enabled, your changes will be saved automatically as a draft. 
 
+  .. seealso::
+     
+     Guide to :ref:`Disable Deployment Drafts <disable-deployment-drafts>`.
+
   .. note::
      
      You can only create draft changes through the {+ui+} or Admin

--- a/source/includes/steps-disable-deployment-drafts.yaml
+++ b/source/includes/steps-disable-deployment-drafts.yaml
@@ -1,0 +1,30 @@
+title: Navigate to the Deployment Section
+ref: navigate-to-deployment-section
+content: |
+  Click :guilabel:`Deployment` in the {+leftnav+} to navigate to
+  your app's deployment history table.
+
+---
+title: Select the Configuration Tab
+ref: navigate-to-configuration-tab
+content: |
+  In the :guilabel:`Deployment` page select the :guilabel:`Configuration` tab at the top.
+
+---
+title: Disable Drafts
+ref: disable-drafts
+content: |
+  In the :guilabel:`Configuration` tab, there is a section titled 
+  :guilabel:`Disable Drafts in Realm`. If you click :guilabel:`Disable Drafts` here, 
+  future changes made in the UI will be deployed immediately without a draft. 
+  You will no longer have the chance to review changes before deploying.
+
+  .. note::
+     
+     This setting will not affect the ability to create drafts in the Realm API.
+
+---
+title: Confirm Disable Drafts
+ref: confirm-disable-drafts
+content: |
+  Click :guilabel:`Disable Drafts` again in the dialog box to confirm your decision.

--- a/source/manage-apps/deploy.txt
+++ b/source/manage-apps/deploy.txt
@@ -21,6 +21,7 @@ Application Deployment
    Automate Deployment </manage-apps/deploy/automated>
    Deployment Models & Regions </manage-apps/deploy/deployment-models-and-regions>
    Deployment Draft </manage-apps/deploy/deployment-draft>
+   Disable Deployment Drafts </manage-apps/deploy/disable-deployment-drafts>
 
 Overview
 --------

--- a/source/manage-apps/deploy/deployment-draft.txt
+++ b/source/manage-apps/deploy/deployment-draft.txt
@@ -28,7 +28,7 @@ deploy or discard as a single unit.
      - Yes
      - Any changes you make to your {+app+}'s configuration in the {+ui+} will be 
        automatically saved as a draft that you can manually deploy, 
-       unless you have disabled drafts in the settings.
+       unless you have :ref:`disabled drafts <disable-deployment-drafts>` in the settings.
 
    * - :ref:`{+service-short+} Admin API <deploy-api>`
      - Yes

--- a/source/manage-apps/deploy/disable-deployment-drafts.txt
+++ b/source/manage-apps/deploy/disable-deployment-drafts.txt
@@ -1,0 +1,25 @@
+.. _disable-deployment-drafts:
+
+=========================
+Disable Deployment Drafts
+=========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+:ref:`Deployment drafts <deployment-draft>` are automatically enabled in the UI, 
+meaning all app changes you make in the UI are automatically saved as a draft and 
+you must :ref:`manually deploy <deploy-ui>` them. This behavior can be disabled in the UI.
+
+Procedure
+---------
+
+.. include:: /includes/steps/disable-deployment-drafts.rst

--- a/source/manage-apps/deploy/manual/deploy-ui.txt
+++ b/source/manage-apps/deploy/manual/deploy-ui.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 When you make changes to your application through the {+ui+}, those
-changes are saved in a :ref:`draft state<deployment-draft>`. 
+changes are saved in a :ref:`draft state <deployment-draft>`. 
 Draft changes do not affect your production application and are invisible to end users. 
 This is particularly useful in situations where you need to make related changes
 to multiple components in your application and want to avoid bugs and a


### PR DESCRIPTION
## Pull Request Info

- this PR goes after [this one](https://github.com/mongodb/docs-realm/pull/1401) and the branch pulls in those changes

### Jira

- https://jira.mongodb.org/browse/DOCSP-18595

### Staged Changes (Requires MongoDB Corp SSO)

- [Disable Deployment Drafts](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18595/manage-apps/deploy/disable-deployment-drafts/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
