### PR TITLE
(DOCSP-19894): Add Partition-Based Sync info to Sync data endpoint

### DIFF
--- a/source/openapi-admin-v3.yaml
+++ b/source/openapi-admin-v3.yaml
@@ -876,6 +876,7 @@ paths:
         - sync
       operationId: adminGetSync
       summary: Get sync information for a specific linked MongoDB cluster.
+      description: Retrieve partition field data when using [Partition-Based Sync](https://docs.mongodb.com/realm/sync/data-access-patterns/partitions/). 
       responses:
         "200":
           description: Successfully retrieved.


### PR DESCRIPTION
## Pull Request Info

Note: This is the only endpoint in the Admin API that specifically shows a Sync object, and this endpoint only shows partition field data when PBS is enabled. When Flexible Sync is enabled, it returns an empty object. So I think this is the only update that will be needed relative to Flexible Sync.

### Jira

- https://jira.mongodb.org/browse/DOCSP-19894

### Staged Changes (Requires MongoDB Corp SSO)

- [Admin API -> GET sync/data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19894/admin/api/v3/#operation/adminGetSync): Adds a description stating that this endpoint returns partition field data when using Partition-Based Sync.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
