### PR TITLE
(DOCS-14173): Update import Realm app documentation with secrets

### DIFF
--- a/source/includes/note-secrets-not-exported.rst
+++ b/source/includes/note-secrets-not-exported.rst
@@ -4,5 +4,4 @@
    :ref:`secrets <app-secret>`. 
 
    To import secrets from an exported {+app+}, refer to the documentation on 
-   :ref:`migrating secrets from an exported {+app+}
-   <migrate-secrets-to-imported-realm-app>`.
+   :ref:`importing {+app+}s <import-realm-app>`.

--- a/source/includes/note-secrets-not-exported.rst
+++ b/source/includes/note-secrets-not-exported.rst
@@ -1,0 +1,8 @@
+.. note:: Secrets Not Exported
+
+   When you export your {+app+}, the export does not include the 
+   :ref:`secrets <app-secret>`. 
+
+   To import secrets from an exported {+app+}, refer to the documentation on 
+   :ref:`migrating secrets from an exported {+app+}
+   <migrate-secrets-to-imported-realm-app>`.

--- a/source/includes/steps-import-cli.yaml
+++ b/source/includes/steps-import-cli.yaml
@@ -1,0 +1,101 @@
+title: Log In to MongoDB Cloud
+ref: export-app-cli-log-in-to-mongodb-cloud
+content: |
+  To configure your app with {+cli-bin+}, you must log in to MongoDB Cloud using
+  an :atlas:`API key </configure-api-access/#programmatic-api-keys>` scoped to the organization or
+  project that contains the app.
+
+  .. code-block:: bash
+
+     realm-cli login --api-key="<MongoDB Cloud Public API Key>" --private-api-key="<MongoDB Cloud Private API Key>"
+---
+title: Pull the Latest Version of Your Exporting App
+ref: export-app-cli-pull-the-latest-version-of-your-app
+content: |
+  You'll need a local copy of the configuration files for the {+app+} you're exporting.
+  Pull a local copy of the latest version of your app:
+
+  .. code-block:: bash
+
+     realm-cli pull --remote="<Your Exported App ID>"
+
+  .. tip::
+
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deployment > Export App` screen in the {+ui+}.
+---
+title: Create New App
+ref: export-app-cli-create-new-app
+content: |
+  Create a new {+app+}. This is where you'll add the configuration files from 
+  the exported app in later steps. To create the app, run: 
+
+  .. code-block:: bash
+     
+     realm-cli app create
+
+  Follow the CLI prompts to complete app creation.
+---
+title: Copy Exported App Configuration to New App
+ref: export-app-cli-copy-exported-app-to-new-app
+content: |
+  Delete all the configuration files in the new app except for ``realm_config.json``.
+  We're going to handle ``realm_config.json`` in the next step. 
+
+  Copy all the :ref:`configuration files and folders <app-configuration>` of your exported app
+  to the imported app folder except for the ``realm_config.json`` file.
+
+---
+title: Configure the New App's ``realm_config.json``
+ref: export-app-cli-configure-realm-config-json
+content: |
+  In the new app's ``realm_config.json``, replace all the contents except for the 
+  ``"app_id"`` and ``"name"``.
+
+  The new app's ``realm_config.json`` should look like: 
+
+  .. code-block:: bash
+
+    {
+      "app_id": "mynewapp-abcde", // don't change
+      "name": "MyNewApp", // don't change
+      "config_version": 20210101, // copy from exported app
+      "location": "US-VA", // copy from exported app
+      "deployment_model": "GLOBAL" // copy from exported app
+    }
+---
+title: Migrate Secrets to New App
+ref: export-app-cli-migrate-secrets
+content: |
+  When you :ref:`export your {+app+} <export-realm-app>`, the export does not include the app's 
+  :ref:`secrets <app-secret>`. As secrets cannot be read once they're defined, 
+  you must also have access to the secrets outside of {+service-short+} to import 
+  them into a {+app+}. If your app doesn't have any secrets, you can skip this step.
+
+  To add the secrets from another Realm app:
+
+  #. Get the names of all the secrets from the exported app by following the 
+    :ref:`view secrets documentation <list-secrets>`.
+  #. Save the names of all the secrets to a secure location. You won't have access 
+    to the actual secrets, but It'll be useful to have a list of the secret names 
+    to add to your imported app.
+  #. Gather the secrets. This cannot be done from within {+service-short+}. 
+  #. Add all the secrets to the imported app by following the :ref:`define a secret documentation <define-secret>`.
+    Secrets must be added one at a time.
+---
+title: Push New App to Realm
+ref: export-app-cli-push-to-realm
+content: |
+  Now that the app configuration and secrets are updated, push them to your
+  remote app. {+cli+} immediately deploys the updated configurations on push.
+
+  .. code-block:: bash
+
+     realm-cli push --remote="<Your New App ID>"
+
+  .. tip::
+
+     If you have :ref:`deployment drafts <deployment-draft>` 
+     enabled, you'll be prompted to review and confirm your changes in the 
+     terminal. When you approve, {+cli+} immediately deploys the updated 
+     configurations.

--- a/source/includes/steps-import-cli.yaml
+++ b/source/includes/steps-import-cli.yaml
@@ -40,7 +40,7 @@ title: Copy Exported App Configuration to New App
 ref: export-app-cli-copy-exported-app-to-new-app
 content: |
   Delete all the configuration files in the new app except for ``realm_config.json``.
-  We're going to handle ``realm_config.json`` in the next step. 
+  You'll handle ``realm_config.json`` in the next step. 
 
   Copy all the :ref:`configuration files and folders <app-configuration>` of your exported app
   to the imported app folder except for the ``realm_config.json`` file.
@@ -52,9 +52,9 @@ content: |
   In the new app's ``realm_config.json``, replace all the contents except for the 
   ``"app_id"`` and ``"name"``.
 
-  The new app's ``realm_config.json`` should look like: 
+  The new app's ``realm_config.json`` should look something like: 
 
-  .. code-block:: bash
+  .. code-block:: javascript
 
     {
       "app_id": "mynewapp-abcde", // don't change
@@ -75,7 +75,7 @@ content: |
   To add the secrets from another Realm app:
 
   #. Get the names of all the secrets from the exported app by following the 
-    :ref:`view secrets documentation <list-secrets>`.
+     :ref:`view secrets documentation <list-secrets>`.
   #. Save the names of all the secrets to a secure location. You won't have access 
     to the actual secrets, but It'll be useful to have a list of the secret names 
     to add to your imported app.

--- a/source/includes/steps-import-github.yaml
+++ b/source/includes/steps-import-github.yaml
@@ -47,7 +47,7 @@ title: Copy Exported App Configuration to New App
 ref: export-app-github-copy-exported-app-to-new-app
 content: |
   Delete all the configuration files in the new app except for ``realm_config.json``.
-  We're going to handle ``realm_config.json`` in the next step. 
+  You'll handle ``realm_config.json`` in the next step. 
 
   Copy all the :ref:`configuration files and folders <app-configuration>` of your exported app
   to the imported app folder except for the ``realm_config.json`` file.
@@ -59,9 +59,9 @@ content: |
   In the new app's ``realm_config.json``, replace all the contents except for the 
   ``"app_id"`` and ``"name"``.
 
-  The new app's ``realm_config.json`` should look like: 
+  The new app's ``realm_config.json`` should look something like: 
 
-  .. code-block:: bash
+  .. code-block:: javascript
 
     {
       "app_id": "mynewapp-abcde", // don't change
@@ -82,7 +82,7 @@ content: |
   To add the secrets from another Realm app:
 
   #. Get the names of all the secrets from the exported app by following the 
-    :ref:`view secrets documentation <list-secrets>`.
+     :ref:`view secrets documentation <list-secrets>`.
   #. Save the names of all the secrets to a secure location. You won't have access 
     to the actual secrets, but It'll be useful to have a list of the secret names 
     to add to your imported app.

--- a/source/includes/steps-import-github.yaml
+++ b/source/includes/steps-import-github.yaml
@@ -1,0 +1,109 @@
+title: Create New App
+ref: export-app-github-create-new-app
+content: |
+  Create a new {+app+}. This is where you'll add the configuration files from 
+  the exported app in later steps. To create the app, run: 
+
+  .. code-block:: bash
+     
+     realm-cli app create
+
+  Follow the CLI prompts to complete app creation.
+---
+title: Set up Github Automatic Deployment
+ref: export-app-github-set-up-github
+content: |
+  Follow the :ref:`documentation to set up Github Automatic Deployment <deploy-github>`
+  for your {+app+}.
+---
+title: Log In to MongoDB Cloud
+ref: export-app-github-log-in-to-mongodb-cloud
+content: |
+  You need to use the {+cli+} as part of app import process.
+  You must log in to MongoDB Cloud  with the {+cli+} using
+  an :atlas:`API key </configure-api-access/#programmatic-api-keys>` scoped to the organization or
+  project that contains the app.
+
+  .. code-block:: bash
+
+     realm-cli login --api-key="<MongoDB Cloud Public API Key>" --private-api-key="<MongoDB Cloud Private API Key>"
+---
+title: Pull the Latest Version of Your Exporting App
+ref: export-app-github-pull-the-latest-version-of-your-app
+content: |
+  You'll need a local copy of the configuration files for the {+app+} you're exporting.
+  Pull a local copy of the latest version of your app:
+
+  .. code-block:: bash
+
+     realm-cli pull --remote="<Your Exported App ID>"
+
+  .. tip::
+
+     You can also download a copy of your application's configuration files from
+     the :guilabel:`Deployment > Export App` screen in the {+ui+}.
+---
+title: Copy Exported App Configuration to New App
+ref: export-app-github-copy-exported-app-to-new-app
+content: |
+  Delete all the configuration files in the new app except for ``realm_config.json``.
+  We're going to handle ``realm_config.json`` in the next step. 
+
+  Copy all the :ref:`configuration files and folders <app-configuration>` of your exported app
+  to the imported app folder except for the ``realm_config.json`` file.
+
+---
+title: Configure the New App's ``realm_config.json``
+ref: export-app-github-configure-realm-config-json
+content: |
+  In the new app's ``realm_config.json``, replace all the contents except for the 
+  ``"app_id"`` and ``"name"``.
+
+  The new app's ``realm_config.json`` should look like: 
+
+  .. code-block:: bash
+
+    {
+      "app_id": "mynewapp-abcde", // don't change
+      "name": "MyNewApp", // don't change
+      "config_version": 20210101, // copy from exported app
+      "location": "US-VA", // copy from exported app
+      "deployment_model": "GLOBAL" // copy from exported app
+    }
+---
+title: Migrate Secrets to New App
+ref: export-app-github-migrate-secrets
+content: |
+  When you :ref:`export your {+app+} <export-realm-app>`, the export does not include the app's 
+  :ref:`secrets <app-secret>`. As secrets cannot be read once they're defined, 
+  you must also have access to the secrets outside of {+service-short+} to import 
+  them into a {+app+}. If your app doesn't have any secrets, you can skip this step.
+
+  To add the secrets from another Realm app:
+
+  #. Get the names of all the secrets from the exported app by following the 
+    :ref:`view secrets documentation <list-secrets>`.
+  #. Save the names of all the secrets to a secure location. You won't have access 
+    to the actual secrets, but It'll be useful to have a list of the secret names 
+    to add to your imported app.
+  #. Gather the secrets. This cannot be done from within {+service-short+}. 
+  #. Add all the secrets to the imported app by following the :ref:`define a secret documentation <define-secret>`.
+    Secrets must be added one at a time.
+---
+title: Push New App to Github
+ref: export-app-github-push-to-github
+content: |
+  When you are ready to import the app, commit the application 
+  configuration files and then push them to GitHub:
+
+  .. code-block:: sh
+
+     git add -A
+     git commit -m "<commit message>"
+     git push origin <branch name>
+
+  Once you successfully push your changes to GitHub, {+service-short+}
+  immediately deploys a new version of your application that matches the state
+  of the latest commit. Client applications will automatically use the newest
+  version, so make sure that you also update your client code to use the new
+  version.

