### PR TITLE
Add info on bundling a synced realm; add new code snippet; replace deprecated GetSession()

### DIFF
--- a/examples/dotnet/Examples/BundleARealmExamples.cs
+++ b/examples/dotnet/Examples/BundleARealmExamples.cs
@@ -35,18 +35,30 @@ namespace Examples
         [Test]
         public async Task TestWriteCopySynced()
         {
-            var app = App.Create(Config.appid);
-            var user = app.CurrentUser;
+            var appConfig = new AppConfiguration(Config.appid);
+            var app = App.Create(appConfig);
+            var user = app.LogInAsync(Credentials.Anonymous()).Result;
 
             // :code-block-start: copy_a_synced_realm
+
             // open an existing realm
-            var realm = await Realm.GetInstanceAsync();
+            // :uncomment-start:
+            // var existingConfig = new SyncConfiguration("myPartition", user);
+            // :uncomment-end:
+            // :hide-start:
+            var existingConfig = new SyncConfiguration("myPartition", user)
+            {
+                Schema = new[] { typeof(Examples.Models.User) }
+            };
+            // :hide-end:
+            var realm = await Realm.GetInstanceAsync(existingConfig);
 
             // Create a RealmConfiguration for the *copy*
-            var config = new SyncConfiguration("myPart", user, "bundled.realm");
+            // Be sure the partition name matches the original
+            var bundledConfig = new SyncConfiguration("myPartition", user, "bundled.realm");
 
             // Make sure the file doesn't already exist
-            Realm.DeleteRealm(config);
+            Realm.DeleteRealm(bundledConfig);
 
             // IMPORTANT: When copying a Synced realm, you must ensure
             // that there are no pending Sync operations. You do this
@@ -56,10 +68,10 @@ namespace Examples
             await session.WaitForDownloadAsync();
 
             // Copy the realm
-            realm.WriteCopy(config);
+            realm.WriteCopy(bundledConfig);
 
             // Want to know where the copy is?
-            var locationOfCopy = config.DatabasePath;
+            var locationOfCopy = existingConfig.DatabasePath;
             // :code-block-end:
         }
 

--- a/examples/dotnet/Examples/BundleARealmExamples.cs
+++ b/examples/dotnet/Examples/BundleARealmExamples.cs
@@ -2,8 +2,10 @@
 using System.IO;
 using System.Reflection;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Realms;
+using Realms.Sync;
 
 namespace Examples
 {
@@ -21,6 +23,37 @@ namespace Examples
 
             // Make sure the file doesn't already exist
             Realm.DeleteRealm(config);
+
+            // Copy the realm
+            realm.WriteCopy(config);
+
+            // Want to know where the copy is?
+            var locationOfCopy = config.DatabasePath;
+            // :code-block-end:
+        }
+
+        [Test]
+        public async Task TestWriteCopySynced()
+        {
+            var app = App.Create(Config.appid);
+            var user = app.CurrentUser;
+
+            // :code-block-start: copy_a_synced_realm
+            // open an existing realm
+            var realm = await Realm.GetInstanceAsync();
+
+            // Create a RealmConfiguration for the *copy*
+            var config = new SyncConfiguration("myPart", user, "bundled.realm");
+
+            // Make sure the file doesn't already exist
+            Realm.DeleteRealm(config);
+
+            // IMPORTANT: When copying a Synced realm, you must ensure
+            // that there are no pending Sync operations. You do this
+            // by calling WaitForUploadAsync() and WaitForDownloadAsync():
+            var session = realm.SyncSession;
+            await session.WaitForUploadAsync();
+            await session.WaitForDownloadAsync();
 
             // Copy the realm
             realm.WriteCopy(config);

--- a/examples/dotnet/Examples/ClientResetExamples.cs
+++ b/examples/dotnet/Examples/ClientResetExamples.cs
@@ -67,7 +67,7 @@ namespace Examples
                 }
             };
             // :code-block-end:
