### PR TITLE
(DOCSP-19356): Update Google Auth for Web SDK

### DIFF
--- a/source/authentication/google.txt
+++ b/source/authentication/google.txt
@@ -191,7 +191,14 @@ options:
        If ``true``, the provider uses :google:`OpenID Connect
        <identity/protocols/oauth2/openid-connect>` to authenticate users.
        
-       .. important:: OpenID Connect Does Not Support Metadata Fields
+       .. important:: OpenID Connect Support Varies by SDK
+
+          Refer to SDK-specific documentation about support for OpenID Connect. 
+          Not all SDK implementations of Google Authentication support OpenID Connect, 
+          while others require it. 
+
+       
+       .. note:: OpenID Connect Does Not Support Metadata Fields
           
           Google supports OpenID as part of their OAuth 2.0 implementation but does
           not provide access to restricted scopes for OpenID authentication. This

--- a/source/authentication/google.txt
+++ b/source/authentication/google.txt
@@ -24,12 +24,39 @@ provides {+service+} with an `OAuth 2.0 access token
 {+service-short+} uses the token to identify the user and access approved data from
 Google APIs on their behalf.
 
+.. _auth-gcp-project-setup:
+
+Set Up a Project in the Google API Console
+------------------------------------------
+
+You must set up a project in the Google API Console before you :ref:`configure 
+Google Authentication in {+service+}<auth-google-configuration>`. Follow the 
+SDK-specific steps to set up Google Authentication in the Google API Console.
+
+
+.. tabs-realm-sdks::
+
+   tabs:
+     - id: javascript
+       content: ""
+     - id: android
+       content: ""
+     - id: ios
+       content: ""
+
+The Google authentication provider requires a :gcp:`project in the Google
+API Console </>` to manage authentication and user permissions. The
+following steps walk through creating the project, generating OAuth
+credentials, and configuring the provider to connect with the project.
+
+.. include:: /includes/steps/auth-google-project-setup.rst
+
 .. _openIdConnect:
 .. _auth-google-configuration:
 .. _config-oauth2-google:
 
-Configuration
--------------
+Configure in Realm
+------------------
 
 .. tabs-realm-admin-interfaces::
    
@@ -170,28 +197,6 @@ options:
           not provide access to restricted scopes for OpenID authentication. This
           means that Realm cannot access metadata fields for users authenticated
           with OpenID Connect.
-
-.. _auth-gcp-project-setup:
-
-Set Up a Project in the Google API Console
-------------------------------------------
-
-.. tabs-realm-sdks::
-
-   tabs:
-     - id: javascript
-       content: ""
-     - id: android
-       content: ""
-     - id: ios
-       content: ""
-
-The Google authentication provider requires a :gcp:`project in the Google
-API Console </>` to manage authentication and user permissions. The
-following steps walk through creating the project, generating OAuth
-credentials, and configuring the provider to connect with the project.
-
-.. include:: /includes/steps/auth-google-project-setup.rst
 
 .. _google-authentication-examples:
 

--- a/source/includes/note-secrets-not-exported.rst
+++ b/source/includes/note-secrets-not-exported.rst
@@ -2,5 +2,5 @@
 
    When you export your {+app+}, the export does not include the 
    :ref:`secrets <app-secret>`. To add your secrets to a different app, 
-   refer to the :ref:`documentation on migrating secrets to a new {+app+}
-   <copy-app-cli-migrate-secrets>`.
+   refer to the :ref:`documentation on migrating configuration, including secrets, to a new {+app+}
+   <copy-realm-app>`.

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -366,6 +366,7 @@ require you to install a Google SDK. The built-in flow follows three main steps:
    user's Realm access token and closes the window. Your original app window will
    automatically detect the access token and finish logging the user in.
 
+<<<<<<< HEAD
 .. example:: Basic Web Login Flow
 
     This example shows how to set up Google Authentication with Realm in 
@@ -430,6 +431,101 @@ require you to install a Google SDK. The built-in flow follows three main steps:
           Realm.handleAuthRedirect();
         </script>
       </html>
+=======
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: javascript
+      
+      .. example:: Basic Web Login Flow
+
+         This example shows how to set up Google Authentication with Realm in 
+         a very basic web app. The app has the following files: 
+
+         .. code-block::
+
+            .
+            ├── auth.html
+            ├── index.html
+
+         .. code-block:: html
+            :caption: index.html
+
+            <!DOCTYPE html>
+            <html lang="en">
+              <head>
+                <title>Google Auth Example</title>
+              </head>
+              <body>
+                <h1>Google Auth Example</h1>
+                <button id="google-auth">Authenticate!</button>
+              </body>
+              <!-- Load MongoDB Realm -->
+              <script src="https://unpkg.com/realm-web/dist/bundle.iife.js"></script>
+              <!-- Log in with Realm and Google Authentication -->
+              <script>
+                const app = new Realm.App({
+                  id: "<Your-App-ID>",
+                });
+
+                const authButton = document.getElementById("google-auth");
+                authButton.addEventListener("click", () => {
+                  // The redirect URI should be on the same domain as this app and
+                  // specified in the auth provider configuration.
+                  const redirectUri = "http://yourDomain/auth.html";
+                  const credentials = Realm.Credentials.google(redirectUri);
+                  // Calling logIn() opens a Google authentication screen in a new window.
+                  app
+                    .logIn(credentials)
+                    .then((user) => {
+                      // The logIn() promise will not resolve until you call `handleAuthRedirect()`
+                      // from the new window after the user has successfully authenticated.
+                      console.log(`Logged in with id: ${user.id}`);
+                    })
+                    .catch((err) => console.error(err));
+                });
+              </script>
+            </html>
+
+         .. code-block:: html
+            :caption: auth.html
+
+            <!DOCTYPE html>
+            <html lang="en">
+              <head>
+                <title>Google Auth Redirect</title>
+              </head>
+              <body>
+                <p>Redirects come here for Google Authentication</p>
+              </body>
+              <script>
+                Realm.handleAuthRedirect();
+              </script>
+            </html>
+
+   .. tab::
+      :tabid: typescript
+      
+      .. code-block:: typescript
+         
+         // The redirect URI should be on the same domain as this app and
+         // specified in the auth provider configuration.
+         const redirectUri = "https://app.example.com/handleOAuthLogin";
+         const credentials = Realm.Credentials.google(redirectUri);
+         
+         // Calling logIn() opens a Google authentication screen in a new window.
+         app.logIn(credentials).then((user: Realm.User) => {
+           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
+           // from the new window after the user has successfully authenticated.
+           console.log(`Logged in with id: ${user.id}`);
+         })
+         
+         // When the user is redirected back to your app, handle the redirect to
+         // save the user's access token and close the redirect window. This
+         // returns focus to the original application window and automatically
+         // logs the user in.
+         Realm.handleAuthRedirect();
+>>>>>>> ea90ecb4 (fix example formatting)
 
 .. important:: Built-In OAuth 2.0 Redirect Limitations for Google
    

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -295,6 +295,10 @@ Authenticate with Google One Tap
    log Google users in to your web app, you must :ref:`enable OpenID Connect
    <openIdConnect>` in the {+service-short+} authentication provider configuration.
 
+:google:`Google One Tap <identity/one-tap/web/guides/get-google-api-clientid>`
+is a Google SDK that lets users sign up to or log in to a website with one click (or tap).
+See the below example to see how to set up Google One Tap in your {+app+}: 
+
 .. example:: Basic Google One Tap Flow
     
     This example shows how to set up Google Authentication with Realm in 
@@ -329,7 +333,7 @@ Authenticate with Google One Tap
           const app = new Realm.App({
             id: "<your_realm_app_id>",
           });
-          // Callback used in `data-callback` to handle response and log user into Realm
+          // Callback used in `data-callback` to handle Google's response and log user into Realm
           function handleCredentialsResponse(response) {
             const credentials = Realm.Credentials.google(response.credential);
             app
@@ -354,15 +358,15 @@ Use the Built-In Google OAuth 2.0 Flow
 The Realm Web SDK includes methods to handle the OAuth 2.0 process and does not
 require you to install a Google SDK. The built-in flow follows three main steps:
 
-1. Call ``app.logIn()`` with a Google credential. The credential must
+#. Call ``app.logIn()`` with a Google credential. The credential must
    specify a URL for your app that is also listed as a redirect URI in the
    provider configuration.
 
-2. A new window opens to a Google authentication screen and the user
+#. A new window opens to a Google authentication screen and the user
    authenticates and authorizes your app in that window. Once complete, the new
    window redirects to the URL specified in the credential.
 
-3. Call ``handleAuthRedirect()`` on the redirected page, which stores the
+#. Call ``handleAuthRedirect()`` on the redirected page, which stores the
    user's Realm access token and closes the window. Your original app window will
    automatically detect the access token and finish logging the user in.
 

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -317,10 +317,17 @@ Authenticate with Google One Tap
 Use the Built-In Google OAuth 2.0 Flow
 ++++++++++++++++++++++++++++++++++++++
 
+.. note:: Do Not Use OpenID Connect
+
+   Do not use :ref:`OpenID Connect <openIdConnect>` with {+service-short+}'s 
+   built-in Google OAuth 2.0 flow. It does not work. If you'd like to use 
+   OpenID Connect with the Realm Web SDK, use the 
+   :ref:`Authentication with Google One Tap <web-google-onetap>` flow.
+
 The Realm Web SDK includes methods to handle the OAuth 2.0 process and does not
 require you to install a Google SDK. The built-in flow follows three main steps:
 
-1. You call ``app.logIn()`` with a Google credential. The credential must
+1. Call ``app.logIn()`` with a Google credential. The credential must
    specify a URL for your app that is also listed as a redirect URI in the
    provider configuration.
 
@@ -328,29 +335,74 @@ require you to install a Google SDK. The built-in flow follows three main steps:
    authenticates and authorizes your app in that window. Once complete, the new
    window redirects to the URL specified in the credential.
 
-3. You call ``handleAuthRedirect()`` on the redirected page, which stores the
+3. Call ``handleAuthRedirect()`` on the redirected page, which stores the
    user's Realm access token and closes the window. Your original app window will
    automatically detect the access token and finish logging the user in.
 
-.. code-block:: javascript
+.. example:: Basic Web Login Flow
 
-    // The redirect URI should be on the same domain as this app and
-    // specified in the auth provider configuration.
-    const redirectUri = "https://app.example.com/handleOAuthLogin";
-    const credentials = Realm.Credentials.google(redirectUri);
+    This example shows how to set up Google Authentication with Realm in 
+    a very basic web app. The app has the following files: 
 
-    // Calling logIn() opens a Google authentication screen in a new window.
-    app.logIn(credentials).then(user => {
-      // The logIn() promise will not resolve until you call `handleAuthRedirect()`
-      // from the new window after the user has successfully authenticated.
-      console.log(`Logged in with id: ${user.id}`);
-    })
+    .. code-block::
+      .
+      ├── auth.html
+      ├── index.html
 
-    // When the user is redirected back to your app, handle the redirect to
-    // save the user's access token and close the redirect window. This
-    // returns focus to the original application window and automatically
-    // logs the user in.
-    Realm.handleAuthRedirect();
+    .. code-block:: html
+      :caption: index.html
+
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <title>Google Auth Example</title>
+        </head>
+        <body>
+          <h1>Google Auth Example</h1>
+          <button id="google-auth">Authenticate!</button>
+        </body>
+        <!-- Load MongoDB Realm -->
+        <script src="https://unpkg.com/realm-web/dist/bundle.iife.js"></script>
+        <!-- Log in with Realm and Google Authentication -->
+        <script>
+          const app = new Realm.App({
+            id: "myapp-zufnj",
+          });
+
+          const authButton = document.getElementById("google-auth");
+          authButton.addEventListener("click", () => {
+            // The redirect URI should be on the same domain as this app and
+            // specified in the auth provider configuration.
+            const redirectUri = "http://localhost:5501/auth.html";
+            const credentials = Realm.Credentials.google(redirectUri);
+            // Calling logIn() opens a Google authentication screen in a new window.
+            app
+              .logIn(credentials)
+              .then((user) => {
+                // The logIn() promise will not resolve until you call `handleAuthRedirect()`
+                // from the new window after the user has successfully authenticated.
+                console.log(`Logged in with id: ${user.id}`);
+              })
+              .catch((err) => console.error(err));
+          });
+        </script>
+      </html>
+
+    .. code-block:: html
+      :caption: auth.html
+
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <title>Google Auth Redirect</title>
+        </head>
+        <body>
+          <p>Redirects come here for Google Authentication</p>
+        </body>
+        <script>
+          Realm.handleAuthRedirect();
+        </script>
+      </html>
 
 .. important:: Built-In OAuth 2.0 Redirect Limitations for Google
    

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -293,24 +293,51 @@ Authenticate with Google One Tap
    
    Google One Tap only supports user authentication through OpenID Connect. To
    log Google users in to your web app, you must :ref:`enable OpenID Connect
