### PR TITLE
(DOCSP-19900): Add note about partition field in schema

### DIFF
--- a/source/sync/data-model/sync-schema-overview.txt
+++ b/source/sync/data-model/sync-schema-overview.txt
@@ -69,6 +69,14 @@ in the :guilabel:`Schema` sidebar entry of the {+ui+}:
      }
    }
 
+.. tip:: Partition field
+
+   When using :ref:`Partition-Based Sync <partition-based-sync>`, your
+   object schema should include a :ref:`partition key <partition-key>`. 
+   This may be a synthetic property such as the ``_partition`` field
+   shown here. When using :ref:`Flexible Sync <flexible-sync>`, your 
+   schema does not need a partition key.
+
 .. _property-schema:
 
 Property Schema


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-19900

Note: the Jira ticket calls for this update to be putting the Partition-Based Sync Schema in a tab, and adding another tab for a Flexible Sync Schema object, but as the only difference was a partition field, I decided a callout was a better solution.

### Staged Changes (Requires MongoDB Corp SSO)

- [Sync Schema Overview](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19900/sync/data-model/sync-schema-overview/#object-schema): New Tip after the schema code block

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