--- a/source/manage-apps/configure/export-realm-app.txt
+++ b/source/manage-apps/configure/export-realm-app.txt
@@ -33,6 +33,8 @@ Exported application directories use the same name as the {+app+}
 and the application's ObjectId. Every configuration file must conform to its
 :ref:`configuration file schema <app-configuration>`.
 
+.. include:: /includes/note-secrets-not-exported.rst
+
 Output
 ------
 

--- a/source/manage-apps/configure/export/export-with-api.txt
+++ b/source/manage-apps/configure/export/export-with-api.txt
@@ -15,6 +15,8 @@ Export a Realm App with Realm API
 You can use the :ref:`Realm Admin API <admin-api>` to export your {+app+}'s 
 configuration.
 
+.. include:: /includes/note-secrets-not-exported.rst
+
 Prerequisites
 -------------
 

--- a/source/manage-apps/configure/export/export-with-cli.txt
+++ b/source/manage-apps/configure/export/export-with-cli.txt
@@ -15,6 +15,8 @@ Export a Realm App with Realm CLI
 You can use the :ref:`MongoDB Realm CLI <realm-cli-quickstart>` to export 
 your {+app+}'s configuration.
 
+.. include:: /includes/note-secrets-not-exported.rst
+
 .. note::
 
    ``Export`` is the :ref:`v1 Realm CLI <realm-cli-v1>` command, and is an

