### PR TITLE
(DOCSP-19418): Swift SDK Flexible Sync

### DIFF
--- a/source/sdk/swift/examples.txt
+++ b/source/sdk/swift/examples.txt
@@ -14,6 +14,7 @@ Usage Examples - Swift SDK
    Connect to a MongoDB Realm Backend App </sdk/swift/examples/connect-to-a-mongodb-realm-backend-app>
    Work with Users </sdk/swift/examples/work-with-users>
    Sync Changes Between Devices </sdk/swift/examples/sync-changes-between-devices>
+   Flexible Sync </sdk/swift/examples/flexible-sync>
    SwiftUI Guide </sdk/swift/examples/swiftui-guide>
    Legacy Realm Sync Open Methods </sdk/swift/examples/sync-realm-open-legacy>
    Call a Function </sdk/swift/examples/call-a-function>
@@ -35,6 +36,7 @@ Application Services (Sync)
 ---------------------------
 - :doc:`Connect to a MongoDB Realm Backend App </sdk/swift/examples/connect-to-a-mongodb-realm-backend-app>`
 - :doc:`Work with Users </sdk/swift/examples/work-with-users>`
+- :doc:`Flexible Sync </sdk/swift/examples/flexible-sync>`
 - :doc:`Sync Changes Between Devices </sdk/swift/examples/sync-changes-between-devices>`
 - :doc:`Call a Function </sdk/swift/examples/call-a-function>`
 - :doc:`Create & Manage User API Keys </sdk/swift/examples/manage-user-api-keys>`

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -178,7 +178,7 @@ to open a synced realm.
    let app = App(id: YOUR_APP_ID_HERE)
    let user = try await app.login(credentials: Credentials.emailPassword(email: "email", password: "password"))
    let config = user.flexibleSyncConfiguration()
-   let realm = try await Realm.init(configuration: config, downloadBeforeOpen: .always)
+   let realm = try await Realm(configuration: config, downloadBeforeOpen: .always)
 
 .. _ios-specify-download-behavior:
 

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -71,6 +71,139 @@ Open a Local Realm
       .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.codeblock.open-local-realm.m
          :language: objectivec
 
+.. _ios-login-and-open-realm:
+
+Open a Synced Realm
+-------------------
+
+The typical flow for opening a synced {+realm+} involves:
+
+1. :ref:`Authenticating the user <ios-authenticate-users>`.
+#. Creating a sync configuration.
+#. Opening the user's synced {+realm+} with the configuration.
+
+At authentication, we cache user credentials in a ``sync_metadata.realm`` 
+file on device.
+
+When you open a synced {+realm+} after authenticating, you can bypass the 
+login flow and go directly to opening the synced {+realm+}, using the same 
+sync configuration you already created.
+
+With cached credentials, you can:
+
+- Open a synced {+realm+} immediately with the data that is on the device.
+  You can use this method offline or online.
+- Open a synced {+realm+} after downloading changes from your {+app+}. 
+  This requires the user to have an active internet connection.
+
+Synced Realms vs Local Realms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Synced {+realms+} differ from local {+client-database+} in a few ways:
+
+- Synced {+realms+} attempt to sync changes with your backend {+app+},
+  whereas local {+realms+} do not.
+- Synced {+realms+} can be accessed by authenticated users, while local 
+  {+realms+} do not require any concept of users or authentication.
+- With synced {+realms+}, you can :ref:`specify the download behavior 
+  <ios-specify-download-behavior>` to download updates before opening a 
+  {+realm+}. However, this requires users to be online. Local {+realms+} - 
+  with no sync capability - can always be used offline.
+
+You can copy data from a :ref:`local {+client-database+} <ios-open-a-local-realm>` 
+to a synced {+realm+}, but you cannot sync a local {+client-database+}.
+
+.. _ios-partition-based-sync-open-realm:
+
+Open a Synced Realm with Partition-Based Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Initialize a synced {+realm+} with a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`.
+This enables you to specify a partition value whose data should sync to the realm.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      .. versionchanged:: 10.15.0
+
+      .. seealso::
+         
+         This example uses async/await introduced in Swift 5.5 for iOS 15. If you're
+         using an older version of Swift or need to support older platforms, see:
+         :ref:`Legacy Realm Sync Open Methods <ios-realm-open-legacy>`. 
+
+      Pass a logged-in user's :swift-sdk:`configuration <Structs/Realm/Configuration.html>` 
+      object with the desired :ref:`partition value <partition-value>` to 
+      :swift-sdk:`{+realm+} initializers 
+      <Structs/Realm.html#/s:10RealmSwift0A0V13configuration5queueA2C13ConfigurationV_So012OS_dispatch_D0CSgtKcfc>`.
+
+      You can optionally :ref:`specify whether a {+realm+} should download 
+      changes before opening <ios-specify-download-behavior>`. If you do not
+      specify download behavior, this opens a {+realm+} with data that is on
+      the device, and attempts to sync changes in the background.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      The first time you log in and open a synced {+realm+}, you'll log in the
+      user, and pass the user's :objc-sdk:`RLMSyncConfiguration 
+      <Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)syncConfiguration>` 
+      object with the desired :objc-sdk:`partitionValue 
+      <Classes/RLMSyncConfiguration.html#/c:objc(cs)RLMSyncConfiguration(py)partitionValue>` 
+      to :objc-sdk:`+[RLMRealm realmWithConfiguration:error:]
+      <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`.
+
+      This opens a synced {+realm+} on the device. The {+realm+} 
+      attempts to sync with your {+app+} in the background to check for changes 
+      on the server, or upload changes that the user has made.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.init-synced-realm.m
+         :language: swift
+
+.. _ios-flexible-sync-open-realm:
+
+Open a Synced Realm with a Flexible Sync Configuration
+------------------------------------------------------
+
+When you use Flexible Sync, use the ``flexibleSyncConfiguration()``
+to open a synced realm. 
+
+.. code-block:: swift
+
+   let app = App(id: YOUR_APP_ID_HERE)
+   let user = try await app.login(credentials: Credentials.emailPassword(email: "email", password: "password"))
+   let config = user.flexibleSyncConfiguration()
+   let realm = try await Realm.init(configuration: config, downloadBeforeOpen: .always)
+
+.. _ios-specify-download-behavior:
+
+Download Changes Before Open
+----------------------------
+
+.. versionadded:: 10.15.0
+
+When you open a synced {+realm+} with the Swift SDK, you can pass the 
+``downloadBeforeOpen`` parameter to specify whether to download the 
+changeset from your {+app+} before opening the {+realm+}. This parameter 
+accepts a case from the ``OpenBehavior`` enum:
+
+- ``never``: Immediately open the {+realm+} on the device. Download changes 
+  in the background when the user has internet, but don't block opening
+  the {+realm+}.
+- ``always``: Check for changes every time you open the {+realm+}.
+  Requires the user to have an active internet connection.
+- ``once``: Download data before opening a {+realm+} for the first time, but
+  open it without downloading changes on subsequent opens. This lets you 
+  populate a {+realm+} with initial data, but enables offline-first 
+  functionality on subsequent opens.
+
+.. include:: /examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
+
 .. _ios-close-a-realm:
 
 Close a Realm

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -96,15 +96,15 @@ With cached credentials, you can:
 - Open a synced {+realm+} after downloading changes from your {+app+}. 
   This requires the user to have an active internet connection.
 