-   <openIdConnect>` in the authentication provider configuration.
+   <openIdConnect>` in the {+service-short+} authentication provider configuration.
 
+.. example: Basic Google One Tap Flow
+    
+    This example shows how to set up Google Authentication with Realm in 
+    a very basic web app. The app only contains an ``index.html`` file.
 
-.. code-block:: javascript
+    .. code-block:: html
+      :caption: index.html
 
-    import * as Realm from "realm-web";
-    import googleOneTap from 'google-one-tap';
-
-    const app = new Realm.App("<Your Realm App ID>");
-    const client_id = "<Your Google Client ID>";
-
-    // Open the Google One Tap menu
-    googleOneTap({ client_id }, async (response) => {
-      // Upon successful Google authentication, log in to Realm with the user's credential
-      const credentials = Realm.Credentials.google(response.credential)
-      const user = await app.logIn(credentials);
-      console.log(`Logged in with id: ${user.id}`);
-    });
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <title>Google One Tap Example</title>
+        </head>
+        <body>
+          <h1>Google One Tap Example</h1>
+          <!-- The data-callback HTML attribute sets the callback function that is run 
+            when the user logs in. Here we're calling the handleCredentialsResponse JavaScript 
+            function defined in the below script section to log the user into Realm.       
+          -->
+          <div
+            id="g_id_onload"
+            data-client_id="<your_google_client_id>"
+            data-callback="handleCredentialsResponse"
+          ></div>
+        </body>
+        <!-- Load MongoDB Realm -->
+        <script src="https://unpkg.com/realm-web/dist/bundle.iife.js"></script>
+        <!-- Load Google One Tap -->
+        <script src="https://accounts.google.com/gsi/client"></script>
+        <!-- Log in with Realm and Google Authentication -->
+        <script async defer>
+          const app = new Realm.App({
+            id: "<your_realm_app_id>",
+          });
+          // Callback used in `data-callback` to handle response and log user into Realm
+          function handleCredentialsResponse(response) {
+            const credentials = Realm.Credentials.google(response.credential);
+            app
+              .logIn(credentials)
+              .then((user) => alert(`Logged in with id: ${user.id}`));
+          }
+        </script>
+      </html>
 
 .. _web-google-builtin:
 
