### PR TITLE
(DOCSP-19563): Add support for Retry Custom Confirmation Functions + Copy improvements to Manage Email Pass Users [Node/RN]

### DIFF
--- a/source/sdk/node/examples/manage-email-password-users.txt
+++ b/source/sdk/node/examples/manage-email-password-users.txt
@@ -57,41 +57,6 @@ New users must confirm that they own their email address before they can log in
 to your app unless the provider is configured to :ref:`automatically confirm new
 users <auth-automatically-confirm-users>`.
 
-.. _node-send-confirmation-email:
-
-Send a Confirmation Email
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If the provider is configured to :ref:`send a confirmation email
-<auth-send-a-confirmation-email>`, {+service+} automatically sends a
-confirmation email when a user registers. The email contains a link to the
-configured :guilabel:`Email Confirmation URL` with a token that is valid for 30
-minutes after the email is sent. If a user did not receive the initial email or
-didn't click the confirmation link in time, you can use the SDK to send a new
-confirmation email to the user.
-
-To send a new confirmation email to a user, pass their email address to
-:js-sdk:`EmailPasswordAuth.resendConfirmationEmail()
-<Realm.Auth.EmailPasswordAuth.html#resendConfirmationEmail>`.
-
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: javascript
-
-      .. code-block:: javascript
-
-         const email = "someone@example.com"; // The user's email address
-         await app.emailPasswordAuth.resendConfirmationEmail({ email });
-
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-
-         const email = "someone@example.com"; // The user's email address
-         await app.emailPasswordAuth.resendConfirmationEmail({ email });
-
 .. _node-complete-confirmation:
 
 Complete a User Confirmation
@@ -128,6 +93,76 @@ To confirm a registered user, pass a valid ``token`` and ``tokenId`` to
       .. code-block:: typescript
 
          await app.emailPasswordAuth.confirmUser({ token, tokenId });
+
+.. _node-email-password-retry-user-confirmation:
+
+Retry User Confirmation Methods
+-------------------------------
+
+The SDK provides methods to resend user confirmation emails or retry custom 
+confirmation methods.
+
+.. _node-resend-confirmation-email:
+
+Resend a Confirmation Email
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the provider is configured to :ref:`send a confirmation email
+<auth-send-a-confirmation-email>`, {+service+} automatically sends a
+confirmation email when a user registers. The email contains a link to the
+configured :guilabel:`Email Confirmation URL` with a token that is valid for 30
+minutes after the email is sent. If a user did not receive the initial email or
+didn't click the confirmation link in time, you can use the SDK to send a new
+confirmation email to the user.
+
+To send a new confirmation email to a user, pass their email address to
+:js-sdk:`EmailPasswordAuth.resendConfirmationEmail()
+<Realm.Auth.EmailPasswordAuth.html#resendConfirmationEmail>`.
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: javascript
+
+      .. code-block:: javascript
+
+         const email = "someone@example.com"; // The user's email address
+         await app.emailPasswordAuth.resendConfirmationEmail({ email });
+
+   .. tab::
+      :tabid: typescript
+
+      .. code-block:: typescript
+
+         const email = "someone@example.com"; // The user's email address
+         await app.emailPasswordAuth.resendConfirmationEmail({ email });
+
+.. _node-email-password-resend-confirmation-function:
+
+Retry a User Confirmation Function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To re-run your :ref:`custom confirmation function
+<auth-run-a-confirmation-function>`, call the ``retryCustomConfirmation()`` method
+with the user's email address:
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. code-block:: javascript
+         
+         const email = "someone@example.com"; // The user's email address
+         await app.emailPasswordAuth.retryCustomConfirmation({ email });
+   
+   .. tab::
+      :tabid: typescript
+      
+      .. code-block:: typescript
+         
+         const email = "someone@example.com"; // The user's email address
+         await app.emailPasswordAuth.retryCustomConfirmation({ email });
 
 .. _node-reset-password:
 

