### PR TITLE
(DOCSP-19833): [iOS] Add static framework install instructions

### DIFF
--- a/source/includes/steps-install-swift-static-framework.yaml
+++ b/source/includes/steps-install-swift-static-framework.yaml
@@ -1,0 +1,25 @@
+title: Download and Extract the Framework
+ref: download-and-extract-the-framework
+content: |
+
+   Download the `latest release of Realm 
+   <https://github.com/realm/realm-cocoa/releases>`__ and extract the zip.
+
+---
+title: Copy Framework(s) Into Your Project
+ref: copy-frameworks
+content: |
+
+   Drag ``Realm.xcframework`` and ``RealmSwift.xcframework`` (if using) 
+   to the File Navigator of your Xcode project. Select the 
+   :guilabel:`Copy items if needed` checkbox and press :guilabel:`Finish`.
+
+---
+title: Link Binaries
+ref: link-binaries
+content: |
+
+   Select your project in the Xcode File Navigator. Select your app’s 
+   target and go to the :guilabel:`Build Phases` tab. Under 
+   :guilabel:`Link Binary with Libraries`, click :guilabel:`+` and add 
+   ``libc++.tbd`` and ``libz.tbd``.

--- a/source/sdk/ios/install.txt
+++ b/source/sdk/ios/install.txt
@@ -63,6 +63,24 @@ You can use ``SwiftPM``, ``CocoaPods``, or ``Carthage`` to add the
 
       .. include:: /includes/steps/install-carthage.rst
 
+   .. tab:: Static Framework
+      :tabid: static-framework
+
+      Installing the Realm Swift SDK as a static framework is only available
+      for iOS targets.
+
+      .. include:: /includes/steps/install-swift-static-framework.rst
+       
+      .. tip::
+      
+         If using the Realm Objective-C API within a Swift project, we 
+         recommend you include both Realm Swift and Realm Objective-C in your 
+         project. Within your Swift files, you can access the Swift API and 
+         all required wrappers. Using the RealmSwift API in mixed 
+         Swift/Objective-C projects is possible because the vast majority of 
+         RealmSwift types are directly aliased from their Objective-C 
+         counterparts.
+
 Import Realm
 ------------
 


### PR DESCRIPTION
## Pull Request Info

This ticket ports over the Static Framework install instructions from the legacy Realm docs. I manually verified these instructions in a new Xcode Swift project and they work as written.

### Jira

- https://jira.mongodb.org/browse/DOCSP-19833

### Staged Changes (Requires MongoDB Corp SSO)

- [Install Realm](https://docs-mongodbcom-staging.corp.mongodb.com/52907b97/8682f5b/realm/docsworker-xlarge/master/sdk/ios/install/#installation): New tab: **Static Framework**

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
