### PR TITLE
(DOCSP-15044): Add http/2 to partially supported built-in modules

### DIFF
--- a/source/functions/built-in-module-support.txt
+++ b/source/functions/built-in-module-support.txt
@@ -115,13 +115,16 @@ fs
 
 .. _partially-supported-module-http:
 
-http and https
-~~~~~~~~~~~~~~
+http, http/2 and https
+~~~~~~~~~~~~~~~~~~~~~~
 
 {+service-short+} supports all of the :nodejs:`http <docs/v10.18.1/api/http.html>` 
 and :nodejs:`https <docs/v10.18.1/api/https.html>` APIs **except** 
 for the :nodejs:`Server <docs/v10.18.1/api/http.html#http_class_http_server>` 
 class functionality.
+
+Similarly, {+service-short+} supports only the client-side APIs of
+:nodejs:`http/2 <docs/v10.18.1/api/http2.html>`.
 
 .. _partially-supported-module-process:
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-15044

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/http2-finally/functions/built-in-module-support/#http--http-2-and-https

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
