### PR TITLE
(DOCSP-19020): React Native JS SDK refresh of page "Open a Synced Realm"

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -23,7 +23,7 @@ raw: realm/sdk/node/fundamentals/mongodb-realm-cloud -> ${base}/sdk/node/fundame
 raw: realm/sdk/react-native/fundamentals/mongodb-realm-cloud -> ${base}/sdk/react-native/fundamentals/application-services/
 raw: realm/get-started/find-your-app-id -> ${base}/get-started/find-your-project-or-app-id/
 raw: realm/sdk/node/examples/open-and-close-a-local-realm -> ${base}/sdk/node/examples/open-and-close-a-realm/
-raw: realm/sdk/react-native/examples/open-and-close-a-local-realm -> ${base}/sdk/react-native/examples/open-and-close-a-realm/
+ raw: realm/sdk/android/advanced-guides/migrations -> ${base}/sdk/android/examples/modify-an-object-schema/
 
 # App Structure V2 (https://jira.mongodb.org/browse/DOCSP-14491)
 raw: realm/deploy/application-configuration-files -> ${base}/configuration/legacy/

--- a/config/redirects
+++ b/config/redirects
@@ -22,8 +22,8 @@ raw: realm/sdk/dotnet/fundamentals/mongodb-realm-cloud -> ${base}/sdk/dotnet/fun
 raw: realm/sdk/node/fundamentals/mongodb-realm-cloud -> ${base}/sdk/node/fundamentals/application-services/
 raw: realm/sdk/react-native/fundamentals/mongodb-realm-cloud -> ${base}/sdk/react-native/fundamentals/application-services/
 raw: realm/get-started/find-your-app-id -> ${base}/get-started/find-your-project-or-app-id/
-raw: realm/sdk/node/examples/open-and-close-a-local-realm/ ${base}/sdk/node/examples/open-and-close-a-realm/
-raw: realm/sdk/react-native/examples/open-and-close-a-local-realm/ -> ${base}/sdk/react-native/examples/open-and-close-a-realm/
+raw: realm/sdk/node/examples/open-and-close-a-local-realm -> ${base}/sdk/node/examples/open-and-close-a-realm/
+raw: realm/sdk/react-native/examples/open-and-close-a-local-realm -> ${base}/sdk/react-native/examples/open-and-close-a-realm/
 
 # App Structure V2 (https://jira.mongodb.org/browse/DOCSP-14491)
 raw: realm/deploy/application-configuration-files -> ${base}/configuration/legacy/

--- a/config/redirects
+++ b/config/redirects
@@ -22,8 +22,8 @@ raw: realm/sdk/dotnet/fundamentals/mongodb-realm-cloud -> ${base}/sdk/dotnet/fun
 raw: realm/sdk/node/fundamentals/mongodb-realm-cloud -> ${base}/sdk/node/fundamentals/application-services/
 raw: realm/sdk/react-native/fundamentals/mongodb-realm-cloud -> ${base}/sdk/react-native/fundamentals/application-services/
 raw: realm/get-started/find-your-app-id -> ${base}/get-started/find-your-project-or-app-id/
-raw: realm/sdk/node/examples/open-and-close-a-local-realm -> ${base}/sdk/node/examples/open-and-close-a-realm/
-raw: realm/sdk/android/advanced-guides/migrations -> ${base}/sdk/android/examples/modify-an-object-schema/
+raw: realm/sdk/node/examples/open-and-close-a-local-realm/ ${base}/sdk/node/examples/open-and-close-a-realm/
+raw: realm/sdk/react-native/examples/open-and-close-a-local-realm/ -> ${base}/sdk/react-native/examples/open-and-close-a-realm/
 
 # App Structure V2 (https://jira.mongodb.org/browse/DOCSP-14491)
 raw: realm/deploy/application-configuration-files -> ${base}/configuration/legacy/
@@ -120,7 +120,7 @@ raw: realm/react-native/mongodb-realm -> ${base}/sdk/react-native/
 raw: realm/react-native/mongodb -> ${base}/sdk/react-native/examples/query-mongodb/
 raw: realm/react-native/notifications -> ${base}/sdk/react-native/examples/react-to-changes/
 raw: realm/react-native/objects -> ${base}/sdk/react-native/fundamentals/realms/
-raw: realm/react-native/open-a-realm -> ${base}/sdk/react-native/examples/open-and-close-a-local-realm/
+raw: realm/react-native/open-a-realm -> ${base}/sdk/react-native/examples/open-and-close-a-realm/
 raw: realm/react-native/query-engine -> ${base}/sdk/react-native/advanced/query-engine/
 raw: realm/react-native/quick-start -> ${base}/sdk/react-native/quick-start/
 raw: realm/react-native/reads -> ${base}/sdk/react-native/examples/read-and-write-data/

--- a/examples/node/Examples/open-and-close-a-realm.js
+++ b/examples/node/Examples/open-and-close-a-realm.js
@@ -152,4 +152,47 @@ describe("Open and Close a Realm", () => {
     nock.cleanAll();
     nock.enableNetConnect();
   });
