### PR TITLE
(DOCSP-19134): Refactor Node "Open & Close a Realm" to follow style of React Native

### DIFF
--- a/source/includes/node-open-a-synced-realm.rst
+++ b/source/includes/node-open-a-synced-realm.rst
@@ -1,5 +1,11 @@
-If you're opening a synced {+realm+}, the configuration you use depends on whether 
-or not the user's device is connected to the Internet. Learn how to handle different
-connection states in the :ref:`Open a Synced Realm While Online <node-open-a-synced-realm-while-online>` 
-and :ref:`Open a Synced Realm While Offline <node-open-a-synced-realm-while-offline>` 
-sections.
+To open a synced {+realm+}, call :js-sdk:`Realm.open() <Realm.html#.open>`. 
+Pass in a :js-sdk:`Configuration <Realm.html#~Configuration>`
+object, which must include the ``sync`` property defining a 
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object. 
+In the SyncConfiguration, you must include include ``user`` and ``partitionValue``.
+
+When opening a synced {+realm+}, the configuration you use depends on the initial sync behavior you want. You can connect to a synced {+realm+} in the following ways: 
+
+- :ref:`Sync all data before returning <node-sync-all-data-before-returning>`
+- :ref:`Return after a timeout with background sync <node-return-after-timeout-with-background-sync>`
+- :ref:`Return immediately with background sync <node-open-immediately-with-background-sync>`

--- a/source/sdk/node/examples/open-and-close-a-realm.txt
+++ b/source/sdk/node/examples/open-and-close-a-realm.txt
@@ -26,61 +26,64 @@ Open a Synced Realm
 
 .. include:: /includes/node-open-a-synced-realm.rst
 
-.. _node-open-a-synced-realm-while-online:
+.. warning:: 
 
-Open a Synced Realm While Online
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   When attempting to synchronize a {+realm+} while not connected to 
+   the Internet, you must pass ``Realm.open()`` a :js-sdk:`Configuration <Realm.html#~Configuration>`
+   object that contains the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` properties. If you 
+   don't include these properties, ``Realm.open()`` continues trying
+   to connect to the server indefinitely without opening. 
+   
+   For more information about connecting to your synced {+realm+} 
+   while offline, see :ref:`Open Immediately with Background Sync <node-open-immediately-with-background-sync>`.
 
-To open a synced {+realm+} while online, call :js-sdk:`Realm.open() <Realm.html#.open>`. 
-Pass in a :js-sdk:`Configuration <Realm.html#~Configuration>`
-object, which must include the ``sync`` property defining a 
-:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object. 
+.. _node-sync-all-data-before-returning:
 
 Sync All Data Before Returning
-``````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The default behavior for {+realm+} is to sync all data from the server before returning. 
-In the :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`, 
-you must include include the ``user`` and ``partitionValue``.
+By default, {+service-short+} syncs all data from the server before returning. 
 
 .. example:: 
 
    The following example shows how to open a synced {+realm+} with with a 
    ``SyncConfiguration`` object that uses a predefined
    ``CarSchema`` :doc:`schema </sdk/node/examples/define-a-realm-object-model>`, 
-   the currently logged in user, and a partition value of "MyPartition".
+   the currently logged in user, and a partition value of "myPartition".
 
    .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-online-with-car-schema.js
       :language: javascript
 
-.. _node-open-synced-realm-config:
-
+.. _node-return-after-timeout-with-background-sync:
 
 Return After Timeout with Background Sync
-`````````````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you don't need to sync all data before before returning, configure your SyncConfiguration
-to include ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` each with
-the same :js-sdk:`OpenRealmBehaviorConfiguration <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`.  
+If you don't need to sync all data before before returning the {+realm+}, configure the
+``newRealmFileBehavior`` and ``existingRealmFileBehavior`` properties of your
+SyncConfiguration to automatically open the realm after a timeout period elapses. You
+can use a single :js-sdk:`OpenRealmBehaviorConfiguration <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>`
+for both ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` 
+that contains the following property values:  
 
-Set the OpenRealmBehaviorConfiguration to have ``type: 'downloadBeforeOpen'``, 
-``timeOut: <time in milliseconds>`` and ``timeOutBehavior: 'openLocalRealm'``.
-These properties make ``Realm.open()`` return at the end of the ``timeOut`` period, and open a local {+realm+}. 
-Syncing between local data and the server continues in the background. For example: 
+- ``type``: "downloadBeforeOpen"
+- ``timeOut``: <time in milliseconds>
+- ``timeOutBehavior``: "openLocalRealm"
+
+These properties force the ``Realm.open()`` method to return an open {+realm+} after ``timeOut`` milliseconds, or when the {+realm+} has completely downloaded, whichever comes first. 
+If the {+realm+} doesn't finish downloading before the timeout, the initial realm sync continues in the background. For example: 
 
 .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-config.js
   :language: javascript
 
 This configuration is also useful if you're attempting to sync in an environment 
