### PR TITLE
(DOCSP-19347): Add note about escape characters to path name explanation

### DIFF
--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -337,18 +337,18 @@ whenever they log in and exposes the fields in the ``data`` object of the
 
        .. note:: Escaping periods in JWT keys
 
-        Use a backslash (``\``) to escape period (``.``) characters in JWT keys. 
-        Take this JSON object for example: 
+          Use a backslash (``\``) to escape period (``.``) characters in JWT keys. 
+          Take this JSON object for example: 
 
-        .. code-block:: json
+          .. code-block:: json
 
-          { "valid.json.key": {
-              "nested_key": "val"
+            { "valid.json.key": {
+                "nested_key": "val"
+              }
             }
-          }
 
-        You could represent the ``"nested_key"`` in the path name as
-        ``valid\.json\.key.nested_key``.
+          You could represent the ``"nested_key"`` in the path name as
+          ``valid\.json\.key.nested_key``.
 
    * - | :guilabel:`Field Name`
        | *field_name*

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -335,10 +335,20 @@ whenever they log in and exposes the fields in the ``data`` object of the
        an embedded object, use :manual:`dot notation
        </core/document/#dot-notation>`.
 
-       A backslash (``\``) can be used to escape period (``.``) characters in JWT keys. 
-       For example if a JWT contains the following metadata object: 
-       ``{ "valid.json.key": { "nested_key": "nested_value"}``, you could register the ``"nested_key"``
-       in the path as ``valid\.json\.key.nested_key``.
+       .. note:: Escaping periods in JWT keys
+
+        Use a backslash (``\``) to escape period (``.``) characters in JWT keys. 
+        Take this JSON object for example: 
+
+        .. code-block:: json
+
+          { "valid.json.key": {
+              "nested_key": "val"
+            }
+          }
+
+        You could represent the ``"nested_key"`` in the path name as
+        ``valid\.json\.key.nested_key``.
 
    * - | :guilabel:`Field Name`
        | *field_name*

--- a/source/authentication/custom-jwt.txt
+++ b/source/authentication/custom-jwt.txt
@@ -335,6 +335,11 @@ whenever they log in and exposes the fields in the ``data`` object of the
        an embedded object, use :manual:`dot notation
        </core/document/#dot-notation>`.
 
+       A backslash (``\``) can be used to escape period (``.``) characters in JWT keys. 
+       For example if a JWT contains the following metadata object: 
+       ``{ "valid.json.key": { "nested_key": "nested_value"}``, you could register the ``"nested_key"``
+       in the path as ``valid\.json\.key.nested_key``.
+
    * - | :guilabel:`Field Name`
        | *field_name*
 


### PR DESCRIPTION
## Pull Request Info

Add note about escape characters to metadata path name information. Updating documentation to reflect previously undocumented feature. 

Periods are supported as part of valid JSON keys, but also serve to semantically break down nested keys in this path. Using escape character `\` allows for using periods in paths for JWT metadata config. 
 
### Jira

- https://jira.mongodb.org/browse/DOCSP-19347

### Staged Changes (Requires MongoDB Corp SSO)

- [Custom JWT Authentication](https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19347/authentication/custom-jwt/#metadata-fields)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