@@ -319,8 +346,8 @@ Use the Built-In Google OAuth 2.0 Flow
 
 .. note:: Do Not Use OpenID Connect for Built-In Google OAuth 2.0 Flow
 
-   Do not use :ref:`OpenID Connect <openIdConnect>` with {+service-short+}'s 
-   built-in Google OAuth 2.0 flow. It does not work. If you'd like to use 
+  :ref:`OpenID Connect <openIdConnect>` does not work with {+service-short+}'s 
+   built-in Google OAuth 2.0 flow. If you'd like to use 
    OpenID Connect with the Realm Web SDK, use the 
    :ref:`Authentication with Google One Tap <web-google-onetap>` flow.
 

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -317,7 +317,7 @@ Authenticate with Google One Tap
 Use the Built-In Google OAuth 2.0 Flow
 ++++++++++++++++++++++++++++++++++++++
 
-.. note:: Do Not Use OpenID Connect
+.. note:: Do Not Use OpenID Connect for Built-In Google OAuth 2.0 Flow
 
    Do not use :ref:`OpenID Connect <openIdConnect>` with {+service-short+}'s 
    built-in Google OAuth 2.0 flow. It does not work. If you'd like to use 

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -295,7 +295,7 @@ Authenticate with Google One Tap
    log Google users in to your web app, you must :ref:`enable OpenID Connect
    <openIdConnect>` in the {+service-short+} authentication provider configuration.
 