+
+  test.skip("Should open and close a realm with background sync", async () => {
+    const Car = {
+      name: "Car",
+      properties: {
+        make: "string",
+        model: "string",
+        miles: "int",
+      },
+    };
+
+    const app = new Realm.App({ id: "demo_app-cicfi" });
+
+    try {
+      await app.logIn(new Realm.Credentials.anonymous());
+    } catch (err) {
+      console.error("failed to login user", err.message);
+    }
+    // :code-block-start: open-synced-realm-with-background-sync
+    const OpenRealmBehaviorConfiguration = {
+      type: "openImmediately",
+    };
+
+    const config = {
+      schema: [Car], // predefined schema
+      sync: {
+        user: app.currentUser,
+        partitionValue: "myPartition",
+        newRealmFileBehavior: OpenRealmBehaviorConfiguration,
+        existingRealmFileBehavior: OpenRealmBehaviorConfiguration,
+      },
+    };
+    // :code-block-end:
+
+    try {
+      const realm = await Realm.open(config);
+
+      realm.close();
+      expect(realm.isClosed).toBe(true);
+    } catch (err) {
+      console.error("failed to open realm", err.message);
+    }
+  });
 });

--- a/source/examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-with-background-sync.js
+++ b/source/examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-with-background-sync.js
@@ -1,0 +1,13 @@
+const OpenRealmBehaviorConfiguration = {
+  type: "openImmediately",
+};
+
+const config = {
+  schema: [Car], // predefined schema
+  sync: {
+    user: app.currentUser,
+    partitionValue: "myPartition",
+    newRealmFileBehavior: OpenRealmBehaviorConfiguration,
+    existingRealmFileBehavior: OpenRealmBehaviorConfiguration,
+  },
+};

--- a/source/includes/react-native-open--synced-realm.rst
+++ b/source/includes/react-native-open--synced-realm.rst
@@ -1,0 +1,5 @@
+If you're opening a synced {+realm+}, the configuration you use depends on whether 
+or not the user's device is connected to the Internet. Learn how to handle different
+connection states in the :ref:`Open a Synced Realm While Online <react-native-open-a-synced-realm-while-online>` 
+and :ref:`Open a Synced Realm While Offline <react-native-open-a-synced-realm-while-offline>` 
+sections.

--- a/source/includes/react-native-open-a-synced-realm.rst
+++ b/source/includes/react-native-open-a-synced-realm.rst
@@ -1,0 +1,5 @@
+If you're opening a synced {+realm+}, the configuration you use depends on whether 
+or not the user's device is connected to the Internet. Learn how to handle different
+connection states in the :ref:`Open a Synced Realm While Online <react-native-open-a-synced-realm-while-online>` 
+and :ref:`Open a Synced Realm While Offline <react-native-open-a-synced-realm-while-offline>` 
+sections.

--- a/source/includes/react-native-open-a-synced-realm.rst
+++ b/source/includes/react-native-open-a-synced-realm.rst
@@ -1,5 +1,12 @@
-When opening a synced {+realm+}, the configuration you use depends on whether 
-or not the user's device is connected to the Internet. Learn how to handle different
-connection states in the :ref:`Open a Synced Realm While Online <react-native-open-a-synced-realm-while-online>` 
-and :ref:`Open a Synced Realm While Offline <react-native-open-a-synced-realm-while-offline>` 
-sections.
+To open a synced {+realm+}, call :js-sdk:`Realm.open() <Realm.html#.open>`. 
+Pass in a :js-sdk:`Configuration <Realm.html#~Configuration>`
+object, which must include the ``sync`` property defining a 
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object. 
+
+When opening a synced {+realm+}, the configuration you use depends on the behavior you want
+for how the client to sync with the server. On a high level, the ways to connect 
+to a synced {+realm+} are: 
+
+- :ref:`Syncing all data before returning <react-native-sync-all-data-before-returning>`
+- :ref:`Returning after a timeout with background sync <react-native-return-after-timeout-with-background-sync>`
+- :ref:`Opening immediately with background sync <react-native-open-immediately-with-background-sync>`

--- a/source/includes/react-native-open-a-synced-realm.rst
+++ b/source/includes/react-native-open-a-synced-realm.rst
@@ -2,6 +2,7 @@ To open a synced {+realm+}, call :js-sdk:`Realm.open() <Realm.html#.open>`.
 Pass in a :js-sdk:`Configuration <Realm.html#~Configuration>`
 object, which must include the ``sync`` property defining a 
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object. 
+In the SyncConfiguration, you must include include ``user`` and ``partitionValue``.
 
 When opening a synced {+realm+}, the configuration you use depends on the initial sync behavior you want. You can connect to a synced {+realm+} in the following ways: 
 

--- a/source/includes/react-native-open-a-synced-realm.rst
+++ b/source/includes/react-native-open-a-synced-realm.rst
@@ -3,10 +3,8 @@ Pass in a :js-sdk:`Configuration <Realm.html#~Configuration>`
 object, which must include the ``sync`` property defining a 
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object. 
 
-When opening a synced {+realm+}, the configuration you use depends on the behavior you want
-for syncing the client with the server. The ways to connect 
-to a synced {+realm+} are: 
+When opening a synced {+realm+}, the configuration you use depends on the initial sync behavior you want. You can connect to a synced {+realm+} in the following ways: 
 
-- :ref:`Syncing all data before returning <react-native-sync-all-data-before-returning>`
-- :ref:`Returning after a timeout with background sync <react-native-return-after-timeout-with-background-sync>`
-- :ref:`Opening immediately with background sync <react-native-open-immediately-with-background-sync>`
+- :ref:`Sync all data before returning <react-native-sync-all-data-before-returning>`
+- :ref:`Return after a timeout with background sync <react-native-return-after-timeout-with-background-sync>`
+- :ref:`Open immediately with background sync <react-native-open-immediately-with-background-sync>`

