### PR TITLE
Fix: properly format redirect to node/examples/open-and-close-a-realm/

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -22,7 +22,7 @@ raw: realm/sdk/dotnet/fundamentals/mongodb-realm-cloud/ -> ${base}/sdk/dotnet/fu
 raw: realm/sdk/node/fundamentals/mongodb-realm-cloud/ -> ${base}/sdk/node/fundamentals/application-services/
 raw: realm/sdk/react-native/fundamentals/mongodb-realm-cloud/ -> ${base}/sdk/react-native/fundamentals/application-services/
 raw: realm/get-started/find-your-app-id -> ${base}/get-started/find-your-project-or-app-id/
-raw: realm/sdk/node/examples/open-and-close-a-local-realm/ ${base}/sdk/node/examples/open-and-close-a-realm/
+raw: realm/sdk/node/examples/open-and-close-a-local-realm/ -> ${base}/sdk/node/examples/open-and-close-a-realm/
 
 # App Structure V2 (https://jira.mongodb.org/browse/DOCSP-14491)
 raw: realm/deploy/application-configuration-files -> ${base}/configuration/legacy/


### PR DESCRIPTION
## Pull Request Info

fix issue with malformatted redirect. updated the config so that the page https://docs.mongodb.com/realm/sdk/node/examples/open-and-close-a-local-realm/ correctly redirects to https://docs.mongodb.com/realm/sdk/node/examples/open-and-close-a-realm/

### Jira

- N/A

### Staged Changes (Requires MongoDB Corp SSO)

- N/A (redirects don't show up in staging unfortunately)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
