### PR TITLE
[Sync] Add a link to moved content

### DIFF
--- a/source/sync.txt
+++ b/source/sync.txt
@@ -15,3 +15,5 @@ Realm Sync Overview
    Handle Errors </sync/error-handling>
    Add Sync to a Local-Only App </sync/local-to-sync>
    Sync Production Load Testing </sync/production-load-testing>
+
+Want to learn more about {+sync+}? See: :ref:`Realm Sync Overview <sync-overview>`.


### PR DESCRIPTION
## Pull Request Info

It was pointed out that the UI links directly to the `/sync` page, which is now an empty container page. This PR adds a text link to the content that used to live on this page as an interim fix until UI can change the URL directly.

### Staged Changes (Requires MongoDB Corp SSO)

- [Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/add-sync-redirect-note/sync)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
