### PR TITLE
(DOCSP-20092): [Swift SDK] Delete user documentation

### DIFF
--- a/examples/ios/Examples/Authenticate.swift
+++ b/examples/ios/Examples/Authenticate.swift
@@ -1,9 +1,9 @@
 import XCTest
- import RealmSwift
- import GoogleSignIn
- import FBSDKLoginKit
+import RealmSwift
+import GoogleSignIn
+import FBSDKLoginKit
 
- class Authenticate: XCTestCase {
+class Authenticate: XCTestCase {
     func testGoogleCredentials() {
         let expectation = XCTestExpectation(description: "login completes")
 
@@ -268,4 +268,4 @@ import XCTest
         // :code-block-end:
         wait(for: [expectation], timeout: 10)
     }
- }
+}

--- a/examples/ios/Examples/Authenticate.swift
+++ b/examples/ios/Examples/Authenticate.swift
@@ -1,9 +1,9 @@
 import XCTest
-import RealmSwift
-import GoogleSignIn
-import FBSDKLoginKit
+ import RealmSwift
+ import GoogleSignIn
+ import FBSDKLoginKit
 
-class Authenticate: XCTestCase {
+ class Authenticate: XCTestCase {
     func testGoogleCredentials() {
         let expectation = XCTestExpectation(description: "login completes")
 
@@ -140,6 +140,8 @@ class Authenticate: XCTestCase {
         }
         // :code-block-end:
         wait(for: [expectation], timeout: 10)
+        // Delete this user so it doesn't interfere with the DeleteUsers tests
+        app.currentUser?.delete()
     }
 
     func testApiKeyCredentials() {
@@ -266,4 +268,4 @@ class Authenticate: XCTestCase {
         // :code-block-end:
         wait(for: [expectation], timeout: 10)
     }
-}
+ }

--- a/examples/ios/Examples/DeleteUsers.swift
+++ b/examples/ios/Examples/DeleteUsers.swift
@@ -1,0 +1,69 @@
+import XCTest
+import RealmSwift
+
+class DeleteUsers: XCTestCase {
+    func testDeleteUserWithCompletion() {
+        var syncUser: User?
+
+        let loginExpectation = XCTestExpectation(description: "User created and logged in")
+        // :code-block-start: closure-delete-user
+        // Logging in using anonymous authentication creates a user object
+        app.login(credentials: Credentials.anonymous) { [self] (result) in
+            switch result {
+            case .failure(let error):
+                fatalError("Login failed: \(error.localizedDescription)")
+            case .success(let user):
+                // Assign the user object to a variable to demonstrate user deletion
+                syncUser = user
+                // :hide-start:
+                loginExpectation.fulfill()
+                // :hide-end:
+            }
+        }
+        // :hide-start:
+        wait(for: [loginExpectation], timeout: 10)
+        // :hide-end:
+
+        // Now we have a user, and the total users in the app = 1
+        XCTAssertNotNil(syncUser)
+        XCTAssertEqual(app.allUsers.count, 1)
+
+        // :hide-start:
+        let deleteExpectation = XCTestExpectation(description: "User deleted")
+        // :hide-end:
+        // Call the `delete` method to delete the user
+        syncUser?.delete { (error) in
+            XCTAssertNil(error)
+            // :hide-start:
+            deleteExpectation.fulfill()
+            // :hide-end:
+        }
+        // :hide-start:
+        wait(for: [deleteExpectation], timeout: 10)
+        // :hide-end:
+
+        // When you delete the user, the SyncSession is destroyed and
+        // there is no current user.
+        XCTAssertNil(app.currentUser)
+        // Now that we've deleted the user, the app has no users.
+        XCTAssertEqual(app.allUsers.count, 0)
+        // :code-block-end:
+    }
+
+    // :code-block-start: async-await-delete-user
+    func testAsyncDeleteUser() async throws {
+        // Logging in using anonymous authentication creates a user object
+        let syncUser = try await app.login(credentials: Credentials.anonymous)
+        // Now we have a user, and the total users in the app = 1
+        XCTAssertNotNil(syncUser)
+        XCTAssertEqual(app.allUsers.count, 1)
+        // Call the `delete` method to delete the user
+        try await syncUser.delete()
+        // When you delete the user, the SyncSession is destroyed and
+        // there is no current user.
+        XCTAssertNil(app.currentUser)
+        // Now that we've deleted the user, the app has no users.
+        XCTAssertEqual(app.allUsers.count, 0)
+    }
+    // :code-block-end:
+}

--- a/examples/ios/Examples/DeleteUsers.swift
+++ b/examples/ios/Examples/DeleteUsers.swift
@@ -24,7 +24,8 @@ class DeleteUsers: XCTestCase {
         wait(for: [loginExpectation], timeout: 10)
         // :hide-end:
 
-        // Now we have a user, and the total users in the app = 1
+        // Later, after the user is loggedd in we have a user,
+        // and the total users in the app = 1
         XCTAssertNotNil(syncUser)
         XCTAssertEqual(app.allUsers.count, 1)
 
@@ -32,7 +33,7 @@ class DeleteUsers: XCTestCase {
         let deleteExpectation = XCTestExpectation(description: "User deleted")
         // :hide-end:
         // Call the `delete` method to delete the user
-        syncUser?.delete { (error) in
+        syncUser!.delete { (error) in
             XCTAssertNil(error)
             // :hide-start:
             deleteExpectation.fulfill()

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '15.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', '=10.22.0'
-  pod 'RealmSwift', '=10.22.0'
+  pod 'Realm', '=10.23.0'
+  pod 'RealmSwift', '=10.23.0'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,14 +13,14 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '=10.22.0'
+  pod 'RealmSwift', '=10.23.0'
 end
 
 target 'SwiftUIExamples' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '=10.22.0'
+  pod 'RealmSwift', '=10.23.0'
 end
 
 post_install do |installer|

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -44,9 +44,23 @@ SPEC REPOS:
     - GoogleSignIn
     - GTMAppAuth
     - GTMSessionFetcher
-    - Realm
-    - RealmSwift
     - SwiftLint
+
+EXTERNAL SOURCES:
+  Realm:
+    :branch: lm/delete-user
+    :git: https://github.com/realm/realm-swift.git
+  RealmSwift:
+    :branch: lm/delete-user
+    :git: https://github.com/realm/realm-swift.git
+
+CHECKOUT OPTIONS:
+  Realm:
+    :commit: c8298126273a8283bfd410abdaf16560898eeffc
+    :git: https://github.com/realm/realm-swift.git
+  RealmSwift:
+    :commit: c8298126273a8283bfd410abdaf16560898eeffc
+    :git: https://github.com/realm/realm-swift.git
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		91C6880D274D91A2001A5DBE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 91C6880C274D91A2001A5DBE /* LaunchScreen.storyboard */; };
 		91CEF5FE260E308100A029E0 /* Compacting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CEF5FD260E308100A029E0 /* Compacting.swift */; };
 		91CEF606260E325000A029E0 /* Compacting.m in Sources */ = {isa = PBXBuildFile; fileRef = 91CEF605260E325000A029E0 /* Compacting.m */; };
+		91FBD320279865080005C10C /* DeleteUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FBD31F279865080005C10C /* DeleteUsers.swift */; };
 		91FDC13B261E5DE3006A6E13 /* MutableSetExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FDC13A261E5DE3006A6E13 /* MutableSetExample.swift */; };
 		9693C7E1A0EB364049783775 /* Pods_SwiftUIExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C6EAFA4554E3F8917F6DAC1 /* Pods_SwiftUIExamples.framework */; };
 		AF99F5877D8B6A122C53FC08 /* Pods_QuickStartSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A56BE659D55DD6B9972241E4 /* Pods_QuickStartSwiftUI.framework */; };