-.. example: Basic Google One Tap Flow
+.. example:: Basic Google One Tap Flow
     
     This example shows how to set up Google Authentication with Realm in 
     a very basic web app. The app only contains an ``index.html`` file.
@@ -366,13 +366,13 @@ require you to install a Google SDK. The built-in flow follows three main steps:
    user's Realm access token and closes the window. Your original app window will
    automatically detect the access token and finish logging the user in.
 
-<<<<<<< HEAD
 .. example:: Basic Web Login Flow
 
     This example shows how to set up Google Authentication with Realm in 
     a very basic web app. The app has the following files: 
 
     .. code-block::
+
       .
       ├── auth.html
       ├── index.html
@@ -394,14 +394,14 @@ require you to install a Google SDK. The built-in flow follows three main steps:
         <!-- Log in with Realm and Google Authentication -->
         <script>
           const app = new Realm.App({
-            id: "myapp-zufnj",
+            id: "<Your-App-ID>",
           });
 
           const authButton = document.getElementById("google-auth");
           authButton.addEventListener("click", () => {
             // The redirect URI should be on the same domain as this app and
             // specified in the auth provider configuration.
-            const redirectUri = "http://localhost:5501/auth.html";
+            const redirectUri = "http://yourDomain/auth.html";
             const credentials = Realm.Credentials.google(redirectUri);
             // Calling logIn() opens a Google authentication screen in a new window.
             app
@@ -431,101 +431,6 @@ require you to install a Google SDK. The built-in flow follows three main steps:
           Realm.handleAuthRedirect();
         </script>
       </html>
-=======
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. example:: Basic Web Login Flow
-
-         This example shows how to set up Google Authentication with Realm in 
-         a very basic web app. The app has the following files: 
-
-         .. code-block::
-
-            .
-            ├── auth.html
-            ├── index.html
-
-         .. code-block:: html
-            :caption: index.html
-
-            <!DOCTYPE html>
-            <html lang="en">
-              <head>
-                <title>Google Auth Example</title>
-              </head>
-              <body>
-                <h1>Google Auth Example</h1>
-                <button id="google-auth">Authenticate!</button>
-              </body>
-              <!-- Load MongoDB Realm -->
-              <script src="https://unpkg.com/realm-web/dist/bundle.iife.js"></script>
-              <!-- Log in with Realm and Google Authentication -->
-              <script>
-                const app = new Realm.App({
-                  id: "<Your-App-ID>",
-                });
-
-                const authButton = document.getElementById("google-auth");
-                authButton.addEventListener("click", () => {
-                  // The redirect URI should be on the same domain as this app and
-                  // specified in the auth provider configuration.
-                  const redirectUri = "http://yourDomain/auth.html";
-                  const credentials = Realm.Credentials.google(redirectUri);
-                  // Calling logIn() opens a Google authentication screen in a new window.
-                  app
-                    .logIn(credentials)
-                    .then((user) => {
-                      // The logIn() promise will not resolve until you call `handleAuthRedirect()`
-                      // from the new window after the user has successfully authenticated.
-                      console.log(`Logged in with id: ${user.id}`);
-                    })
-                    .catch((err) => console.error(err));
-                });
-              </script>
-            </html>
-
-         .. code-block:: html
-            :caption: auth.html
-
-            <!DOCTYPE html>
-            <html lang="en">
-              <head>
-                <title>Google Auth Redirect</title>
-              </head>
-              <body>
-                <p>Redirects come here for Google Authentication</p>
-              </body>
-              <script>
-                Realm.handleAuthRedirect();
-              </script>
-            </html>
-
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         // The redirect URI should be on the same domain as this app and
-         // specified in the auth provider configuration.
-         const redirectUri = "https://app.example.com/handleOAuthLogin";
-         const credentials = Realm.Credentials.google(redirectUri);
-         
-         // Calling logIn() opens a Google authentication screen in a new window.
-         app.logIn(credentials).then((user: Realm.User) => {
-           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
-           // from the new window after the user has successfully authenticated.
-           console.log(`Logged in with id: ${user.id}`);
-         })
-         
-         // When the user is redirected back to your app, handle the redirect to
-         // save the user's access token and close the redirect window. This
-         // returns focus to the original application window and automatically
-         // logs the user in.
-         Realm.handleAuthRedirect();
->>>>>>> ea90ecb4 (fix example formatting)
 
 .. important:: Built-In OAuth 2.0 Redirect Limitations for Google
    

--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -297,7 +297,6 @@ Authenticate with Google One Tap
 
 :google:`Google One Tap <identity/one-tap/web/guides/get-google-api-clientid>`
 is a Google SDK that lets users sign up to or log in to a website with one click (or tap).
-See the below example to see how to set up Google One Tap in your {+app+}: 
 
 .. example:: Basic Google One Tap Flow
     


### PR DESCRIPTION
## Pull Request Info

* update examples for Google Auth for Web SDK
* moved the set up `Set Up a Project in the Google API Console` section b/c it's the first action you should do when setting up google auth for project

### Jira

- https://jira.mongodb.org/browse/DOCSP-19356

### Staged Changes (Requires MongoDB Corp SSO)

- [Authentication, Google Authentication section (Web SDK)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19356/web/authenticate/#google-authentication)
- [Google Authentication](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19356/authentication/google/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