-            TestingExtensions.SimulateError(realm.GetSession(),
+            TestingExtensions.SimulateError(realm.SyncSession,
                 ErrorCode.DivergingHistories, "diverging histories!", false);
         }
     }

--- a/examples/dotnet/Examples/DataSyncExamples.cs
+++ b/examples/dotnet/Examples/DataSyncExamples.cs
@@ -10,7 +10,7 @@ namespace Examples
         public void TestsCustomSetter()
         {
             // :code-block-start: pause-synced-realm
-            var session = realm.GetSession();
+            var session = realm.SyncSession;
             session.Stop();
             //later...
             session.Start();

--- a/examples/dotnet/Examples/ErrorHandler.cs
+++ b/examples/dotnet/Examples/ErrorHandler.cs
@@ -75,7 +75,7 @@ namespace Examples
                 }
             };
             // :code-block-end:
-            TestingExtensions.SimulateError(realm.GetSession(),
+            TestingExtensions.SimulateError(realm.SyncSession,
             ErrorCode.PermissionDenied, "No permission to work with the Realm", false);
 
             // Close the Realm before doing the reset as it'll need

--- a/examples/dotnet/Examples/ProgressNotifications.cs
+++ b/examples/dotnet/Examples/ProgressNotifications.cs
@@ -37,7 +37,7 @@ namespace Examples
 
                 // :uncomment-end:
                 var realm = Realm.GetInstance(config);
-                await realm.GetSession().WaitForDownloadAsync();
+                await realm.SyncSession.WaitForDownloadAsync();
                 // :code-block-end:
                 realm.Dispose();
             }
@@ -59,7 +59,7 @@ namespace Examples
             config = new SyncConfiguration("myPartition", user);
             var realm = Realm.GetInstance(config);
             // :code-block-start: upload-download-progress-notification
