### PR TITLE
Add note about ineligible clusters in Enable Flexible Sync docs

### DIFF
--- a/source/includes/steps-configure-flexible-sync-ui.yaml
+++ b/source/includes/steps-configure-flexible-sync-ui.yaml
@@ -24,6 +24,14 @@ content: |
   application. Determine which cluster you want to use and select it from
   the :guilabel:`Select Cluster To {+sync-short+}` dropdown menu.
 
+  .. important:: Ineligible Clusters
+
+     Flexible Sync requires MongoDB 5.0, which is not currently available
+     on shared clusters. Clusters display as gray and not-selectable
+     in the UI when they do not meet the requirements for Flexible Sync. 
+     You currently need a minimum of an M10 cluster running MongoDB 5.0 to 
+     enable Flexible Sync in your Realm application.
+
   .. figure:: /images/flex-sync-select-development-details.png
      :width: 750px
      :alt: Select Development Details Menu


### PR DESCRIPTION
## Pull Request Info

Multiple people have run into a state where a cluster is grayed out and not selectable in the UI when they try to enable Flexible Sync. This note explains this state at the point in the procedure when someone would encounter this state.

### Staged Changes (Requires MongoDB Corp SSO)

- [Enable Realm Sync -> Flexible Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/add-ineligible-cluster-note-to-flex-sync-config/sync/configure/enable-sync/#enable-flexible-sync): Adds note in Step 2

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