--- a/source/includes/react-native-open-a-synced-realm.rst
+++ b/source/includes/react-native-open-a-synced-realm.rst
@@ -8,4 +8,4 @@ When opening a synced {+realm+}, the configuration you use depends on the initia
 
 - :ref:`Sync all data before returning <react-native-sync-all-data-before-returning>`
 - :ref:`Return after a timeout with background sync <react-native-return-after-timeout-with-background-sync>`
-- :ref:`Open immediately with background sync <react-native-open-immediately-with-background-sync>`
+- :ref:`Return immediately with background sync <react-native-open-immediately-with-background-sync>`

--- a/source/includes/react-native-open-a-synced-realm.rst
+++ b/source/includes/react-native-open-a-synced-realm.rst
@@ -4,7 +4,7 @@ object, which must include the ``sync`` property defining a
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object. 
 
 When opening a synced {+realm+}, the configuration you use depends on the behavior you want
-for how the client to sync with the server. On a high level, the ways to connect 
+for syncing the client with the server. The ways to connect 
 to a synced {+realm+} are: 
 
 - :ref:`Syncing all data before returning <react-native-sync-all-data-before-returning>`

--- a/source/includes/react-native-open-a-synced-realm.rst
+++ b/source/includes/react-native-open-a-synced-realm.rst
@@ -1,4 +1,4 @@
-If you're opening a synced {+realm+}, the configuration you use depends on whether 
+When opening a synced {+realm+}, the configuration you use depends on whether 
 or not the user's device is connected to the Internet. Learn how to handle different
 connection states in the :ref:`Open a Synced Realm While Online <react-native-open-a-synced-realm-while-online>` 
 and :ref:`Open a Synced Realm While Offline <react-native-open-a-synced-realm-while-offline>` 

--- a/source/sdk/react-native.txt
+++ b/source/sdk/react-native.txt
@@ -181,7 +181,7 @@ For practical code samples of common tasks in {+client-database+} and
      
      - :doc:`Define a Realm Object Schema </sdk/react-native/examples/define-a-realm-object-model>`
      
-       :doc:`Open & Close a Local Realm </sdk/react-native/examples/open-and-close-a-local-realm>`
+       :doc:`Open & Close a Realm </sdk/react-native/examples/open-and-close-a-realm>`
        
        :doc:`Read & Write Data </sdk/react-native/examples/read-and-write-data>`
        

--- a/source/sdk/react-native/examples.txt
+++ b/source/sdk/react-native/examples.txt
@@ -24,7 +24,7 @@ Realm-Database (Non-Sync)
 -------------------------
 - :doc:`Connect to a MongoDB Realm Backend App </sdk/react-native/examples/connect-to-mongodb-realm-backend-app>`
 - :doc:`Define a Realm Object Model </sdk/react-native/examples/define-a-realm-object-model>`
-- :doc:`Open & Close a Local Realm </sdk/react-native/examples/open-and-close-a-local-realm>`
+- :doc:`Open & Close a Realm </sdk/react-native/examples/open-and-close-a-realm>`
 - :doc:`Read & Write Data </sdk/react-native/examples/read-and-write-data>`
 - :doc:`React to Changes </sdk/react-native/examples/react-to-changes>`
 - :doc:`Use Change Listeners In Components </sdk/react-native/examples/use-change-listeners-in-components>`

--- a/source/sdk/react-native/examples.txt
+++ b/source/sdk/react-native/examples.txt
@@ -7,7 +7,7 @@ Usage Examples - React Native SDK
    :hidden:
    
    Define a Realm Object Schema </sdk/react-native/examples/define-a-realm-object-model>
-   Open & Close a Local Realm </sdk/react-native/examples/open-and-close-a-local-realm>
+   Open & Close a Realm </sdk/react-native/examples/open-and-close-a-realm>
    Read & Write Data </sdk/react-native/examples/read-and-write-data>
    React to Changes </sdk/react-native/examples/react-to-changes>
    Use Change Listeners In Components </sdk/react-native/examples/use-change-listeners-in-components>

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -1,8 +1,8 @@
 .. _react-native-open-close-realm:
 
-=============================================
-Open & Close a Local Realm - React Native SDK
-=============================================
+=======================================
+Open & Close a Realm - React Native SDK
+=======================================
 
 .. default-domain:: mongodb
 

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -60,12 +60,11 @@ Return After Timeout with Background Sync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you don't need to sync all data before before returning the {+realm+}, configure the
-``newRealmFileBehavior`` and ``existingRealmFileBehavior`` fields of your
+``newRealmFileBehavior`` and ``existingRealmFileBehavior`` properties of your
 SyncConfiguration to automatically open the realm after a timeout period elapses. You
-can use a single :js-sdk:`OpenRealmBehaviorConfiguration
-<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`for both
-``newRealmFileBehavior`` and ``existingRealmFileBehavior`` that contains the following
-field values:  
+can use a single :js-sdk:`OpenRealmBehaviorConfiguration <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`
+for both ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` 
+that contains the following property values:  
 
 - ``type``: "downloadBeforeOpen"
 - ``timeOut``: <time in milliseconds>
@@ -101,21 +100,22 @@ Open Immediately With Background Sync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When you want to connect to the {+realm+} immediately and sync data from the server 
-in the background, you must use  a a :js-sdk:`OpenRealmBehaviorConfiguration
+in the background, you must use  a :js-sdk:`OpenRealmBehaviorConfiguration
 <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` that includes the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` 
-fields. This configuration is useful if a user's device is not connected to the Internet or you're not certain if it's 
+properties. This configuration is useful if a user's device is not connected to the Internet or you're not certain if it's 
 connected. 
 
 Create a :js-sdk:`OpenRealmBehaviorConfiguration
 <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object and set the
