### PR TITLE
Fix: Update Admin API auth token anchor link

### DIFF
--- a/source/includes/api-authenticate-instructions.rst
+++ b/source/includes/api-authenticate-instructions.rst
@@ -25,4 +25,4 @@ Save the ``access_token``, which you'll use as the Bearer token to authenticate 
 
 .. seealso::
   
-   :admin-api-endpoint:`API Authentication Documentation <section/API-Authentication>`
+   :admin-api-endpoint:`API Authentication Documentation <section/Get-Authentication-Tokens>`

--- a/source/includes/steps-api-delete.yaml
+++ b/source/includes/steps-api-delete.yaml
@@ -34,7 +34,7 @@ content: |
 
   - The :admin-api-endpoint:`Group ID/Project ID <section/Project-and-Application-IDs>` from step 2.
 
-  - The :admin-api-endpoint:`Application ID <section/API-Authentication>` from step 3.
+  - The :admin-api-endpoint:`Application ID <section/Get-Authentication-Tokens>` from step 3.
 
   .. code-block:: shell
     

--- a/source/logs/api.txt
+++ b/source/logs/api.txt
@@ -50,7 +50,7 @@ Application ID
 In order to request your application's log entries, you'll need the application's 
 object ID. You can find your application ID in the URL when you are accessing 
 your {+service-short+} app through `cloud.mongodb.com <https://cloud.mongodb.com?tck=docs_realm>`__.
-You can also get the :admin-api-endpoint:`application ID via curl <section/API-Authentication>`. 
+You can also get the :admin-api-endpoint:`application ID via curl <section/Get-Authentication-Tokens>`. 
 
 .. example:: 
   When you access your {+service-short+} app, you should have a URL of the 

--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -151,7 +151,7 @@ paths:
                     type: string
                     description: |-
                       An access token you may provide in the `Authorization` header of API
-                      requests. [The Realm API Authentication section](#section/API-Authentication) demonstrates how to use this token.
+                      requests. [The Realm API Authentication section](#section/Get-Authentication-Tokens) demonstrates how to use this token.
                   refresh_token:
                     type: string
                     description: |

--- a/source/reference/authenticate-http-client-requests.txt
+++ b/source/reference/authenticate-http-client-requests.txt
@@ -186,7 +186,7 @@ in the administration API.
 This endpoint accepts a ``POST`` request that includes these details:
 
 - the client access token you got using one of the :ref:`above methods <get-client-api-access-token>` for the payload
-- an :admin-api-endpoint:`Admin API access token <section/API-Authentication>` ``Authorization`` header
+- an :admin-api-endpoint:`Admin API access token <section/Get-Authentication-Tokens>` ``Authorization`` header
 - the :admin-api-endpoint:`{groupId} and {appId} <section/Project-and-Application-IDs>` for your backend {+app+}
 
 With this information, call this API endpoint to verify that the client access 


### PR DESCRIPTION
## Pull Request Info

update the anchor link to API spec section about getting user auth token. (currently pointing to a header that doesn't exist.)

### Jira

- N/A

### Staged Changes (Requires MongoDB Corp SSO)

- N/A

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
