### PR TITLE
(DOCSP-15666): Update documentation for utils.jwt.decode() method

### DIFF
--- a/source/functions/utilities.txt
+++ b/source/functions/utilities.txt
@@ -239,6 +239,9 @@ The ``utils.jwt`` package provides methods for working with
         - Array of Strings
         
         - Optional. Array of accepted signing methods. For example, ``["PS256", "HS256"]``.
+          This argument should be included to prevent against 
+          `known JWT security vulnerabilities 
+          <https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/#RSA-or-HMAC->`_.
    
    :returns:
        If ``returnHeader`` is ``false``, returns the decoded EJSON
@@ -280,7 +283,7 @@ The ``utils.jwt`` package provides methods for working with
          
          exports = function(jwtString) {
            const key = "SuperSecret";
-           return utils.jwt.decode(jwtString, key);
+           return utils.jwt.decode(jwtString, key, false, ["HS512"]);
          }
       
       The function returns the following EJSON representation of the JWT

--- a/source/functions/utilities.txt
+++ b/source/functions/utilities.txt
@@ -235,6 +235,10 @@ The ``utils.jwt`` package provides methods for working with
         - If ``true``, return the JWT's `JOSE header
           <https://tools.ietf.org/html/rfc7515#section-4>`__ in addition
           to the decoded payload.
+      * - ``acceptedSigningMethods``
+        - Array of Strings
+        
+        - Optional. Array of accepted signing methods. For example, ``["PS256", "HS256"]``.
    
    :returns:
        If ``returnHeader`` is ``false``, returns the decoded EJSON

--- a/source/functions/utilities.txt
+++ b/source/functions/utilities.txt
@@ -236,7 +236,7 @@ The ``utils.jwt`` package provides methods for working with
           <https://tools.ietf.org/html/rfc7515#section-4>`__ in addition
           to the decoded payload.
       * - ``acceptedSigningMethods``
-        - Array of Strings
+        - String[]
         
         - Optional. Array of accepted signing methods. For example, ``["PS256", "HS256"]``.
           This argument should be included to prevent against 


### PR DESCRIPTION
## Pull Request Info

Update the information for the `utils.jwt.decode()` method used by Realm functions. Added argument for `acceptedSigningMethods` along w info about it's usage. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-15666
### Staged Changes (Requires MongoDB Corp SSO)

- [Utility Packages, `utils.jwt.decode()` section](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-15666/functions/utilities/#mongodb-method-utils.jwt.decode)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