-where it's uncertain if the user has an Internet connection. The client attempts 
-to sync until the end of the the ``timeOut`` period, and then opens the local {+realm+},
-even if the it never connects to the server. 
+where it's uncertain if the user has an Internet connection.
 
 .. example::
   
   The following example shows opening a synced {+realm+} with a 
   ``Configuration`` object using a predefined ``Car`` :doc:`schema </sdk/node/examples/define-a-realm-object-model>`, 
-  the currently logged in user, a partition value of "MyPartition", and a 
+  the currently logged in user, a partition value of "myPartition", and a 
   :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`. The SyncConfiguration includes  
   ``existingRealmFileBehavior`` and ``newRealmFileBehavior`` set to allow the user 
   to work with the local {+realm+} if the device is doesn't fully sync within the ``timeOut``
@@ -89,48 +92,32 @@ even if the it never connects to the server.
   .. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-offline-with-car-schema.js
     :language: javascript
 
-.. warning:: 
+.. _node-open-immediately-with-background-sync:
 
-   If you are attempting to synchronize a {+realm+} while not connected to 
-   the Internet, you must pass ``Realm.open()`` a :js-sdk:`Configuration <Realm.html#~Configuration>`
-   object with ``newRealmFileBehavior`` and ``existingRealmFileBehavior``. If you 
-   don't include these properties, ``Realm.open()`` continues trying
-   to connect to the server indefinitely without opening. 
-   
-   Refer to the :ref:`Open a Synced Realm While Offline <node-open-a-synced-realm-while-offline>`
-   documentation for more information about connecting to your offline {+realm+}. 
+Open Immediately With Background Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _node-open-a-synced-realm-while-offline:
-
-Open a Synced Realm While Offline
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If a user's device is not connected to the Internet or you're not certain if it's 
-connected, you must use  a a :js-sdk:`OpenRealmBehaviorConfiguration
-<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` that includes ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` 
-properties. 
+When you want to connect to the {+realm+} immediately and sync data from the server 
+in the background, you must use  a :js-sdk:`OpenRealmBehaviorConfiguration
+<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` that includes the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` 
+properties. This configuration is useful if a user's device is not connected to the Internet or you're not certain if it's 
+connected. 
 
 Create a :js-sdk:`OpenRealmBehaviorConfiguration
-<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object and set its
-``type`` to ``"openImmediately"``. This configuration opens a local {+realm+} 
+<Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object and set the
+``type`` property to a value of "openImmediately". This configuration opens a local {+realm+} 
 immediately without attempting to sync with the server. The client continues  
-attempting to connect with the server in the background.
+attempting to connect with the server in the background. 
 
-.. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-sync-changes-in-the-background-create-OpenRealmBehaviorObject.js
-      :language: javascript
-
-Create a :js-sdk:`Configuration <Realm.html#~Configuration>` object, which must
+Then create a :js-sdk:`Configuration <Realm.html#~Configuration>` object, which must
 include the ``sync`` property defining a :js-sdk:`SyncConfiguration
 <Realm.App.Sync.html#~SyncConfiguration>` object. Set this
-``OpenRealmBehaviorConfiguration`` object as the value for
-the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` fields of the
+OpenRealmBehaviorConfiguration object as the value for
+the ``newRealmFileBehavior`` and ``existingRealmFileBehavior`` properties of the
 ``SyncConfiguration``. 
 
-.. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-sync-changes-in-the-background-create-config.js
+.. literalinclude:: /examples/generated/node/open-and-close-a-realm.codeblock.open-synced-realm-with-background-sync.js
       :language: javascript
-
-Finally,  call :js-sdk:`Realm.open() <Realm.html#.open>`
-to open the local {+realm+} and attempt syncing with the server in the background. 
 
 .. _node-close-a-realm:
 
@@ -138,14 +125,3 @@ Close a Realm
 -------------
 
 .. include:: /includes/js-close-a-realm.rst
-
-
-.. .. _node-local-realm-configuration:
-
-.. Local Realm Configuration
-.. -------------------------
-
-.. .. _node-provide-a-subset-of-classes-to-a-realm:
-
-.. Provide a Subset of Classes to a Realm
-.. ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Refactor content on the Open & Close a Realm page for Node SDK to follow the same formatting as the Open & Close a Realm page for React Native. These pages are the same exact content with different Refs. So the only thing was copy-pasting over the content, and changing the refs. 

For original work on the React Native page, see https://github.com/mongodb/docs-realm/pull/1420

### Jira

- https://jira.mongodb.org/browse/DOCSP-19134

### Staged Changes (Requires MongoDB Corp SSO)

- [Open & Close a Realm (Node)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19134/sdk/node/examples/open-and-close-a-realm/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