-``type`` field to a value of "openImmediately". This configuration opens a local {+realm+} 
+``type`` property to a value of "openImmediately". This configuration opens a local {+realm+} 
 immediately without attempting to sync with the server. The client continues  
 attempting to connect with the server in the background. 
+
 Then create a :js-sdk:`Configuration <Realm.html#~Configuration>` object, which must
 include the ``sync`` property defining a :js-sdk:`SyncConfiguration
 <Realm.App.Sync.html#~SyncConfiguration>` object. Set this
-``OpenRealmBehaviorConfiguration`` object as the value for
-the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` fields of the
+OpenRealmBehaviorConfiguration object as the value for
+the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` properties of the
 ``SyncConfiguration``. 
 
 .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-with-background-sync.js

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -17,46 +17,128 @@ Open & Close a Local Realm - React Native SDK
 Open a Local Realm
 ------------------
 
-To open a local (non-synced) {+realm+}, pass a :js-sdk:`Realm.Configuration
-<Realm.html#~Configuration>` object to :js-sdk:`Realm.open()
-<Realm.html#.open>`.
+.. include:: /includes/js-open-a-local-realm.rst
 
-.. note:: Accessing the Default Realm Path
+.. _react-native-open-a-synced-realm:
 
-   If the ``path`` property is not specified in your ``Configuration`` object,
-   the default path is used. You can access and change the default Realm path
-   using the ``Realm.defaultPath`` global property.
+Open a Synced Realm
+-------------------
 
-.. literalinclude:: /examples/generated/node/open-and-close-a-local-realm.codeblock.open-local-realm-with-car-schema.js
+.. include:: /includes/node-open-a-synced-realm.rst
+
+.. _react-native-open-a-synced-realm-while-online:
+
+Open a Synced Realm While Online
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To open a synced {+realm+} while online, call :js-sdk:`Realm.open() <Realm.html#.open>`. 
+Pass in a :js-sdk:`Configuration <Realm.html#~Configuration>`
+object, which must include the ``sync`` property defining a 
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object. 
+
+Sync All Data Before Returning
+``````````````````````````````
+
+The default behavior for {+realm+} is to sync all data from the server before returning. 
+In the :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`, 
+you must include include the ``user`` and ``partitionValue``.
+
+.. example:: 
+
+   The following example shows how to open a synced {+realm+} with with a 
+   ``SyncConfiguration`` object that uses a predefined
+   ``CarSchema`` :doc:`schema </sdk/node/examples/define-a-realm-object-model>`, 
+   the currently logged in user, and a partition value of "MyPartition".
+
+   .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-online-with-car-schema.js
+      :language: javascript
+
+.. _react-native-open-synced-realm-config:
+
+
+Return After Timeout with Background Sync
+`````````````````````````````````````````
+
+If you don't need to sync all data before before returning, configure your SyncConfiguration
+to include ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` each with
+the same :js-sdk:`OpenRealmBehaviorConfiguration <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`.  
+
+Set the OpenRealmBehaviorConfiguration to have ``type: 'downloadBeforeOpen'``, 
+``timeOut: <time in milliseconds>`` and ``timeOutBehavior: 'openLocalRealm'``.
+These properties make ``Realm.open()`` return at the end of the ``timeOut`` period, and open a local {+realm+}. 
+Syncing between local data and the server continues in the background. For example: 
+
+.. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-config.js
   :language: javascript
-  :emphasize-lines: 2
 
-In the above example, the code shows how to open the {+realm+} *asynchronously*
-by calling ``realm.open()``. You can also open a realm synchronously by passing
-a ``Configuration object`` to a new instance of the :js-sdk:`Realm
-<Realm.html>` object. This works even if the device is offline. 
+This configuration is also useful if you're attempting to sync in an environment 
+where it's uncertain if the user has an Internet connection. The client attempts 
+to sync until the end of the the ``timeOut`` period, and then opens the local {+realm+},
+even if the it never connects to the server. 
 
-.. literalinclude:: /examples/generated/node/open-and-close-a-local-realm.codeblock.open-local-realm-synchronously.js
-  :language: javascript
-  :emphasize-lines: 2
+.. example::
+  
+  The following example shows opening a synced {+realm+} with a 
+  ``Configuration`` object using a predefined ``Car`` :doc:`schema </sdk/node/examples/define-a-realm-object-model>`, 
+  the currently logged in user, a partition value of "MyPartition", and a 
+  :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`. The SyncConfiguration includes  
+  ``existingRealmFileBehavior`` and ``newRealmFileBehavior`` set to allow the user 
+  to work with the local {+realm+} if the device is doesn't fully sync within the ``timeOut``
+  period of 1000 milliseconds.  
 
-.. note::
+  .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-offline-with-car-schema.js
+    :language: javascript
 
-   The first time a user logs on to your realm app, you should open the realm 
-   *asynchronously* to sync data from the server to the device. After that initial 
-   connection, you can open a realm *synchronously* to ensure the app works in 
-   an offline state. 
+.. warning:: 
+
+   If you are attempting to synchronize a {+realm+} while not connected to 
+   the Internet, you must pass ``Realm.open()`` a :js-sdk:`Configuration <Realm.html#~Configuration>`
+   object with ``newRealmFileBehavior`` and ``existingRealmFileBehavior``. If you 
+   don't include these properties, ``Realm.open()`` continues trying
+   to connect to the server indefinitely without opening. 
    