-Synced Realms vs Local Realms
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Synced Realms vs. Local Realms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Synced {+realms+} differ from local {+client-database+} in a few ways:
 
 - Synced {+realms+} attempt to sync changes with your backend {+app+},
   whereas local {+realms+} do not.
 - Synced {+realms+} can be accessed by authenticated users, while local 
-  {+realms+} do not require any concept of users or authentication.
+  {+realms+} have no concept of users or authentication.
 - With synced {+realms+}, you can :ref:`specify the download behavior 
   <ios-specify-download-behavior>` to download updates before opening a 
   {+realm+}. However, this requires users to be online. Local {+realms+} - 

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -168,7 +168,7 @@ This enables you to specify a partition value whose data should sync to the real
 .. _ios-flexible-sync-open-realm:
 
 Open a Synced Realm with a Flexible Sync Configuration
-------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When you use Flexible Sync, use the ``flexibleSyncConfiguration()``
 to open a synced realm. 

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -46,7 +46,7 @@ syncs to the client device.
 About the Examples on This Page
 -------------------------------
    
-The examples in this page use a simple data set for a
+The examples on this page use a simple data set for a
 task list app. The two Realm object types are ``Team``
 and ``Task``. A ``Task`` has a ``taskName``, assignee's name, and
 completed flag. There is also an arbitrary number for
@@ -92,7 +92,7 @@ You can:
 Data matching the subscription, where the user has the appropriate 
 permissions, syncs between devices and the backend application.
 
-You can specify an optional a string name for your subscription.
+You can specify an optional string name for your subscription.
 
 When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
