### PR TITLE
(DOCSP-19366): Bump minimum required Xcode version for Swift SDK to 12.4

### DIFF
--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -27,7 +27,7 @@ Prerequisites
 Before getting started, ensure your development environment
 meets the following prerequisites:
 
-- `Xcode <https://developer.apple.com/xcode/>`__ version 12.2 or higher.
+- `Xcode <https://developer.apple.com/xcode/>`__ version 12.4 or higher.
 - Target of iOS 9.0 or higher, macOS 10.9 or higher, tvOS 9.0 or higher, or watchOS 2.0 or higher.
 - If using Swift Package Manager, target of iOS 11+ or macOS 10.10+ is required.
 

--- a/source/sdk/swift/swiftui.txt
+++ b/source/sdk/swift/swiftui.txt
@@ -16,7 +16,7 @@ Use Realm Database with SwiftUI
 Prerequisites
 -------------
 
-- Have Xcode 12.2 or later (minimum Swift version 5.3.1).
+- Have Xcode 12.4 or later (minimum Swift version 5.3.1).
 - Create a new Xcode project using the SwiftUI "App" template with a minimum iOS target of 15.0.
 - :ref:`Install the Swift SDK. <ios-install>` This SwiftUI app requires a minimum
   SDK version of 10.19.0.

--- a/source/tutorial/ios-swift.txt
+++ b/source/tutorial/ios-swift.txt
@@ -46,7 +46,7 @@ Part 1: Set up the Mobile App
 
 .. important:: Prerequisites
 
-   -  `Xcode <https://developer.apple.com/xcode/>`__ version 12.2 or higher, which requires macOS 10.15.4 or higher.
+   -  `Xcode <https://developer.apple.com/xcode/>`__ version 12.4 or higher, which requires macOS 10.15.4 or higher.
    - Target of iOS 13.0.
 
 .. include:: /includes/steps/tutorial-ios-swift-local.rst


### PR DESCRIPTION
## Pull Request Info

Note: the upstream PR referenced in this Jira ticket has been merged, but the changes won't apply until the next Swift SDK release, so don't merge until the next Cocoa release.

### Jira

- https://jira.mongodb.org/browse/DOCSP-19366

### Staged Changes (Requires MongoDB Corp SSO)

- [Install Realm for iOS](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19366/sdk/ios/install/)
- [Quick Start with SwiftUI](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19366/sdk/ios/swiftui/)
- [iOS Swift Tutorial](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19366/tutorial/ios-swift/#part-1--set-up-the-mobile-app)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