+   Refer to the :ref:`Open a Synced Realm While Offline <node-open-a-synced-realm-while-offline>`
+   documentation for more information about connecting to your offline {+realm+}. 
+
+.. _react-native-open-a-synced-realm-while-offline:
+
+Open a Synced Realm While Offline
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If a user's device is not connected to the Internet or you're not certain if it's 
+connected, you must use  a a :js-sdk:`OpenRealmBehaviorConfiguration
+<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` that includes ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` 
+properties. 
+
+Create a :js-sdk:`OpenRealmBehaviorConfiguration
+<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object and set its
+``type`` to ``"openImmediately"``. This configuration opens a local {+realm+} 
+immediately without attempting to sync with the server. The client continues  
+attempting to connect with the server in the background.
+
+.. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-sync-changes-in-the-background-create-OpenRealmBehaviorObject.js
+      :language: javascript
+
+Create a :js-sdk:`Configuration <Realm.html#~Configuration>` object, which must
+include the ``sync`` property defining a :js-sdk:`SyncConfiguration
+<Realm.App.Sync.html#~SyncConfiguration>` object. Set this
+``OpenRealmBehaviorConfiguration`` object as the value for
+the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` fields of the
+``SyncConfiguration``. 
+
+.. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-sync-changes-in-the-background-create-config.js
+      :language: javascript
+
+Finally,  call :js-sdk:`Realm.open() <Realm.html#.open>`
+to open the local {+realm+} and attempt syncing with the server in the background. 
+
+
 .. _react-native-close-a-realm:
 
 Close a Realm
 -------------
 
-It is important to remember to call the ``close()`` method when done with a
-{+realm+} instance to avoid memory leaks.
-
-.. literalinclude:: /examples/generated/node/open-and-close-a-local-realm.codeblock.close-local-realm.js
-  :language: javascript
+.. include:: /includes/js-close-a-realm.rst
 
 .. .. _react-native-local-realm-configuration:
 

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -30,7 +30,7 @@ Open a Synced Realm
 
    When attempting to synchronize a {+realm+} while not connected to 
    the Internet, you must pass ``Realm.open()`` a :js-sdk:`Configuration <Realm.html#~Configuration>`
-   object with ``newRealmFileBehavior`` and ``existingRealmFileBehavior``. If you 
+   object that contains the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` properties. If you 
    don't include these properties, ``Realm.open()`` continues trying
    to connect to the server indefinitely without opening. 
    
@@ -77,15 +77,13 @@ If the {+realm+} doesn't finish downloading before the timeout, the initial real
   :language: javascript
 
 This configuration is also useful if you're attempting to sync in an environment 
-where it's uncertain if the user has an Internet connection. The client attempts 
-to sync until the end of the the ``timeOut`` period, and then opens the local {+realm+},
-even if the it never connects to the server. 
+where it's uncertain if the user has an Internet connection.
 
 .. example::
   
   The following example shows opening a synced {+realm+} with a 
   ``Configuration`` object using a predefined ``Car`` :doc:`schema </sdk/node/examples/define-a-realm-object-model>`, 
-  the currently logged in user, a partition value of "MyPartition", and a 
+  the currently logged in user, a partition value of "myPartition", and a 
   :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`. The SyncConfiguration includes  
   ``existingRealmFileBehavior`` and ``newRealmFileBehavior`` set to allow the user 
   to work with the local {+realm+} if the device is doesn't fully sync within the ``timeOut``

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -79,7 +79,7 @@ Configure your ``OpenRealmBehaviorConfiguration`` with the following field value
 - ``timeOut``: <time in milliseconds>
 - ``timeOutBehavior``: 'openLocalRealm'
 
-These properties force the ``Realm.open()`` method to return an open {+realm+} after ``timeOut`` milliseconds, or when the {+realm+} has completely downloaded -- whichever comes first. 
+These properties force the ``Realm.open()`` method to return an open {+realm+} after ``timeOut`` milliseconds, or when the {+realm+} has completely downloaded, whichever comes first. 
 If the {+realm+} doesn't finish downloading before the timeout, the initial realm sync continues in the background. For example: 
 
 .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-config.js

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -34,9 +34,8 @@ Open a Synced Realm
    don't include these properties, ``Realm.open()`` continues trying
    to connect to the server indefinitely without opening. 
    
-   Refer to the :ref:`Open Immediately with Background Sync <react-native-open-a-synced-realm-with-background-sync>`
-   documentation for more information about connecting to your synced {+realm+} 
-   while offline. 
+   For more information about connecting to your synced {+realm+} 
+   while offline, see :ref:`Open Immediately with Background Sync <react-native-open-a-synced-realm-with-background-sync>`.
 
 .. _react-native-sync-all-data-before-returning:
 
@@ -52,7 +51,7 @@ you must include include the ``user`` and ``partitionValue``.
    The following example shows how to open a synced {+realm+} with with a 
    ``SyncConfiguration`` object that uses a predefined
    ``CarSchema`` :doc:`schema </sdk/node/examples/define-a-realm-object-model>`, 
-   the currently logged in user, and a partition value of "MyPartition".
+   the currently logged in user, and a partition value of "myPartition".
 
    .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-online-with-car-schema.js
       :language: javascript
@@ -62,11 +61,13 @@ you must include include the ``user`` and ``partitionValue``.
 Return After Timeout with Background Sync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you don't need to sync all data before before returning the {+realm+}, configure your SyncConfiguration
