### PR TITLE
(DOCSP-19359): Add required  flags to  Generated GraphQL Schema Array Type examples

### DIFF
--- a/source/graphql/custom-resolvers.txt
+++ b/source/graphql/custom-resolvers.txt
@@ -52,7 +52,7 @@ The resolvers all reference ``Sale`` documents, which have the following schema:
            year: String!
            month: String!
            saleTotal: Float!
-           notes: [String]
+           notes: [String!]
          }
    
    .. tab:: JSON Schema
@@ -336,7 +336,7 @@ The resolver uses the following configuration:
                   year: String!
                   month: String!
                   saleTotal: Float!
-                  notes: [String]
+                  notes: [String!]
                 }
           
           .. tab:: JSON Schema
@@ -427,8 +427,8 @@ adds the resolver to its parent type, ``Sale``:
      year: String!
      month: String!
      saleTotal: Float!
-     notes: [String]
-     customerSupportCases: [CustomerSupportCase]
+     notes: [String!]
+     customerSupportCases: [CustomerSupportCase!]
    }
    
    type CustomerSupportCase {
@@ -497,8 +497,8 @@ The resolver uses the following configuration:
                   year: String!
                   month: String!
                   saleTotal: Float!
-                  notes: [String]
-                  customerSupportCases: [CustomerSupportCase]
+                  notes: [String!]
+                  customerSupportCases: [CustomerSupportCase!]
                 }
 
    * - :guilabel:`Function`


### PR DESCRIPTION
## Pull Request Info

Add the required flag `!` to examples of generated GraphQL Array types to align with the work done in the ticket https://jira.mongodb.org/browse/REALMC-9030. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-19359

### Staged Changes (Requires MongoDB Corp SSO)

- [Define a Custom Resolver](https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19359/graphql/custom-resolvers/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
