### PR TITLE
(DOCSP-20055): Remove unnecessary TypeScript examples from Web SDK 

### DIFF
--- a/source/web/authenticate.txt
+++ b/source/web/authenticate.txt
@@ -35,53 +35,25 @@ to your application with ephemeral accounts that have no associated information.
 
 To log in, create an anonymous credential and pass it to ``App.logIn()``:
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         :emphasize-lines: 3, 6
-         
-         async function loginAnonymous() {
-           // Create an anonymous credential
-           const credentials = Realm.Credentials.anonymous();
-           try {
-             // Authenticate the user
-             const user = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id)
-             return user
-           } catch(err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginAnonymous().then(user => {
-           console.log("Successfully logged in!", user)
-         })
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         :emphasize-lines: 3, 6
+.. code-block:: javascript
+    :emphasize-lines: 3, 6
 
-         async function loginAnonymous() {
-           // Create an anonymous credential
-           const credentials = Realm.Credentials.anonymous();
-           try {
-             // Authenticate the user
-             const user: Realm.User = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id)
-             return user
-           } catch(err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginAnonymous().then(user => {
-           console.log("Successfully logged in!", user)
-         })
+    async function loginAnonymous() {
+      // Create an anonymous credential
+      const credentials = Realm.Credentials.anonymous();
+      try {
+        // Authenticate the user
+        const user = await app.logIn(credentials);
+        // `App.currentUser` updates to match the logged in user
+        assert(user.id === app.currentUser.id)
+        return user
+      } catch(err) {
+        console.error("Failed to log in", err);
+      }
+    }
+    loginAnonymous().then(user => {
+      console.log("Successfully logged in!", user)
+    })
 
 .. _web-login-email-password:
 
@@ -95,53 +67,25 @@ password.
 To log in, create an email/password credential with the user's email address and
 password and pass it to ``App.logIn()``:
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginEmailPassword(email, password) {
-           // Create an anonymous credential
-           const credentials = Realm.Credentials.emailPassword(email, password);
-           try {
-             // Authenticate the user
-             const user = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id)
-             return user
-           } catch(err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginEmailPassword("joe.jasper@example.com", "passw0rd").then(user => {
-           console.log("Successfully logged in!", user)
-         })
+.. code-block:: javascript
+    :emphasize-lines: 3, 6, 14
 
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginEmailPassword(email: string, password: string) {
-           // Create an anonymous credential
-           const credentials = Realm.Credentials.emailPassword(email, password);
-           try {
-             // Authenticate the user
-             const user: Realm.User = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id)
-             return user
-           } catch(err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginEmailPassword("joe.jasper@example.com", "passw0rd").then(user => {
-           console.log("Successfully logged in!", user)
-         })
+    async function loginEmailPassword(email, password) {
+      // Create an anonymous credential
+      const credentials = Realm.Credentials.emailPassword(email, password);
+      try {
+        // Authenticate the user
+        const user = await app.logIn(credentials);
+        // `App.currentUser` updates to match the logged in user
+        assert(user.id === app.currentUser.id)
+        return user
+      } catch(err) {
+        console.error("Failed to log in", err);
+      }
+    }
+    loginEmailPassword("joe.jasper@example.com", "passw0rd").then(user => {
+      console.log("Successfully logged in!", user)
+    })
 
 .. _web-login-api-key:
 
@@ -154,53 +98,25 @@ server processes to access your app directly or on behalf of a user.
 To log in with an API key, create an API Key credential with a server or user
 API key and pass it to ``App.logIn()``:
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginApiKey(apiKey) {
-           // Create an API Key credential
-           const credentials = Realm.Credentials.apiKey(apiKey);
-           try {
-             // Authenticate the user
-             const user = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id)
-             return user
-           } catch(err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginApiKey("To0SQOPC...ZOU0xUYvWw").then(user => {
-           console.log("Successfully logged in!", user)
-         })
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginApiKey(apiKey: string) {
-           // Create an API Key credential
-           const credentials = Realm.Credentials.apiKey(apiKey);
-           try {
-             // Authenticate the user
-             const user: Realm.User = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id)
-             return user
-           } catch(err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginApiKey("To0SQOPC...ZOU0xUYvWw").then(user => {
-           console.log("Successfully logged in!", user)
-         })
+.. code-block:: javascript
+    :emphasize-lines: 3, 6, 14
+    
+    async function loginApiKey(apiKey) {
+      // Create an API Key credential
+      const credentials = Realm.Credentials.apiKey(apiKey);
+      try {
+        // Authenticate the user
+        const user = await app.logIn(credentials);
+        // `App.currentUser` updates to match the logged in user
+        assert(user.id === app.currentUser.id)
+        return user
+      } catch(err) {
+        console.error("Failed to log in", err);
+      }
+    }
+    loginApiKey("To0SQOPC...ZOU0xUYvWw").then(user => {
+      console.log("Successfully logged in!", user)
+    })
 
 .. _web-login-custom-function:
 
@@ -214,53 +130,26 @@ provider allows you to handle user authentication by running a :doc:`function
 To log in with the custom function provider, create a Custom Function credential
 with a payload object and pass it to ``App.logIn()``:
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginCustomFunction(payload) {
-           // Create a Custom Function credential
-           const credentials = Realm.Credentials.function(payload);
-           try {
-             // Authenticate the user
-             const user = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id);
-             return user;
-           } catch (err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginCustomFunction({ username: "mongolover" }).then((user) => {
-           console.log("Successfully logged in!", user);
-         });
 
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginCustomFunction(payload: Realm.Credentials.FunctionPayload) {
-           // Create a Custom Function credential
-           const credentials = Realm.Credentials.function(payload);
-           try {
-             // Authenticate the user
-             const user: Realm.User = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id);
-             return user;
-           } catch (err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginCustomFunction({ username: "mongolover" }).then((user) => {
-           console.log("Successfully logged in!", user);
-         });
+.. code-block:: javascript
+    :emphasize-lines: 3, 6, 14
+
+    async function loginCustomFunction(payload) {
+      // Create a Custom Function credential
+      const credentials = Realm.Credentials.function(payload);
+      try {
+        // Authenticate the user
+        const user = await app.logIn(credentials);
+        // `App.currentUser` updates to match the logged in user
+        assert(user.id === app.currentUser.id);
+        return user;
+      } catch (err) {
+        console.error("Failed to log in", err);
+      }
+    }
+    loginCustomFunction({ username: "mongolover" }).then((user) => {
+      console.log("Successfully logged in!", user);
+    });
 
 .. _web-login-custom-jwt:
 
@@ -274,53 +163,27 @@ returns a :ref:`JSON web token <json-web-tokens>`.
 To log in, create a Custom JWT credential with a JWT from the external system
 and pass it to ``App.logIn()``:
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginCustomJwt(jwt) {
-           // Create a Custom JWT credential
-           const credentials = Realm.Credentials.jwt(jwt);
-           try {
-             // Authenticate the user
-             const user = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id);
-             return user;
-           } catch (err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginCustomJwt("eyJ0eXAi...Q3NJmnU8oP3YkZ8").then((user) => {
-           console.log("Successfully logged in!", user);
-         });
 
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         :emphasize-lines: 3, 6, 14
-         
-         async function loginCustomJwt(jwt: Realm.Credentials.JWTPayload) {
-           // Create a Custom JWT credential
-           const credentials = Realm.Credentials.jwt(jwt);
-           try {
-             // Authenticate the user
-             const user: Realm.User = await app.logIn(credentials);
-             // `App.currentUser` updates to match the logged in user
-             assert(user.id === app.currentUser.id);
-             return user;
-           } catch (err) {
-             console.error("Failed to log in", err);
-           }
-         }
-         loginCustomJwt("eyJ0eXAi...Q3NJmnU8oP3YkZ8").then((user) => {
-           console.log("Successfully logged in!", user);
-         });
+.. code-block:: javascript
+    :emphasize-lines: 3, 6, 14
+
+    async function loginCustomJwt(jwt) {
+      // Create a Custom JWT credential
+      const credentials = Realm.Credentials.jwt(jwt);
+      try {
+        // Authenticate the user
+        const user = await app.logIn(credentials);
+        // `App.currentUser` updates to match the logged in user
+        assert(user.id === app.currentUser.id);
+        return user;
+      } catch (err) {
+        console.error("Failed to log in", err);
+      }
+    }
+    loginCustomJwt("eyJ0eXAi...Q3NJmnU8oP3YkZ8").then((user) => {
+      console.log("Successfully logged in!", user);
+    });
+
 
 .. _web-login-facebook:
 
@@ -357,53 +220,25 @@ require you to install the Facebook SDK. The built in flow follows three main st
    user's Realm access token and closes the window. Your original app window will
    automatically detect the access token and finish logging the user in.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         // The redirect URI should be on the same domain as this app and
-         // specified in the auth provider configuration.
-         const redirectUri = "https://app.example.com/handleOAuthLogin";
-         const credentials = Realm.Credentials.facebook(redirectUri);
-         
-         // Calling logIn() opens a Facebook authentication screen in a new window.
-         app.logIn(credentials).then(user => {
-           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
-           // from the new window after the user has successfully authenticated.
-           console.log(`Logged in with id: ${user.id}`);
-         })
-         
-         // When the user is redirected back to your app, handle the redirect to
-         // save the user's access token and close the redirect window. This
-         // returns focus to the original application window and automatically
-         // logs the user in.
-         Realm.handleAuthRedirect();
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         // The redirect URI should be on the same domain as this app and
-         // specified in the auth provider configuration.
-         const redirectUri = "https://app.example.com/handleOAuthLogin";
-         const credentials = Realm.Credentials.facebook(redirectUri);
-         
-         // Calling logIn() opens a Facebook authentication screen in a new window.
-         app.logIn(credentials).then((user: Realm.User) => {
-           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
-           // from the new window after the user has successfully authenticated.
-           console.log(`Logged in with id: ${user.id}`);
-         })
-         
-         // When the user is redirected back to your app, handle the redirect to
-         // save the user's access token and close the redirect window. This
-         // returns focus to the original application window and automatically
-         // logs the user in.
-         Realm.handleAuthRedirect();
+    // The redirect URI should be on the same domain as this app and
+    // specified in the auth provider configuration.
+    const redirectUri = "https://app.example.com/handleOAuthLogin";
+    const credentials = Realm.Credentials.facebook(redirectUri);
+
+    // Calling logIn() opens a Facebook authentication screen in a new window.
+    app.logIn(credentials).then(user => {
+      // The logIn() promise will not resolve until you call `handleAuthRedirect()`
+      // from the new window after the user has successfully authenticated.
+      console.log(`Logged in with id: ${user.id}`);
+    })
+
+    // When the user is redirected back to your app, handle the redirect to
+    // save the user's access token and close the redirect window. This
+    // returns focus to the original application window and automatically
+    // logs the user in.
+    Realm.handleAuthRedirect();
 
 .. _web-facebook-auth-token:
 
@@ -415,35 +250,16 @@ handle the user authentication and redirect flow. Once authenticated, the
 Facebook SDK returns an access token that you can use to finish logging the user
 in to your app.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         // Get the access token from the Facebook SDK
-         const { accessToken } = FB.getAuthResponse();
-         // Define credentials with the access token from the Facebook SDK
-         const credentials = Realm.Credentials.facebook(accessToken);
-         // Log the user in to your app
-         app.logIn(credentials).then(user => {
-           console.log(`Logged in with id: ${user.id}`);
-         });
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         // Get the access token from the Facebook SDK
-         const { accessToken } = FB.getAuthResponse();
-         // Define credentials with the access token from the Facebook SDK
-         const credentials = Realm.Credentials.facebook(accessToken);
-         // Log the user in to your app
-         app.logIn(credentials).then((user: Realm.User) => {
-           console.log(`Logged in with id: ${user.id}`);
-         });
+    // Get the access token from the Facebook SDK
+    const { accessToken } = FB.getAuthResponse();
+    // Define credentials with the access token from the Facebook SDK
+    const credentials = Realm.Credentials.facebook(accessToken);
+    // Log the user in to your app
+    app.logIn(credentials).then(user => {
+      console.log(`Logged in with id: ${user.id}`);
+    });
 
 .. _web-login-google:
 
@@ -479,45 +295,22 @@ Authenticate with Google One Tap
    log Google users in to your web app, you must :ref:`enable OpenID Connect
    <openIdConnect>` in the authentication provider configuration.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         import * as Realm from "realm-web";
-         import googleOneTap from 'google-one-tap';
-         
-         const app = new Realm.App("<Your Realm App ID>");
-         const client_id = "<Your Google Client ID>";
-         
-         // Open the Google One Tap menu
-         googleOneTap({ client_id }, async (response) => {
-           // Upon successful Google authentication, log in to Realm with the user's credential
-           const credentials = Realm.Credentials.google(response.credential)
-           const user = await app.logIn(credentials);
-           console.log(`Logged in with id: ${user.id}`);
-         });
 
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         import * as Realm from "realm-web";
-         import googleOneTap from 'google-one-tap';
-         
-         const app = new Realm.App("<Your Realm App ID>");
-         const client_id = "<Your Google Client ID>";
-         
-         // Open the Google One Tap menu
-         googleOneTap({ client_id }, async (response: { credential: string }) => {
-           // Upon successful Google authentication, log in to Realm with the user's credential
-           const credentials = Realm.Credentials.google(response.credential)
-           const user = await app.logIn(credentials);
-           console.log(`Logged in with id: ${user.id}`);
-         });
+.. code-block:: javascript
+
+    import * as Realm from "realm-web";
+    import googleOneTap from 'google-one-tap';
+
+    const app = new Realm.App("<Your Realm App ID>");
+    const client_id = "<Your Google Client ID>";
+
+    // Open the Google One Tap menu
+    googleOneTap({ client_id }, async (response) => {
+      // Upon successful Google authentication, log in to Realm with the user's credential
+      const credentials = Realm.Credentials.google(response.credential)
+      const user = await app.logIn(credentials);
+      console.log(`Logged in with id: ${user.id}`);
+    });
 
 .. _web-google-builtin:
 
@@ -539,53 +332,25 @@ require you to install a Google SDK. The built-in flow follows three main steps:
    user's Realm access token and closes the window. Your original app window will
    automatically detect the access token and finish logging the user in.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         // The redirect URI should be on the same domain as this app and
-         // specified in the auth provider configuration.
-         const redirectUri = "https://app.example.com/handleOAuthLogin";
-         const credentials = Realm.Credentials.google(redirectUri);
-         
-         // Calling logIn() opens a Google authentication screen in a new window.
-         app.logIn(credentials).then(user => {
-           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
-           // from the new window after the user has successfully authenticated.
-           console.log(`Logged in with id: ${user.id}`);
-         })
-         
-         // When the user is redirected back to your app, handle the redirect to
-         // save the user's access token and close the redirect window. This
-         // returns focus to the original application window and automatically
-         // logs the user in.
-         Realm.handleAuthRedirect();
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         // The redirect URI should be on the same domain as this app and
-         // specified in the auth provider configuration.
-         const redirectUri = "https://app.example.com/handleOAuthLogin";
-         const credentials = Realm.Credentials.google(redirectUri);
-         
-         // Calling logIn() opens a Google authentication screen in a new window.
-         app.logIn(credentials).then((user: Realm.User) => {
-           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
-           // from the new window after the user has successfully authenticated.
-           console.log(`Logged in with id: ${user.id}`);
-         })
-         
-         // When the user is redirected back to your app, handle the redirect to
-         // save the user's access token and close the redirect window. This
-         // returns focus to the original application window and automatically
-         // logs the user in.
-         Realm.handleAuthRedirect();
+    // The redirect URI should be on the same domain as this app and
+    // specified in the auth provider configuration.
+    const redirectUri = "https://app.example.com/handleOAuthLogin";
+    const credentials = Realm.Credentials.google(redirectUri);
+
+    // Calling logIn() opens a Google authentication screen in a new window.
+    app.logIn(credentials).then(user => {
+      // The logIn() promise will not resolve until you call `handleAuthRedirect()`
+      // from the new window after the user has successfully authenticated.
+      console.log(`Logged in with id: ${user.id}`);
+    })
+
+    // When the user is redirected back to your app, handle the redirect to
+    // save the user's access token and close the redirect window. This
+    // returns focus to the original application window and automatically
+    // logs the user in.
+    Realm.handleAuthRedirect();
 
 .. important:: Built-In OAuth 2.0 Redirect Limitations for Google
    
@@ -635,53 +400,25 @@ steps:
    user's Realm access token and closes the window. Your original app window will
    automatically detect the access token and finish logging the user in.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         // The redirect URI should be on the same domain as this app and
-         // specified in the auth provider configuration.
-         const redirectUri = "https://app.example.com/handleOAuthLogin";
-         const credentials = Realm.Credentials.apple(redirectUri);
-         
-         // Calling logIn() opens an Apple authentication screen in a new window.
-         app.logIn(credentials).then(user => {
-           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
-           // from the new window after the user has successfully authenticated.
-           console.log(`Logged in with id: ${user.id}`);
-         })
-         
-         // When the user is redirected back to your app, handle the redirect to
-         // save the user's access token and close the redirect window. This
-         // returns focus to the original application window and automatically
-         // logs the user in.
-         Realm.handleAuthRedirect();
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         // The redirect URI must be on the same domain as this app and
-         // must be specified in the auth provider configuration.
-         const redirectUri = "https://app.example.com/handleOAuthLogin";
-         const credentials = Realm.Credentials.apple(redirectUri);
-         
-         // Calling logIn() opens an Apple authentication screen in a new window.
-         app.logIn(credentials).then((user: Realm.User) => {
-           // The logIn() promise will not resolve until you call `handleAuthRedirect()`
-           // from the new window after the user has successfully authenticated.
-           console.log(`Logged in with id: ${user.id}`);
-         })
-         
-         // When the user is redirected back to your app, handle the redirect to
-         // save the user's access token and close the redirect window. This
-         // returns focus to the original application window and automatically
-         // logs the user in.
-         Realm.handleAuthRedirect();
+    // The redirect URI should be on the same domain as this app and
+    // specified in the auth provider configuration.
+    const redirectUri = "https://app.example.com/handleOAuthLogin";
+    const credentials = Realm.Credentials.apple(redirectUri);
+
+    // Calling logIn() opens an Apple authentication screen in a new window.
+    app.logIn(credentials).then(user => {
+      // The logIn() promise will not resolve until you call `handleAuthRedirect()`
+      // from the new window after the user has successfully authenticated.
+      console.log(`Logged in with id: ${user.id}`);
+    })
+
+    // When the user is redirected back to your app, handle the redirect to
+    // save the user's access token and close the redirect window. This
+    // returns focus to the original application window and automatically
+    // logs the user in.
+    Realm.handleAuthRedirect();
 
 .. _web-apple-auth-token:
 
@@ -693,41 +430,19 @@ You can use the :apple:`official Sign in with Apple JS SDK
 authentication and redirect flow. Once authenticated, the Apple JS SDK returns
 an ID token that you can use to finish logging the user in to your app.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         // Get the ID token from the Apple SDK
-         AppleID.auth.signIn()
-           .then(({ id_token }) => {
-             // Define credentials with the ID token from the Apple SDK
-             const credentials = Realm.Credentials.apple(id_token)
-             // Log the user in to your app
-             return app.logIn(credentials)
-           })
-           .then(user => {
-             console.log(`Logged in with id: ${user.id}`);
-           });
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         // Get the ID token from the Apple SDK
-         AppleID.auth.signIn()
-           .then(({ id_token: string }) => {
-             // Define credentials with the ID token from the Apple SDK
-             const credentials = Realm.Credentials.apple(id_token)
-             // Log the user in to your app
-             return app.logIn(credentials)
-           })
-           .then((user: Realm.User) => {
-             console.log(`Logged in with id: ${user.id}`);
-           });
+    // Get the ID token from the Apple SDK
+    AppleID.auth.signIn()
+      .then(({ id_token }) => {
+        // Define credentials with the ID token from the Apple SDK
+        const credentials = Realm.Credentials.apple(id_token)
+        // Log the user in to your app
+        return app.logIn(credentials)
+      })
+      .then(user => {
+        console.log(`Logged in with id: ${user.id}`);
+      });
 
 .. include:: /includes/authorization-appleidcredential-string.rst
 
@@ -738,24 +453,9 @@ Log Out
 
 To log any user out, call the ``User.logOut()`` on their user instance.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         // Log out the current user
-         await app.currentUser.logOut();
-         // Log out a specific user
-         await app.allUsers[2].logOut();
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         // Log out the current user
-         await app.currentUser.logOut();
-         // Log out a specific user
-         await app.allUsers[2].logOut();
+.. code-block:: javascript
+
+    // Log out the current user
+    await app.currentUser.logOut();
+    // Log out a specific user
+    await app.allUsers[2].logOut();

--- a/source/web/call-a-function.txt
+++ b/source/web/call-a-function.txt
@@ -42,41 +42,16 @@ In the Node SDK you call functions as a logged in user with the
 Call a Function
 ~~~~~~~~~~~~~~~
 
-.. tabs-realm-languages::
+.. code-block:: javascript
+   
+   const result = await user.functions.sum(2, 3);
 
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         const result = await user.functions.sum(2, 3);
-
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-         
-         const result: number = await user.functions.sum(2, 3);
 
 Call a Function Programmatically
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         const functionName = "sum";
-         const args = [2, 3];
-         const result = await user.callFunction(functionName, args);
-
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-         
-         const functionName = "sum";
-         const args = [2, 3];
-         const result: number = await user.callFunction(functionName, args);
+.. code-block:: javascript
+   
+   const functionName = "sum";
+   const args = [2, 3];
+   const result = await user.callFunction(functionName, args);

--- a/source/web/create-manage-api-keys.txt
+++ b/source/web/create-manage-api-keys.txt
@@ -38,23 +38,10 @@ user's API keys.
 
 .. include:: /includes/note-store-user-api-key-value.rst
 
-.. tabs-realm-languages::
+.. code-block:: javascript
    
-   .. tab::
-      :tabid: javascript
-
-      .. code-block:: javascript
-         
-         const user = app.currentUser;
-         const key = await user.apiKeys.create("apiKeyName");
-   
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-         
-         const user: Realm.User = app.currentUser;
-         const key: Realm.Auth.ApiKey = await user.apiKeys.create("apiKeyName");
+   const user = app.currentUser;
+   const key = await user.apiKeys.create("apiKeyName");
 
 .. _web-api-key-look-up-user-key:
 
@@ -65,29 +52,13 @@ To get an array that lists all of a user's API keys, call
 ``ApiKeyAuth.fetchAll()``. You can also find a specific API key by calling
 ``ApiKeyAuth.fetch()`` with the key's ``_id``.
 
-.. tabs-realm-languages::
+.. code-block:: javascript
    
-   .. tab::
-      :tabid: javascript
-
-      .. code-block:: javascript
-         
-         const user = app.currentUser;
-         // List all of a user's keys
-         const keys = await user.apiKeys.fetchAll();
-         // Get a specific key by its ID
-         const key = await user.apiKeys.fetch("5eb5931548d79bc784adf46e");
-   
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-         
-         const user: Realm.User = app.currentUser;
-         // List all of a user's keys
-         const keys: Realm.Auth.ApiKey[] = await user.apiKeys.fetchAll();
-         // Get a specific key by its ID
-         const key: Realm.Auth.ApiKey = await user.apiKeys.fetch("5eb5931548d79bc784adf46e");
+   const user = app.currentUser;
+   // List all of a user's keys
+   const keys = await user.apiKeys.fetchAll();
+   // Get a specific key by its ID
+   const key = await user.apiKeys.fetch("5eb5931548d79bc784adf46e");
 
 .. _web-api-key-enable-disable:
 
@@ -98,37 +69,17 @@ You can enable or disable a user API key by calling ``ApiKeyAuth.enable()`` or
 ``ApiKeyAuth.disable()`` with the key's ``_id``. When a key is disabled, it
 cannot be used to log in on behalf of the user.
 
-.. tabs-realm-languages::
+.. code-block:: javascript
    
-   .. tab::
-      :tabid: javascript
-
-      .. code-block:: javascript
-         
-         // Get the ID of a User API Key
-         const user = app.currentUser;
-         const apiKeys = await user.apiKeys.fetchAll();
-         const keyId = apiKeys[0]["_id"];
-         
-         // Enable the User API Key
-         await user.apiKey.enable(keyId);
-         // Disable the User API Key
-         await user.apiKey.disable(keyId);
+   // Get the ID of a User API Key
+   const user = app.currentUser;
+   const apiKeys = await user.apiKeys.fetchAll();
+   const keyId = apiKeys[0]["_id"];
    
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-         
-         // Get the ID of a User API Key
-         const user: Realm.User = app.currentUser;
-         const apiKeys: Realm.Auth.ApiKey[] = await user.apiKeys.fetchAll();
-         const keyId: string = apiKeys[0]["_id"];
-         
-         // Enable the User API Key
-         await user.apiKey.enable(keyId);
-         // Disable the User API Key
-         await user.apiKey.disable(keyId);
+   // Enable the User API Key
+   await user.apiKey.enable(keyId);
+   // Disable the User API Key
+   await user.apiKey.disable(keyId);
 
 .. _web-api-key-delete:
 
@@ -139,30 +90,12 @@ You can permanently delete a user API key by calling ``ApiKeyAuth.delete()``
 with the key's ``_id``. Deleted keys can no longer be used to log in on behalf
 of the user.
 
-.. tabs-realm-languages::
+.. code-block:: javascript
    
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         // Get the ID of a User API Key
-         const user = app.currentUser;
-         const apiKeys = await user.apiKeys.fetchAll();
-         const keyId = apiKeys[0]["_id"];
-         
-         // Delete the User API Key
-         await user.apiKey.delete(keyId);
+   // Get the ID of a User API Key
+   const user = app.currentUser;
+   const apiKeys = await user.apiKeys.fetchAll();
+   const keyId = apiKeys[0]["_id"];
    
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         // Get the ID of a User API Key
-         const user: Realm.User = app.currentUser;
-         const apiKeys: Realm.Auth.ApiKey[] = await user.apiKeys.fetchAll();
-         const keyId: string = apiKeys[0]["_id"];
-         
-         // Delete the User API Key
-         await user.apiKey.delete(keyId);
+   // Delete the User API Key
+   await user.apiKey.delete(keyId);

--- a/source/web/init-realmclient.txt
+++ b/source/web/init-realmclient.txt
@@ -21,21 +21,9 @@ Access the App Client
 
 Pass the {+service+} App ID for your {+app+}, which you can :ref:`find in the Realm UI <find-your-app-id>`.
 
-.. tabs-realm-languages::
+.. code-block:: javascript
 
-      .. tab::
-         :tabid: typescript
-
-         .. code-block:: typescript
-
-            const id = "<Your App ID>"; // replace this with your App ID
-
-      .. tab::
-         :tabid: javascript
-
-         .. code-block:: javascript
-
-            const id = "<Your App ID>"; // replace this with your App ID
+   const id = "<Your App ID>"; // replace this with your App ID
 
 .. _web-client-configurations:
 
@@ -45,30 +33,15 @@ Configuration
 To set up your {+app+} client, pass a configuration object to an instance
 of ``Realm.App``.
 
-.. tabs-realm-languages::
+.. code-block:: javascript
 
-      .. tab::
-         :tabid: typescript
-
-         .. code-block:: typescript
-
-            const config = {
-              id,
-            };
-            const app: Realm.App = new Realm.App(config);
-
-      .. tab::
-         :tabid: javascript
-
-         .. code-block:: javascript
-
-            const config = {
-              id,
-            };
-            const app = new Realm.App(config);
+   const config = {
+      id,
+   };
+   const app = new Realm.App(config);
 
 .. note:: 
-    
+
    ``id`` is a required field of the application configuration object. To see the full list of fields for the configuration object that ``Realm.App`` accepts as a parameter, view the :js-sdk:`App Configuration Type Definitions <Realm.App.html#~AppConfiguration>`.
    
 
@@ -79,18 +52,6 @@ Retrieve an Instance of the App Client
 
 To retrieve an instance of the App Client from anywhere in your application, call :js-sdk:`Realm.App.getApp() <Realm.App.html#getApp>` and pass in your ``App ID``. 
 
-.. tabs-realm-languages::
+.. code-block:: javascript
 
-      .. tab::
-         :tabid: typescript
-
-         .. code-block:: typescript
-
-            const app: Realm.App =  Realm.App.getApp("<Your App ID>"); // replace this with your App ID
-
-      .. tab::
-         :tabid: javascript
-
-         .. code-block:: javascript
-
-            const app = Realm.App.getApp("<Your App ID>"); // replace this with your App ID
+   const app = Realm.App.getApp("<Your App ID>"); // replace this with your App ID

--- a/source/web/manage-email-password-users.txt
+++ b/source/web/manage-email-password-users.txt
@@ -29,25 +29,11 @@ the user's email address and desired password. The email address must not be
 associated with another email/password user and the password must be between 6
 and 128 characters.
 
-.. tabs-realm-languages::
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: javascript
-
-      .. code-block:: javascript
-
-         const email = "someone@example.com";
-         const password = "Pa55w0rd";
-         await app.emailPasswordAuth.registerUser({ email, password });
-
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-
-         const email = "someone@example.com";
-         const password = "Pa55w0rd";
-         await app.emailPasswordAuth.registerUser({ email, password });
+   const email = "someone@example.com";
+   const password = "Pa55w0rd";
+   await app.emailPasswordAuth.registerUser({ email, password });
 
 .. note:: Confirm New Users
 
@@ -97,21 +83,9 @@ places depending on the provider configuration:
 To confirm a registered user, call the ``confirmUser()`` method with the user's
 valid ``token`` and ``tokenId``:
 
-.. tabs-realm-languages::
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: javascript
-
-      .. code-block:: javascript
-
-         await app.emailPasswordAuth.confirmUser({ token, tokenId });
-
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-
-         await app.emailPasswordAuth.confirmUser({ token, tokenId });
+   await app.emailPasswordAuth.confirmUser({ token, tokenId });
 
 .. _web-email-password-retry-user-confirmation:
 
@@ -129,23 +103,10 @@ Resend a Confirmation Email
 To resend the confirmation email to a user, call the ``resendConfirmationEmail()``
 method with the user's email address:
 
-.. tabs-realm-languages::
+.. code-block:: javascript
    
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         const email = "someone@example.com"; // The user's email address
-         await app.emailPasswordAuth.resendConfirmationEmail({ email });
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         const email = "someone@example.com"; // The user's email address
-         await app.emailPasswordAuth.resendConfirmationEmail({ email });
+   const email = "someone@example.com"; // The user's email address
+   await app.emailPasswordAuth.resendConfirmationEmail({ email });
 
 .. _web-email-password-resend-confirmation-function:
 
@@ -158,23 +119,10 @@ To re-run your :ref:`custom confirmation function
 <auth-run-a-confirmation-function>`, call the ``retryCustomConfirmation()`` method
 with the user's email address:
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. code-block:: javascript
-         
-         const email = "someone@example.com"; // The user's email address
-         await app.emailPasswordAuth.retryCustomConfirmation({ email });
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. code-block:: typescript
-         
-         const email = "someone@example.com"; // The user's email address
-         await app.emailPasswordAuth.retryCustomConfirmation({ email });
+.. code-block:: javascript
+
+   const email = "someone@example.com"; // The user's email address
+   await app.emailPasswordAuth.retryCustomConfirmation({ email });
 
 .. _web-email-password-reset-password:
 
@@ -191,25 +139,11 @@ If the provider is configured to :ref:`send a password reset email
 reset email to a user. The email contains a link to the configured
 :guilabel:`Password Reset URL`.
 
-.. tabs-realm-languages::
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: javascript
-
-      .. code-block:: javascript
-
-         // The user's email address
-         const email = "joe.jasper@example.com"
-         await app.emailPasswordAuth.sendResetPasswordEmail({ email });
-
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-
-         // The user's email address
-         const email = "joe.jasper@example.com"
-         await app.emailPasswordAuth.sendResetPasswordEmail({ email });
+   // The user's email address
+   const email = "joe.jasper@example.com"
+   await app.emailPasswordAuth.sendResetPasswordEmail({ email });
 
 .. _web-call-password-reset-function:
 
@@ -219,35 +153,16 @@ Call a Password Reset Function
 If the provider is configured to :ref:`run a password reset function
 <auth-run-a-password-reset-function>`, you can use the SDK to run the function.
 
-.. tabs-realm-languages::
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: javascript
+   // The user's email address
+   const email = "joe.jasper@example.com";
+   // The new password to use
+   const password = "newPassw0rd";
+   // Additional arguments for the reset function
+   const args = [];
 
-      .. code-block:: javascript
-
-         // The user's email address
-         const email = "joe.jasper@example.com";
-         // The new password to use
-         const password = "newPassw0rd";
-         // Additional arguments for the reset function
-         const args = [];
-
-         await app.emailPasswordAuth.callResetPasswordFunction({ email, password }, args);
-
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-
-         // The user's email address
-         const email = "joe.jasper@example.com";
-         // The new password to use
-         const password = "newPassw0rd";
-         // Additional arguments for the reset function
-         const args: any[] = [];
-
-         await app.emailPasswordAuth.callResetPasswordFunction({ email, password }, args);
+   await app.emailPasswordAuth.callResetPasswordFunction({ email, password }, args);
 
 .. _web-email-password-complete-password-reset:
 
@@ -260,21 +175,9 @@ function <web-call-password-reset-function>`, Realm generates a pair of unique
 ``token`` and ``tokenId`` values that they can use to complete the password
 reset within 30 minutes of the initial request.
 
-.. tabs-realm-languages::
+.. code-block:: javascript
 
-   .. tab::
-      :tabid: javascript
-
-      .. code-block:: javascript
-
-         await app.emailPasswordAuth.resetPassword({ password: "newPassw0rd", token, tokenId });
-
-   .. tab::
-      :tabid: typescript
-
-      .. code-block:: typescript
-
-         await app.emailPasswordAuth.resetPassword({ password: "newPassw0rd", token, tokenId });
+   await app.emailPasswordAuth.resetPassword({ password: "newPassw0rd", token, tokenId });
 
 .. example:: Get the Token and TokenID
 
@@ -282,32 +185,13 @@ reset within 30 minutes of the initial request.
    ``tokenId`` are included as query parameters in the password reset URL. You
    can access them like so:
 
-   .. tabs-realm-languages::
+.. code-block:: javascript
 
-      .. tab::
-         :tabid: javascript
-
-         .. code-block:: javascript
-
-            const params = new URLSearchParams(window.location.search);
-            const token = params.get("token");
-            const tokenId = params.get("tokenId");
-            if (!token || !tokenId) {
-              throw new Error(
-                "You can only call resetPassword() if the user followed a confirmation email link"
-              );
-            }
-
-      .. tab::
-         :tabid: typescript
-
-         .. code-block:: typescript
-
-            const params = new URLSearchParams(window.location.search);
-            const token: string | null = params.get("token");
-            const tokenId: string | null = params.get("tokenId");
-            if (!token || !tokenId) {
-              throw new Error(
-                "You can only call resetPassword() if the user followed a confirmation email link"
-              );
-            }
+   const params = new URLSearchParams(window.location.search);
+   const token = params.get("token");
+   const tokenId = params.get("tokenId");
+   if (!token || !tokenId) {
+      throw new Error(
+         "You can only call resetPassword() if the user followed a confirmation email link"
+      );
+   }

--- a/source/web/work-with-multiple-users.txt
+++ b/source/web/work-with-multiple-users.txt
@@ -72,19 +72,8 @@ The {+service-short+} SDK automatically saves user data to a browser's local
 storage when they log in for the first time on that browser. When a user logs
 in, they immediately become the application's :ref:`active user <active-user>`.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. literalinclude:: /examples/MultiUser/AddUser/AddUser.js
-         :language: javascript
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. literalinclude:: /examples/MultiUser/AddUser/AddUser.ts
-         :language: typescript
+.. literalinclude:: /examples/MultiUser/AddUser/AddUser.js
+   :language: javascript
 
 .. _web-list-users:
 
@@ -95,19 +84,8 @@ You can access a list of all :ref:`user accounts <user-accounts>` associated
 with the browser. This list includes all users that have logged in to the client
 app regardless of whether they are currently authenticated.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. literalinclude:: /examples/MultiUser/ListUsers/ListUsers.js
-         :language: javascript
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. literalinclude:: /examples/MultiUser/ListUsers/ListUsers.ts
-         :language: typescript
+.. literalinclude:: /examples/MultiUser/ListUsers/ListUsers.js
+   :language: javascript
 
 .. _web-switch-user:
 
@@ -117,19 +95,9 @@ Switch the Active User
 You can quickly switch an app's :ref:`active user <active-user>` to another
 logged in user at any time.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. literalinclude:: /examples/MultiUser/SwitchUser/SwitchUser.js
-         :language: javascript
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. literalinclude:: /examples/MultiUser/SwitchUser/SwitchUser.ts
-         :language: typescript
+.. literalinclude:: /examples/MultiUser/SwitchUser/SwitchUser.js
+   :language: javascript
+
 
 .. _web-remove-user:
 
@@ -139,16 +107,5 @@ Remove a User from the Device
 You can remove all information about a user from the browser and automatically
 log the user out.
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-      
-      .. literalinclude:: /examples/MultiUser/LogoutUser/LogoutUser.js
-         :language: javascript
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. literalinclude:: /examples/MultiUser/LogoutUser/LogoutUser.ts
-         :language: typescript
+.. literalinclude:: /examples/MultiUser/LogoutUser/LogoutUser.js
+   :language: javascript


### PR DESCRIPTION
## Pull Request Info

Remove all TypeScript examples that
* don't provide useful information
* are the same as the JS examples
* do not use type inference

this was done to streamline docs and remove errors where switching between language tabs causes the interface to jerk around the page. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-20055

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20055/web/init-realmclient/
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20055/web/authenticate/
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20055/web/manage-email-password-users/
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20055/web/create-manage-api-keys/
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20055/web/work-with-multiple-users/
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20055/web/access-custom-user-data/
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20055/web/call-a-function/

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
