### PR TITLE
RN tutorial fix: missing Task in schema error

### DIFF
--- a/tutorial/rn/providers/TasksProvider.js
+++ b/tutorial/rn/providers/TasksProvider.js
@@ -22,6 +22,7 @@ const TasksProvider = ({ children, projectPartition }) => {
     };
     // :code-block-start: open-project-realm
     const config = {
+      schema: [Task.schema],
       sync: {
         user: user,
         partitionValue: projectPartition,


### PR DESCRIPTION
- If schema not downloaded from Atlas first, this error results
- Credit to @Macilias

See https://github.com/mongodb-university/realm-tutorial-react-native/pull/10