@@ -199,7 +199,7 @@ Async/Await
 ```````````
 
 If your application uses async/await, you don't need the ``onComplete`` 
-block. The write transaction executes asynchronously, and throws an 
+block. The write transaction executes asynchronously and throws an 
 error if the transaction cannot complete successfully.
 
 .. code-block:: swift

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -38,6 +38,35 @@ syncs to the client device.
    general information about using Realm Sync, see: :ref:`Sync Changes 
    Between Devices <ios-sync-changes-between-devices>`.
 
+About the Examples on This Page
+-------------------------------
+   
+The examples in this page use a simple data set for a
+task list app. The two Realm object types are ``Team``
+and ``Task``. A ``Task`` has a ``taskName``, assignee's name, and
+completed flag. There is also an arbitrary number for
+priority -- higher is more important -- and a count of
+minutes spent working on it. A ``Team`` has a ``teamName``, 
+zero or more ``Tasks``, and a list of ``members``.
+
+.. code-block:: swift
+
+   class Task: Object {
+      @Persisted(primaryKey: true) var id: ObjectId
+      @Persisted var taskName: String
+      @Persisted var assignee: String?
+      @Persisted var completed: Bool
+      @Persisted var progressMinutes: Int
+   }
+
+   class Team: Object {
+      @Persisted(primaryKey: true) var id: ObjectId
+      @Persisted var teamName: String
+      @Persisted var tasks: List<Task>
+      @Persisted var members: List<String>
+   }
+
+
 .. _ios-sync-subscribe-to-queryable-fields:
 
 Subscribe to Queryable Fields
@@ -53,13 +82,12 @@ You can:
 - Add subscriptions
 - Check subscription state
 - Update subscriptions with new queries
-- Remove individual subscriptions or all subscriptions of a type
+- Remove individual subscriptions or all subscriptions for an object type
 
 Data matching the subscription, where the user has the appropriate 
 permissions, syncs between devices and the backend application.
 
-You can specify a string name for your subscription. If you do not give your
-subscription a name, Realm uses the query string as the name.
+You can specify an optional a string name for your subscription.
 
 When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
@@ -67,23 +95,22 @@ object types. You can also have multiple queries on the same object type.
 
 .. example::
 
-   When you create a subscription with no explicit name, the name becomes
-   a string version of the query. In this example, it's 
-   ``$0.name == "Developer Education"``.
-
-   .. code-block:: swift
-
-      QuerySubscription<Team> {
-         $0.name == "Developer Education"
-      }
-
-   You can also create a subscription with an explicit name. Then, you can
+   You can create a subscription with an explicit name. Then, you can
    search for that subscription by name to update or remove it.
 
    .. code-block:: swift 
 
       QuerySubscription<Task>(name: "long-running-completed") {
-         $0.status == "complete" && $0.progressMinutes > 120
+         $0.complete == true && $0.progressMinutes > 120
+      }
+
+   If you do not specify a ``name`` for a subscription, you can search 
+   for the subscription by the query string.
+
+   .. code-block:: swift
+
+      QuerySubscription<Team> {
+         $0.teamName == "Developer Education"
       }
 
 .. _ios-sync-add-subscription:
@@ -98,14 +125,13 @@ new subscription to the client's Realm subscriptions.
 
    let subscriptions = realm.subscriptions
    if subscriptions.isEmpty {
-      try! await subscriptions.write {
-         try! subscriptions.append {
+      try! subscriptions.write {
+         subscriptions.append {
             QuerySubscription<Team> {
-               $0.name == "Developer Education"
+               $0.teamName == "Developer Education"
             }
          }
       }
-      try! await subscriptions.waitForAsync()
    }
 
 .. _ios-sync-check-subscription-state:
@@ -124,14 +150,14 @@ enum. You can use subscription state to:
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try! await subscriptions.write {
-      try! subscriptions.remove {
+   try! subscriptions.write {
+      subscriptions.remove {
          QuerySubscription<Task> {
-            $0.owner == "Joe Doe"
+            $0.assignee == "Joe Doe"
          }
       }
    }
-   for await state in subscriptions.state {
+   for state in subscriptions.state {
       // Notify state changes
       print(state)
    }
@@ -148,12 +174,12 @@ subscription with a new query.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   let query = { QuerySubscription<Team> { $0.name == "Developer Education" } }
+   let query = { QuerySubscription<Team> { $0.teamName == "Developer Education" } }
    if let subscription = subscriptions.first(where: query) {
       try! subscriptions.write {
          subscription.update {
             QuerySubscription<Team>(name: "docs-team") {
-               $0.name == "Documentation"
+               $0.teamName == "Documentation"
             }
          }
       }
@@ -182,9 +208,9 @@ name to find the appropriate query subscription to remove.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   if let subscription = subscriptions.first(where: { $0.name == "docs-team" }) {   
+   if let subscription = subscriptions.first(where: { QuerySubscription<Team>  { $0.teamName == "docs-team" }}) {   
       try! subscriptions.write {
-         try! subscriptions.remove(subscription)
+         subscriptions.remove(subscription)
       }
    }
 
@@ -197,7 +223,6 @@ If you want to remove all subscriptions to a specific object type, use the
 .. code-block:: swift
 
    let subscriptions = ream.subscriptions
-   try! await subscriptions.write {
-      try! subscriptions.removeAll(ofType: Team.self)
+   try! subscriptions.write {
+      subscriptions.removeAll(ofType: Team.self)
    }
-   try! await subscriptions.waitforAsync()

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -20,7 +20,7 @@ data to sync with your {+app+}.
 
 To use Flexible Sync in an iOS client:
 
-- Configure Flexible Sync on the backend [LINK TO BACKEND CONFIG PAGE WHEN COMPLETE]
+- :ref:`Configure Flexible Sync on the backend <enable-flexible-sync>`
 - :ref:`Initialize the app <ios-quick-start-init-app>`
 - :ref:`Authenticate a user <ios-quick-start-authenticate>` in
   your client project.
@@ -227,9 +227,9 @@ Additionally, you can watch the state of the subscription set with the
 Superseded
 ``````````
 
-``superceded`` is a ``SyncSubscriptionState`` that can occur when another
+``superseded`` is a ``SyncSubscriptionState`` that can occur when another
 thread writes a subscription on a different instance of the 
-subscription set. If the state becomes ``superceded``, you must obtain 
+subscription set. If the state becomes ``superseded``, you must obtain 
 a new instance of the subscription set before you can write to it.
 
 .. _ios-update-subscriptions-with-new-query:
@@ -343,6 +343,12 @@ Remove All Subscriptions
 
 To remove all subscriptions from the subscription set, use the ``removeAll``
 method in a subscription write block.
+
+.. important::
+
+   If you remove all subscriptions and do not add a new one, you'll 
+   get an error. A realm opened with a flexible sync configuration needs
+   at least one subscription to sync with the server.
 
 .. code-block:: swift
 

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -58,19 +58,12 @@ You can:
 Data matching the subscription, where the user has the appropriate 
 permissions, syncs between devices and the backend application.
 
-A Realm subscription has:
-
-- Identifier
-- Name
-- Created and updated dates
-
 You can specify a string name for your subscription. If you do not give your
-subscription a name, it uses the value of the query as a string name.
+subscription a name, Realm uses the query string as the name.
 
 When you create a subscription, Realm looks for data matching a query on a
-specific object type. You can have subscriptions on several different object 
-types, or several queries on the same object type, in your Flexible Sync 
-subscriptions.
+specific object type. You can have multiple subscription sets on different 
+object types. You can also have multiple queries on the same object type.
 
 .. example::
 
@@ -99,20 +92,20 @@ Add a Subscription
 ~~~~~~~~~~~~~~~~~~
 
 Add a subscription in a subscriptions write block. You append each
-new subscription to the client's realm subscriptions.
+new subscription to the client's Realm subscriptions.
 
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
    if subscriptions.isEmpty {
-      try await subscriptions.write {
-         try subscriptions.append {
+      try! await subscriptions.write {
+         try! subscriptions.append {
             QuerySubscription<Team> {
                $0.name == "Developer Education"
             }
          }
       }
-      try await subscriptions.waitForAsync()
+      try! await subscriptions.waitForAsync()
    }
 
 .. _ios-sync-check-subscription-state:
@@ -131,8 +124,8 @@ enum. You can use subscription state to:
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try await subscriptions.write {
-      try subscriptions.remove {
+   try! await subscriptions.write {
+      try! subscriptions.remove {
          QuerySubscription<Task> {
             $0.owner == "Joe Doe"
          }
@@ -149,7 +142,7 @@ Update Subscriptions with a New Query
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can update subscriptions using ``update``. In this example, we 
-search for a subscription matching our query, and then update that 
+search for a subscription matching our query and then update that 
 subscription with a new query. 
 
 .. code-block:: swift
@@ -157,7 +150,7 @@ subscription with a new query.
    let subscriptions = realm.subscriptions
    let query = { QuerySubscription<Team> { $0.name == "Developer Education" } }
    if let subscription = subscriptions.first(where: query) {
-      try subscriptions.write {
+      try! subscriptions.write {
          subscription.update {
             QuerySubscription<Team>(name: "docs-team") {
                $0.name == "Documentation"
@@ -174,29 +167,29 @@ Remove Subscriptions
 To remove subscriptions, you can:
 
 - Remove a single subscription query
-- Remove all subscriptions of a specific type
+- Remove all subscriptions to a specific object type
 
-When you remove a subscription query, the server asynchronously removes 
-synced data from the client device.
+When you remove a subscription query, Realm asynchronously removes the
+synced data that matched the query from the client device.
 
 Remove a Single Subscription
 ````````````````````````````
 
 You can remove a specific subscription query in a subscription write block 
-using ``remove``. Specify the query by name, or use the query as a string 
+using ``remove``. Specify the query by name or use the query as a string 
 name to find the appropriate query subscription to remove.
 
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
    if let subscription = subscriptions.first(where: { $0.name == "docs-team" }) {   
-      try subscriptions.write {
-         try subscriptions.remove(subscription)
+      try! subscriptions.write {
+         try! subscriptions.remove(subscription)
       }
    }
 
-Remove All Subscriptions of a Type
-``````````````````````````````````
+Remove All Subscriptions to an Object Type
+``````````````````````````````````````````
 
 If you want to remove all subscriptions to a specific object type, use the 
 ``removeAll`` method in a subscription write block.
@@ -204,7 +197,7 @@ If you want to remove all subscriptions to a specific object type, use the
 .. code-block:: swift
 
    let subscriptions = ream.subscriptions
-   try await subscriptions.write {
-      try subscriptions.removeAll(ofType: Team.self)
+   try! await subscriptions.write {
+      try! subscriptions.removeAll(ofType: Team.self)
    }
-   try await subscriptions.waitforAsync()
+   try! await subscriptions.waitforAsync()

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -34,9 +34,13 @@ syncs to the client device.
 
 .. seealso::
 
-   This page details how to manage subscriptions for Flexible Sync. For 
-   general information about using Realm Sync, see: :ref:`Sync Changes 
-   Between Devices <ios-sync-changes-between-devices>`.
+   This page details how to manage subscriptions for Flexible Sync. 
+   
+   For general information about using Realm Sync with the Swift SDK, 
+   see: :ref:`Sync Changes Between Devices <ios-sync-changes-between-devices>`.
+
+   For information about setting up permissions for Flexible Sync, see:
+   :ref:`Flexible Sync Rules & Permissions <flexible-sync-rules-and-permissions>`.
 
 About the Examples on This Page
 -------------------------------
@@ -93,6 +97,10 @@ When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
 object types. You can also have multiple queries on the same object type.
 
+Subscription names must be unique. If you do not explicitly name a 
+subscription, and instead subscribe to the same unnamed query more than
+once, Realm ignores the duplicate query subscriptions.
+
 .. example::
 
    You can create a subscription with an explicit name. Then, you can
@@ -144,8 +152,16 @@ enum. You can use subscription state to:
 
 - Trigger error handling
 - Show a progress indicator while data is downloading
-- Find out when a subscription set is superseded and you should obtain a
-  new instance of the subscription set to write a subscription change
+- Find out when a subscription set becomes superseded
+
+Subscription state is only one component of changing a subscription.
+After the subscription change, the realm syncs to resolve any updates to
+the data as a result of the subscription change. This could mean adding 
+or removing data from the synced realm. You can wait for a synced 
+realm to update data by using the ``waitForDownloads(for: realm)``.
+If you want to react to subscription state changes by redrawing a UI, 
+for example, or taking another action based on changes to the data set,
+wait for the realm to sync after making subscription updates.
 
 .. code-block:: swift
 
@@ -157,10 +173,22 @@ enum. You can use subscription state to:
          }
       }
    }
-   for state in subscriptions.state {
-      // Notify state changes
-      print(state)
+   subscriptions?.observe { state in
+      if case .complete = state {
+            // Do something when state is complete
+      }
    }
+
+   // After the state change, wait for the synced realm to update data
+   waitForDownloads(for: realm)
+
+Superseded
+``````````
+
+``superceded`` is a ``SyncSubscriptionState`` that can occur when another
+thread writes a subscription on a different instance of the 
+subscription set. If the state becomes ``superceded``, you must obtain 
+a new instance of the subscription set before you can write to it.
 
 .. _ios-update-subscriptions-with-new-query:
 
@@ -181,6 +209,22 @@ subscription with a new query.
             QuerySubscription<Team>(name: "docs-team") {
                $0.teamName == "Documentation"
             }
+         }
+      }
+   }
+
+You can also search for a subscription by name. In this example, we 
+search for a subscription by name and then update that subscription with
+a new query.
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   let foundSubscription = subscriptions.first(named: "docs-team")
+   try! subscriptions.write {
+      foundSubscription.update {
+         QuerySubscription<Team>(name: "docs-team") {
+            $0.teamName == "Documentation"
          }
       }
    }
@@ -208,21 +252,33 @@ name to find the appropriate query subscription to remove.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   if let subscription = subscriptions.first(where: { QuerySubscription<Team>  { $0.teamName == "docs-team" }}) {   
-      try! subscriptions.write {
-         subscriptions.remove(subscription)
-      }
+   let foundSubscription = subscriptions.first(named: "docs-team")   
+   try! subscriptions.write {
+      subscriptions.remove(foundSubscription!)
    }
 
 Remove All Subscriptions to an Object Type
 ``````````````````````````````````````````
 
 If you want to remove all subscriptions to a specific object type, use the 
-``removeAll`` method in a subscription write block.
+``removeAll`` method with ``ofType`` in a subscription write block.
 
 .. code-block:: swift
 
-   let subscriptions = ream.subscriptions
+   let subscriptions = realm.subscriptions
    try! subscriptions.write {
       subscriptions.removeAll(ofType: Team.self)
+   }
+
+Remove All Subscriptions
+````````````````````````
+
+To remove all subscriptions from the subscription set, use the ``removeAll``
+method in a subscription write block.
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   try! subscriptions.write {
+      subscriptions.removeAll()
    }

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -37,6 +37,7 @@ syncs to the client device.
    This page details how to manage subscriptions for Flexible Sync. 
    
    For general information about using Realm Sync with the Swift SDK, 
+   such as how to sync changes in the background or pause a sync session,
    see: :ref:`Sync Changes Between Devices <ios-sync-changes-between-devices>`.
 
    For information about setting up permissions for Flexible Sync, see:
@@ -84,7 +85,7 @@ queryable fields.
 You can:
 
 - Add subscriptions
-- Check subscription state
+- React to subscription state
 - Update subscriptions with new queries
 - Remove individual subscriptions or all subscriptions for an object type
 
@@ -96,10 +97,6 @@ You can specify an optional a string name for your subscription.
 When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
 object types. You can also have multiple queries on the same object type.
-
-Subscription names must be unique. If you do not explicitly name a 
-subscription, and instead subscribe to the same unnamed query more than
-once, Realm ignores the duplicate query subscriptions.
 
 .. example::
 
@@ -121,6 +118,18 @@ once, Realm ignores the duplicate query subscriptions.
          $0.teamName == "Developer Education"
       }
 
+.. note:: Duplicate subscriptions
+
+   Subscription names must be unique. Trying to append a subscription 
+   with the same name as an existing subscription throws an error.
+   
+   If you do not explicitly name a subscription, and instead subscribe 
+   to the same unnamed query more than once, Realm does not persist 
+   duplicate queries to the subscription set. 
+   
+   If you subscribe to the same query more than once under different names, 
+   Realm persists both subscriptions to the subscription set.
+
 .. _ios-sync-add-subscription:
 
 Add a Subscription
@@ -132,55 +141,88 @@ new subscription to the client's Realm subscriptions.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   if subscriptions.isEmpty {
-      try! subscriptions.write {
-         subscriptions.append {
-            QuerySubscription<Team> {
-               $0.teamName == "Developer Education"
-            }
+   subscriptions.write {
+      subscriptions.append {
+         QuerySubscription<Team> {
+            $0.teamName == "Developer Education"
          }
+      }
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
       }
    }
 
 .. _ios-sync-check-subscription-state:
+.. _ios-sync-react-to-subscription-changes:
 
-Check Subscription State
-~~~~~~~~~~~~~~~~~~~~~~~~
+Wait for Subscription Changes to Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can watch the state of the subscription set with the ``SyncSubscriptionState``
-enum. You can use subscription state to:
+Writing an update to the subscription set locally is only one component 
+of changing a subscription. After the local subscription change, the realm 
+synchronizes with the server to resolve any updates to the data due to 
+the subscription change. This could mean adding or removing data from the 
+synced realm. 
 
-- Trigger error handling
-- Show a progress indicator while data is downloading
-- Find out when a subscription set becomes superseded
+Pre Async/Await
+```````````````
 
