### PR TITLE
(DOCSP-19319): Add info about pagination to Admin API 

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -824,6 +824,8 @@ paths:
           content:
             application/json:
               schema:
+                type: array 
+                maxItems: 50
                 items:
                   $ref: "#/components/schemas/User"
     post:
@@ -1411,6 +1413,7 @@ paths:
                 properties:
                   logs:
                     type: array
+                    maxItems: 100
                     items:
                       type: object
                       properties:

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -826,6 +826,7 @@ paths:
               schema:
                 type: array 
                 maxItems: 50
+                description: At most 50 results per request. 
                 items:
                   $ref: "#/components/schemas/User"
     post:
@@ -1414,6 +1415,7 @@ paths:
                   logs:
                     type: array
                     maxItems: 100
+                    description: At most 100 results per request. 
                     items:
                       type: object
                       properties:


### PR DESCRIPTION
## Pull Request Info

Tweaked info about pagination to make clearer which endpoints use. 

wasn't able to implement as much change as i would have liked here due to feature limitation of snooty's openapi parse. see ticket for more info. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-19319

### Staged Changes (Requires MongoDB Corp SSO)

- [Admin API Reference](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19319/admin/api/v3/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