@@ -184,6 +185,7 @@
 		91C6880C274D91A2001A5DBE /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		91CEF5FD260E308100A029E0 /* Compacting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compacting.swift; sourceTree = "<group>"; };
 		91CEF605260E325000A029E0 /* Compacting.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Compacting.m; sourceTree = "<group>"; };
+		91FBD31F279865080005C10C /* DeleteUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteUsers.swift; sourceTree = "<group>"; };
 		91FDC13A261E5DE3006A6E13 /* MutableSetExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutableSetExample.swift; sourceTree = "<group>"; };
 		9A2E9352D426560510A7F487 /* Pods-SwiftUIExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUIExamples.debug.xcconfig"; path = "Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples.debug.xcconfig"; sourceTree = "<group>"; };
 		A56BE659D55DD6B9972241E4 /* Pods_QuickStartSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStartSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -294,6 +296,7 @@
 				48BF3415251076E4004139AF /* CompleteQuickStart.swift */,
 				48F38B5325278ECB00DDEB65 /* CustomUserData.m */,
 				48F38B512527843B00DDEB65 /* CustomUserData.swift */,
+				91FBD31F279865080005C10C /* DeleteUsers.swift */,
 				48944D9F25C0E79C0092B8AC /* EmbeddedObjects.m */,
 				485C5D17258A9F960069AAE8 /* EmbeddedObjects.swift */,
 				485C5D0F258A9BDF0069AAE8 /* Encrypt.m */,
