### PR TITLE
Flexible Sync: Link Concept & Configure content

### DIFF
--- a/source/includes/note-unsupported-flex-sync-rql-operators.rst
+++ b/source/includes/note-unsupported-flex-sync-rql-operators.rst
@@ -1,0 +1,5 @@
+.. important::
+
+   Flexible Sync does not support all the operators available in Realm 
+   Query Language. See :ref:`Flexible Sync RQL Limitations 
+   <flexible-sync-rql-limitations>` for details.

--- a/source/sdk/swift/fundamentals/realm-sync.txt
+++ b/source/sdk/swift/fundamentals/realm-sync.txt
@@ -15,11 +15,10 @@ Realm Sync - Swift SDK
 Overview
 --------
 
-Realm Sync <sync-overview> automatically synchronizes data between 
-client applications and a :ref:`MongoDB Realm backend application 
-<realm-cloud>`. When a client device is online, {+sync-short+} asynchronously 
-synchronizes data in a background thread between the device and your backend 
-{+app+}. 
+Realm Sync automatically synchronizes data between client applications and 
+a :ref:`MongoDB Realm backend application <realm-cloud>`. When a client 
+device is online, {+sync-short+} asynchronously synchronizes data in a 
+background thread between the device and your backend {+app+}. 
 
 When you use Sync in your client application, your implementation must match 
 the Sync Mode you select in your backend {+app+} configuration. The Sync Mode
@@ -33,7 +32,7 @@ Partition-Based Sync and Flexible Sync within the same {+app+}.
 
 .. seealso::
 
-   [ADD LINK] (Backend app configuration content)
+   :ref:`enable-realm-sync`
 
 .. _ios-partition-based-sync-fundamentals:
 
@@ -47,7 +46,7 @@ partition value. This is the value of the :ref:`partition key
 
 The partition value determines which data the client application can access.
 
-You pass in the partition value when you open a synced realm [ADD LINK].
+You pass in the partition value when you open a synced realm.
 
 .. _ios-flexible-sync-fundamentals:
 
@@ -60,25 +59,21 @@ queries on :ref:`queryable fields <queryable-fields>`. Flexible Sync works
 by synchronizing data that matches query subscriptions you maintain in the 
 client application. 
 
-A subscription contains a set of queries. Realm Flexible Sync returns 
+A subscription set contains a set of queries. Realm Flexible Sync returns 
 documents matching those queries, where the user has the appropriate 
 :ref:`permissions <flexible-sync-rules-and-permissions>` to read and/or 
-read and write the documents. If there are documents that match the query, 
-but the client does not have the permission to read or write them, they 
-do not sync to the client application.
+read and write the documents. If documents match the query, but the client 
+does not have the permission to read or write them, they do not sync to 
+the client application.
 
-You can form queries using Realm Query Language [ADD LINK].
+You can form queries using :ref:`Realm Query Language <realm-query-language>`.
 
-.. important::
-
-   Flexible Sync does not support all the operators available in Realm 
-   Query Language. See Realm Query Language: Flexible Sync Supported 
-   Operators [ADD LINK] for details.
+.. include:: /includes/note-unsupported-flex-sync-rql-operators.rst
 
 Subscription sets are based on a specific type of :ref:`realm object 
-<ios-realm-objects>`. You might have multiple subscription sets if you 
+<ios-realm-objects>`. You might have multiple subscriptions if you 
 have many types of realm objects.
 
 To use Flexible Sync in your client application, open a synced realm 
-with a flexible sync configuration [ADD LINK]. Then, manage subscriptions
-to determine which documents to sync [ADD LINK].
+with a flexible sync configuration. Then, manage subscriptions
+to determine which documents to sync.

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -32,7 +32,7 @@ and rules for your {+app+}. If you haven't already decided how you want to
 configure your data model and access {+sync-short+}, see:
 
 - :ref:`Configure Your Data Model <sync-schema-overview>`
-- :ref:`Partitions <sync-partitions>`
+- :ref:`Choose Your Sync Mode <sync-modes>`
 - :ref:`Sync Rules and Permissions <sync-permissions>`
 
 .. _enable-pbs-sync:


### PR DESCRIPTION
## Pull Request Info

The Flexible Sync content was created in several different PRs. This PR links the content that has now been merged to the query-based-sync branch. It adds a note/include that we should include on all of the SDK Flexible Sync pages regarding Realm Query Operators. And also some (very) minor wording tweaks and link cleanup for pages that are not yet merged.

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/link-concept-configure-content/sdk/swift/fundamentals/realm-sync/)
- [Enable Realm Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/link-concept-configure-content/sync/configure/enable-sync/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