-to include ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` each with
-the same :js-sdk:`OpenRealmBehaviorConfiguration <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`.  
-
-Configure your ``OpenRealmBehaviorConfiguration`` with the following field values:
+If you don't need to sync all data before before returning the {+realm+}, configure the
+``newRealmFileBehavior`` and ``existingRealmFileBehavior``fields of your
+SyncConfiguration to automatically open the realm after a timeout period elapses. You
+can use a single :js-sdk:`OpenRealmBehaviorConfiguration
+<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`for both
+``newRealmFileBehavior`` and ``existingRealmFileBehavior`` that contains the following
+field values:  
 
 - ``type``: "downloadBeforeOpen"
 - ``timeOut``: <time in milliseconds>
@@ -103,13 +104,13 @@ Open Immediately With Background Sync
 
 When you want to connect to the {+realm+} immediately and sync data from the server 
 in the background, you must use  a a :js-sdk:`OpenRealmBehaviorConfiguration
-<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` that includes ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` 
-properties. This configuration is useful if a user's device is not connected to the Internet or you're not certain if it's 
+<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` that includes the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` 
+fields. This configuration is useful if a user's device is not connected to the Internet or you're not certain if it's 
 connected. 
 
 Create a :js-sdk:`OpenRealmBehaviorConfiguration
-<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object and set its
-``type: "openImmediately"``. This configuration opens a local {+realm+} 
+<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object and set the
+``type`` field to a value of "openImmediately". This configuration opens a local {+realm+} 
 immediately without attempting to sync with the server. The client continues  
 attempting to connect with the server in the background.
 

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -1,4 +1,4 @@
-.. _react-native-open-close-local-realm:
+.. _react-native-open-close-realm:
 
 =============================================
 Open & Close a Local Realm - React Native SDK
@@ -12,7 +12,7 @@ Open & Close a Local Realm - React Native SDK
    :depth: 2
    :class: singlecol
 
-.. _react-native-open-a-local-realm:
+.. _react-native-open-a-realm:
 
 Open a Local Realm
 ------------------

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -34,8 +34,9 @@ Open a Synced Realm
    don't include these properties, ``Realm.open()`` continues trying
    to connect to the server indefinitely without opening. 
    
-   Refer to the :ref:`Open a Synced Realm with Background Sync <react-native-open-a-synced-realm-with-background-sync>`
-   documentation for more information about connecting to your offline {+realm+}. 
+   Refer to the :ref:`Open Immediately with Background Sync <react-native-open-a-synced-realm-with-background-sync>`
+   documentation for more information about connecting to your synced {+realm+} 
+   while offline. 
 
 .. _react-native-sync-all-data-before-returning:
 
@@ -67,9 +68,9 @@ the same :js-sdk:`OpenRealmBehaviorConfiguration <Realm.App.Sync.html#~OpenRealm
 
 Configure your ``OpenRealmBehaviorConfiguration`` with the following field values:
 
-- ``type``: 'downloadBeforeOpen'
+- ``type``: "downloadBeforeOpen"
 - ``timeOut``: <time in milliseconds>
-- ``timeOutBehavior``: 'openLocalRealm'
+- ``timeOutBehavior``: "openLocalRealm"
 
 These properties force the ``Realm.open()`` method to return an open {+realm+} after ``timeOut`` milliseconds, or when the {+realm+} has completely downloaded, whichever comes first. 
 If the {+realm+} doesn't finish downloading before the timeout, the initial realm sync continues in the background. For example: 
@@ -108,7 +109,7 @@ connected.
 
 Create a :js-sdk:`OpenRealmBehaviorConfiguration
 <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object and set its
-``type`` to ``"openImmediately"``. This configuration opens a local {+realm+} 
+``type: "openImmediately"``. This configuration opens a local {+realm+} 
 immediately without attempting to sync with the server. The client continues  
 attempting to connect with the server in the background.
 

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -35,7 +35,7 @@ Open a Synced Realm
    to connect to the server indefinitely without opening. 
    
    For more information about connecting to your synced {+realm+} 
-   while offline, see :ref:`Open Immediately with Background Sync <react-native-open-a-synced-realm-with-background-sync>`.
+   while offline, see :ref:`Open Immediately with Background Sync <react-native-open-immediately-with-background-sync>`.
 
 .. _react-native-sync-all-data-before-returning:
 
@@ -43,8 +43,6 @@ Sync All Data Before Returning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, {+service-short+} syncs all data from the server before returning. 
-In the :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`, 
-you must include include the ``user`` and ``partitionValue``.
 
 .. example:: 
 
@@ -62,7 +60,7 @@ Return After Timeout with Background Sync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you don't need to sync all data before before returning the {+realm+}, configure the
-``newRealmFileBehavior`` and ``existingRealmFileBehavior``fields of your
+``newRealmFileBehavior`` and ``existingRealmFileBehavior`` fields of your
 SyncConfiguration to automatically open the realm after a timeout period elapses. You
 can use a single :js-sdk:`OpenRealmBehaviorConfiguration
 <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`for both
@@ -112,24 +110,16 @@ Create a :js-sdk:`OpenRealmBehaviorConfiguration
 <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object and set the
 ``type`` field to a value of "openImmediately". This configuration opens a local {+realm+} 
 immediately without attempting to sync with the server. The client continues  
-attempting to connect with the server in the background.
-
-.. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-sync-changes-in-the-background-create-OpenRealmBehaviorObject.js
-      :language: javascript
-
-Create a :js-sdk:`Configuration <Realm.html#~Configuration>` object, which must
+attempting to connect with the server in the background. 
+Then create a :js-sdk:`Configuration <Realm.html#~Configuration>` object, which must
 include the ``sync`` property defining a :js-sdk:`SyncConfiguration
 <Realm.App.Sync.html#~SyncConfiguration>` object. Set this
 ``OpenRealmBehaviorConfiguration`` object as the value for
 the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` fields of the
 ``SyncConfiguration``. 
 
-.. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-sync-changes-in-the-background-create-config.js
+.. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-with-background-sync.js
       :language: javascript
-
-Finally, call :js-sdk:`Realm.open() <Realm.html#.open>`
-to open the local {+realm+} and attempt syncing with the server in the background. 
-
 
 .. _react-native-close-a-realm:
 

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -26,6 +26,17 @@ Open a Synced Realm
 
 .. include:: /includes/react-native-open-a-synced-realm.rst
 