@@ -782,6 +785,7 @@
 				9136A4DB26409A7E00FFA03B /* AnyRealmValue.swift in Sources */,
 				48944D8B25BF7BCA0092B8AC /* ObjectModels.swift in Sources */,
 				48FE4E8B2666A93600720F92 /* MapExample.swift in Sources */,
+				91FBD320279865080005C10C /* DeleteUsers.swift in Sources */,
 				48BF341D25111194004139AF /* Task.swift in Sources */,
 				48E63FB8252646A700F883B1 /* Authenticate.swift in Sources */,
 				48F38B58252793F600DDEB65 /* ManageApiKeys.swift in Sources */,

--- a/source/examples/generated/code/start/DeleteUsers.codeblock.async-await-delete-user.swift
+++ b/source/examples/generated/code/start/DeleteUsers.codeblock.async-await-delete-user.swift
@@ -1,0 +1,14 @@
+func testAsyncDeleteUser() async throws {
+    // Logging in using anonymous authentication creates a user object
+    let syncUser = try await app.login(credentials: Credentials.anonymous)
+    // Now we have a user, and the total users in the app = 1
+    XCTAssertNotNil(syncUser)
+    XCTAssertEqual(app.allUsers.count, 1)
+    // Call the `delete` method to delete the user
+    try await syncUser.delete()
+    // When you delete the user, the SyncSession is destroyed and
+    // there is no current user.
+    XCTAssertNil(app.currentUser)
+    // Now that we've deleted the user, the app has no users.
+    XCTAssertEqual(app.allUsers.count, 0)
+}

--- a/source/examples/generated/code/start/DeleteUsers.codeblock.closure-delete-user.swift
+++ b/source/examples/generated/code/start/DeleteUsers.codeblock.closure-delete-user.swift
@@ -9,12 +9,13 @@ app.login(credentials: Credentials.anonymous) { [self] (result) in
     }
 }
 
-// Now we have a user, and the total users in the app = 1
+// Later, after the user is loggedd in we have a user,
+// and the total users in the app = 1
 XCTAssertNotNil(syncUser)
 XCTAssertEqual(app.allUsers.count, 1)
 
 // Call the `delete` method to delete the user