-            var session = realm.GetSession();
+            var session = realm.SyncSession;
             var token = session.GetProgressObservable(ProgressDirection.Upload,
                 ProgressMode.ReportIndefinitely)
                 .Subscribe(progress =>

--- a/source/examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_synced_realm.cs
+++ b/source/examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_synced_realm.cs
@@ -1,0 +1,21 @@
+// open an existing realm
+var realm = await Realm.GetInstanceAsync();
+
+// Create a RealmConfiguration for the *copy*
+var config = new SyncConfiguration("myPart", user, "bundled.realm");
+
+// Make sure the file doesn't already exist
+Realm.DeleteRealm(config);
+
+// IMPORTANT: When copying a Synced realm, you must ensure
+// that there are no pending Sync operations. You do this
+// by calling WaitForUploadAsync() and WaitForDownloadAsync():
+var session = realm.SyncSession;
+await session.WaitForUploadAsync();
+await session.WaitForDownloadAsync();
+
+// Copy the realm
+realm.WriteCopy(config);
+
+// Want to know where the copy is?
+var locationOfCopy = config.DatabasePath;

--- a/source/examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_synced_realm.cs
+++ b/source/examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_synced_realm.cs
@@ -1,11 +1,14 @@
+
 // open an existing realm
-var realm = await Realm.GetInstanceAsync();
+var existingConfig = new SyncConfiguration("myPartition", user);
+var realm = await Realm.GetInstanceAsync(existingConfig);
 
 // Create a RealmConfiguration for the *copy*
-var config = new SyncConfiguration("myPart", user, "bundled.realm");
+// Be sure the partition name matches the original
+var bundledConfig = new SyncConfiguration("myPartition", user, "bundled.realm");
 
 // Make sure the file doesn't already exist
-Realm.DeleteRealm(config);
+Realm.DeleteRealm(bundledConfig);
 
 // IMPORTANT: When copying a Synced realm, you must ensure
 // that there are no pending Sync operations. You do this
@@ -15,7 +18,7 @@ await session.WaitForUploadAsync();
 await session.WaitForDownloadAsync();
 
 // Copy the realm
-realm.WriteCopy(config);
+realm.WriteCopy(bundledConfig);
 
 // Want to know where the copy is?
-var locationOfCopy = config.DatabasePath;
+var locationOfCopy = existingConfig.DatabasePath;

--- a/source/examples/generated/dotnet/DataSyncExamples.codeblock.pause-synced-realm.cs
+++ b/source/examples/generated/dotnet/DataSyncExamples.codeblock.pause-synced-realm.cs
@@ -1,4 +1,4 @@
-var session = realm.GetSession();
+var session = realm.SyncSession;
 session.Stop();
 //later...
 session.Start();

--- a/source/examples/generated/dotnet/ProgressNotifications.codeblock.upload-download-progress-notification.cs
+++ b/source/examples/generated/dotnet/ProgressNotifications.codeblock.upload-download-progress-notification.cs
@@ -1,4 +1,4 @@
-var session = realm.GetSession();
+var session = realm.SyncSession;
 var token = session.GetProgressObservable(ProgressDirection.Upload,
     ProgressMode.ReportIndefinitely)
     .Subscribe(progress =>

--- a/source/examples/generated/dotnet/ProgressNotifications.codeblock.wait-for-changes-to-download-async-progress-notification.cs
+++ b/source/examples/generated/dotnet/ProgressNotifications.codeblock.wait-for-changes-to-download-async-progress-notification.cs
@@ -1,4 +1,4 @@
 using Realms.Sync;
 
 var realm = Realm.GetInstance(config);
-await realm.GetSession().WaitForDownloadAsync();
+await realm.SyncSession.WaitForDownloadAsync();

--- a/source/sdk/dotnet/advanced-guides/bundle-a-realm.txt
+++ b/source/sdk/dotnet/advanced-guides/bundle-a-realm.txt
@@ -109,7 +109,7 @@ add code to use it. The code you add depends on the type of app:
       you can do this during start-up of the app; note that it will only run when no 
       {+realm+} file is found at the specified location.
 
-      .. literalinclude:: /examples/generated/dotnet/WriteCopy.codeblock.extract_and_copy_realm.cs
+      .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.codeblock.extract_and_copy_realm.cs
          :language: csharp
 
    .. tab:: Unity

--- a/source/sdk/dotnet/advanced-guides/bundle-a-realm.txt
+++ b/source/sdk/dotnet/advanced-guides/bundle-a-realm.txt
@@ -46,19 +46,19 @@ Copy a Realm File
       and 
       :dotnet-sdk:`WaitForDownloadAsync <reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForDownloadAsync>`
 
-.. tabs::
+   .. tabs::
 
-   .. tab:: Local Realm
-      :tabid: copy_local
+      .. tab:: Local Realm
+         :tabid: copy_local
 
-      .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_realm.cs
-         :language: csharp
+         .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_realm.cs
+            :language: csharp
 
-   .. tab:: Synced Realm
-      :tabid: copy_sync
+      .. tab:: Synced Realm
+         :tabid: copy_sync
 
-      .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_synced_realm.cs
-         :language: csharp
+         .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_synced_realm.cs
+            :language: csharp
 
 Include the Realm File in Your Project
 --------------------------------------

--- a/source/sdk/dotnet/advanced-guides/bundle-a-realm.txt
+++ b/source/sdk/dotnet/advanced-guides/bundle-a-realm.txt
@@ -42,23 +42,23 @@ Copy a Realm File
 
       When copying a Synced {+realm+}, you must ensure that there are no pending 
       sync processes. You do this by calling 
-      :dotnet-sdk:`WaitForUploadAsync <reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForDownloadAsync>`
+      :dotnet-sdk:`WaitForUploadAsync <reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForUploadAsync>`
       and 
-      :dotnet-sdk:`WaitForDownloadAsync <reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForUploadAsync>`
+      :dotnet-sdk:`WaitForDownloadAsync <reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForDownloadAsync>`
 
-   .. tabs::
+.. tabs::
 
-      .. tab:: Local Realm
-         :tabid: copy_local
+   .. tab:: Local Realm
+      :tabid: copy_local
 
-         .. literalinclude:: /examples/generated/dotnet/WriteCopy.codeblock.copy_a_realm.cs
-            :language: csharp
+      .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_realm.cs
+         :language: csharp
 
-      .. tab:: Synced Realm
-         :tabid: copy_sync
+   .. tab:: Synced Realm
+      :tabid: copy_sync
 
-         .. literalinclude:: /examples/generated/dotnet/WriteCopy.codeblock.copy_a_synced_realm.cs
-            :language: csharp
+      .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_synced_realm.cs
+         :language: csharp
 
 Include the Realm File in Your Project
 --------------------------------------

--- a/source/sdk/dotnet/advanced-guides/bundle-a-realm.txt
+++ b/source/sdk/dotnet/advanced-guides/bundle-a-realm.txt
@@ -23,13 +23,7 @@ to users on the initial launch of the app. To do this, you:
 
 In your production app (the one that will use this bundled {+realm+} when first 
 loading), you add a few lines of code to extract the {+realm+} and save it in the 
-app data. The following sections provide more information on these steps.
-
-.. important:: Synced Realms Are Not Supported
-
-   For now, bundling a synced {+realm+} is not supported. If you are using Sync, 
-   the local database will be synced when it is initialized.
-   
+app data. The following sections provide more information on these steps.   
 
 .. _copy_a_realm_file:
 
@@ -42,11 +36,29 @@ Copy a Realm File
 #. Use the 
    :dotnet-sdk:`WriteCopy() <reference/Realms.Realm.html#Realms_Realm_WriteCopy_Realms_RealmConfigurationBase_>` 
    method to make a copy of the {+realm+} to a new location and/or name. The 
-   following code demonstrates this:
+   following code demonstrates this. 
 
-   .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.codeblock.copy_a_realm.cs
-      :language: csharp
+   .. important:: Copying Synced Realms
 
+      When copying a Synced {+realm+}, you must ensure that there are no pending 
+      sync processes. You do this by calling 
+      :dotnet-sdk:`WaitForUploadAsync <reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForDownloadAsync>`
+      and 
+      :dotnet-sdk:`WaitForDownloadAsync <reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForUploadAsync>`
+
+   .. tabs::
+
+      .. tab:: Local Realm
+         :tabid: copy_local
+
+         .. literalinclude:: /examples/generated/dotnet/WriteCopy.codeblock.copy_a_realm.cs
+            :language: csharp
+
+      .. tab:: Synced Realm
+         :tabid: copy_sync
+
+         .. literalinclude:: /examples/generated/dotnet/WriteCopy.codeblock.copy_a_synced_realm.cs
+            :language: csharp
 
 Include the Realm File in Your Project
 --------------------------------------
@@ -97,7 +109,7 @@ add code to use it. The code you add depends on the type of app:
       you can do this during start-up of the app; note that it will only run when no 
       {+realm+} file is found at the specified location.
 
-      .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.codeblock.extract_and_copy_realm.cs
+      .. literalinclude:: /examples/generated/dotnet/WriteCopy.codeblock.extract_and_copy_realm.cs
          :language: csharp
 
    .. tab:: Unity

--- a/source/sdk/dotnet/examples/sync-changes-between-devices.txt
+++ b/source/sdk/dotnet/examples/sync-changes-between-devices.txt
@@ -101,11 +101,13 @@ You can check on the status of your current changes by :ref:`waiting for changes
 
 Wait for Changes to be Uploaded or Downloaded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-To asynchronously wait for your changes to be completed, get the sync session by calling `Realms.Sync.GetSession()
-<https://docs.mongodb.com/realm-sdks/dotnet/latest/reference/Realms.Sync.RealmSyncExtensions.html#Realms_Sync_RealmSyncExtensions_GetSession_Realms_Realm_>`_.
-Then call `session.WaitForUploadAsync()
-<https://docs.mongodb.com/realm-sdks/dotnet/10.0.0/reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForUploadAsync>`_  or `session.WaitForDownloadAsync()
-<https://docs.mongodb.com/realm-sdks/dotnet/10.0.0/reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForDownloadAsync>`_.
+To asynchronously wait for your changes to be completed, get the sync session 
+by calling :dotnet-sdk:`Realms.Sync.GetSession()
+<reference/Realms.Sync.RealmSyncExtensions.html#Realms_Sync_RealmSyncExtensions_GetSession_Realms_Realm_>`.
+Then call :dotnet-sdk:`session.WaitForUploadAsync()
+<reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForUploadAsync>` or 
+:dotnet-sdk:`session.WaitForDownloadAsync()
+<reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForDownloadAsync>`.
 
 .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.codeblock.wait-for-changes-to-download-async-progress-notification.cs
    :language: csharp

--- a/source/sdk/dotnet/examples/sync-changes-between-devices.txt
+++ b/source/sdk/dotnet/examples/sync-changes-between-devices.txt
@@ -102,12 +102,13 @@ You can check on the status of your current changes by :ref:`waiting for changes
 Wait for Changes to be Uploaded or Downloaded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 To asynchronously wait for your changes to be completed, get the sync session 
-by calling :dotnet-sdk:`Realms.Sync.GetSession()
-<reference/Realms.Sync.RealmSyncExtensions.html#Realms_Sync_RealmSyncExtensions_GetSession_Realms_Realm_>`.
-Then call :dotnet-sdk:`session.WaitForUploadAsync()
+from the :dotnet-sdk:`Realms.Sync.SyncSession
+<reference/Realms.Realm.html#Realms_Realm_SyncSession>`
+property, and then call the :dotnet-sdk:`session.WaitForUploadAsync()
 <reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForUploadAsync>` or 
 :dotnet-sdk:`session.WaitForDownloadAsync()
-<reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForDownloadAsync>`.
+<reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForDownloadAsync>` 
+methods.
 
 .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.codeblock.wait-for-changes-to-download-async-progress-notification.cs
    :language: csharp
@@ -116,8 +117,12 @@ Then call :dotnet-sdk:`session.WaitForUploadAsync()
 
 Display a Progress Bar
 ~~~~~~~~~~~~~~~~~~~~~~
-You can use progress notifications to display a progress bar. First, get the sync session by calling `Realms.Sync.GetSession() <https://docs.mongodb.com/realm-sdks/dotnet/latest/reference/Realms.Sync.RealmSyncExtensions.html#Realms_Sync_RealmSyncExtensions_GetSession_Realms_Realm_>`_. Then, add a progress
-notification using the `session.GetProgressObservable() <https://docs.mongodb.com/realm-sdks/dotnet/latest/reference/Realms.Sync.Session.html#Realms_Sync_Session_GetProgressObservable_Realms_Sync_ProgressDirection_Realms_Sync_ProgressMode_>`_ method.
+You can use progress notifications to display a progress bar. First, get the 
+sync session from the :dotnet-sdk:`Realms.Sync.SyncSession 
+<reference/Realms.Realm.html#Realms_Realm_SyncSession>` property, then add a 
+progress notification by calling the 
+:dotnet-sdk:`session.GetProgressObservable() <reference/Realms.Sync.Session.html#Realms_Sync_Session_GetProgressObservable_Realms_Sync_ProgressDirection_Realms_Sync_ProgressMode_>` 
+method.
 
 The ``session.GetProgressObservable`` method takes in the following two parameters:
 


### PR DESCRIPTION
## Pull Request Info

### Jira
- [Bundle Synced Realm](https://jira.mongodb.org/browse/DOCSP-16502)
- [Replace GetSession()](https://jira.mongodb.org/browse/DOCSP-19890)


- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/bundledsyncrealm/sdk/dotnet/advanced-guides/bundle-a-realm/
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/bundledsyncrealm/sdk/dotnet/examples/sync-changes-between-devices