--- a/source/sdk/react-native/examples/manage-email-password-users.txt
+++ b/source/sdk/react-native/examples/manage-email-password-users.txt
@@ -57,41 +57,6 @@ New users must confirm that they own their email address before they can log in
 to your app unless the provider is configured to :ref:`automatically confirm new
 users <auth-automatically-confirm-users>`.
 
-.. _react-native-send-confirmation-email:
-
-Send a Confirmation Email
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If the provider is configured to :ref:`send a confirmation email
-<auth-send-a-confirmation-email>`, {+service+} automatically sends a
-confirmation email when a user registers. The email contains a link to the
-configured :guilabel:`Email Confirmation URL` with a token that is valid for 30
-minutes after the email is sent. If a user did not receive the initial email or
-didn't click the confirmation link in time, you can use the SDK to send a new
-confirmation email to the user.
-
-To send a new confirmation email to a user, pass their email address to
-:js-sdk:`EmailPasswordAuth.resendConfirmationEmail()
-<Realm.Auth.EmailPasswordAuth.html#resendConfirmationEmail>`.
-
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: javascript
-
-      .. code-block:: javascript
-
-         const email = "someone@example.com"; // The user's email address
-         await app.emailPasswordAuth.resendConfirmation({ email });
-
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-
-         const email = "someone@example.com"; // The user's email address
-         await app.emailPasswordAuth.resendConfirmation({ email });
-
 .. _react-native-complete-confirmation:
 
 Complete a User Confirmation
@@ -128,6 +93,77 @@ To confirm a registered user, pass a valid ``token`` and ``tokenId`` to
       .. code-block:: typescript
 
          await app.emailPasswordAuth.confirmUser({ token, tokenId });
+
+
+.. _react-native-email-password-retry-user-confirmation:
+
+Retry User Confirmation Methods
+-------------------------------
+
+The SDK provides methods to resend user confirmation emails or retry custom 
+confirmation methods.
+
+.. _react-native-resend-confirmation-email:
+
+Resend a Confirmation Email
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the provider is configured to :ref:`send a confirmation email
+<auth-send-a-confirmation-email>`, {+service+} automatically sends a
+confirmation email when a user registers. The email contains a link to the
+configured :guilabel:`Email Confirmation URL` with a token that is valid for 30
+minutes after the email is sent. If a user did not receive the initial email or
+didn't click the confirmation link in time, you can use the SDK to send a new
+confirmation email to the user.
+
+To send a new confirmation email to a user, pass their email address to
+:js-sdk:`EmailPasswordAuth.resendConfirmationEmail()
+<Realm.Auth.EmailPasswordAuth.html#resendConfirmationEmail>`.
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: javascript
+
+      .. code-block:: javascript
+
+         const email = "someone@example.com"; // The user's email address
+         await app.emailPasswordAuth.resendConfirmation({ email });
+
+   .. tab::
+      :tabid: typescript
+
+      .. code-block:: typescript
+
+         const email = "someone@example.com"; // The user's email address
+         await app.emailPasswordAuth.resendConfirmation({ email });
+
+.. _react-native-email-password-resend-confirmation-function:
+
+Retry a User Confirmation Function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To re-run your :ref:`custom confirmation function
+<auth-run-a-confirmation-function>`, call the ``retryCustomConfirmation()`` method
+with the user's email address:
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. code-block:: javascript
+         
+         const email = "someone@example.com"; // The user's email address
+         await app.emailPasswordAuth.retryCustomConfirmation({ email });
+   
+   .. tab::
+      :tabid: typescript
+      
+      .. code-block:: typescript
+         
+         const email = "someone@example.com"; // The user's email address
+         await app.emailPasswordAuth.retryCustomConfirmation({ email });
 
 .. _react-native-reset-password:
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-19563

### Staged Changes (Requires MongoDB Corp SSO)

- [Manage Email/Password Users - React Native SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19563-custom-confirm-fix-node-rn/sdk/react-native/examples/manage-email-password-users/)
- [Manage Email/Password Users - Node.js SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19563-custom-confirm-fix-node-rn/sdk/node/examples/manage-email-password-users/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
