### PR TITLE
(DOCSP-19418): Swift SDK Flexible Sync

### DIFF
--- a/examples/ios/Examples/FlexibleSync.swift
+++ b/examples/ios/Examples/FlexibleSync.swift
@@ -1,0 +1,495 @@
+// :replace-start: {
+//   "terms": {
+//     "FlexibleSync_": ""
+//   }
+// }
+
+let APPID = "swift-flexible-vkljj"
+
+import XCTest
+import RealmSwift
+
+// :code-block-start: flexible-sync-models
+class FlexibleSync_Task: Object {
+   @Persisted(primaryKey: true) var _id: ObjectId
+   @Persisted var taskName: String
+   @Persisted var assignee: String?
+   @Persisted var completed: Bool
+   @Persisted var progressMinutes: Int
+}
+
+class FlexibleSync_Team: Object {
+   @Persisted(primaryKey: true) var _id: ObjectId
+   @Persisted var teamName: String
+   @Persisted var tasks: List<FlexibleSync_Task>
+   @Persisted var members: List<String>
+}
+// :code-block-end:
+
+class FlexibleSync: XCTestCase {
+    func testAddSingleSubscription() {
+        let expectation = XCTestExpectation(description: "it completes")
+        let app = App(id: APPID)
+        app.login(credentials: Credentials.anonymous) { (result) in
+            switch result {
+            case .failure(let error):
+                fatalError("Login failed: \(error.localizedDescription)")
+            case .success:
+                // Continue
+                print("Successfully logged in to app")
+                let user = app.currentUser
+                var flexSyncConfig = user?.flexibleSyncConfiguration()
+                flexSyncConfig?.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+                Realm.asyncOpen(configuration: flexSyncConfig!) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Failed to open realm: \(error.localizedDescription)")
+                        // handle error
+                    case .success(let realm):
+                        print("Successfully opened realm: \(realm)")
+                        // :code-block-start: add-single-subscription
+                        let subscriptions = realm.subscriptions
+                        subscriptions.write({
+                           subscriptions.append(
+                              QuerySubscription<FlexibleSync_Team> {
+                                 $0.teamName == "Developer Education"
+                              })
+                        }, onComplete: { error in // error is optional
+                           if error == nil {
+                              // Flexible Sync has updated data to match the subscription
+                           } else {
+                              // Handle the error
+                           }
+                        })
+                        // :code-block-end:
+                        subscriptions.write({
+                            subscriptions.removeAll()
+                        })
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func testAddMultipleSubscriptions() {
+        let expectation = XCTestExpectation(description: "it completes")
+        let app = App(id: APPID)
+        app.login(credentials: Credentials.anonymous) { (result) in
+            switch result {
+            case .failure(let error):
+                fatalError("Login failed: \(error.localizedDescription)")
+            case .success:
+                // Continue
+                print("Successfully logged in to app")
+                let user = app.currentUser
+                var flexSyncConfig = user?.flexibleSyncConfiguration()
+                flexSyncConfig?.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+                Realm.asyncOpen(configuration: flexSyncConfig!) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Failed to open realm: \(error.localizedDescription)")
+                        // handle error
+                    case .success(let realm):
+                        print("Successfully opened realm: \(realm)")
+                        // :code-block-start: add-multiple-subscriptions
+                        let subscriptions = realm.subscriptions
+                        subscriptions.write({
+                            subscriptions.append(
+                                QuerySubscription<FlexibleSync_Task>(name: "completed-tasks") {
+                                     $0.completed == true
+                            })
+                            subscriptions.append(
+                                QuerySubscription<FlexibleSync_Team> {
+                                  $0.teamName == "Developer Education"
+                            })
+                        }, onComplete: { error in // error is optional
+                           if error == nil {
+                              // Flexible Sync has updated data to match the subscription
+                           } else {
+                              // Handle the error
+                           }
+                        })
+                        // :code-block-end:
+                        subscriptions.write({
+                            subscriptions.removeAll()
+                        })
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func testAddSubscriptionWithOnComplete() {
+        let expectation = XCTestExpectation(description: "it completes")
+        let app = App(id: APPID)
+        app.login(credentials: Credentials.anonymous) { (result) in
+            switch result {
+            case .failure(let error):
+                fatalError("Login failed: \(error.localizedDescription)")
+            case .success:
+                // Continue
+                print("Successfully logged in to app")
+                let user = app.currentUser
+                var flexSyncConfig = user?.flexibleSyncConfiguration()
+                flexSyncConfig?.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+                Realm.asyncOpen(configuration: flexSyncConfig!) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Failed to open realm: \(error.localizedDescription)")
+                        // handle error
+                    case .success(let realm):
+                        print("Successfully opened realm: \(realm)")
+                        // :code-block-start: add-subscription-with-oncomplete
+                        let subscriptions = realm.subscriptions
+                        subscriptions.write({
+                           subscriptions.append(
+                              QuerySubscription<FlexibleSync_Task> {
+                                 $0.assignee == "John Doe"
+                              })
+                        }, onComplete: { error in // error is optional
+                            if error == nil {
+                               // Flexible Sync has updated data to match the subscription
+                            } else {
+                               // Handle the error
+                            }
+                         })
+                         // :code-block-end:
+                        subscriptions.write({
+                            subscriptions.append(
+                                // :code-block-start: query-subscription-by-name
+                                QuerySubscription<FlexibleSync_Task>(name: "long-running-completed") {
+                                    $0.completed == true && $0.progressMinutes > 120
+                                }
+                                // :code-block-end:
+                            )
+                            subscriptions.append(
+                                // :code-block-start: query-subscription-without-name
+                                QuerySubscription<FlexibleSync_Team> {
+                                   $0.teamName == "Developer Education"
+                                }
+                                // :code-block-end:
+                            )
+                        }, onComplete: { error in // error is optional
+                            if error == nil {
+                               // Flexible Sync has updated data to match the subscription
+                            } else {
+                               // Handle the error
+                            }
+                         })
+                        subscriptions.write({
+                            subscriptions.removeAll()
+                        })
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func testUpdateSubscription() {
+        let expectation = XCTestExpectation(description: "it completes")
+        let app = App(id: APPID)
+        app.login(credentials: Credentials.anonymous) { (result) in
+            switch result {
+            case .failure(let error):
+                fatalError("Login failed: \(error.localizedDescription)")
+            case .success:
+                // Continue
+                print("Successfully logged in to app")
+                let user = app.currentUser
+                var flexSyncConfig = user?.flexibleSyncConfiguration()
+                flexSyncConfig?.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+                Realm.asyncOpen(configuration: flexSyncConfig!) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Failed to open realm: \(error.localizedDescription)")
+                        // handle error
+                    case .success(let realm):
+                        print("Successfully opened realm: \(realm)")
+                        // :code-block-start: update-subscription
+                        let subscriptions = realm.subscriptions
+                        // :hide-start:
+                        // Add subscription to update
+                        subscriptions.write({
+                            subscriptions.append(QuerySubscription<FlexibleSync_Team> {
+                                $0.teamName == "Developer Education"
+                             })
+                        }, onComplete: { error in // error is optional
+                            if error == nil {
+                              // Flexible Sync has updated data to match the subscription
+                            } else {
+                              // Handle the error
+                            }
+                        })
+                        // :hide-end:
+                        let foundSubscription = subscriptions.first(ofType: FlexibleSync_Team.self, where: {
+                              $0.teamName == "Developer Education"
+                        })
+                        subscriptions.write({
+                            foundSubscription?.update(toType: FlexibleSync_Team.self, where: {
+                                 $0.teamName == "Documentation"
+                            })
+                        }, onComplete: { error in // error is optional
+                            if error == nil {
+                              // Flexible Sync has updated data to match the subscription
+                            } else {
+                              // Handle the error
+                            }
+                        })
+                        // :code-block-end:
+                        subscriptions.write({
+                            subscriptions.removeAll()
+                        })
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 20)
+    }
+
+    func testUpdateSubscriptionByName() {
+        let expectation = XCTestExpectation(description: "it completes")
+        let app = App(id: APPID)
+        app.login(credentials: Credentials.anonymous) { (result) in
+            switch result {
+            case .failure(let error):
+                fatalError("Login failed: \(error.localizedDescription)")
+            case .success:
+                // Continue
+                print("Successfully logged in to app")
+                let user = app.currentUser
+                var flexSyncConfig = user?.flexibleSyncConfiguration()
+                flexSyncConfig?.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+                Realm.asyncOpen(configuration: flexSyncConfig!) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Failed to open realm: \(error.localizedDescription)")
+                        // handle error
+                    case .success(let realm):
+                        print("Successfully opened realm: \(realm)")
+                        // :code-block-start: update-subscription-by-name
+                        let subscriptions = realm.subscriptions
+                        // :hide-start:
+                        // Add subscription to update
+                        subscriptions.write({
+                            subscriptions.append(QuerySubscription<FlexibleSync_Team>(name: "user-team") {
+                                $0.teamName == "Docs"
+                             })
+                        }, onComplete: { error in // error is optional
+                            if error == nil {
+                              // Flexible Sync has updated data to match the subscription
+                            } else {
+                              // Handle the error
+                            }
+                        })
+                        // :hide-end:
+                        let foundSubscription = subscriptions.first(named: "user-team")
+                        subscriptions.write({
+                            foundSubscription?.update(toType: FlexibleSync_Team.self, where: {
+                                 $0.teamName == "Documentation"
+                            })
+                        }, onComplete: { error in // error is optional
+                            if error == nil {
+                              // Flexible Sync has updated data to match the subscription
+                            } else {
+                              // Handle the error
+                            }
+                        })
+                        // :code-block-end:
+                        subscriptions.write({
+                            subscriptions.removeAll()
+                        })
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 30)
+    }
+
+    func testRemoveSingleSubscription() {
+        let expectation = XCTestExpectation(description: "it completes")
+        let app = App(id: APPID)
+        app.login(credentials: Credentials.anonymous) { (result) in
+            switch result {
+            case .failure(let error):
+                fatalError("Login failed: \(error.localizedDescription)")
+            case .success:
+                // Continue
+                print("Successfully logged in to app")
+                let user = app.currentUser
+                var flexSyncConfig = user?.flexibleSyncConfiguration()
+                flexSyncConfig?.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+                Realm.asyncOpen(configuration: flexSyncConfig!) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Failed to open realm: \(error.localizedDescription)")
+                        // handle error
+                    case .success(let realm):
+                        print("Successfully opened realm: \(realm)")
+                        // :code-block-start: remove-single-subscription
+                        let subscriptions = realm.subscriptions
+                        // :hide-start:
+                        // Add subscriptions to remove
+                        subscriptions.write {
+                            subscriptions.append(
+                                QuerySubscription<FlexibleSync_Team>(name: "docs-team") {
+                                    $0.teamName == "Documentation"
+                                })
+                            subscriptions.append(
+                                QuerySubscription<FlexibleSync_Team>(name: "existing-subscription") {
+                                    $0.teamName == "Engineering"
+                                })
+                        }
+                        // :hide-end:
+                        // Look for a specific subscription, and then remove it
+                        let foundSubscription = subscriptions.first(named: "docs-team")
+                        subscriptions.write({
+                            subscriptions.remove(foundSubscription!)
+                        }, onComplete: { error in // error is optional
+                            if error == nil {
+                              // Flexible Sync has updated data to match the subscription
+                            } else {
+                              // Handle the error
+                            }
+                        })
+
+                        // Or remove a subscription that you know exists without querying for it
+                        subscriptions.write {
+                            subscriptions.remove(named: "existing-subscription")
+                        }
+                        // :code-block-end:
+                        subscriptions.write({
+                            subscriptions.removeAll()
+                        })
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 30)
+    }
+
+    func testRemoveAllSubscriptionsObjectType() {
+        let expectation = XCTestExpectation(description: "it completes")
+        let app = App(id: APPID)
+        app.login(credentials: Credentials.anonymous) { (result) in
+            switch result {
+            case .failure(let error):
+                fatalError("Login failed: \(error.localizedDescription)")
+            case .success:
+                // Continue
+                print("Successfully logged in to app")
+                let user = app.currentUser
+                var flexSyncConfig = user?.flexibleSyncConfiguration()
+                flexSyncConfig?.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+                Realm.asyncOpen(configuration: flexSyncConfig!) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Failed to open realm: \(error.localizedDescription)")
+                        // handle error
+                    case .success(let realm):
+                        print("Successfully opened realm: \(realm)")
+                        // :code-block-start: remove-subscriptions-to-object-type
+                        let subscriptions = realm.subscriptions
+                        // :hide-start:
+                        // Add subscriptions to remove
+                        subscriptions.write {
+                            subscriptions.append(
+                                QuerySubscription<FlexibleSync_Team>(name: "documentation-team") {
+                                    $0.teamName == "Documentation"
+                                })
+                            subscriptions.append(
+                                QuerySubscription<FlexibleSync_Team>(name: "another-subscription") {
+                                    $0.teamName == "Engineering"
+                                })
+                        }
+                        // :hide-end:
+                        subscriptions.write({
+                            subscriptions.removeAll(ofType: FlexibleSync_Team.self)
+                        }, onComplete: { error in // error is optional
+                            if error == nil {
+                              // Flexible Sync has updated data to match the subscription
+                            } else {
+                              // Handle the error
+                            }
+                        })
+                        // :code-block-end:
+                        subscriptions.write({
+                            subscriptions.removeAll()
+                        })
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 20)
+    }
+
+    func testRemoveAllSubscriptions() {
+        let expectation = XCTestExpectation(description: "it completes")
+        let app = App(id: APPID)
+        app.login(credentials: Credentials.anonymous) { (result) in
+            switch result {
+            case .failure(let error):
+                fatalError("Login failed: \(error.localizedDescription)")
+            case .success:
+                // Continue
+                print("Successfully logged in to app")
+                let user = app.currentUser
+                var flexSyncConfig = user?.flexibleSyncConfiguration()
+                flexSyncConfig?.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+                Realm.asyncOpen(configuration: flexSyncConfig!) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Failed to open realm: \(error.localizedDescription)")
+                        // handle error
+                    case .success(let realm):
+                        print("Successfully opened realm: \(realm)")
+                        // :code-block-start: remove-all-subscriptions
+                        let subscriptions = realm.subscriptions
+                        subscriptions.write({
+                            subscriptions.removeAll()
+                        }, onComplete: { error in // error is optional
+                            if error == nil {
+                              // Flexible Sync has updated data to match the subscription
+                            } else {
+                              // Handle the error
+                            }
+                        })
+                        // :code-block-end:
+                        subscriptions.write({
+                            subscriptions.removeAll()
+                        })
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func testOpenFlexSyncRealm() async throws {
+        // :code-block-start: flex-sync-open-realm
+        let app = App(id: APPID)
+        let user = try await app.login(credentials: Credentials.anonymous)
+        var config = user.flexibleSyncConfiguration()
+        // Pass object types to the Flexible Sync configuration
+        // as a temporary workaround for not being able to add complete schema
+        // for a Flexible Sync app
+        config.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+        let realm = try await Realm(configuration: config, downloadBeforeOpen: .always)
+        // :code-block-end:
+        print("Successfully opened realm: \(realm)")
+        XCTAssertNotNil(realm)
+        try await app.currentUser?.logOut()
+    }
+}
+
+// :replace-end:

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '15.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', :git => 'https://github.com/realm/realm-swift.git', :branch => 'dp/flexible_sync_v1.0.0'
-  pod 'RealmSwift', :git => 'https://github.com/realm/realm-swift.git', :branch => 'dp/flexible_sync_v1.0.0'
+  pod 'Realm', '=10.22.0'
+  pod 'RealmSwift', '=10.22.0'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,14 +13,14 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', :git => 'https://github.com/realm/realm-swift.git', :branch => 'dp/flexible_sync_v1.0.0'
+  pod 'RealmSwift', '=10.22.0'
 end
 
 target 'SwiftUIExamples' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', :git => 'https://github.com/realm/realm-swift.git', :branch => 'dp/flexible_sync_v1.0.0'
+  pod 'RealmSwift', '=10.22.0'
 end
 
 post_install do |installer|

--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -3,8 +3,8 @@ platform :ios, '15.0'
 target 'RealmExamples' do
   use_frameworks!
   pod 'SwiftLint'
-  pod 'Realm', '=10.21.0'
-  pod 'RealmSwift', '=10.21.0'
+  pod 'Realm', :git => 'https://github.com/realm/realm-swift.git', :branch => 'dp/flexible_sync_v1.0.0'
+  pod 'RealmSwift', :git => 'https://github.com/realm/realm-swift.git', :branch => 'dp/flexible_sync_v1.0.0'
   pod 'GoogleSignIn'
   pod 'FBSDKLoginKit', '=8.1.0'
 end
@@ -13,14 +13,14 @@ target 'QuickStartSwiftUI' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '=10.21.0'
+  pod 'RealmSwift', :git => 'https://github.com/realm/realm-swift.git', :branch => 'dp/flexible_sync_v1.0.0'
 end
 
 target 'SwiftUIExamples' do
   use_frameworks!
 
   pod 'SwiftLint'
-  pod 'RealmSwift', '=10.21.0'
+  pod 'RealmSwift', :git => 'https://github.com/realm/realm-swift.git', :branch => 'dp/flexible_sync_v1.0.0'
 end
 
 post_install do |installer|

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Realm (10.21.1):
-    - Realm/Headers (= 10.21.1)
-  - Realm/Headers (10.21.1)
-  - RealmSwift (10.21.1):
-    - Realm (= 10.21.1)
+  - Realm (10.22.0):
+    - Realm/Headers (= 10.22.0)
+  - Realm/Headers (10.22.0)
+  - RealmSwift (10.22.0):
+    - Realm (= 10.22.0)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (from `https://github.com/realm/realm-swift.git`, branch `dp/flexible_sync_v1.0.0`)
-  - RealmSwift (from `https://github.com/realm/realm-swift.git`, branch `dp/flexible_sync_v1.0.0`)
+  - Realm (= 10.22.0)
+  - RealmSwift (= 10.22.0)
   - SwiftLint
 
 SPEC REPOS:
@@ -44,23 +44,9 @@ SPEC REPOS:
     - GoogleSignIn
     - GTMAppAuth
     - GTMSessionFetcher
+    - Realm
+    - RealmSwift
     - SwiftLint
-
-EXTERNAL SOURCES:
-  Realm:
-    :branch: dp/flexible_sync_v1.0.0
-    :git: https://github.com/realm/realm-swift.git
-  RealmSwift:
-    :branch: dp/flexible_sync_v1.0.0
-    :git: https://github.com/realm/realm-swift.git
-
-CHECKOUT OPTIONS:
-  Realm:
-    :commit: a936e18444a7d344503f42367cb6024fa7968a35
-    :git: https://github.com/realm/realm-swift.git
-  RealmSwift:
-    :commit: a936e18444a7d344503f42367cb6024fa7968a35
-    :git: https://github.com/realm/realm-swift.git
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
@@ -69,10 +55,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: 7bbac92a27160d99adc81fb8b95a4ad011d181dc
-  RealmSwift: dbf9a4eb06e0c929d51c4ef2e8f951bca541feab
+  Realm: d9e4e5877095a6722145811f56fe89a531c9659d
+  RealmSwift: e4191b4b957fcfcbed23751ec65eec98f8173ab5
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 6bf815d2128e7869527afde4ea624ee291900c86
+PODFILE CHECKSUM: f8bd419115b18303cc4e3e988b323e68d59b2a72
 
 COCOAPODS: 1.10.1

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Realm (10.21.0):
-    - Realm/Headers (= 10.21.0)
-  - Realm/Headers (10.21.0)
-  - RealmSwift (10.21.0):
-    - Realm (= 10.21.0)
+  - Realm (10.21.1):
+    - Realm/Headers (= 10.21.1)
+  - Realm/Headers (10.21.1)
+  - RealmSwift (10.21.1):
+    - Realm (= 10.21.1)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (= 10.21.0)
-  - RealmSwift (= 10.21.0)
+  - Realm (from `https://github.com/realm/realm-swift.git`, branch `dp/flexible_sync_v1.0.0`)
+  - RealmSwift (from `https://github.com/realm/realm-swift.git`, branch `dp/flexible_sync_v1.0.0`)
   - SwiftLint
 
 SPEC REPOS:
@@ -44,9 +44,23 @@ SPEC REPOS:
     - GoogleSignIn
     - GTMAppAuth
     - GTMSessionFetcher
-    - Realm
-    - RealmSwift
     - SwiftLint
+
+EXTERNAL SOURCES:
+  Realm:
+    :branch: dp/flexible_sync_v1.0.0
+    :git: https://github.com/realm/realm-swift.git
+  RealmSwift:
+    :branch: dp/flexible_sync_v1.0.0
+    :git: https://github.com/realm/realm-swift.git
+
+CHECKOUT OPTIONS:
+  Realm:
+    :commit: a936e18444a7d344503f42367cb6024fa7968a35
+    :git: https://github.com/realm/realm-swift.git
+  RealmSwift:
+    :commit: a936e18444a7d344503f42367cb6024fa7968a35
+    :git: https://github.com/realm/realm-swift.git
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
@@ -55,10 +69,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Realm: 55220cda83aabd773740d18518e05fdbe00b87cc
-  RealmSwift: 129dce1dd6b5d9194a37f568aaf32a6c10d1a803
+  Realm: 7bbac92a27160d99adc81fb8b95a4ad011d181dc
+  RealmSwift: dbf9a4eb06e0c929d51c4ef2e8f951bca541feab
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 84d147d7ba28de501bafc4614942d7d3c6eba988
+PODFILE CHECKSUM: 6bf815d2128e7869527afde4ea624ee291900c86
 
 COCOAPODS: 1.10.1

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		914601F726A86B9100BC91EA /* Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914601F526A86B9000BC91EA /* Sync.swift */; };
 		915E96A825FAB36500AABC09 /* LandingPageCodeExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915E96A725FAB36500AABC09 /* LandingPageCodeExamples.swift */; };
 		916AC598273036C100270C64 /* ClassProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916AC597273036C100270C64 /* ClassProjection.swift */; };
+		917097DA279F182600F1D65B /* FlexibleSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917097D9279F182600F1D65B /* FlexibleSync.swift */; };
 		917D8C9F26167B69001B7A61 /* TestingAndDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917D8C9E26167B69001B7A61 /* TestingAndDebugging.swift */; };
 		917E73E726B8A9F80068242A /* MongoDBRemoteAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E73E526B8A9F80068242A /* MongoDBRemoteAccess.swift */; };
 		917E73E826B8A9F80068242A /* MongoDBRemoteAccessAggregate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E73E626B8A9F80068242A /* MongoDBRemoteAccessAggregate.swift */; };
@@ -170,6 +171,7 @@
 		914601F526A86B9000BC91EA /* Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sync.swift; sourceTree = "<group>"; };
 		915E96A725FAB36500AABC09 /* LandingPageCodeExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LandingPageCodeExamples.swift; sourceTree = "<group>"; };
 		916AC597273036C100270C64 /* ClassProjection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClassProjection.swift; sourceTree = "<group>"; };
+		917097D9279F182600F1D65B /* FlexibleSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexibleSync.swift; sourceTree = "<group>"; };
 		917D8C9E26167B69001B7A61 /* TestingAndDebugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestingAndDebugging.swift; sourceTree = "<group>"; };
 		917E73E526B8A9F80068242A /* MongoDBRemoteAccess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MongoDBRemoteAccess.swift; sourceTree = "<group>"; };
 		917E73E626B8A9F80068242A /* MongoDBRemoteAccessAggregate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MongoDBRemoteAccessAggregate.swift; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				228B6F9026166ED10075A6E0 /* Errors.swift */,
 				4896EE57251051C800D1FABF /* ExampleObjcTestCase.m */,
 				4896EE54251051A600D1FABF /* ExampleSwiftTestCase.swift */,
+				917097D9279F182600F1D65B /* FlexibleSync.swift */,
 				4834235B25D6E0CB002CE6B0 /* Functions.m */,
 				48F38B552527926500DDEB65 /* Functions.swift */,
 				48924B972515008100CC9567 /* Info.plist */,
@@ -794,6 +797,7 @@
 				487F77C3253F94C000BDC8CE /* OpenCloseRealm.swift in Sources */,
 				228B6F9226166ED10075A6E0 /* Errors.swift in Sources */,
 				48F38B5C2527A3FE00DDEB65 /* ManageApiKeys.m in Sources */,
+				917097DA279F182600F1D65B /* FlexibleSync.swift in Sources */,
 				48C072042511B5D5004B02BB /* ManageEmailPasswordUsers.swift in Sources */,
 				48F38B522527843B00DDEB65 /* CustomUserData.swift in Sources */,
 			);

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.add-multiple-subscriptions.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.add-multiple-subscriptions.swift
@@ -1,0 +1,17 @@
+let subscriptions = realm.subscriptions
+subscriptions.write({
+    subscriptions.append(
+        QuerySubscription<Task>(name: "completed-tasks") {
+             $0.completed == true
+    })
+    subscriptions.append(
+        QuerySubscription<Team> {
+          $0.teamName == "Developer Education"
+    })
+}, onComplete: { error in // error is optional
+   if error == nil {
+      // Flexible Sync has updated data to match the subscription
+   } else {
+      // Handle the error
+   }
+})

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.add-single-subscription.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.add-single-subscription.swift
@@ -1,0 +1,13 @@
+let subscriptions = realm.subscriptions
+subscriptions.write({
+   subscriptions.append(
+      QuerySubscription<Team> {
+         $0.teamName == "Developer Education"
+      })
+}, onComplete: { error in // error is optional
+   if error == nil {
+      // Flexible Sync has updated data to match the subscription
+   } else {
+      // Handle the error
+   }
+})

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.add-subscription-with-oncomplete.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.add-subscription-with-oncomplete.swift
@@ -1,0 +1,13 @@
+let subscriptions = realm.subscriptions
+subscriptions.write({
+   subscriptions.append(
+      QuerySubscription<Task> {
+         $0.assignee == "John Doe"
+      })
+}, onComplete: { error in // error is optional
+    if error == nil {
+       // Flexible Sync has updated data to match the subscription
+    } else {
+       // Handle the error
+    }
+ })

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.flex-sync-open-realm.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.flex-sync-open-realm.swift
@@ -1,0 +1,8 @@
+let app = App(id: APPID)
+let user = try await app.login(credentials: Credentials.anonymous)
+var config = user.flexibleSyncConfiguration()
+// Pass object types to the Flexible Sync configuration
+// as a temporary workaround for not being able to add complete schema
+// for a Flexible Sync app
+config.objectTypes = [Task.self, Team.self]
+let realm = try await Realm(configuration: config, downloadBeforeOpen: .always)

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.flexible-sync-models.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.flexible-sync-models.swift
@@ -1,0 +1,14 @@
+class Task: Object {
+   @Persisted(primaryKey: true) var _id: ObjectId
+   @Persisted var taskName: String
+   @Persisted var assignee: String?
+   @Persisted var completed: Bool
+   @Persisted var progressMinutes: Int
+}
+
+class Team: Object {
+   @Persisted(primaryKey: true) var _id: ObjectId
+   @Persisted var teamName: String
+   @Persisted var tasks: List<Task>
+   @Persisted var members: List<String>
+}

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.query-subscription-by-name.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.query-subscription-by-name.swift
@@ -1,0 +1,3 @@
+QuerySubscription<Task>(name: "long-running-completed") {
+    $0.completed == true && $0.progressMinutes > 120
+}

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.query-subscription-without-name.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.query-subscription-without-name.swift
@@ -1,0 +1,3 @@
+QuerySubscription<Team> {
+   $0.teamName == "Developer Education"
+}

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.remove-all-subscriptions.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.remove-all-subscriptions.swift
@@ -1,0 +1,10 @@
+let subscriptions = realm.subscriptions
+subscriptions.write({
+    subscriptions.removeAll()
+}, onComplete: { error in // error is optional
+    if error == nil {
+      // Flexible Sync has updated data to match the subscription
+    } else {
+      // Handle the error
+    }
+})

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.remove-single-subscription.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.remove-single-subscription.swift
@@ -1,0 +1,17 @@
+let subscriptions = realm.subscriptions
+// Look for a specific subscription, and then remove it
+let foundSubscription = subscriptions.first(named: "docs-team")
+subscriptions.write({
+    subscriptions.remove(foundSubscription!)
+}, onComplete: { error in // error is optional
+    if error == nil {
+      // Flexible Sync has updated data to match the subscription
+    } else {
+      // Handle the error
+    }
+})
+
+// Or remove a subscription that you know exists without querying for it
+subscriptions.write {
+    subscriptions.remove(named: "existing-subscription")
+}

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.remove-subscriptions-to-object-type.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.remove-subscriptions-to-object-type.swift
@@ -1,0 +1,10 @@
+let subscriptions = realm.subscriptions
+subscriptions.write({
+    subscriptions.removeAll(ofType: Team.self)
+}, onComplete: { error in // error is optional
+    if error == nil {
+      // Flexible Sync has updated data to match the subscription
+    } else {
+      // Handle the error
+    }
+})

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.update-subscription-by-name.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.update-subscription-by-name.swift
@@ -1,0 +1,13 @@
+let subscriptions = realm.subscriptions
+let foundSubscription = subscriptions.first(named: "user-team")
+subscriptions.write({
+    foundSubscription?.update(toType: Team.self, where: {
+         $0.teamName == "Documentation"
+    })
+}, onComplete: { error in // error is optional
+    if error == nil {
+      // Flexible Sync has updated data to match the subscription
+    } else {
+      // Handle the error
+    }
+})

--- a/source/examples/generated/code/start/FlexibleSync.codeblock.update-subscription.swift
+++ b/source/examples/generated/code/start/FlexibleSync.codeblock.update-subscription.swift
@@ -1,0 +1,15 @@
+let subscriptions = realm.subscriptions
+let foundSubscription = subscriptions.first(ofType: Team.self, where: {
+      $0.teamName == "Developer Education"
+})
+subscriptions.write({
+    foundSubscription?.update(toType: Team.self, where: {
+         $0.teamName == "Documentation"
+    })
+}, onComplete: { error in // error is optional
+    if error == nil {
+      // Flexible Sync has updated data to match the subscription
+    } else {
+      // Handle the error
+    }
+})

--- a/source/sdk/swift/examples.txt
+++ b/source/sdk/swift/examples.txt
@@ -15,6 +15,7 @@ Usage Examples - Swift SDK
    Connect to a MongoDB Realm Backend App </sdk/swift/examples/connect-to-a-mongodb-realm-backend-app>
    Work with Users </sdk/swift/examples/work-with-users>
    Sync Changes Between Devices </sdk/swift/examples/sync-changes-between-devices>
+   Flexible Sync </sdk/swift/examples/flexible-sync>
    SwiftUI Guide </sdk/swift/examples/swiftui-guide>
    Legacy Realm Sync Open Methods </sdk/swift/examples/sync-realm-open-legacy>
    Call a Function </sdk/swift/examples/call-a-function>
@@ -37,6 +38,7 @@ Application Services (Sync)
 ---------------------------
 - :doc:`Connect to a MongoDB Realm Backend App </sdk/swift/examples/connect-to-a-mongodb-realm-backend-app>`
 - :doc:`Work with Users </sdk/swift/examples/work-with-users>`
+- :doc:`Flexible Sync </sdk/swift/examples/flexible-sync>`
 - :doc:`Sync Changes Between Devices </sdk/swift/examples/sync-changes-between-devices>`
 - :doc:`Call a Function </sdk/swift/examples/call-a-function>`
 - :doc:`Create & Manage User API Keys </sdk/swift/examples/manage-user-api-keys>`

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -170,6 +170,8 @@ This enables you to specify a partition value whose data should sync to the real
 Open a Synced Realm with a Flexible Sync Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 10.22.0
+
 When you use Flexible Sync, use the ``flexibleSyncConfiguration()``
 to open a synced realm. 
 

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -178,7 +178,7 @@ to open a synced realm.
    let app = App(id: YOUR_APP_ID_HERE)
    let user = try await app.login(credentials: Credentials.emailPassword(email: "email", password: "password"))
    let config = user.flexibleSyncConfiguration()
-   let realm = try await Realm.init(configuration: config, downloadBeforeOpen: .always)
+   let realm = try await Realm(configuration: config, downloadBeforeOpen: .always)
 
 .. _ios-specify-download-behavior:
 

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -173,12 +173,8 @@ Open a Synced Realm with a Flexible Sync Configuration
 When you use Flexible Sync, use the ``flexibleSyncConfiguration()``
 to open a synced realm. 
 
-.. code-block:: swift
-
-   let app = App(id: YOUR_APP_ID_HERE)
-   let user = try await app.login(credentials: Credentials.emailPassword(email: "email", password: "password"))
-   let config = user.flexibleSyncConfiguration()
-   let realm = try await Realm(configuration: config, downloadBeforeOpen: .always)
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.flex-sync-open-realm.swift
+   :language: swift
 
 .. _ios-specify-download-behavior:
 

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -71,6 +71,139 @@ Open a Local Realm
       .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.codeblock.open-local-realm.m
          :language: objectivec
 
+.. _ios-login-and-open-realm:
+
+Open a Synced Realm
+-------------------
+
+The typical flow for opening a synced {+realm+} involves:
+
+1. :ref:`Authenticating the user <ios-authenticate-users>`.
+#. Creating a sync configuration.
+#. Opening the user's synced {+realm+} with the configuration.
+
+At authentication, we cache user credentials in a ``sync_metadata.realm`` 
+file on device.
+
+When you open a synced {+realm+} after authenticating, you can bypass the 
+login flow and go directly to opening the synced {+realm+}, using the same 
+sync configuration you already created.
+
+With cached credentials, you can:
+
+- Open a synced {+realm+} immediately with the data that is on the device.
+  You can use this method offline or online.
+- Open a synced {+realm+} after downloading changes from your {+app+}. 
+  This requires the user to have an active internet connection.
+
+Synced Realms vs Local Realms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Synced {+realms+} differ from local {+client-database+} in a few ways:
+
+- Synced {+realms+} attempt to sync changes with your backend {+app+},
+  whereas local {+realms+} do not.
+- Synced {+realms+} can be accessed by authenticated users, while local 
+  {+realms+} do not require any concept of users or authentication.
+- With synced {+realms+}, you can :ref:`specify the download behavior 
+  <ios-specify-download-behavior>` to download updates before opening a 
+  {+realm+}. However, this requires users to be online. Local {+realms+} - 
+  with no sync capability - can always be used offline.
+
+You can copy data from a :ref:`local {+client-database+} <ios-open-a-local-realm>` 
+to a synced {+realm+}, but you cannot sync a local {+client-database+}.
+
+.. _ios-partition-based-sync-open-realm:
+
+Open a Synced Realm with Partition-Based Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Initialize a synced {+realm+} with a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`.
+This enables you to specify a partition value whose data should sync to the realm.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      .. versionchanged:: 10.15.0
+
+      .. seealso::
+         
+         This example uses async/await introduced in Swift 5.5 for iOS 15. If you're
+         using an older version of Swift or need to support older platforms, see:
+         :ref:`Legacy Realm Sync Open Methods <ios-realm-open-legacy>`. 
+
+      Pass a logged-in user's :swift-sdk:`configuration <Structs/Realm/Configuration.html>` 
+      object with the desired :ref:`partition value <partition-value>` to 
+      :swift-sdk:`{+realm+} initializers 
+      <Structs/Realm.html#/s:10RealmSwift0A0V13configuration5queueA2C13ConfigurationV_So012OS_dispatch_D0CSgtKcfc>`.
+
+      You can optionally :ref:`specify whether a {+realm+} should download 
+      changes before opening <ios-specify-download-behavior>`. If you do not
+      specify download behavior, this opens a {+realm+} with data that is on
+      the device, and attempts to sync changes in the background.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      The first time you log in and open a synced {+realm+}, you'll log in the
+      user, and pass the user's :objc-sdk:`RLMSyncConfiguration 
+      <Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)syncConfiguration>` 
+      object with the desired :objc-sdk:`partitionValue 
+      <Classes/RLMSyncConfiguration.html#/c:objc(cs)RLMSyncConfiguration(py)partitionValue>` 
+      to :objc-sdk:`+[RLMRealm realmWithConfiguration:error:]
+      <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`.
+
+      This opens a synced {+realm+} on the device. The {+realm+} 
+      attempts to sync with your {+app+} in the background to check for changes 
+      on the server, or upload changes that the user has made.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.init-synced-realm.m
+         :language: swift
+
+.. _ios-flexible-sync-open-realm:
+
+Open a Synced Realm with a Flexible Sync Configuration
+------------------------------------------------------
+
+When you use Flexible Sync, use the ``flexibleSyncConfiguration()``
+to open a synced realm. 
+
+.. code-block:: swift
+
+   let app = App(id: YOUR_APP_ID_HERE)
+   let user = try await app.login(credentials: Credentials.emailPassword(email: "email", password: "password"))
+   let config = user.flexibleSyncConfiguration()
+   let realm = try await Realm.init(configuration: config, downloadBeforeOpen: .always)
+
+.. _ios-specify-download-behavior:
+
+Download Changes Before Open
+----------------------------
+
+.. versionadded:: 10.15.0
+
+When you open a synced {+realm+} with the Swift SDK, you can pass the 
+``downloadBeforeOpen`` parameter to specify whether to download the 
+changeset from your {+app+} before opening the {+realm+}. This parameter 
+accepts a case from the ``OpenBehavior`` enum:
+
+- ``never``: Immediately open the {+realm+} on the device. Download changes 
+  in the background when the user has internet, but don't block opening
+  the {+realm+}.
+- ``always``: Check for changes every time you open the {+realm+}.
+  Requires the user to have an active internet connection.
+- ``once``: Download data before opening a {+realm+} for the first time, but
+  open it without downloading changes on subsequent opens. This lets you 
+  populate a {+realm+} with initial data, but enables offline-first 
+  functionality on subsequent opens.
+
+.. include:: /examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
+
 .. _ios-close-a-realm:
 
 Close a Realm

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -96,15 +96,15 @@ With cached credentials, you can:
 - Open a synced {+realm+} after downloading changes from your {+app+}. 
   This requires the user to have an active internet connection.
 
-Synced Realms vs Local Realms
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Synced Realms vs. Local Realms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Synced {+realms+} differ from local {+client-database+} in a few ways:
 
 - Synced {+realms+} attempt to sync changes with your backend {+app+},
   whereas local {+realms+} do not.
 - Synced {+realms+} can be accessed by authenticated users, while local 
-  {+realms+} do not require any concept of users or authentication.
+  {+realms+} have no concept of users or authentication.
 - With synced {+realms+}, you can :ref:`specify the download behavior 
   <ios-specify-download-behavior>` to download updates before opening a 
   {+realm+}. However, this requires users to be online. Local {+realms+} - 

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -168,7 +168,7 @@ This enables you to specify a partition value whose data should sync to the real
 .. _ios-flexible-sync-open-realm:
 
 Open a Synced Realm with a Flexible Sync Configuration
-------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When you use Flexible Sync, use the ``flexibleSyncConfiguration()``
 to open a synced realm. 

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -46,7 +46,7 @@ syncs to the client device.
 About the Examples on This Page
 -------------------------------
    
-The examples in this page use a simple data set for a
+The examples on this page use a simple data set for a
 task list app. The two Realm object types are ``Team``
 and ``Task``. A ``Task`` has a ``taskName``, assignee's name, and
 completed flag. There is also an arbitrary number for
@@ -92,7 +92,7 @@ You can:
 Data matching the subscription, where the user has the appropriate 
 permissions, syncs between devices and the backend application.
 
-You can specify an optional a string name for your subscription.
+You can specify an optional string name for your subscription.
 
 When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
@@ -199,7 +199,7 @@ Async/Await
 ```````````
 
 If your application uses async/await, you don't need the ``onComplete`` 
-block. The write transaction executes asynchronously, and throws an 
+block. The write transaction executes asynchronously and throws an 
 error if the transaction cannot complete successfully.
 
 .. code-block:: swift

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -38,6 +38,35 @@ syncs to the client device.
    general information about using Realm Sync, see: :ref:`Sync Changes 
    Between Devices <ios-sync-changes-between-devices>`.
 
+About the Examples on This Page
+-------------------------------
+   
+The examples in this page use a simple data set for a
+task list app. The two Realm object types are ``Team``
+and ``Task``. A ``Task`` has a ``taskName``, assignee's name, and
+completed flag. There is also an arbitrary number for
+priority -- higher is more important -- and a count of
+minutes spent working on it. A ``Team`` has a ``teamName``, 
+zero or more ``Tasks``, and a list of ``members``.
+
+.. code-block:: swift
+
+   class Task: Object {
+      @Persisted(primaryKey: true) var id: ObjectId
+      @Persisted var taskName: String
+      @Persisted var assignee: String?
+      @Persisted var completed: Bool
+      @Persisted var progressMinutes: Int
+   }
+
+   class Team: Object {
+      @Persisted(primaryKey: true) var id: ObjectId
+      @Persisted var teamName: String
+      @Persisted var tasks: List<Task>
+      @Persisted var members: List<String>
+   }
+
+
 .. _ios-sync-subscribe-to-queryable-fields:
 
 Subscribe to Queryable Fields
@@ -53,13 +82,12 @@ You can:
 - Add subscriptions
 - Check subscription state
 - Update subscriptions with new queries
-- Remove individual subscriptions or all subscriptions of a type
+- Remove individual subscriptions or all subscriptions for an object type
 
 Data matching the subscription, where the user has the appropriate 
 permissions, syncs between devices and the backend application.
 
-You can specify a string name for your subscription. If you do not give your
-subscription a name, Realm uses the query string as the name.
+You can specify an optional a string name for your subscription.
 
 When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
@@ -67,23 +95,22 @@ object types. You can also have multiple queries on the same object type.
 
 .. example::
 
-   When you create a subscription with no explicit name, the name becomes
-   a string version of the query. In this example, it's 
-   ``$0.name == "Developer Education"``.
-
-   .. code-block:: swift
-
-      QuerySubscription<Team> {
-         $0.name == "Developer Education"
-      }
-
-   You can also create a subscription with an explicit name. Then, you can
+   You can create a subscription with an explicit name. Then, you can
    search for that subscription by name to update or remove it.
 
    .. code-block:: swift 
 
       QuerySubscription<Task>(name: "long-running-completed") {
-         $0.status == "complete" && $0.progressMinutes > 120
+         $0.complete == true && $0.progressMinutes > 120
+      }
+
+   If you do not specify a ``name`` for a subscription, you can search 
+   for the subscription by the query string.
+
+   .. code-block:: swift
+
+      QuerySubscription<Team> {
+         $0.teamName == "Developer Education"
       }
 
 .. _ios-sync-add-subscription:
@@ -98,14 +125,13 @@ new subscription to the client's Realm subscriptions.
 
    let subscriptions = realm.subscriptions
    if subscriptions.isEmpty {
-      try! await subscriptions.write {
-         try! subscriptions.append {
+      try! subscriptions.write {
+         subscriptions.append {
             QuerySubscription<Team> {
-               $0.name == "Developer Education"
+               $0.teamName == "Developer Education"
             }
          }
       }
-      try! await subscriptions.waitForAsync()
    }
 
 .. _ios-sync-check-subscription-state:
@@ -124,14 +150,14 @@ enum. You can use subscription state to:
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try! await subscriptions.write {
-      try! subscriptions.remove {
+   try! subscriptions.write {
+      subscriptions.remove {
          QuerySubscription<Task> {
-            $0.owner == "Joe Doe"
+            $0.assignee == "Joe Doe"
          }
       }
    }
-   for await state in subscriptions.state {
+   for state in subscriptions.state {
       // Notify state changes
       print(state)
    }
@@ -148,12 +174,12 @@ subscription with a new query.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   let query = { QuerySubscription<Team> { $0.name == "Developer Education" } }
+   let query = { QuerySubscription<Team> { $0.teamName == "Developer Education" } }
    if let subscription = subscriptions.first(where: query) {
       try! subscriptions.write {
          subscription.update {
             QuerySubscription<Team>(name: "docs-team") {
-               $0.name == "Documentation"
+               $0.teamName == "Documentation"
             }
          }
       }
@@ -182,9 +208,9 @@ name to find the appropriate query subscription to remove.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   if let subscription = subscriptions.first(where: { $0.name == "docs-team" }) {   
+   if let subscription = subscriptions.first(where: { QuerySubscription<Team>  { $0.teamName == "docs-team" }}) {   
       try! subscriptions.write {
-         try! subscriptions.remove(subscription)
+         subscriptions.remove(subscription)
       }
    }
 
@@ -197,7 +223,6 @@ If you want to remove all subscriptions to a specific object type, use the
 .. code-block:: swift
 
    let subscriptions = ream.subscriptions
-   try! await subscriptions.write {
-      try! subscriptions.removeAll(ofType: Team.self)
+   try! subscriptions.write {
+      subscriptions.removeAll(ofType: Team.self)
    }
-   try! await subscriptions.waitforAsync()

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -106,7 +106,7 @@ object types. You can also have multiple queries on the same object type.
    .. code-block:: swift 
 
       QuerySubscription<Task>(name: "long-running-completed") {
-         $0.complete == true && $0.progressMinutes > 120
+         $0.completed == true && $0.progressMinutes > 120
       }
 
    If you do not specify a ``name`` for a subscription, you can search 
@@ -138,10 +138,12 @@ Add a Subscription
 Add a subscription in a subscriptions write block. You append each
 new subscription to the client's Realm subscriptions.
 
+.. include:: /includes/note-unsupported-flex-sync-rql-operators.rst
+
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   subscriptions.write {
+   subscriptions.write({
       subscriptions.append {
          QuerySubscription<Team> {
             $0.teamName == "Developer Education"
@@ -153,7 +155,30 @@ new subscription to the client's Realm subscriptions.
       } else {
          // Handle the error
       }
-   }
+   })
+
+You can add multiple subscriptions within a subscription write block, 
+including subscriptions of different object types.
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   subscriptions.write({
+      subscriptions.append {
+         QuerySubscription<Team> {
+            $0.teamName == "Developer Education"
+         }
+         QuerySubscription<Task>(named: "completed-tasks") {
+            $0.completed == true
+         }
+      }
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
+      }
+   })
 
 .. _ios-sync-check-subscription-state:
 .. _ios-sync-react-to-subscription-changes:
@@ -181,7 +206,7 @@ optional errors that occur during synchronization.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   subscriptions.write {
+   subscriptions.write({
       subscriptions.remove {
          QuerySubscription<Task> {
             $0.assignee == "Joe Doe"
@@ -193,7 +218,7 @@ optional errors that occur during synchronization.
       } else {
          // Handle the error
       }
-   }
+   })
 
 Async/Await
 ```````````
@@ -223,12 +248,16 @@ Additionally, you can watch the state of the subscription set with the
 
 - Show a progress indicator while data is downloading
 - Find out when a subscription set becomes superseded
+- Wait for a subscription that has been persisted locally to sync with
+  the server
+- Watch for errors
+
 
 Superseded
 ``````````
 
-``superseded`` is a ``SyncSubscriptionState`` that can occur when another
-thread writes a subscription on a different instance of the 
+The ``superseded`` state is a ``SyncSubscriptionState`` that can occur when 
+another thread writes a subscription on a different instance of the 
 subscription set. If the state becomes ``superseded``, you must obtain 
 a new instance of the subscription set before you can write to it.
 
@@ -249,7 +278,7 @@ subscription with a new query.
          $0.teamName == "Developer Education" 
       }
    }
-   subscriptions.write {
+   subscriptions.write({
       foundSubscription?.update {
          QuerySubscription<Team>(name: "docs-team") {
             $0.teamName == "Documentation"
@@ -260,7 +289,7 @@ subscription with a new query.
          // Flexible Sync has updated data to match the subscription
       } else {
          // Handle the error
-   }
+   })
 
 You can also search for a subscription by name. In this example, we 
 search for a subscription by name and then update that subscription with
@@ -270,7 +299,7 @@ a new query.
 
    let subscriptions = realm.subscriptions
    let foundSubscription = subscriptions.first(named: "docs-team")
-   subscriptions.write {
+   subscriptions.write({
       foundSubscription?.update {
          QuerySubscription<Team>(name: "docs-team") {
             $0.teamName == "Documentation"
@@ -282,7 +311,7 @@ a new query.
       } else {
          // Handle the error
       }
-   }
+   })
 
 .. _ios-remove-subscriptions:
 
@@ -308,8 +337,9 @@ name to find the appropriate query subscription to remove.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
+   // Look for a specific subscription, and then remove it
    let foundSubscription = subscriptions.first(named: "docs-team")   
-   subscriptions.write {
+   subscriptions.write({
       subscriptions.remove(foundSubscription!)
    }, onComplete: { error in // error is optional
       if error == nil {
@@ -317,6 +347,11 @@ name to find the appropriate query subscription to remove.
       } else {
          // Handle the error
       }
+   })
+
+   // Or remove a subscription that you know exists without querying for it
+   subscriptions.write {
+      subscriptions.remove(named: "existing-subscription")
    }
 
 Remove All Subscriptions to an Object Type
@@ -328,7 +363,7 @@ If you want to remove all subscriptions to a specific object type, use the
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   subscriptions.write {
+   subscriptions.write({
       subscriptions.removeAll(ofType: Team.self)
    }, onComplete: { error in // error is optional
       if error == nil {
@@ -336,7 +371,7 @@ If you want to remove all subscriptions to a specific object type, use the
       } else {
          // Handle the error
       }
-   }
+   })
 
 Remove All Subscriptions
 ````````````````````````
@@ -353,7 +388,7 @@ method in a subscription write block.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   subscriptions.write {
+   subscriptions.write({
       subscriptions.removeAll()
    }, onComplete: { error in // error is optional
       if error == nil {
@@ -361,4 +396,4 @@ method in a subscription write block.
       } else {
          // Handle the error
       }
-   }
+   })

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -20,7 +20,7 @@ data to sync with your {+app+}.
 
 To use Flexible Sync in an iOS client:
 
-- Configure Flexible Sync on the backend [LINK TO BACKEND CONFIG PAGE WHEN COMPLETE]
+- :ref:`Configure Flexible Sync on the backend <enable-flexible-sync>`
 - :ref:`Initialize the app <ios-quick-start-init-app>`
 - :ref:`Authenticate a user <ios-quick-start-authenticate>` in
   your client project.
@@ -227,9 +227,9 @@ Additionally, you can watch the state of the subscription set with the
 Superseded
 ``````````
 
-``superceded`` is a ``SyncSubscriptionState`` that can occur when another
+``superseded`` is a ``SyncSubscriptionState`` that can occur when another
 thread writes a subscription on a different instance of the 
-subscription set. If the state becomes ``superceded``, you must obtain 
+subscription set. If the state becomes ``superseded``, you must obtain 
 a new instance of the subscription set before you can write to it.
 
 .. _ios-update-subscriptions-with-new-query:
@@ -343,6 +343,12 @@ Remove All Subscriptions
 
 To remove all subscriptions from the subscription set, use the ``removeAll``
 method in a subscription write block.
+
+.. important::
+
+   If you remove all subscriptions and do not add a new one, you'll 
+   get an error. A realm opened with a flexible sync configuration needs
+   at least one subscription to sync with the server.
 
 .. code-block:: swift
 

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -54,23 +54,8 @@ priority -- higher is more important -- and a count of
 minutes spent working on it. A ``Team`` has a ``teamName``, 
 zero or more ``Tasks``, and a list of ``members``.
 
-.. code-block:: swift
-
-   class Task: Object {
-      @Persisted(primaryKey: true) var id: ObjectId
-      @Persisted var taskName: String
-      @Persisted var assignee: String?
-      @Persisted var completed: Bool
-      @Persisted var progressMinutes: Int
-   }
-
-   class Team: Object {
-      @Persisted(primaryKey: true) var id: ObjectId
-      @Persisted var teamName: String
-      @Persisted var tasks: List<Task>
-      @Persisted var members: List<String>
-   }
-
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.flexible-sync-models.swift
+   :language: swift
 
 .. _ios-sync-subscribe-to-queryable-fields:
 
@@ -103,20 +88,14 @@ object types. You can also have multiple queries on the same object type.
    You can create a subscription with an explicit name. Then, you can
    search for that subscription by name to update or remove it.
 
-   .. code-block:: swift 
-
-      QuerySubscription<Task>(name: "long-running-completed") {
-         $0.completed == true && $0.progressMinutes > 120
-      }
+   .. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.query-subscription-by-name.swift
+      :language: swift
 
    If you do not specify a ``name`` for a subscription, you can search 
    for the subscription by the query string.
 
-   .. code-block:: swift
-
-      QuerySubscription<Team> {
-         $0.teamName == "Developer Education"
-      }
+   .. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.query-subscription-without-name.swift
+      :language: swift
 
 .. note:: Duplicate subscriptions
 
@@ -140,45 +119,14 @@ new subscription to the client's Realm subscriptions.
 
 .. include:: /includes/note-unsupported-flex-sync-rql-operators.rst
 
-.. code-block:: swift
-
-   let subscriptions = realm.subscriptions
-   subscriptions.write({
-      subscriptions.append {
-         QuerySubscription<Team> {
-            $0.teamName == "Developer Education"
-         }
-      }
-   }, onComplete: { error in // error is optional
-      if error == nil {
-         // Flexible Sync has updated data to match the subscription
-      } else {
-         // Handle the error
-      }
-   })
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.add-single-subscription.swift
+   :language: swift
 
 You can add multiple subscriptions within a subscription write block, 
 including subscriptions of different object types.
 
-.. code-block:: swift
-
-   let subscriptions = realm.subscriptions
-   subscriptions.write({
-      subscriptions.append {
-         QuerySubscription<Team> {
-            $0.teamName == "Developer Education"
-         }
-         QuerySubscription<Task>(named: "completed-tasks") {
-            $0.completed == true
-         }
-      }
-   }, onComplete: { error in // error is optional
-      if error == nil {
-         // Flexible Sync has updated data to match the subscription
-      } else {
-         // Handle the error
-      }
-   })
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.add-multiple-subscriptions.swift
+   :language: swift
 
 .. _ios-sync-check-subscription-state:
 .. _ios-sync-react-to-subscription-changes:
@@ -203,22 +151,8 @@ UI, for example, or taking another action based on changes to the data set,
 take those actions in ``onComplete``. This is also where you can handle 
 optional errors that occur during synchronization.
 
-.. code-block:: swift
-
-   let subscriptions = realm.subscriptions
-   subscriptions.write({
-      subscriptions.remove {
-         QuerySubscription<Task> {
-            $0.assignee == "Joe Doe"
-         }
-      }
-   }, onComplete: { error in // error is optional
-      if error == nil {
-         // Flexible Sync has updated data to match the subscription
-      } else {
-         // Handle the error
-      }
-   })
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.add-subscription-with-oncomplete.swift
+   :language: swift
 
 Async/Await
 ```````````
@@ -270,48 +204,15 @@ You can update subscriptions using ``update``. In this example, we
 search for a subscription matching our query and then update that 
 subscription with a new query. 
 
-.. code-block:: swift
-
-   let subscriptions = realm.subscriptions
-   let foundSubscription = subscriptions.first {
-      QuerySubscription<Team> { 
-         $0.teamName == "Developer Education" 
-      }
-   }
-   subscriptions.write({
-      foundSubscription?.update {
-         QuerySubscription<Team>(name: "docs-team") {
-            $0.teamName == "Documentation"
-         }
-      }
-   }, onComplete: { error in // error is optional
-      if error == nil {
-         // Flexible Sync has updated data to match the subscription
-      } else {
-         // Handle the error
-   })
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.update-subscription.swift
+   :language: swift
 
 You can also search for a subscription by name. In this example, we 
 search for a subscription by name and then update that subscription with
 a new query.
 
-.. code-block:: swift
-
-   let subscriptions = realm.subscriptions
-   let foundSubscription = subscriptions.first(named: "docs-team")
-   subscriptions.write({
-      foundSubscription?.update {
-         QuerySubscription<Team>(name: "docs-team") {
-            $0.teamName == "Documentation"
-         }
-      }
-   }, onComplete: { error in // error is optional
-      if error == nil {
-         // Flexible Sync has updated data to match the subscription
-      } else {
-         // Handle the error
-      }
-   })
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.update-subscription-by-name.swift
+   :language: swift
 
 .. _ios-remove-subscriptions:
 
@@ -334,25 +235,8 @@ You can remove a specific subscription query in a subscription write block
 using ``remove``. Specify the query by name or use the query as a string 
 name to find the appropriate query subscription to remove.
 
-.. code-block:: swift
-
-   let subscriptions = realm.subscriptions
-   // Look for a specific subscription, and then remove it
-   let foundSubscription = subscriptions.first(named: "docs-team")   
-   subscriptions.write({
-      subscriptions.remove(foundSubscription!)
-   }, onComplete: { error in // error is optional
-      if error == nil {
-         // Flexible Sync has updated data to match the subscription
-      } else {
-         // Handle the error
-      }
-   })
-
-   // Or remove a subscription that you know exists without querying for it
-   subscriptions.write {
-      subscriptions.remove(named: "existing-subscription")
-   }
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.remove-single-subscription.swift
+   :language: swift
 
 Remove All Subscriptions to an Object Type
 ``````````````````````````````````````````
@@ -360,18 +244,8 @@ Remove All Subscriptions to an Object Type
 If you want to remove all subscriptions to a specific object type, use the 
 ``removeAll`` method with ``ofType`` in a subscription write block.
 
-.. code-block:: swift
-
-   let subscriptions = realm.subscriptions
-   subscriptions.write({
-      subscriptions.removeAll(ofType: Team.self)
-   }, onComplete: { error in // error is optional
-      if error == nil {
-         // Flexible Sync has updated data to match the subscription
-      } else {
-         // Handle the error
-      }
-   })
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.remove-subscriptions-to-object-type.swift
+   :language: swift
 
 Remove All Subscriptions
 ````````````````````````
@@ -385,15 +259,5 @@ method in a subscription write block.
    get an error. A realm opened with a flexible sync configuration needs
    at least one subscription to sync with the server.
 
-.. code-block:: swift
-
-   let subscriptions = realm.subscriptions
-   subscriptions.write({
-      subscriptions.removeAll()
-   }, onComplete: { error in // error is optional
-      if error == nil {
-         // Flexible Sync has updated data to match the subscription
-      } else {
-         // Handle the error
-      }
-   })
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.remove-all-subscriptions.swift
+   :language: swift

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -15,6 +15,8 @@ Flexible Sync - iOS SDK
 Overview
 --------
 
+.. versionadded:: 10.22.0
+
 Flexible Sync uses subscriptions and permissions to determine which
 data to sync with your {+app+}.
 

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -58,19 +58,12 @@ You can:
 Data matching the subscription, where the user has the appropriate 
 permissions, syncs between devices and the backend application.
 
-A Realm subscription has:
-
-- Identifier
-- Name
-- Created and updated dates
-
 You can specify a string name for your subscription. If you do not give your
-subscription a name, it uses the value of the query as a string name.
+subscription a name, Realm uses the query string as the name.
 
 When you create a subscription, Realm looks for data matching a query on a
-specific object type. You can have subscriptions on several different object 
-types, or several queries on the same object type, in your Flexible Sync 
-subscriptions.
+specific object type. You can have multiple subscription sets on different 
+object types. You can also have multiple queries on the same object type.
 
 .. example::
 
@@ -99,20 +92,20 @@ Add a Subscription
 ~~~~~~~~~~~~~~~~~~
 
 Add a subscription in a subscriptions write block. You append each
-new subscription to the client's realm subscriptions.
+new subscription to the client's Realm subscriptions.
 
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
    if subscriptions.isEmpty {
-      try await subscriptions.write {
-         try subscriptions.append {
+      try! await subscriptions.write {
+         try! subscriptions.append {
             QuerySubscription<Team> {
                $0.name == "Developer Education"
             }
          }
       }
-      try await subscriptions.waitForAsync()
+      try! await subscriptions.waitForAsync()
    }
 
 .. _ios-sync-check-subscription-state:
@@ -131,8 +124,8 @@ enum. You can use subscription state to:
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try await subscriptions.write {
-      try subscriptions.remove {
+   try! await subscriptions.write {
+      try! subscriptions.remove {
          QuerySubscription<Task> {
             $0.owner == "Joe Doe"
          }
@@ -149,7 +142,7 @@ Update Subscriptions with a New Query
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can update subscriptions using ``update``. In this example, we 
-search for a subscription matching our query, and then update that 
+search for a subscription matching our query and then update that 
 subscription with a new query. 
 
 .. code-block:: swift
@@ -157,7 +150,7 @@ subscription with a new query.
    let subscriptions = realm.subscriptions
    let query = { QuerySubscription<Team> { $0.name == "Developer Education" } }
    if let subscription = subscriptions.first(where: query) {
-      try subscriptions.write {
+      try! subscriptions.write {
          subscription.update {
             QuerySubscription<Team>(name: "docs-team") {
                $0.name == "Documentation"
@@ -174,29 +167,29 @@ Remove Subscriptions
 To remove subscriptions, you can:
 
 - Remove a single subscription query
-- Remove all subscriptions of a specific type
+- Remove all subscriptions to a specific object type
 
-When you remove a subscription query, the server asynchronously removes 
-synced data from the client device.
+When you remove a subscription query, Realm asynchronously removes the
+synced data that matched the query from the client device.
 
 Remove a Single Subscription
 ````````````````````````````
 
 You can remove a specific subscription query in a subscription write block 
-using ``remove``. Specify the query by name, or use the query as a string 
+using ``remove``. Specify the query by name or use the query as a string 
 name to find the appropriate query subscription to remove.
 
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
    if let subscription = subscriptions.first(where: { $0.name == "docs-team" }) {   
-      try subscriptions.write {
-         try subscriptions.remove(subscription)
+      try! subscriptions.write {
+         try! subscriptions.remove(subscription)
       }
    }
 
-Remove All Subscriptions of a Type
-``````````````````````````````````
+Remove All Subscriptions to an Object Type
+``````````````````````````````````````````
 
 If you want to remove all subscriptions to a specific object type, use the 
 ``removeAll`` method in a subscription write block.
@@ -204,7 +197,7 @@ If you want to remove all subscriptions to a specific object type, use the
 .. code-block:: swift
 
    let subscriptions = ream.subscriptions
-   try await subscriptions.write {
-      try subscriptions.removeAll(ofType: Team.self)
+   try! await subscriptions.write {
+      try! subscriptions.removeAll(ofType: Team.self)
    }
-   try await subscriptions.waitforAsync()
+   try! await subscriptions.waitforAsync()

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -34,9 +34,13 @@ syncs to the client device.
 
 .. seealso::
 
-   This page details how to manage subscriptions for Flexible Sync. For 
-   general information about using Realm Sync, see: :ref:`Sync Changes 
-   Between Devices <ios-sync-changes-between-devices>`.
+   This page details how to manage subscriptions for Flexible Sync. 
+   
+   For general information about using Realm Sync with the Swift SDK, 
+   see: :ref:`Sync Changes Between Devices <ios-sync-changes-between-devices>`.
+
+   For information about setting up permissions for Flexible Sync, see:
+   :ref:`Flexible Sync Rules & Permissions <flexible-sync-rules-and-permissions>`.
 
 About the Examples on This Page
 -------------------------------
@@ -93,6 +97,10 @@ When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
 object types. You can also have multiple queries on the same object type.
 
+Subscription names must be unique. If you do not explicitly name a 
+subscription, and instead subscribe to the same unnamed query more than
+once, Realm ignores the duplicate query subscriptions.
+
 .. example::
 
    You can create a subscription with an explicit name. Then, you can
@@ -144,8 +152,16 @@ enum. You can use subscription state to:
 
 - Trigger error handling
 - Show a progress indicator while data is downloading
-- Find out when a subscription set is superseded and you should obtain a
-  new instance of the subscription set to write a subscription change
+- Find out when a subscription set becomes superseded
+
+Subscription state is only one component of changing a subscription.
+After the subscription change, the realm syncs to resolve any updates to
+the data as a result of the subscription change. This could mean adding 
+or removing data from the synced realm. You can wait for a synced 
+realm to update data by using the ``waitForDownloads(for: realm)``.
+If you want to react to subscription state changes by redrawing a UI, 
+for example, or taking another action based on changes to the data set,
+wait for the realm to sync after making subscription updates.
 
 .. code-block:: swift
 
@@ -157,10 +173,22 @@ enum. You can use subscription state to:
          }
       }
    }
-   for state in subscriptions.state {
-      // Notify state changes
-      print(state)
+   subscriptions?.observe { state in
+      if case .complete = state {
+            // Do something when state is complete
+      }
    }
+
+   // After the state change, wait for the synced realm to update data
+   waitForDownloads(for: realm)
+
+Superseded
+``````````
+
+``superceded`` is a ``SyncSubscriptionState`` that can occur when another
+thread writes a subscription on a different instance of the 
+subscription set. If the state becomes ``superceded``, you must obtain 
+a new instance of the subscription set before you can write to it.
 
 .. _ios-update-subscriptions-with-new-query:
 
@@ -181,6 +209,22 @@ subscription with a new query.
             QuerySubscription<Team>(name: "docs-team") {
                $0.teamName == "Documentation"
             }
+         }
+      }
+   }
+
+You can also search for a subscription by name. In this example, we 
+search for a subscription by name and then update that subscription with
+a new query.
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   let foundSubscription = subscriptions.first(named: "docs-team")
+   try! subscriptions.write {
+      foundSubscription.update {
+         QuerySubscription<Team>(name: "docs-team") {
+            $0.teamName == "Documentation"
          }
       }
    }
@@ -208,21 +252,33 @@ name to find the appropriate query subscription to remove.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   if let subscription = subscriptions.first(where: { QuerySubscription<Team>  { $0.teamName == "docs-team" }}) {   
-      try! subscriptions.write {
-         subscriptions.remove(subscription)
-      }
+   let foundSubscription = subscriptions.first(named: "docs-team")   
+   try! subscriptions.write {
+      subscriptions.remove(foundSubscription!)
    }
 
 Remove All Subscriptions to an Object Type
 ``````````````````````````````````````````
 
 If you want to remove all subscriptions to a specific object type, use the 
-``removeAll`` method in a subscription write block.
+``removeAll`` method with ``ofType`` in a subscription write block.
 
 .. code-block:: swift
 
-   let subscriptions = ream.subscriptions
+   let subscriptions = realm.subscriptions
    try! subscriptions.write {
       subscriptions.removeAll(ofType: Team.self)
+   }
+
+Remove All Subscriptions
+````````````````````````
+
+To remove all subscriptions from the subscription set, use the ``removeAll``
+method in a subscription write block.
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   try! subscriptions.write {
+      subscriptions.removeAll()
    }

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -37,6 +37,7 @@ syncs to the client device.
    This page details how to manage subscriptions for Flexible Sync. 
    
    For general information about using Realm Sync with the Swift SDK, 
+   such as how to sync changes in the background or pause a sync session,
    see: :ref:`Sync Changes Between Devices <ios-sync-changes-between-devices>`.
 
    For information about setting up permissions for Flexible Sync, see:
@@ -84,7 +85,7 @@ queryable fields.
 You can:
 
 - Add subscriptions
-- Check subscription state
+- React to subscription state
 - Update subscriptions with new queries
 - Remove individual subscriptions or all subscriptions for an object type
 
@@ -96,10 +97,6 @@ You can specify an optional a string name for your subscription.
 When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
 object types. You can also have multiple queries on the same object type.
-
-Subscription names must be unique. If you do not explicitly name a 
-subscription, and instead subscribe to the same unnamed query more than
-once, Realm ignores the duplicate query subscriptions.
 
 .. example::
 
@@ -121,6 +118,18 @@ once, Realm ignores the duplicate query subscriptions.
          $0.teamName == "Developer Education"
       }
 
+.. note:: Duplicate subscriptions
+
+   Subscription names must be unique. Trying to append a subscription 
+   with the same name as an existing subscription throws an error.
+   
+   If you do not explicitly name a subscription, and instead subscribe 
+   to the same unnamed query more than once, Realm does not persist 
+   duplicate queries to the subscription set. 
+   
+   If you subscribe to the same query more than once under different names, 
+   Realm persists both subscriptions to the subscription set.
+
 .. _ios-sync-add-subscription:
 
 Add a Subscription
@@ -132,55 +141,88 @@ new subscription to the client's Realm subscriptions.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   if subscriptions.isEmpty {
-      try! subscriptions.write {
-         subscriptions.append {
-            QuerySubscription<Team> {
-               $0.teamName == "Developer Education"
-            }
+   subscriptions.write {
+      subscriptions.append {
+         QuerySubscription<Team> {
+            $0.teamName == "Developer Education"
          }
+      }
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
       }
    }
 
 .. _ios-sync-check-subscription-state:
+.. _ios-sync-react-to-subscription-changes:
 
-Check Subscription State
-~~~~~~~~~~~~~~~~~~~~~~~~
+Wait for Subscription Changes to Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can watch the state of the subscription set with the ``SyncSubscriptionState``
-enum. You can use subscription state to:
+Writing an update to the subscription set locally is only one component 
+of changing a subscription. After the local subscription change, the realm 
+synchronizes with the server to resolve any updates to the data due to 
+the subscription change. This could mean adding or removing data from the 
+synced realm. 
 
-- Trigger error handling
-- Show a progress indicator while data is downloading
-- Find out when a subscription set becomes superseded
+Pre Async/Await
+```````````````
 
-Subscription state is only one component of changing a subscription.
-After the subscription change, the realm syncs to resolve any updates to
-the data as a result of the subscription change. This could mean adding 
-or removing data from the synced realm. You can wait for a synced 
-realm to update data by using the ``waitForDownloads(for: realm)``.
-If you want to react to subscription state changes by redrawing a UI, 
-for example, or taking another action based on changes to the data set,
-wait for the realm to sync after making subscription updates.
+If your application does not use Swift's async/await feature, you can react 
+to subscription changes syncing with the server using the ``onComplete`` 
+block. This block is called after subscriptions are synchronized with the 
+server. If you want to react to subscription state changes by redrawing a 
+UI, for example, or taking another action based on changes to the data set, 
+take those actions in ``onComplete``. This is also where you can handle 
+optional errors that occur during synchronization.
 
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try! subscriptions.write {
+   subscriptions.write {
       subscriptions.remove {
          QuerySubscription<Task> {
             $0.assignee == "Joe Doe"
          }
       }
-   }
-   subscriptions?.observe { state in
-      if case .complete = state {
-            // Do something when state is complete
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
       }
    }
 
-   // After the state change, wait for the synced realm to update data
-   waitForDownloads(for: realm)
+Async/Await
+```````````
+
+If your application uses async/await, you don't need the ``onComplete`` 
+block. The write transaction executes asynchronously, and throws an 
+error if the transaction cannot complete successfully.
+
+.. code-block:: swift
+
+   func changeSubscription() async throws {
+      let subscriptions = realm.subscriptions
+      try await subcriptions.write {
+         subscriptions.remove {
+            QuerySubscription<Task> {
+               $0.assignee == "Joe Doe"
+            }
+         }
+      }
+   }
+
+SyncSubscriptionState Enum
+``````````````````````````
+
+Additionally, you can watch the state of the subscription set with the 
+``SyncSubscriptionState`` enum. You can use subscription state to:
+
+- Show a progress indicator while data is downloading
+- Find out when a subscription set becomes superseded
 
 Superseded
 ``````````
@@ -202,15 +244,22 @@ subscription with a new query.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   let query = { QuerySubscription<Team> { $0.teamName == "Developer Education" } }
-   if let subscription = subscriptions.first(where: query) {
-      try! subscriptions.write {
-         subscription.update {
-            QuerySubscription<Team>(name: "docs-team") {
-               $0.teamName == "Documentation"
-            }
+   let foundSubscription = subscriptions.first {
+      QuerySubscription<Team> { 
+         $0.teamName == "Developer Education" 
+      }
+   }
+   subscriptions.write {
+      foundSubscription?.update {
+         QuerySubscription<Team>(name: "docs-team") {
+            $0.teamName == "Documentation"
          }
       }
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
    }
 
 You can also search for a subscription by name. In this example, we 
@@ -221,11 +270,17 @@ a new query.
 
    let subscriptions = realm.subscriptions
    let foundSubscription = subscriptions.first(named: "docs-team")
-   try! subscriptions.write {
-      foundSubscription.update {
+   subscriptions.write {
+      foundSubscription?.update {
          QuerySubscription<Team>(name: "docs-team") {
             $0.teamName == "Documentation"
          }
+      }
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
       }
    }
 
@@ -238,6 +293,7 @@ To remove subscriptions, you can:
 
 - Remove a single subscription query
 - Remove all subscriptions to a specific object type
+- Remove all subscriptions
 
 When you remove a subscription query, Realm asynchronously removes the
 synced data that matched the query from the client device.
@@ -253,8 +309,14 @@ name to find the appropriate query subscription to remove.
 
    let subscriptions = realm.subscriptions
    let foundSubscription = subscriptions.first(named: "docs-team")   
-   try! subscriptions.write {
+   subscriptions.write {
       subscriptions.remove(foundSubscription!)
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
+      }
    }
 
 Remove All Subscriptions to an Object Type
@@ -266,8 +328,14 @@ If you want to remove all subscriptions to a specific object type, use the
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try! subscriptions.write {
+   subscriptions.write {
       subscriptions.removeAll(ofType: Team.self)
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
+      }
    }
 
 Remove All Subscriptions
@@ -279,6 +347,12 @@ method in a subscription write block.
 .. code-block:: swift
 
    let subscriptions = realm.subscriptions
-   try! subscriptions.write {
+   subscriptions.write {
       subscriptions.removeAll()
+   }, onComplete: { error in // error is optional
+      if error == nil {
+         // Flexible Sync has updated data to match the subscription
+      } else {
+         // Handle the error
+      }
    }

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -1,0 +1,210 @@
+.. _ios-flexible-sync:
+
+=======================
+Flexible Sync - iOS SDK
+=======================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+Flexible Sync uses subscriptions and permissions to determine which
+data to sync with your {+app+}.
+
+To use Flexible Sync in an iOS client:
+
+- Configure Flexible Sync on the backend [LINK TO BACKEND CONFIG PAGE WHEN COMPLETE]
+- :ref:`Initialize the app <ios-quick-start-init-app>`
+- :ref:`Authenticate a user <ios-quick-start-authenticate>` in
+  your client project.
+- :ref:`Open the synced Realm with a Flexible Sync configuration <ios-flexible-sync-open-realm>`
+- :ref:`Add subscriptions to the client application <ios-sync-subscribe-to-queryable-fields>`
+
+You can add, update, and remove query subscriptions to determine which data 
+syncs to the client device.
+
+.. include:: /includes/note-flexible-sync-preview.rst
+
+.. seealso::
+
+   This page details how to manage subscriptions for Flexible Sync. For 
+   general information about using Realm Sync, see: :ref:`Sync Changes 
+   Between Devices <ios-sync-changes-between-devices>`.
+
+.. _ios-sync-subscribe-to-queryable-fields:
+
+Subscribe to Queryable Fields
+-----------------------------
+
+When you configure Flexible Sync on the backend, you specify which fields
+your client application can query. In the client application, use the 
+``subscriptions`` API to manage a set of subscriptions to specific queries on 
+queryable fields.
+
+You can:
+
+- Add subscriptions
+- Check subscription state
+- Update subscriptions with new queries
+- Remove individual subscriptions or all subscriptions of a type
+
+Data matching the subscription, where the user has the appropriate 
+permissions, syncs between devices and the backend application.
+
+A Realm subscription has:
+
+- Identifier
+- Name
+- Created and updated dates
+
+You can specify a string name for your subscription. If you do not give your
+subscription a name, it uses the value of the query as a string name.
+
+When you create a subscription, Realm looks for data matching a query on a
+specific object type. You can have subscriptions on several different object 
+types, or several queries on the same object type, in your Flexible Sync 
+subscriptions.
+
+.. example::
+
+   When you create a subscription with no explicit name, the name becomes
+   a string version of the query. In this example, it's 
+   ``$0.name == "Developer Education"``.
+
+   .. code-block:: swift
+
+      QuerySubscription<Team> {
+         $0.name == "Developer Education"
+      }
+
+   You can also create a subscription with an explicit name. Then, you can
+   search for that subscription by name to update or remove it.
+
+   .. code-block:: swift 
+
+      QuerySubscription<Task>(name: "long-running-completed") {
+         $0.status == "complete" && $0.progressMinutes > 120
+      }
+
+.. _ios-sync-add-subscription:
+
+Add a Subscription
+~~~~~~~~~~~~~~~~~~
+
+Add a subscription in a subscriptions write block. You append each
+new subscription to the client's realm subscriptions.
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   if subscriptions.isEmpty {
+      try await subscriptions.write {
+         try subscriptions.append {
+            QuerySubscription<Team> {
+               $0.name == "Developer Education"
+            }
+         }
+      }
+      try await subscriptions.waitForAsync()
+   }
+
+.. _ios-sync-check-subscription-state:
+
+Check Subscription State
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can watch the state of the subscription set with the ``SyncSubscriptionState``
+enum. You can use subscription state to:
+
+- Trigger error handling
+- Show a progress indicator while data is downloading
+- Find out when a subscription set is superseded and you should obtain a
+  new instance of the subscription set to write a subscription change
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   try await subscriptions.write {
+      try subscriptions.remove {
+         QuerySubscription<Task> {
+            $0.owner == "Joe Doe"
+         }
+      }
+   }
+   for await state in subscriptions.state {
+      // Notify state changes
+      print(state)
+   }
+
+.. _ios-update-subscriptions-with-new-query:
+
+Update Subscriptions with a New Query
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can update subscriptions using ``update``. In this example, we 
+search for a subscription matching our query, and then update that 
+subscription with a new query. 
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   let query = { QuerySubscription<Team> { $0.name == "Developer Education" } }
+   if let subscription = subscriptions.first(where: query) {
+      try subscriptions.write {
+         subscription.update {
+            QuerySubscription<Team>(name: "docs-team") {
+               $0.name == "Documentation"
+            }
+         }
+      }
+   }
+
+.. _ios-remove-subscriptions:
+
+Remove Subscriptions
+~~~~~~~~~~~~~~~~~~~~
+
+To remove subscriptions, you can:
+
+- Remove a single subscription query
+- Remove all subscriptions of a specific type
+
+When you remove a subscription query, the server asynchronously removes 
+synced data from the client device.
+
+Remove a Single Subscription
+````````````````````````````
+
+You can remove a specific subscription query in a subscription write block 
+using ``remove``. Specify the query by name, or use the query as a string 
+name to find the appropriate query subscription to remove.
+
+.. code-block:: swift
+
+   let subscriptions = realm.subscriptions
+   if let subscription = subscriptions.first(where: { $0.name == "docs-team" }) {   
+      try subscriptions.write {
+         try subscriptions.remove(subscription)
+      }
+   }
+
+Remove All Subscriptions of a Type
+``````````````````````````````````
+
+If you want to remove all subscriptions to a specific object type, use the 
+``removeAll`` method in a subscription write block.
+
+.. code-block:: swift
+
+   let subscriptions = ream.subscriptions
+   try await subscriptions.write {
+      try subscriptions.removeAll(ofType: Team.self)
+   }
+   try await subscriptions.waitforAsync()

--- a/source/sdk/swift/examples/sync-changes-between-devices.txt
+++ b/source/sdk/swift/examples/sync-changes-between-devices.txt
@@ -14,119 +14,46 @@ Sync Changes Between Devices - Swift SDK
 
 .. _ios-open-a-synced-realm:
 
-Overview
---------
+Prerequisites
+-------------
 
-The typical flow for opening a synced {+realm+} involves:
+Before you can access a synced {+realm+} from the client, you must:
 
-1. :ref:`Authenticating the user <ios-authenticate-users>`
-#. Creating a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`
-#. Opening the user's synced {+realm+} with the configuration.
+1. :ref:`Enable sync <enable-sync>` in the {+ui+}.
 
-At authentication, we cache user credentials in a ``sync_metadata.realm`` 
-file on device.
+#. :ref:`Initialize the app <ios-quick-start-init-app>`
 
-When you open a synced {+realm+} after authenticating, you can bypass the 
-login flow and go directly to opening the synced {+realm+}, using the same 
-sync configuration you already created.
+#. :ref:`Authenticate a user <ios-quick-start-authenticate>` in
+  your client project.
 
-With cached credentials, you can:
+#. :ref:`Open a Synced Realm <ios-login-and-open-realm>`
 
-- Open a synced {+realm+} immediately with the data that is on the device.
-  You can use this method offline or online.
-- Open a synced {+realm+} after downloading changes from your {+app+}. 
-  This requires the user to have an active internet connection.
+Sync Data
+---------
 
-Synced Realms vs Local Realms
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The syntax to :ref:`read <ios-read-operations>`, :ref:`write
+<ios-write-operations>`, and
+:ref:`watch for changes <ios-react-to-changes>` on a
+synced {+realm+} is identical to the syntax for non-synced {+realms+}. While 
+you work with local data, a background thread efficiently integrates, 
+uploads, and downloads changesets.
 
-Synced {+realms+} differ from local {+client-database+} in a few ways:
+.. important:: When Using Sync, Avoid Writes on the Main Thread
 
-- Synced {+realms+} attempt to sync changes with your backend {+app+},
-  whereas local {+realms+} do not.
-- Synced {+realms+} can be accessed by authenticated users, while local 
-  {+realms+} do not require any concept of users or authentication.
-- With synced {+realms+}, you can :ref:`specify the download behavior 
-  <ios-specify-download-behavior>` to download updates before opening a 
-  {+realm+}. However, this requires users to be online. Local {+realms+} - 
-  with no sync capability - can always be used offline.
+   The fact that {+service-short+} performs sync integrations on a background thread means
+   that if you write to your {+realm+} on the main thread, there's a small chance your UI
+   could appear to hang as it waits for the background sync thread to finish a write
+   transaction. Therefore, it's a best practice :ref:`not to write on the main thread
+   when using {+sync+} <ios-threading-three-rules>`.
 
-You can copy data from a :ref:`local {+client-database+} <ios-open-a-local-realm>` 
-to a synced {+realm+}, but you cannot sync a local {+client-database+}. You
-must initialize a synced {+realm+} with a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`.
+The following code creates a new ``Task`` object and writes it to the {+realm+}:
 
-.. _ios-login-and-open-realm:
+.. literalinclude:: /examples/generated/code/start/CompleteQuickStart.codeblock.create-task.swift
+   :language: swift
 
-Open a Synced Realm
--------------------
+.. seealso::
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: swift
-
-      .. versionchanged:: 10.15.0
-
-      .. seealso::
-         
-         This example uses async/await introduced in Swift 5.5 for iOS 15. If you're
-         using an older version of Swift or need to support older platforms, see:
-         :ref:`Legacy Realm Sync Open Methods <ios-realm-open-legacy>`. 
-
-      Pass a logged-in user's :swift-sdk:`configuration <Structs/Realm/Configuration.html>` 
-      object with the desired :ref:`partition value <partition-value>` to 
-      :swift-sdk:`{+realm+} initializers 
-      <Structs/Realm.html#/s:10RealmSwift0A0V13configuration5queueA2C13ConfigurationV_So012OS_dispatch_D0CSgtKcfc>`.
-
-      You can optionally :ref:`specify whether a {+realm+} should download 
-      changes before opening <ios-specify-download-behavior>`. If you do not
-      specify download behavior, this opens a {+realm+} with data that is on
-      the device, and attempts to sync changes in the background.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.open-synced-realm.swift
-         :language: swift
-
-   .. tab::
-      :tabid: objective-c
-
-      The first time you log in and open a synced {+realm+}, you'll log in the
-      user, and pass the user's :objc-sdk:`RLMSyncConfiguration 
-      <Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)syncConfiguration>` 
-      object with the desired :objc-sdk:`partitionValue 
-      <Classes/RLMSyncConfiguration.html#/c:objc(cs)RLMSyncConfiguration(py)partitionValue>` 
-      to :objc-sdk:`+[RLMRealm realmWithConfiguration:error:]
-      <Classes/RLMRealm.html#/c:objc(cs)RLMRealm(cm)realmWithConfiguration:error:>`.
-
-      This opens a synced {+realm+} on the device. The {+realm+} 
-      attempts to sync with your {+app+} in the background to check for changes 
-      on the server, or upload changes that the user has made.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.codeblock.init-synced-realm.m
-         :language: swift
-
-.. _ios-specify-download-behavior:
-
-Download Changes Before Open
-----------------------------
-
-.. versionadded:: 10.15.0
-
-When you open a synced {+realm+} with the Swift SDK, you can pass the 
-``downloadBeforeOpen`` parameter to specify whether to download the 
-changeset from your {+app+} before opening the {+realm+}. This parameter 
-accepts a case from the ``OpenBehavior`` enum:
-
-- ``never``: Immediately open the {+realm+} on the device. Download changes 
-  in the background when the user has internet, but don't block opening
-  the {+realm+}.
-- ``always``: Check for changes every time you open the {+realm+}.
-  Requires the user to have an active internet connection.
-- ``once``: Download data before opening a {+realm+} for the first time, but
-  open it without downloading changes on subsequent opens. This lets you 
-  populate a {+realm+} with initial data, but enables offline-first 
-  functionality on subsequent opens.
-
-.. include:: /examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
+   :ref:`Threading <ios-client-threading>`
 
 .. _ios-sync-changes-in-the-background:
 

--- a/source/sdk/swift/examples/sync-changes-between-devices.txt
+++ b/source/sdk/swift/examples/sync-changes-between-devices.txt
@@ -24,7 +24,7 @@ Before you can access a synced {+realm+} from the client, you must:
 #. :ref:`Initialize the app <ios-quick-start-init-app>`
 
 #. :ref:`Authenticate a user <ios-quick-start-authenticate>` in
-  your client project.
+   your client project.
 
 #. :ref:`Open a Synced Realm <ios-login-and-open-realm>`
 

--- a/source/sdk/swift/fundamentals/realm-sync.txt
+++ b/source/sdk/swift/fundamentals/realm-sync.txt
@@ -53,6 +53,8 @@ You pass in the partition value when you open a synced realm.
 Flexible Sync
 -------------
 
+.. versionadded:: 10.22.0
+
 When you select :ref:`Flexible Sync <flexible-sync>` for your backend {+app+} 
 configuration, your client implementation must include subscriptions to 
 queries on :ref:`queryable fields <queryable-fields>`. Flexible Sync works 

--- a/source/sync/data-access-patterns/flexible-sync.txt
+++ b/source/sync/data-access-patterns/flexible-sync.txt
@@ -175,8 +175,8 @@ sync objects with the backend {+app+} and can watch for and react to changes.
    .. tab::
       :tabid: ios
 
-      To create queries from the Swift Client SDK, see the Swift SDK guide 
-      to Sync Changes Between Devices with Flexible Sync.
+      To create queries from the Swift Client SDK, see the :ref:`Swift SDK 
+      guide to Flexible Sync <ios-flexible-sync>`.
 
    .. tab::
       :tabid: node


### PR DESCRIPTION
## Pull Request Info

This PR replaces #1540 which was against the `query-based-sync` branch that has now been merged to `master`.

Note for reviewer: the Flexible Sync examples can't currently be tested in our Swift SDK unit test framework. I created an independent project and verified that the syntax compiles, but haven't tested these code examples against a backend. We'll need to update with tested code examples after the feature is live.

### Jira

- https://jira.mongodb.org/browse/DOCSP-19418

### Staged Changes (Requires MongoDB Corp SSO)

- [Flexible Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19418/sdk/swift/examples/flexible-sync/): Net new content about managing subscriptions using the Swift SDK API
- [Sync Changes Between Devices](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19418/sdk/swift/examples/sync-changes-between-devices/): Removed content about opening a realm, match other SDK versions of the page
- [Configure and Open a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19418/sdk/swift/examples/configure-and-open-a-realm/): Moved content here from Sync Changes Between Devices page to match the other SDKs, add an example of opening a Flexible Sync configuration

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)