### PR TITLE
(DOCSP-17188): Update OpenAPI spec with add template for creating new application

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -2494,13 +2494,12 @@ components:
         name:
           type: string
           description: Can only contain ASCII letters, numbers, underscores, and hyphens.
+          required: true
         template_id:
           type: string
           description: Name of :ref:`supported template app <template-apps>` to serve as base template.
         data_source: 
-            $ref: '#/components/schemas/DataSource'
-      required:
-        - name
+          $ref: '#/components/schemas/DataSource'
     DataSource: 
       type: object
       properties: 
@@ -2510,22 +2509,22 @@ components:
           example: mongodb-atlas
           enum: 
             - mongodb-atlas
+          required: true
         type: 
           type: string
           description: Should be `"mongodb-atlas"`.
           example: mongodb-atlas
           enum: 
             - mongodb-atlas
+          required: true
         config:
           type: object
           properties:
             clusterName: 
               type: string
-              description: Name of {+atlas-short+} cluster associated with the {+app+}. 
-      required:
-        - name
-        - type
-        - config
+              description: Name of {+atlas-short+} cluster associated with the {+app+}.
+              required: true
+          required: true
     Service:
       properties:
         _id: {type: string}

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -2494,12 +2494,13 @@ components:
         name:
           type: string
           description: Can only contain ASCII letters, numbers, underscores, and hyphens.
-          required: true
         template_id:
           type: string
           description: Name of :ref:`supported template app <template-apps>` to serve as base template.
         data_source: 
           $ref: '#/components/schemas/DataSource'
+      required:
+      - name
     DataSource: 
       type: object
       properties: 
@@ -2509,22 +2510,24 @@ components:
           example: mongodb-atlas
           enum: 
             - mongodb-atlas
-          required: true
         type: 
           type: string
           description: Should be `"mongodb-atlas"`.
           example: mongodb-atlas
           enum: 
             - mongodb-atlas
-          required: true
         config:
           type: object
           properties:
             clusterName: 
               type: string
               description: Name of {+atlas-short+} cluster associated with the {+app+}.
-              required: true
-          required: true
+          required:
+          - clusterName
+      required:
+      - name
+      - type
+      - config
     Service:
       properties:
         _id: {type: string}

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -2494,7 +2494,32 @@ components:
         name:
           type: string
           description: Can only contain ASCII letters, numbers, underscores, and hyphens.
-      required: [name]
+        template_id:
+          type: string
+          description: Name of :ref:`supported template app <template-apps>` to serve as base template.
+        data_source: 
+            $ref: '#/components/schemas/DataSource'
+      required:
+        - name
+    DataSource: 
+      type: object
+      properties: 
+        name: 
+          type: string
+          description: Should be `"mongodb-atlas"`.
+        type: 
+          type: string
+          description: Should be `"mongodb-atlas"`.
+        config:
+          type: object
+          properties:
+            clusterName: 
+              type: string
+              description: Name of {+atlas-short+} cluster associated with the {+app+}. 
+      required:
+        - name
+        - type
+        - config
     Service:
       properties:
         _id: {type: string}

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -2507,9 +2507,15 @@ components:
         name: 
           type: string
           description: Should be `"mongodb-atlas"`.
+          example: mongodb-atlas
+          enum: 
+            - mongodb-atlas
         type: 
           type: string
           description: Should be `"mongodb-atlas"`.
+          example: mongodb-atlas
+          enum: 
+            - mongodb-atlas
         config:
           type: object
           properties:


### PR DESCRIPTION
## Pull Request Info

Update the OpenAPI spec route for POST `/groups/{groupId}/apps` to include information about adding a template to app creation. 

Note that while updating the spec, a bug with our OpenAPI spec renderer was discovered in which the `data_source` field is marked as required when it's not, presumably because some of its own fields are required _iff_ the data_source is included. However there is no adverse effect of of always the user to always include the data_source field. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-17188

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm Administration API](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-17188/admin/api/v3/#post-/groups/%7Bgroupid%7D/apps)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
