### PR TITLE
Fix broken link to client reset page

### DIFF
--- a/source/sync/get-started.txt
+++ b/source/sync/get-started.txt
@@ -179,7 +179,7 @@ Avoid destructive changes:
 
 Define a client reset handler:
   To recover from a serious error conditions where the client and server
-  histories diverge, you should define a :ref`client reset <client-resets>`
+  histories diverge, you should define a :ref:`client reset <client-resets>`
   handler when you open each synced realm with an SDK.
 
 Define a client maximum offline time:


### PR DESCRIPTION
## Pull Request Info

### Jira

- Just an error I noticed browsing the docs.

### Staged Changes (Requires MongoDB Corp SSO)

- [Get Started with Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/client-reset-link-fix/sync/get-started/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