-Subscription state is only one component of changing a subscription.
-After the subscription change, the realm syncs to resolve any updates to
-the data as a result of the subscription change. This could mean adding 
-or removing data from the synced realm. You can wait for a synced 
-realm to update data by using the ``waitForDownloads(for: realm)``.
-If you want to react to subscription state changes by redrawing a UI, 
-for example, or taking another action based on changes to the data set,
-wait for the realm to sync after making subscription updates.
+If your application does not use Swift's async/await feature, you can react 
+to subscription changes syncing with the server using the ``onComplete`` 
+block. This block is called after subscriptions are synchronized with the 
+server. If you want to react to subscription state changes by redrawing a 
+UI, for example, or taking another action based on changes to the data set, 
+take those actions in ``onComplete``. This is also where you can handle 
+optional errors that occur during synchronization.
 
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try! subscriptions.write {
+   subscriptions.write {
       subscriptions.remove {
          QuerySubscription<Task> {
             $0.assignee == "Joe Doe"
          }
       }
-   }
-   subscriptions?.observe { state in
-      if case .complete = state {
-            // Do something when state is complete
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
       }
    }
 
-   // After the state change, wait for the synced realm to update data
-   waitForDownloads(for: realm)
+Async/Await
+```````````
+
+If your application uses async/await, you don't need the ``onComplete`` 
+block. The write transaction executes asynchronously, and throws an 
+error if the transaction cannot complete successfully.
+
+.. code-block:: swift
+
+   func changeSubscription() async throws {
+      let subscriptions = realm.subscriptions
+      try await subcriptions.write {
+         subscriptions.remove {
+            QuerySubscription<Task> {
+               $0.assignee == "Joe Doe"
+            }
+         }
+      }
+   }
+
+SyncSubscriptionState Enum
+``````````````````````````
+
+Additionally, you can watch the state of the subscription set with the 
+``SyncSubscriptionState`` enum. You can use subscription state to:
+
+- Show a progress indicator while data is downloading
+- Find out when a subscription set becomes superseded
 
 Superseded
 ``````````
@@ -202,15 +244,22 @@ subscription with a new query.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   let query = { QuerySubscription<Team> { $0.teamName == "Developer Education" } }
-   if let subscription = subscriptions.first(where: query) {
-      try! subscriptions.write {
-         subscription.update {
-            QuerySubscription<Team>(name: "docs-team") {
-               $0.teamName == "Documentation"
-            }
+   let foundSubscription = subscriptions.first {
+      QuerySubscription<Team> { 
+         $0.teamName == "Developer Education" 
+      }
+   }
+   subscriptions.write {
+      foundSubscription?.update {
+         QuerySubscription<Team>(name: "docs-team") {
+            $0.teamName == "Documentation"
          }
       }
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
    }
 
 You can also search for a subscription by name. In this example, we 
@@ -221,11 +270,17 @@ a new query.
 
    let subscriptions = realm.subscriptions
    let foundSubscription = subscriptions.first(named: "docs-team")
-   try! subscriptions.write {
-      foundSubscription.update {
+   subscriptions.write {
+      foundSubscription?.update {
          QuerySubscription<Team>(name: "docs-team") {
             $0.teamName == "Documentation"
          }
+      }
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
       }
    }
 
@@ -238,6 +293,7 @@ To remove subscriptions, you can:
 
 - Remove a single subscription query
 - Remove all subscriptions to a specific object type
+- Remove all subscriptions
 
 When you remove a subscription query, Realm asynchronously removes the
 synced data that matched the query from the client device.
@@ -253,8 +309,14 @@ name to find the appropriate query subscription to remove.
 
    let subscriptions = realm.subscriptions
    let foundSubscription = subscriptions.first(named: "docs-team")   
-   try! subscriptions.write {
+   subscriptions.write {
       subscriptions.remove(foundSubscription!)
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
+      }
    }
 
 Remove All Subscriptions to an Object Type
@@ -266,8 +328,14 @@ If you want to remove all subscriptions to a specific object type, use the
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try! subscriptions.write {
+   subscriptions.write {
       subscriptions.removeAll(ofType: Team.self)
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
+      }
    }
 
 Remove All Subscriptions
@@ -279,6 +347,12 @@ method in a subscription write block.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try! subscriptions.write {
+   subscriptions.write {
       subscriptions.removeAll()
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
+      }
    }

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -1,0 +1,210 @@
+.. _ios-flexible-sync:
+
+=======================
+Flexible Sync - iOS SDK
+=======================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+Flexible Sync uses subscriptions and permissions to determine which
+data to sync with your {+app+}.
+
+To use Flexible Sync in an iOS client:
+
+- Configure Flexible Sync on the backend [LINK TO BACKEND CONFIG PAGE WHEN COMPLETE]
+- :ref:`Initialize the app <ios-quick-start-init-app>`
+- :ref:`Authenticate a user <ios-quick-start-authenticate>` in
+  your client project.
+- :ref:`Open the synced Realm with a Flexible Sync configuration <ios-flexible-sync-open-realm>`
+- :ref:`Add subscriptions to the client application <ios-sync-subscribe-to-queryable-fields>`
+
+You can add, update, and remove query subscriptions to determine which data 
+syncs to the client device.
+
+.. include:: /includes/note-flexible-sync-preview.rst
+
+.. seealso::
+
+   This page details how to manage subscriptions for Flexible Sync. For 
+   general information about using Realm Sync, see: :ref:`Sync Changes 
+   Between Devices <ios-sync-changes-between-devices>`.
+
+.. _ios-sync-subscribe-to-queryable-fields:
+
+Subscribe to Queryable Fields
+-----------------------------
+
+When you configure Flexible Sync on the backend, you specify which fields
+your client application can query. In the client application, use the 
+``subscriptions`` API to manage a set of subscriptions to specific queries on 
+queryable fields.
+
+You can:
+
+- Add subscriptions
+- Check subscription state
+- Update subscriptions with new queries
+- Remove individual subscriptions or all subscriptions of a type
+
+Data matching the subscription, where the user has the appropriate 
+permissions, syncs between devices and the backend application.
+
+A Realm subscription has:
+
+- Identifier
+- Name
+- Created and updated dates
+
+You can specify a string name for your subscription. If you do not give your
+subscription a name, it uses the value of the query as a string name.
+
+When you create a subscription, Realm looks for data matching a query on a
+specific object type. You can have subscriptions on several different object 
+types, or several queries on the same object type, in your Flexible Sync 
+subscriptions.
+
+.. example::
+
+   When you create a subscription with no explicit name, the name becomes
+   a string version of the query. In this example, it's 
+   ``$0.name == "Developer Education"``.
+
+   .. code-block:: swift
+
+      QuerySubscription<Team> {
+         $0.name == "Developer Education"
+      }
+
+   You can also create a subscription with an explicit name. Then, you can
+   search for that subscription by name to update or remove it.
+
+   .. code-block:: swift 
+
+      QuerySubscription<Task>(name: "long-running-completed") {
+         $0.status == "complete" && $0.progressMinutes > 120
+      }
+
+.. _ios-sync-add-subscription:
+
+Add a Subscription
+~~~~~~~~~~~~~~~~~~
+
+Add a subscription in a subscriptions write block. You append each
+new subscription to the client's realm subscriptions.
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   if subscriptions.isEmpty {
+      try await subscriptions.write {
+         try subscriptions.append {
+            QuerySubscription<Team> {
+               $0.name == "Developer Education"
+            }
+         }
+      }
+      try await subscriptions.waitForAsync()
+   }
+
+.. _ios-sync-check-subscription-state:
+
+Check Subscription State
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can watch the state of the subscription set with the ``SyncSubscriptionState``
+enum. You can use subscription state to:
+
+- Trigger error handling
+- Show a progress indicator while data is downloading
+- Find out when a subscription set is superseded and you should obtain a
+  new instance of the subscription set to write a subscription change
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   try await subscriptions.write {
+      try subscriptions.remove {
+         QuerySubscription<Task> {
+            $0.owner == "Joe Doe"
+         }
+      }
+   }
+   for await state in subscriptions.state {
+      // Notify state changes
+      print(state)
+   }
+
+.. _ios-update-subscriptions-with-new-query:
+
+Update Subscriptions with a New Query
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can update subscriptions using ``update``. In this example, we 
+search for a subscription matching our query, and then update that 
+subscription with a new query. 
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   let query = { QuerySubscription<Team> { $0.name == "Developer Education" } }
+   if let subscription = subscriptions.first(where: query) {
+      try subscriptions.write {
+         subscription.update {
+            QuerySubscription<Team>(name: "docs-team") {
+               $0.name == "Documentation"
+            }
+         }
+      }
+   }
+
+.. _ios-remove-subscriptions:
+
+Remove Subscriptions
+~~~~~~~~~~~~~~~~~~~~
+
+To remove subscriptions, you can:
+
+- Remove a single subscription query
+- Remove all subscriptions of a specific type
+
+When you remove a subscription query, the server asynchronously removes 
+synced data from the client device.
+
+Remove a Single Subscription
+````````````````````````````
+
+You can remove a specific subscription query in a subscription write block 
+using ``remove``. Specify the query by name, or use the query as a string 
+name to find the appropriate query subscription to remove.
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   if let subscription = subscriptions.first(where: { $0.name == "docs-team" }) {   
+      try subscriptions.write {
+         try subscriptions.remove(subscription)
+      }
+   }
+
+Remove All Subscriptions of a Type
+``````````````````````````````````
+
+If you want to remove all subscriptions to a specific object type, use the 
+``removeAll`` method in a subscription write block.
+
+.. code-block:: swift
+
+   let subscriptions = ream.subscriptions
+   try await subscriptions.write {
+      try subscriptions.removeAll(ofType: Team.self)
+   }
+   try await subscriptions.waitforAsync()

--- a/source/sdk/swift/examples/sync-changes-between-devices.txt
+++ b/source/sdk/swift/examples/sync-changes-between-devices.txt
@@ -14,119 +14,46 @@ Sync Changes Between Devices - Swift SDK
 
 .. _ios-open-a-synced-realm:
 
-Overview
---------
+Prerequisites
+-------------
 
-The typical flow for opening a synced {+realm+} involves:
+Before you can access a synced {+realm+} from the client, you must:
 
-1. :ref:`Authenticating the user <ios-authenticate-users>`
-#. Creating a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`
-#. Opening the user's synced {+realm+} with the configuration.
+1. :ref:`Enable sync <enable-sync>` in the {+ui+}.
 
-At authentication, we cache user credentials in a ``sync_metadata.realm`` 
-file on device.
+#. :ref:`Initialize the app <ios-quick-start-init-app>`
 
-When you open a synced {+realm+} after authenticating, you can bypass the 
-login flow and go directly to opening the synced {+realm+}, using the same 
-sync configuration you already created.
+#. :ref:`Authenticate a user <ios-quick-start-authenticate>` in
+  your client project.
 
-With cached credentials, you can:
+#. :ref:`Open a Synced Realm <ios-login-and-open-realm>`
 
-- Open a synced {+realm+} immediately with the data that is on the device.
-  You can use this method offline or online.
-- Open a synced {+realm+} after downloading changes from your {+app+}. 
-  This requires the user to have an active internet connection.
+Sync Data
+---------
 
-Synced Realms vs Local Realms
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The syntax to :ref:`read <ios-read-operations>`, :ref:`write
+<ios-write-operations>`, and
+:ref:`watch for changes <ios-react-to-changes>` on a
+synced {+realm+} is identical to the syntax for non-synced {+realms+}. While 
+you work with local data, a background thread efficiently integrates, 
+uploads, and downloads changesets.
 
-Synced {+realms+} differ from local {+client-database+} in a few ways:
+.. important:: When Using Sync, Avoid Writes on the Main Thread
 
-- Synced {+realms+} attempt to sync changes with your backend {+app+},
-  whereas local {+realms+} do not.
-- Synced {+realms+} can be accessed by authenticated users, while local 
-  {+realms+} do not require any concept of users or authentication.
-- With synced {+realms+}, you can :ref:`specify the download behavior 
-  <ios-specify-download-behavior>` to download updates before opening a 
-  {+realm+}. However, this requires users to be online. Local {+realms+} - 
-  with no sync capability - can always be used offline.
+   The fact that {+service-short+} performs sync integrations on a background thread means
+   that if you write to your {+realm+} on the main thread, there's a small chance your UI
+   could appear to hang as it waits for the background sync thread to finish a write
+   transaction. Therefore, it's a best practice :ref:`not to write on the main thread
+   when using {+sync+} <ios-threading-three-rules>`.
 
-You can copy data from a :ref:`local {+client-database+} <ios-open-a-local-realm>` 
-to a synced {+realm+}, but you cannot sync a local {+client-database+}. You
-must initialize a synced {+realm+} with a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`.
+The following code creates a new ``Task`` object and writes it to the {+realm+}:
 
-.. _ios-login-and-open-realm:
+.. literalinclude:: /examples/generated/code/start/CompleteQuickStart.codeblock.create-task.swift
+   :language: swift
 
-Open a Synced Realm
--------------------
+.. seealso::
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: swift
-
-      .. versionchanged:: 10.15.0
-
-      .. seealso::
-         
-         This example uses async/await introduced in Swift 5.5 for iOS 15. If you're
-         using an older version of Swift or need to support older platforms, see:
-         :ref:`Legacy Realm Sync Open Methods <ios-realm-open-legacy>`. 
-
-      Pass a logged-in user's :swift-sdk:`configuration <Structs/Realm/Configuration.html>` 
-      object with the desired :ref:`partition value <partition-value>` to 
-      :swift-sdk:`{+realm+} initializers 
-      <Structs/Realm.html#/s:10RealmSwift0A0V13configuration5queueA2C13ConfigurationV_So012OS_dispatch_D0CSgtKcfc>`.
-
-      You can optionally :ref:`specify whether a {+realm+} should download 
-      changes before opening <ios-specify-download-behavior>`. If you do not
-      specify download behavior, this opens a {+realm+} with data that is on
-      the device, and attempts to sync changes in the background.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm.swift
-         :language: swift
-
-   .. tab::
-      :tabid: objective-c
-
-      The first time you log in and open a synced {+realm+}, you'll log in the
-      user, and pass the user's :objc-sdk:`RLMSyncConfiguration 
-      <Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)syncConfiguration>` 
-      object with the desired :objc-sdk:`partitionValue 
-      <Classes/RLMSyncConfiguration.html#/c:objc(cs)RLMSyncConfiguration(py)partitionValue>` 
-      to :objc-sdk:`+[RLMRealm realmWithConfiguration:error:]
-      <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`.
-
-      This opens a synced {+realm+} on the device. The {+realm+} 
-      attempts to sync with your {+app+} in the background to check for changes 
-      on the server, or upload changes that the user has made.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.init-synced-realm.m
-         :language: swift
-
-.. _ios-specify-download-behavior:
-
-Download Changes Before Open
-----------------------------
-
-.. versionadded:: 10.15.0
-
-When you open a synced {+realm+} with the Swift SDK, you can pass the 
-``downloadBeforeOpen`` parameter to specify whether to download the 
-changeset from your {+app+} before opening the {+realm+}. This parameter 
-accepts a case from the ``OpenBehavior`` enum:
-
-- ``never``: Immediately open the {+realm+} on the device. Download changes 
-  in the background when the user has internet, but don't block opening
-  the {+realm+}.
-- ``always``: Check for changes every time you open the {+realm+}.
-  Requires the user to have an active internet connection.
-- ``once``: Download data before opening a {+realm+} for the first time, but
-  open it without downloading changes on subsequent opens. This lets you 
-  populate a {+realm+} with initial data, but enables offline-first 
-  functionality on subsequent opens.
-
-.. include:: /examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
+   :ref:`Threading <ios-client-threading>`
 
 .. _ios-sync-changes-in-the-background:
 

