### PR TITLE
Flexible Sync: Switch 'important' directive to very similar include

### DIFF
--- a/source/includes/steps-configure-flexible-sync-api.yaml
+++ b/source/includes/steps-configure-flexible-sync-api.yaml
@@ -12,9 +12,9 @@ content: |
   .. note:: Authenticating Your Request with an Access Token
     
     To authenticate your request to the Realm Admin API, you need a valid and
-    current authorization token from the MongoDB Cloud API. Read the :ref:`API
-    Authentication <realm-api-authentication>` documentation to learn how to
-    acquire a valid access token.
+    current authorization token from the MongoDB Cloud API. Read the 
+    :admin-api-endpoint:`API Authentication <section/Get-Authentication-Tokens>` 
+    documentation to learn how to acquire a valid access token.
 
   .. code-block:: shell
      

--- a/source/includes/steps-configure-flexible-sync-api.yaml
+++ b/source/includes/steps-configure-flexible-sync-api.yaml
@@ -165,9 +165,9 @@ content: |
   .. note:: Authenticating Your Request with an Access Token
     
     To authenticate your request to the Realm Admin API, you need a valid and
-    current authorization token from the MongoDB Cloud API. Read the :ref:`API
-    Authentication <realm-api-authentication>` documentation to learn how to
-    acquire a valid access token.
+    current authorization token from the MongoDB Cloud API. Read the 
+    :admin-api-endpoint:`API Authentication <section/Get-Authentication-Tokens>` 
+    documentation to learn how to acquire a valid access token.
 
   .. code-block:: shell
      

--- a/source/includes/steps-configure-flexible-sync-cli.yaml
+++ b/source/includes/steps-configure-flexible-sync-cli.yaml
@@ -57,7 +57,7 @@ ref: choose-queryable-fields
 content: |
   The ``queryable_fields_names`` property allows you to define a set of
   queryable fields for the device should query on. A queryable field can be any
-  top-level primitive field with a scalar type, this excludes embedde objects or arrays.
+  top-level primitive field with a scalar type, this excludes embedded objects or arrays.
 
   To learn more about queryable fields, read the :ref:`queryable fields
   <queryable-fields>` documentation.

--- a/source/reference/realm-query-language.txt
+++ b/source/reference/realm-query-language.txt
@@ -28,10 +28,7 @@ query API.
 You can also use Realm Query Language to browse for data in :ref:`Realm Studio 
 <realm-studio>`.
 
-.. important::
-
-   Flexible Sync supports some, but not all, RQL operators. For details, see:
-   :ref:`Flexible Sync RQL Limitations <flexible-sync-rql-limitations>`.
+.. include:: includes/note-unsupported-flex-sync-rql-operators.rst
 
 Expressions
 ~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Based on [Nick's comment on the query-based-sync feature branch](https://github.com/mongodb/docs-realm/pull/1506#discussion_r788103245)

This also fixes a couple of broken :ref:s that are in master 

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm Query Language](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fs-fixups-round-one/reference/realm-query-language/): Swap very similar verbiage for an existing `include`

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