-syncUser?.delete { (error) in
+syncUser!.delete { (error) in
     XCTAssertNil(error)
 }
 

--- a/source/examples/generated/code/start/DeleteUsers.codeblock.closure-delete-user.swift
+++ b/source/examples/generated/code/start/DeleteUsers.codeblock.closure-delete-user.swift
@@ -1,0 +1,25 @@
+// Logging in using anonymous authentication creates a user object
+app.login(credentials: Credentials.anonymous) { [self] (result) in
+    switch result {
+    case .failure(let error):
+        fatalError("Login failed: \(error.localizedDescription)")
+    case .success(let user):
+        // Assign the user object to a variable to demonstrate user deletion
+        syncUser = user
+    }
+}
+
+// Now we have a user, and the total users in the app = 1
+XCTAssertNotNil(syncUser)
+XCTAssertEqual(app.allUsers.count, 1)
+
+// Call the `delete` method to delete the user
+syncUser?.delete { (error) in
+    XCTAssertNil(error)
+}
+
+// When you delete the user, the SyncSession is destroyed and
+// there is no current user.
+XCTAssertNil(app.currentUser)
+// Now that we've deleted the user, the app has no users.
+XCTAssertEqual(app.allUsers.count, 0)

--- a/source/includes/apple-account-deletion-requirements.rst
+++ b/source/includes/apple-account-deletion-requirements.rst
@@ -1,0 +1,9 @@
+.. tip:: Apple Account Deletion Requirements
+
+   Apple :apple:`requires that applications listed through its App Store 
+   <app-store/review/guidelines/#5.1.1>` must give any user who creates 
+   an account the option to delete the account. Whether you use an 
+   authentication method where you must manually register a user, such as 
+   email/password authentication, or one that that automatically creates a 
+   user, such as Sign-In with Apple, you must implement :ref:`user account 
+   deletion <delete-user>`.

--- a/source/includes/apple-account-deletion-requirements.rst
+++ b/source/includes/apple-account-deletion-requirements.rst
@@ -6,4 +6,4 @@
    authentication method where you must manually register a user, such as 
    email/password authentication, or one that that automatically creates a 
    user, such as Sign-In with Apple, you must implement :ref:`user account 
-   deletion <delete-user>`.
+   deletion <delete-user>` by June 30, 2022.

--- a/source/includes/note-delete-user.rst
+++ b/source/includes/note-delete-user.rst
@@ -1,6 +1,9 @@
 .. note::
 
    Realm does not automatically delete any data in your :term:`linked {+atlas+}
-   cluster <linked cluster>` that you have associated with a deleted user, such
-   as by including their ID in an ``owner_id`` field. To remove all traces of a
-   deleted user, you must manually delete or modify any such documents.
+   cluster <linked cluster>` that you have associated with a deleted user. 
+   For example, if your application allows users to create data that linked
+   to a user by including their ID in an ``owner_id`` field, deleting the 
+   user object does not delete the user-created linked data. To remove all 
+   traces of a deleted user, you must manually delete or modify any such 
+   documents.

--- a/source/includes/note-delete-user.rst
+++ b/source/includes/note-delete-user.rst
@@ -1,0 +1,6 @@
+.. note::
+
+   Realm does not automatically delete any data in your :term:`linked {+atlas+}
+   cluster <linked cluster>` that you have associated with a deleted user, such
+   as by including their ID in an ``owner_id`` field. To remove all traces of a
+   deleted user, you must manually delete or modify any such documents.

--- a/source/sdk/swift/examples/users/create-and-delete-users.txt
+++ b/source/sdk/swift/examples/users/create-and-delete-users.txt
@@ -44,8 +44,9 @@ the user from your Realm application.
    user data <ios-custom-user-data>` or user-entered data from your 
    application. Apple :apple:`requires that you disclose data retention 
    and deletion policies <app-store/review/guidelines/#5.1.1>` to your 
-   application customers, and give them a way to request user data deletion.
-   If you collect additional user data, you must handle deleting that data.
+   application customers and give them a way to request user data deletion.
+   If you collect additional user data, you must implement your own methods 
+   or processes to delete that data.
 
 Delete Users with Async/Await
 -----------------------------

--- a/source/sdk/swift/examples/users/create-and-delete-users.txt
+++ b/source/sdk/swift/examples/users/create-and-delete-users.txt
@@ -32,11 +32,12 @@ authenticate to a Realm application.
 Delete a User
 -------------
 
-.. versionadded:: 10.20.?
+.. versionadded:: 10.23.0
 
-You can call the ``delete`` method on a user object to delete 
-the user object from your Realm application. This deletes the object from
-the server in addition to clearing local data.
+You can call the :swift-sdk:`delete 
+<Extensions/User.html#/s:So7RLMUserC10RealmSwiftE6delete7Combine6FutureCyyts5Error_pGyF>` 
+method on a user object to delete the user object from your Realm application. 
+This deletes the object from the server in addition to clearing local data.
 
 .. important::
 

--- a/source/sdk/swift/examples/users/create-and-delete-users.txt
+++ b/source/sdk/swift/examples/users/create-and-delete-users.txt
@@ -35,7 +35,8 @@ Delete a User
 .. versionadded:: 10.20.?
 
 You can call the ``delete`` method on a user object to delete 
-the user from your Realm application.
+the user object from your Realm application. This deletes the object from
+the server in addition to clearing local data.
 
 .. important::
 

--- a/source/sdk/swift/examples/users/create-and-delete-users.txt
+++ b/source/sdk/swift/examples/users/create-and-delete-users.txt
@@ -1,0 +1,65 @@
+.. _ios-create-and-delete-users:
+
+===================================
+Create and Delete Users - Swift SDK
+===================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. _ios-create-user:
+
+Create a User
+-------------
+
+For most :ref:`authentication methods <authentication-providers>`, Realm 
+automatically creates a :ref:`user object <user-objects>` the first time 
+a user authenticates. The only exception is email/password authentication. 
+When you use email/password authentication, you must :ref:`register 
+<ios-register-a-new-user-account>` and :ref:`confirm 
+<ios-confirm-a-new-users-email-address>` a user before the user can 
+authenticate to a Realm application.
+
+.. include:: /includes/apple-account-deletion-requirements.rst
+
+.. _ios-delete-user:
+
+Delete a User
+-------------
+
+.. versionadded:: 10.20.?
+
+You can call the ``delete`` method on a user object to delete 
+the user from your Realm application.
+
+.. important::
+
+   Deleting a user only deletes the user object, which may contain associated 
+   :ref:`metadata <ios-user-metadata>`. This does not delete :ref:`custom 
+   user data <ios-custom-user-data>` or user-entered data from your 
+   application. Apple :apple:`requires that you disclose data retention 
+   and deletion policies <app-store/review/guidelines/#5.1.1>` to your 
+   application customers, and give them a way to request user data deletion.
+   If you collect additional user data, you must handle deleting that data.
+
+Delete Users with Async/Await
+-----------------------------
+
+If your application uses :apple:`Apple's async/await syntax
+<documentation/swift/swift_standard_library/concurrency/updating_an_app_to_use_swift_concurrency>`:
+
+.. literalinclude:: /examples/generated/code/start/DeleteUsers.codeblock.async-await-delete-user.swift
+   :language: swift
+
+Delete Users with Completion Handlers
+-------------------------------------
+
+If your application does not use async/await:
+
+.. literalinclude:: /examples/generated/code/start/DeleteUsers.codeblock.closure-delete-user.swift
+   :language: swift

--- a/source/sdk/swift/examples/users/manage-email-password-users.txt
+++ b/source/sdk/swift/examples/users/manage-email-password-users.txt
@@ -44,6 +44,25 @@ Register a New User Account
       .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.register-email-objc.m
          :language: objectivec
 
+.. _ios-confirm-a-new-users-email-address:
+
+Confirm a New User's Email Address
+----------------------------------
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.confirm-new-user-email.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.confirm-new-user-email-objc.m
+         :language: objectivec
+
 .. _ios-retry-user-confirmation:
 
 Retry User Confirmation Methods
@@ -71,26 +90,6 @@ Retry a :ref:`custom user confirmation function <auth-run-a-confirmation-functio
 
 .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.retry-confirmation-function.swift
    :language: swift
-
-.. _ios-confirm-a-new-users-email-address:
-
-Confirm a New User's Email Address
-----------------------------------
-
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: swift
-
-      .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.confirm-new-user-email.swift
-         :language: swift
-
-   .. tab::
-      :tabid: objective-c
-
-      .. literalinclude:: /examples/generated/code/start/ManageEmailPasswordUsers.codeblock.confirm-new-user-email-objc.m
-         :language: objectivec
-
 
 .. _ios-reset-a-users-password:
 

--- a/source/sdk/swift/examples/users/user-metadata.txt
+++ b/source/sdk/swift/examples/users/user-metadata.txt
@@ -14,7 +14,7 @@ User Metadata - Swift SDK
 
 .. _ios-read-user-metadata:
 
-Read a User’s Metadata
+Read a User's Metadata
 ----------------------
 
 You can read the :ref:`user metadata <user-metadata>` of a

--- a/source/sdk/swift/examples/work-with-users.txt
+++ b/source/sdk/swift/examples/work-with-users.txt
@@ -9,6 +9,7 @@ Work with Users - Swift SDK
 .. toctree::
    :titlesonly:
 
+   Create and Delete Users </sdk/swift/examples/users/create-and-delete-users>
    Authenticate Users </sdk/swift/examples/users/authenticate-users>
    Custom User Data </sdk/swift/examples/users/custom-user-data>
    User Metadata </sdk/swift/examples/users/user-metadata>
@@ -23,9 +24,27 @@ When you use {+backend+} to back your client {+app+}, you get access to a
 :ref:`user object <user-objects>`. Use client SDK methods with this user 
 object to conveniently:
 
+- Create and delete users
 - Log users in and out
 - Create and update custom user data
 - Read user metadata from social login providers
+
+.. _ios-creating-and-deleting-users:
+
+Create and Delete Users
+-----------------------
+
+For all authentication providers other than email/password authentication,
+{+backend+} automatically :ref:`creates a user object <ios-create-user>` 
+the first time a user authenticates. If a user authenticates via more than 
+one method, you can :ref:`link these user identities <ios-link-user-identities>` 
+to a single user object. 
+
+You can :ref:`delete user objects <ios-delete-user>`. Deleting a user object 
+deletes metadata attached to the user object, but does not delete user-entered
+data from your application.
+
+.. include:: /includes/apple-account-deletion-requirements.rst
 
 .. _ios-access-the-app-client:
 
@@ -51,8 +70,6 @@ When you have a logged-in user, SDK methods enable you to:
 - :ref:`Change the active user <ios-change-the-active-user>` in a multi-user 
   application
 - :ref:`Remove a user <ios-remove-a-user-from-the-device>` from the device
-- :ref:`Link multiple identities <ios-link-user-identities>` to a single 
-  user object
 
 {+service-short+} caches credentials on the device upon successful login in a 
 ``sync_metadata.realm`` file. You can bypass the login flow and access the 

--- a/source/users/create.txt
+++ b/source/users/create.txt
@@ -10,8 +10,68 @@ Create a User
    :depth: 1
    :class: singlecol
 
+Create a User Upon First Authentication
+---------------------------------------
+
+For most :ref:`authentication providers <authentication-providers>`, 
+{+backend+} automatically creates a :ref:`user object <user-objects>` the 
+first time a user authenticates through the authentication provider. The 
+only exception is :ref:`email/password user authentication 
+<email-password-authentication>`, in which you must register and confirm 
+a user before the user can authenticate.
+
+.. include:: /includes/apple-account-deletion-requirements.rst
+
+Create an Email/Password User
+-----------------------------
+
+When you use :ref:`email/password user authentication 
+<email-password-authentication>`, you must register a user, which creates 
+the user object. You can register users in your client application
+using your preferred SDK, or you can manually create email/password users.
+
+Create an Email/Password User in the SDK
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each SDK offers an API that enables you to register an email/password user. 
+After registering the user, you must confirm the user before the they can 
+authenticate.
+
+.. tabs-realm-sdks::
+   
+   .. tab::
+      :tabid: node
+      
+      Learn how to :ref:`register an email/password user from a Node
+      application <node-register-new-user>`.
+
+   .. tab::
+      :tabid: react-native
+      
+      Learn how to :ref:`register an email/password user from a React Native
+      application <react-native-register-new-user>`.
+
+   .. tab::
+      :tabid: android
+
+      Learn how to :ref:`register an email/password user from an Android
+      application <android-register-a-new-user-account>`.
+
+   .. tab::
+      :tabid: ios
+
+      Learn how to :ref:`register an email/password user from an iOS
+      application <ios-register-a-new-user-account>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      Learn how to :ref:`register an email/password user from a .NET
+      application <dotnet-email-password-register-new-user>`.
+
+
 Manually Create an Email/Password User
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can create a new :ref:`Email/Password <email-password-authentication>` user
 from the UI or CLI. Manually-created users bypass any configured user
@@ -122,8 +182,6 @@ A manually-confirmed user continues to appear in the :guilabel:`PENDING`
 user list until they log in to your application for the first time, at
 which point {+backend+} moves them into the list of confirmed users and
 transitions their :guilabel:`User Status` to ``confirmed``.
-
-.. include:: /includes/seealso-client-guides-manage-email-password-users.rst
 
 Re-run the User Confirmation Workflow
 -------------------------------------

--- a/source/users/delete-or-revoke.txt
+++ b/source/users/delete-or-revoke.txt
@@ -23,6 +23,23 @@ and authentication provider identities.
    If you don't want to delete the user's account, you can :ref:`disable their
    account <disable-user>` to temporarily suspend their access.
 
+Delete a User in the SDK
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can give users the option to delete their own account from a client 
+application when you use the SDK to delete users.
+
+.. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: ios
+
+      Learn how to :ref:`delete a user from an iOS application 
+      <ios-delete-user>`.
+
+Manually Delete a User
+~~~~~~~~~~~~~~~~~~~~~~
+
 .. tabs-realm-admin-interfaces::
    
    .. tab::
@@ -65,12 +82,7 @@ and authentication provider identities.
             
             realm-cli users delete --user=6099694d5debcbcc873ff413,60996996b78eca4a8d615d3a
 
-.. note::
-
-   Realm does not automatically delete any data in your :term:`linked {+atlas+}
-   cluster <linked cluster>` that you have associated with a deleted user, such
-   as by including their ID in an ``owner_id`` field. To remove all traces of a
-   deleted user, you must manually delete or modify any such documents.
+.. include:: /includes/note-delete-user.rst
 
 .. _disable-user:
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-20092

### Staged Changes (Requires MongoDB Corp SSO)

- [Create and Delete Users (Swift SDK)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20092/sdk/swift/examples/users/create-and-delete-users/): New page w/new code examples for deleting the user
- [Work with Users/Create and Delete Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20092/sdk/swift/examples/work-with-users/#create-and-delete-users): New section on existing page
- [Create a User (Cloud)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20092/users/create/): Added a section about first authentication automatically creating user objects, and a link to SDK pages where devs can create email/password users
- [Delete a User (Cloud)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20092/users/delete-or-revoke/#delete-a-user-in-the-sdk): New section with a link to the Swift SDK where you can delete a user via SDK. As more SDKs add the user.delete API, we can add tabs

---

### Before merging:
- [x] Update `..versionadded` to reflect the release version
- [x] Update Podfile to point to release version
- [x] Add link from ``delete`` to generated SDK reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