--- a/source/sdk/swift/examples/sync-changes-between-devices.txt
+++ b/source/sdk/swift/examples/sync-changes-between-devices.txt
@@ -24,7 +24,7 @@ Before you can access a synced {+realm+} from the client, you must:
 #. :ref:`Initialize the app <ios-quick-start-init-app>`
 
 #. :ref:`Authenticate a user <ios-quick-start-authenticate>` in
-  your client project.
+   your client project.
 
 #. :ref:`Open a Synced Realm <ios-login-and-open-realm>`
 

--- a/source/sync/data-access-patterns/flexible-sync.txt
+++ b/source/sync/data-access-patterns/flexible-sync.txt
@@ -173,8 +173,8 @@ sync objects with the backend {+app+} and can watch for and react to changes.
    .. tab::
       :tabid: ios
 
-      To create queries from the Swift Client SDK, see the Swift SDK guide 
-      to Sync Changes Between Devices with Flexible Sync.
+      To create queries from the Swift Client SDK, see the :ref:`Swift SDK 
+      guide to Flexible Sync <ios-flexible-sync>`.
 
    .. tab::
       :tabid: node


### PR DESCRIPTION
## Pull Request Info

Note for reviewer: the Flexible Sync examples can't currently be tested in our Swift SDK unit test framework. I created an independent project and verified that the syntax compiles, but haven't tested these code examples against a backend. We'll need to update with tested code examples after the feature is live.

### Jira

- https://jira.mongodb.org/browse/DOCSP-19418

### Staged Changes (Requires MongoDB Corp SSO)

- [Flexible Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19418/sdk/swift/examples/flexible-sync/): Net new content about managing subscriptions using the Swift SDK API
- [Sync Changes Between Devices](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19418/sdk/swift/examples/sync-changes-between-devices/): Removed content about opening a realm, match other SDK versions of the page
- [Configure and Open a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19418/sdk/swift/examples/configure-and-open-a-realm/): Moved content here from Sync Changes Between Devices page to match the other SDKs, add an example of opening a Flexible Sync configuration

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