+.. warning:: 
+
+   When attempting to synchronize a {+realm+} while not connected to 
+   the Internet, you must pass ``Realm.open()`` a :js-sdk:`Configuration <Realm.html#~Configuration>`
+   object with ``newRealmFileBehavior`` and ``existingRealmFileBehavior``. If you 
+   don't include these properties, ``Realm.open()`` continues trying
+   to connect to the server indefinitely without opening. 
+   
+   Refer to the :ref:`Open a Synced Realm While Offline <react-native-open-a-synced-realm-while-offline>`
+   documentation for more information about connecting to your offline {+realm+}. 
+
 .. _react-native-open-a-synced-realm-while-online:
 
 Open a Synced Realm While Online
@@ -58,7 +69,7 @@ you must include include the ``user`` and ``partitionValue``.
 Return After Timeout with Background Sync
 `````````````````````````````````````````
 
-If you don't need to sync all data before before returning, configure your SyncConfiguration
+If you don't need to sync all data before before returning the {+realm+}, configure your SyncConfiguration
 to include ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` each with
 the same :js-sdk:`OpenRealmBehaviorConfiguration <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`.  
 
@@ -67,6 +78,7 @@ Configure your ``OpenRealmBehaviorConfiguration`` with the following field value
 - ``type``: 'downloadBeforeOpen'
 - ``timeOut``: <time in milliseconds>
 - ``timeOutBehavior``: 'openLocalRealm'
+
 These properties force the ``Realm.open()`` method to return an open {+realm+} after ``timeOut`` milliseconds, or when the {+realm+} has completely downloaded -- whichever comes first. 
 If the {+realm+} doesn't finish downloading before the timeout, the initial realm sync continues in the background. For example: 
 
@@ -90,17 +102,6 @@ even if the it never connects to the server.
 
   .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-offline-with-car-schema.js
     :language: javascript
-
-.. warning:: 
-
-   When attempting to synchronize a {+realm+} while not connected to 
-   the Internet, you must pass ``Realm.open()`` a :js-sdk:`Configuration <Realm.html#~Configuration>`
-   object with ``newRealmFileBehavior`` and ``existingRealmFileBehavior``. If you 
-   don't include these properties, ``Realm.open()`` continues trying
-   to connect to the server indefinitely without opening. 
-   
-   Refer to the :ref:`Open a Synced Realm While Offline <node-open-a-synced-realm-while-offline>`
-   documentation for more information about connecting to your offline {+realm+}. 
 
 .. _react-native-open-a-synced-realm-while-offline:
 
@@ -141,13 +142,3 @@ Close a Realm
 -------------
 
 .. include:: /includes/js-close-a-realm.rst
-
-.. .. _react-native-local-realm-configuration:
-
-.. Local Realm Configuration
-.. -------------------------
-
-.. .. _react-native-provide-a-subset-of-classes-to-a-realm:
-
-.. Provide a Subset of Classes to a Realm
-.. ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -39,7 +39,7 @@ object, which must include the ``sync`` property defining a
 Sync All Data Before Returning
 ``````````````````````````````
 
-The default behavior for {+realm+} is to sync all data from the server before returning. 
+By default, {+service-short+} syncs all data from the server before returning. 
 In the :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`, 
 you must include include the ``user`` and ``partitionValue``.
 
@@ -62,10 +62,13 @@ If you don't need to sync all data before before returning, configure your SyncC
 to include ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` each with
 the same :js-sdk:`OpenRealmBehaviorConfiguration <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`.  
 
-Set the OpenRealmBehaviorConfiguration to have ``type: 'downloadBeforeOpen'``, 
-``timeOut: <time in milliseconds>`` and ``timeOutBehavior: 'openLocalRealm'``.
-These properties make ``Realm.open()`` return at the end of the ``timeOut`` period, and open a local {+realm+}. 
-Syncing between local data and the server continues in the background. For example: 
+Configure your ``OpenRealmBehaviorConfiguration`` with the following field values:
+
+- ``type``: 'downloadBeforeOpen'
+- ``timeOut``: <time in milliseconds>
+- ``timeOutBehavior``: 'openLocalRealm'
+These properties force the ``Realm.open()`` method to return an open {+realm+} after ``timeOut`` milliseconds, or when the {+realm+} has completely downloaded -- whichever comes first. 
+If the {+realm+} doesn't finish downloading before the timeout, the initial realm sync continues in the background. For example: 
 
 .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-config.js
   :language: javascript
@@ -90,7 +93,7 @@ even if the it never connects to the server.
 
 .. warning:: 
 
-   If you are attempting to synchronize a {+realm+} while not connected to 
+   When attempting to synchronize a {+realm+} while not connected to 
    the Internet, you must pass ``Realm.open()`` a :js-sdk:`Configuration <Realm.html#~Configuration>`
    object with ``newRealmFileBehavior`` and ``existingRealmFileBehavior``. If you 
    don't include these properties, ``Realm.open()`` continues trying