--- a/source/manage-apps/configure/export/export-with-realm-ui.txt
+++ b/source/manage-apps/configure/export/export-with-realm-ui.txt
@@ -19,6 +19,8 @@ You can export {+app+}s to a local application directory from the {+ui+}.
 Exported application directories use the name of the {+app+} and the 
 application's ObjectId.
 
+.. include:: /includes/note-secrets-not-exported.rst
+
 Prerequisites
 -------------
 

--- a/source/manage-apps/configure/import-realm-app.txt
+++ b/source/manage-apps/configure/import-realm-app.txt
@@ -7,7 +7,7 @@ Import an Existing Realm Application
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 1
    :class: singlecol
 
 Overview
@@ -52,8 +52,8 @@ If you need to include secrets in your imported +{app+}, refer to the
 
 .. tabs::
 
-   .. tab:: 
-      :tabid: Realm CLI
+   .. tab:: CLI
+      :tabid: cli
 
       .. warning::
 
@@ -65,29 +65,7 @@ If you need to include secrets in your imported +{app+}, refer to the
       .. include:: /includes/steps/import-cli.rst
 
    .. tab:: 
-      :tabid: GitHub
+      :tabid: Github Auto Deploy
+      :tabid: github
 
-      When you have enabled :ref:`GitHub deployment <deploy-github>`, you can
-      import your application by updating the configuration files in the
-      linked GitHub repository. 
-
-      Make any additions, modifications, or deletions to the application 
-      configuration files in the linked repository. Refer to the 
-      :ref:`app-configuration` reference page and individual component
-      reference pages for details on the structure and schema of your 
-      application directory.
-
-      When you are ready to import the app, commit the application 
-      configuration files and then push them to GitHub:
-
-      .. code-block:: sh
-
-        git add -A
-        git commit -m "<commit message>"
-        git push origin <branch name>
-
-      Once you successfully push your changes to GitHub, {+service-short+}
-      immediately deploys a new version of your application that matches the state
-      of the latest commit. Client applications will automatically use the newest
-      version, so make sure that you also update your client code to use the new
-      version.
+      .. include:: /includes/steps/import-github.rst

