### PR TITLE
(DOCSP-18926): Add --include-hosting flag to CLI deploy

### DIFF
--- a/source/includes/steps-enable-hosting-import-export.yaml
+++ b/source/includes/steps-enable-hosting-import-export.yaml
@@ -34,7 +34,7 @@ content: |
   
   .. code-block:: bash
      
-     realm-cli push --remote="<Your App ID>"
+     realm-cli push --remote="<Your App ID>  --include-hosting"
 
   .. note::
      

--- a/source/includes/steps-host-a-single-page-application-code-deploy.yaml
+++ b/source/includes/steps-host-a-single-page-application-code-deploy.yaml
@@ -53,5 +53,5 @@ content: |
   
   .. code-block:: bash
      
-     realm-cli push --remote="<Your App ID>"
+     realm-cli push --remote="<Your App ID> --include-hosting"
 ...


### PR DESCRIPTION
## Pull Request Info

Add --include-hosting flag to CLI deployment guides, as it's required. 

Previously, it was only included in the page https://docs.mongodb.com/realm/hosting/upload-content-to-realm/

### Jira

- https://jira.mongodb.org/browse/DOCSP-18926

### Staged Changes (Requires MongoDB Corp SSO)

- [Enable Hosting](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18926/hosting/enable-hosting/)
- [Host a Single-Page Application](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-18926/hosting/host-a-single-page-application/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