@@ -128,7 +131,7 @@ the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` fields of the
 .. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-sync-changes-in-the-background-create-config.js
       :language: javascript
 
-Finally,  call :js-sdk:`Realm.open() <Realm.html#.open>`
+Finally, call :js-sdk:`Realm.open() <Realm.html#.open>`
 to open the local {+realm+} and attempt syncing with the server in the background. 
 
 

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -34,21 +34,13 @@ Open a Synced Realm
    don't include these properties, ``Realm.open()`` continues trying
    to connect to the server indefinitely without opening. 
    
-   Refer to the :ref:`Open a Synced Realm While Offline <react-native-open-a-synced-realm-while-offline>`
+   Refer to the :ref:`Open a Synced Realm with Background Sync <react-native-open-a-synced-realm-with-background-sync>`
    documentation for more information about connecting to your offline {+realm+}. 
 
-.. _react-native-open-a-synced-realm-while-online:
-
-Open a Synced Realm While Online
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To open a synced {+realm+} while online, call :js-sdk:`Realm.open() <Realm.html#.open>`. 
-Pass in a :js-sdk:`Configuration <Realm.html#~Configuration>`
-object, which must include the ``sync`` property defining a 
-:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object. 
+.. _react-native-sync-all-data-before-returning:
 
 Sync All Data Before Returning
-``````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, {+service-short+} syncs all data from the server before returning. 
 In the :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`, 
@@ -64,10 +56,10 @@ you must include include the ``user`` and ``partitionValue``.
    .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-online-with-car-schema.js
       :language: javascript
 
-.. _react-native-open-synced-realm-config:
+.. _react-native-return-after-timeout-with-background-sync:
 
 Return After Timeout with Background Sync
-`````````````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you don't need to sync all data before before returning the {+realm+}, configure your SyncConfiguration
 to include ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` each with
@@ -103,15 +95,16 @@ even if the it never connects to the server.
   .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-offline-with-car-schema.js
     :language: javascript
 
-.. _react-native-open-a-synced-realm-while-offline:
+.. _react-native-open-immediately-with-background-sync:
 
-Open a Synced Realm While Offline
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Open Immediately With Background Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If a user's device is not connected to the Internet or you're not certain if it's 
-connected, you must use  a a :js-sdk:`OpenRealmBehaviorConfiguration
+When you want to connect to the {+realm+} immediately and sync data from the server 
+in the background, you must use  a a :js-sdk:`OpenRealmBehaviorConfiguration
 <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` that includes ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` 
-properties. 
+properties. This configuration is useful if a user's device is not connected to the Internet or you're not certain if it's 
+connected. 
 
 Create a :js-sdk:`OpenRealmBehaviorConfiguration
 <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object and set its

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -12,7 +12,7 @@ Open & Close a Local Realm - React Native SDK
    :depth: 2
    :class: singlecol
 
-.. _react-native-open-a-realm:
+.. _react-native-open-a-local-realm:
 
 Open a Local Realm
 ------------------
@@ -24,7 +24,7 @@ Open a Local Realm
 Open a Synced Realm
 -------------------
 
-.. include:: /includes/node-open-a-synced-realm.rst
+.. include:: /includes/react-native-open-a-synced-realm.rst
 
 .. _react-native-open-a-synced-realm-while-online:
 
@@ -54,7 +54,6 @@ you must include include the ``user`` and ``partitionValue``.
       :language: javascript
 
 .. _react-native-open-synced-realm-config:
-
 
 Return After Timeout with Background Sync
 `````````````````````````````````````````

--- a/source/sdk/react-native/examples/sync-changes-between-devices.txt
+++ b/source/sdk/react-native/examples/sync-changes-between-devices.txt
@@ -12,14 +12,13 @@ Sync Changes Between Devices - React Native SDK
    :depth: 2
    :class: singlecol
 
-.. _react-native-open-a-synced-realm:
+.. _react-native-open-a-synced-realm-sync-changes:
 
 Open a Synced Realm
 -------------------
-To open a synced {+realm+}, call :js-sdk:`Realm.open() <Realm.html#.open>`. 
-Pass in a :js-sdk:`Configuration <Realm.html#~Configuration>`
-object, which must include the ``sync`` property defining a 
-:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object.
+
+.. include:: /includes/react-native-open-a-synced-realm.rst
+
 
 
 .. example::

--- a/source/sdk/react-native/fundamentals/realms.txt
+++ b/source/sdk/react-native/fundamentals/realms.txt
@@ -19,7 +19,7 @@ the objects.
 
 .. tip:: Learn How to Work With a Realm
    
-   See :ref:`Open & Close a Local Realm <react-native-open-close-local-realm>` for code
+   See :ref:`Open & Close a Realm <react-native-open-close-realm>` for code
    examples that show how to configure and open a {+realm+} in the React Native SDK.
 
 Realm vs Other Databases


### PR DESCRIPTION
## Pull Request Info

Refresh page content for React native SDK page "Open a Synced Realm". 

This is largely a copy and paste job from the newly created Node docs (https://jira.mongodb.org/browse/DOCSP-17709). It's a separate PR w the content copy-pasted instead of just using an include b.c the refs need to change. 

Content changes focus on using the method `Realm.open()` to open a new realm instead of `new Realm()`, as this is the currently preferred method per the JS SDK team.

Additional changes: 
* In addition to main changes on the page `source/sdk/react-native/examples/open-and-close-a-realm.txt`, there are updates to the refs in the page and renaming the text in links to the page. 
* redirect from old page URL to the new

### Jira

- https://jira.mongodb.org/browse/DOCSP-19020

### Staged Changes (Requires MongoDB Corp SSO)

- [Open & Close a Realm (React Native)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19020/sdk/react-native/examples/open-and-close-a-realm/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