--- a/source/manage-apps/configure/import-realm-app.txt
+++ b/source/manage-apps/configure/import-realm-app.txt
@@ -47,6 +47,9 @@ You can import and deploy your application's configuration files in two ways:
 - With the :ref:`Realm CLI <deploy-cli>` 
 - With :ref:`GitHub deployment <deploy-github>`
 
+If you need to include secrets in your imported +{app+}, refer to the 
+:ref:`secrets migration documentation <migrate-secrets-to-imported-realm-app>`.
+
 .. tabs::
 
    .. tab:: 
@@ -59,7 +62,7 @@ You can import and deploy your application's configuration files in two ways:
          <deploy-github-make-changes-cli>`. Instead, push your changes to the 
          linked GitHub repository.
 
-      .. include:: /includes/steps/deploy-cli.rst
+      .. include:: /includes/steps/import-cli.rst
 
    .. tab:: 
       :tabid: GitHub
@@ -88,17 +91,3 @@ You can import and deploy your application's configuration files in two ways:
       of the latest commit. Client applications will automatically use the newest
       version, so make sure that you also update your client code to use the new
       version.
-
-.. _migrate-secrets-to-imported-realm-app:
-
-Migrate Secrets to Imported Realm App
--------------------------------------
-
-When you :ref:`export your {+app+} <export-realm-app>`, the export does not include the app's 
-:ref:`secrets <app-secret>`. If you want to add the secrets from another Realm app, 
-you must take the following steps:
-
-#. Get all the secrets from the exported app by following the :ref:`list secrets documentation <list-secrets>`.
-#. Save the secrets to a secure location. 
-#. Add all the secrets to the imported app by following the :ref:`define a secret documentation <define-secret>`.
-   Secrets must be added one at a time. 

--- a/source/manage-apps/configure/import-realm-app.txt
+++ b/source/manage-apps/configure/import-realm-app.txt
@@ -94,4 +94,11 @@ You can import and deploy your application's configuration files in two ways:
 Migrate Secrets to Imported Realm App
 -------------------------------------
 
-TODO(DOCS-14173): Build out this section
+When you :ref:`export your {+app+} <export-realm-app>`, the export does not include the app's 
+:ref:`secrets <app-secret>`. If you want to add the secrets from another Realm app, 
+you must take the following steps:
+
+#. Get all the secrets from the exported app by following the :ref:`list secrets documentation <list-secrets>`.
+#. Save the secrets to a secure location. 
+#. Add all the secrets to the imported app by following the :ref:`define a secret documentation <define-secret>`.
+   Secrets must be added one at a time. 

--- a/source/manage-apps/configure/import-realm-app.txt
+++ b/source/manage-apps/configure/import-realm-app.txt
@@ -88,3 +88,10 @@ You can import and deploy your application's configuration files in two ways:
       of the latest commit. Client applications will automatically use the newest
       version, so make sure that you also update your client code to use the new
       version.
+
+.. _migrate-secrets-to-imported-realm-app:
+
+Migrate Secrets to Imported Realm App
+-------------------------------------
+
+TODO(DOCS-14173): Build out this section

--- a/source/manage-apps/configure/import-realm-app.txt
+++ b/source/manage-apps/configure/import-realm-app.txt
@@ -47,7 +47,7 @@ You can import and deploy your application's configuration files in two ways:
 - With the :ref:`Realm CLI <deploy-cli>` 
 - With :ref:`GitHub deployment <deploy-github>`
 
-If you need to include secrets in your imported +{app+}, refer to the 
+If you need to include secrets in your imported {+app+}, refer to the 
 :ref:`secrets migration documentation <migrate-secrets-to-imported-realm-app>`.
 
 .. tabs::
@@ -64,8 +64,7 @@ If you need to include secrets in your imported +{app+}, refer to the
 
       .. include:: /includes/steps/import-cli.rst
 
-   .. tab:: 
-      :tabid: Github Auto Deploy
+   .. tab:: Github Auto Deploy
       :tabid: github
 
       .. include:: /includes/steps/import-github.rst


### PR DESCRIPTION
## Pull Request Info

Updated import and export Realm app documentation to make clear that secrets are not included by default. Also refactored the import steps for clarity and to include how to import secrets. 

### Jira

- https://jira.mongodb.org/browse/DOCS-14173

### Staged Changes (Requires MongoDB Corp SSO)

- [Import an Existing Realm Application](https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCS-14173/manage-apps/configure/import-realm-app/) (main changes)
- additionally, same note added to the following pages: 
  - https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCS-14173/manage-apps/configure/export-realm-app/
  - https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCS-14173/manage-apps/configure/export/export-with-realm-ui/
  - https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCS-14173/manage-apps/configure/export/export-with-realm-cli/
  - https://docs-mongodborg-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCS-14173/manage-apps/configure/export/export-with-realm-api/

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
