### PR TITLE
(DOCSP-19805): Change Array documentation to exclude required values with `!`

### DIFF
--- a/source/graphql/types-and-resolvers.txt
+++ b/source/graphql/types-and-resolvers.txt
@@ -92,7 +92,7 @@ is specified.
      rated: String
      runtime: Int
      director: String
-     cast: [String!]
+     cast: [String]
    }
 
 .. _graphql-field-mapping:
@@ -351,7 +351,7 @@ Comparison operator fields have the following form:
        | ``ObjectId``
        | ``DateTime``
        | ``Array``
-     - ``[<Field Type>!]``
+     - ``[<Field Type>]``
      - Finds documents where the field is equal to any value in the specified
        array. If the field is an ``Array``, this finds all documents where
        any value in the field array is also included in the specified array.
@@ -376,7 +376,7 @@ Comparison operator fields have the following form:
        | ``ObjectId``
        | ``DateTime``
        | ``Array``
-     - ``[<Field Type>!]``
+     - ``[<Field Type>]``
      - Finds documents where the field is not equal to any value in the
        specified array. If the field is an ``Array``, this finds all documents
        where any value in the field array is also in the specified


### PR DESCRIPTION
## Pull Request Info

This pull request updates the GraphQL documentation to make it so that arrays are not required to have values in them. 

It should be noted that this is actually contrary to the GraphQL specification. However this change updates the documentation to reflect the current state of our GraphQL implementation. For more information on the subject, see https://jira.mongodb.org/browse/REALMC-9030. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-19805

### Staged Changes (Requires MongoDB Corp SSO)

- [GraphQL Types, Resolvers, and Operators](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19805/graphql/types-and-resolvers/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
