### PR TITLE
(DOCSP-19661): Temporarily refactor CLI hosting docs

### DIFF
--- a/source/hosting/enable-hosting.txt
+++ b/source/hosting/enable-hosting.txt
@@ -1,3 +1,5 @@
+.. _enable-hosting:
+
 ==============
 Enable Hosting
 ==============
@@ -22,6 +24,9 @@ Select the tab below that corresponds to the method you want to use.
 
 Procedure
 ---------
+
+.. TODO(DOCSP-19662): when enable cli hosting functionality restored,
+.. remove the below content and replace with the currently commented out content.
 
 Enable hosting from the UI with the following procedure: 
 

--- a/source/hosting/enable-hosting.txt
+++ b/source/hosting/enable-hosting.txt
@@ -23,17 +23,21 @@ Select the tab below that corresponds to the method you want to use.
 Procedure
 ---------
 
-Select a tab below to see instructions on enabling static hosting for
-the corresponding method.
+Enable hosting from the UI with the following procedure: 
 
-.. tabs-realm-admin-interfaces::
+.. include:: /includes/steps/enable-hosting-realm-ui.rst
 
-   .. tab::
-      :tabid: ui
+.. Select a tab below to see instructions on enabling static hosting for
+.. the corresponding method.
+
+.. .. tabs-realm-admin-interfaces::
+
+..    .. tab::
+..       :tabid: ui
       
-      .. include:: /includes/steps/enable-hosting-realm-ui.rst
+..       .. include:: /includes/steps/enable-hosting-realm-ui.rst
 
-   .. tab::
-      :tabid: cli
+..    .. tab::
+..       :tabid: cli
       
-      .. include:: /includes/steps/enable-hosting-import-export.rst
+..       .. include:: /includes/steps/enable-hosting-import-export.rst

--- a/source/hosting/host-a-single-page-application.txt
+++ b/source/hosting/host-a-single-page-application.txt
@@ -46,4 +46,6 @@ Procedure
    .. tab::
       :tabid: cli
       
+      .. include:: /includes/enable-hosting-in-ui-note.rst
+      
       .. include:: /includes/steps/host-a-single-page-application-code-deploy.rst

--- a/source/hosting/upload-content-to-realm.txt
+++ b/source/hosting/upload-content-to-realm.txt
@@ -32,8 +32,10 @@ Procedure
    .. tab::
       :tabid: cli
       
-.. TODO(DOCSP-19662): remove note when enable cli hosting functionality restored
 
       .. include:: /includes/enable-hosting-in-ui-note.rst
       
       .. include:: /includes/steps/upload-content-to-realm-import-export.rst
+
+.. TODO(DOCSP-19662): when enable cli hosting functionality restored, 
+.. remove above note `.. include:: /includes/enable-hosting-in-ui-note.rst`

--- a/source/hosting/upload-content-to-realm.txt
+++ b/source/hosting/upload-content-to-realm.txt
@@ -32,4 +32,8 @@ Procedure
    .. tab::
       :tabid: cli
       
+.. TODO(DOCSP-19662): remove note when enable cli hosting functionality restored
+
+      .. include:: /includes/enable-hosting-in-ui-note.rst
+      
       .. include:: /includes/steps/upload-content-to-realm-import-export.rst

--- a/source/includes/enable-hosting-in-ui-note.rst
+++ b/source/includes/enable-hosting-in-ui-note.rst
@@ -1,0 +1,6 @@
+.. TODO(DOCSP-19662): delete file when enable cli hosting functionality restored
+
+.. note:: Enable hosting in the UI
+  
+  Before you start using the {+cli+} with Realm Static Hosting, you must 
+  :ref:`enable hosting in the {+ui+} <enable-hosting>`.    

--- a/source/includes/steps-host-a-single-page-application-code-deploy.yaml
+++ b/source/includes/steps-host-a-single-page-application-code-deploy.yaml
@@ -53,5 +53,5 @@ content: |
   
   .. code-block:: bash
      
-     realm-cli push --remote="<Your App ID> --include-hosting"
+     realm-cli push --remote="<Your App ID>" --include-hosting
 ...

--- a/source/includes/steps-use-a-custom-domain-name-import-export.yaml
+++ b/source/includes/steps-use-a-custom-domain-name-import-export.yaml
@@ -64,7 +64,7 @@ content: |
   
   .. code-block:: bash
      
-     realm-cli push --remote="<Your App ID>"
+     realm-cli push --remote="<Your App ID>" --include-hosting
 
 ---
 title: Add a Validation CNAME Record


### PR DESCRIPTION
## Pull Request Info

Refactor the docs about static hosting to take into account the fact that the feature for enabling static hosting from the CLI is not working, and won't be working for another couple of months, per https://jira.mongodb.org/browse/REALMC-10454.  

Removed procedure for enabling hosting with CLI, and for other CLI-related pages, added note about need to enable hosting with the UI first.

All stuff that should be removed was prepended with a comment `TODO(DOCSP-19662):`. [DOCSP-19662](https://jira.mongodb.org/browse/DOCSP-19662) is the ticket to revert the content to its previous state. 

Also added a few slight tweaks to observed errors in CLI examples. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-19661

### Staged Changes (Requires MongoDB Corp SSO)

- [Enable Hosting](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19661/hosting/enable-hosting/)
- [Host a Single Page Application](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19661/hosting/host-a-single-page-application/)
- [Upload Content to Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19661/hosting/upload-content-to-realm/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
