### PR TITLE
(DOCSP-20605): Remove inaccurate Development Mode info

### DIFF
--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -92,11 +92,10 @@ Glossary
       :term:`{+backend-schema+}`.
 
    development mode
-      A toggle that, when enabled, disables :term:`{+backend-schema+}`
-      validation and automatically updates your {+backend-schema+} to match the
-      :term:`{+frontend-schema+}` used by synced client applications. As the
-      name suggests, this mode is insecure and should not be enabled for
-      production use.
+      A toggle that, when enabled, automatically updates your 
+      {+backend-schema+} to match the :term:`{+frontend-schema+}` used by 
+      synced client applications. As the name suggests, this mode should not 
+      be enabled for production use.
 
    GraphQL
       Open-source data query and manipulation language for APIs. {+service+}

--- a/source/get-started/glossary.txt
+++ b/source/get-started/glossary.txt
@@ -86,12 +86,12 @@ Glossary
       :term:`{+service-short+} data model`. You can customize {+service-short+}
       types for your {+app+} in two different ways: by altering or creating
       {+frontend-schema+} definitions in the {+service-short+} SDK with
-      :term:`development mode` enabled in your {+app+} or by creating or editing
+      :term:`Development Mode` enabled in your {+app+} or by creating or editing
       a :ref:`schema <schemas>` assigned to a collection in the {+ui+} or
       {+cli-bin+}, which directly edits the {+app+}'s
       :term:`{+backend-schema+}`.
 
-   development mode
+   Development Mode
       A toggle that, when enabled, automatically updates your 
       {+backend-schema+} to match the :term:`{+frontend-schema+}` used by 
       synced client applications. As the name suggests, this mode should not 

--- a/source/includes/appschema-mongodb.rst
+++ b/source/includes/appschema-mongodb.rst
@@ -54,7 +54,7 @@ the cluster.
        "sync": {
          "state": <Boolean>,
          "development_mode_enabled": <Boolean>,
-         "database_name": "<Developer Mode Database Name>",
+         "database_name": "<Development Mode Database Name>",
          "partition": {
            "key": "<Partition Key Field Name>",
            "type": "<Partition Key Value Type>",
@@ -84,7 +84,7 @@ the cluster.
    * - | ``sync.development_mode_enabled``
        | Boolean
      - If ``true``, :term:`development mode` is enabled for the cluster. While
-       enabled, Realm, stores synced objects in a specific database within 
+       enabled, Realm stores synced objects in a specific database within 
        the cluster, and mirrors object types in that database's collection 
        schemas.
 

--- a/source/includes/appschema-mongodb.rst
+++ b/source/includes/appschema-mongodb.rst
@@ -83,7 +83,7 @@ the cluster.
    
    * - | ``sync.development_mode_enabled``
        | Boolean
-     - If ``true``, :term:`development mode` is enabled for the cluster. While
+     - If ``true``, :term:`Development Mode` is enabled for the cluster. While
        enabled, Realm stores synced objects in a specific database within 
        the cluster, and mirrors object types in that database's collection 
        schemas.
@@ -93,7 +93,7 @@ the cluster.
      - The name of the database in the synced cluster where Realm should store
        synced objects.
        
-       When :term:`development mode` is enabled, Realm stores synced objects in
+       When :term:`Development Mode` is enabled, Realm stores synced objects in
        this database. Each object type maps to its own collection in the
        database with a schema that matches the synced objects.
    

--- a/source/includes/appschema-mongodb.rst
+++ b/source/includes/appschema-mongodb.rst
@@ -84,9 +84,9 @@ the cluster.
    * - | ``sync.development_mode_enabled``
        | Boolean
      - If ``true``, :term:`development mode` is enabled for the cluster. While
-       enabled, Realm does not enforce sync rules, stores synced objects in a
-       specific database within the cluster, and mirrors object types in that
-       database's collection schemas.
+       enabled, Realm, stores synced objects in a specific database within 
+       the cluster, and mirrors object types in that database's collection 
+       schemas.
 
    * - | ``sync.database_name``
        | String

--- a/source/includes/note-beta-feature.rst
+++ b/source/includes/note-beta-feature.rst
@@ -8,7 +8,7 @@
    - The API may change.
    - New data types are not backwards compatible. 
 
-   To add new data types via :ref:`development mode <enable-development-mode>`, 
+   To add new data types via :ref:`Development Mode <enable-development-mode>`, 
    you must update the client SDK. {+sync+} client applications using older
    protocol versions will no longer be able to connect.
 

--- a/source/includes/realm-database.rst
+++ b/source/includes/realm-database.rst
@@ -261,7 +261,7 @@ Applications that use {+sync+} define their schema on the backend using
 `JSON Schema <https://json-schema.org/learn/getting-started-step-by-step.html>`__.
 Client applications must match that backend schema to synchronize data.
 However, if you prefer to define your initial schema in your application's
-programming language, you can use :ref:`development mode
+programming language, you can use :ref:`Development Mode
 <concept-development-mode>` to create a backend JSON Schema based on
 native SDK objects as you write your application. However, once your
 application is used for production purposes, you should alter your

--- a/source/includes/steps-configure-flexible-sync-ui.yaml
+++ b/source/includes/steps-configure-flexible-sync-ui.yaml
@@ -8,14 +8,14 @@ title: Select Development Details
 ref: select-development-details
 content: |
   Under the :guilabel:`Select Development Details` heading, you can configure
-  various development details, such as {+sync-short+} types, development mode,
+  various development details, such as {+sync-short+} types, Development Mode,
   and a cluster to {+sync-short+}.
 
   Below the :guilabel:`{+sync-short+} types` subheading, select the :guilabel:`Flexible`
   option to enable Flexible {+sync-short+}.
   
   Next, under the :guilabel:`Development Mode` subheading, you can choose to
-  toggle :ref:`development mode <enable-disable-development-mode>` on/off.
+  toggle :ref:`Development Mode <enable-disable-development-mode>` on/off.
   Enabling ``Development Mode`` allows you to define schemas directly in your
   client application code and is suitable if you are in development and do not
   have application data in Atlas yet.

--- a/source/includes/steps-development-mode-cli.yaml
+++ b/source/includes/steps-development-mode-cli.yaml
@@ -111,7 +111,7 @@ ref: enable-development-mode
 content: |
   You can turn development mode on and off by setting a boolean value for
   ``development_mode_enabled`` in your app's ``sync/config.json`` file. To
-  enable dev mode, set the value to ``true``:
+  enable development mode, set the value to ``true``:
 
   .. code-block:: json
      :caption: sync/config.json

--- a/source/includes/steps-development-mode-cli.yaml
+++ b/source/includes/steps-development-mode-cli.yaml
@@ -10,7 +10,7 @@ content: |
 title: Select a Cluster to Sync
 ref: select-a-cluster-to-sync
 content: |
-  You can enable development mode sync for a single :term:`linked cluster` in
+  You can enable Development Mode sync for a single :term:`linked cluster` in
   your application. If you have not yet linked the cluster to your application,
   follow the :ref:`Link a MongoDB Atlas Cluster <link-a-data-source>` guide to
   link it before you continue.
@@ -42,7 +42,7 @@ content: |
 title: Choose a Target Database
 ref: choose-a-target-database
 content: |
-  While development mode is enabled, Realm maps every synced object type to its
+  While Development Mode is enabled, Realm maps every synced object type to its
   own collection in the linked cluster. The collections use the pluralized name
   of the object type and are located in a specific database.
 
@@ -109,9 +109,9 @@ content: |
 title: Enable Development Mode
 ref: enable-development-mode
 content: |
-  You can turn development mode on and off by setting a boolean value for
+  You can turn Development Mode on and off by setting a boolean value for
   ``development_mode_enabled`` in your app's ``sync/config.json`` file. To
-  enable development mode, set the value to ``true``:
+  enable Development Mode, set the value to ``true``:
 
   .. code-block:: json
      :caption: sync/config.json
@@ -123,7 +123,7 @@ content: |
 title: Deploy the Updated App Configuration
 ref: deploy-the-updated-app-configuration
 content: |
-  Now that you've configured development mode and specified that it's enabled,
+  Now that you've configured Development Mode and specified that it's enabled,
   you can deploy your changes to turn it on.
 
   To deploy your changes, import your app configuration:

--- a/source/includes/steps-development-mode-realm-schema.yaml
+++ b/source/includes/steps-development-mode-realm-schema.yaml
@@ -1,7 +1,7 @@
 title: Enable Development Mode Sync
 ref: enable-development-mode-sync
 content: |
-  First,  :ref:`enable development mode sync <enable-development-mode>`.
+  First,  :ref:`enable Development Mode sync <enable-development-mode>`.
 
   You can alter or define a Realm Object Model through your mobile client SDK.
   Changes to your Realm Object Model are only allowed when
@@ -86,11 +86,11 @@ content: |
     can follow this procedure again.
 
   .. figure:: /images/turn-off-dev-mode.png
-     :alt: The banner in the UI that shows development mode is enabled
+     :alt: The banner in the UI that shows Development Mode is enabled
      :width: 750px
      :lightbox:
 
   .. figure:: /images/view-my-json-schema.png
-     :alt: The modal that confirms turning off development mode in the UI
+     :alt: The modal that confirms turning off Development Mode in the UI
      :width: 461px
      :lightbox:

--- a/source/includes/steps-development-mode-ui.yaml
+++ b/source/includes/steps-development-mode-ui.yaml
@@ -1,14 +1,14 @@
 title: Navigate to the Sync Configuration Screen
 ref: navigate-to-the-sync-configuration-screen
 content: |
-  To configure and enable development mode for your application, navigate to to
+  To configure and enable Development Mode for your application, navigate to to
   the :guilabel:`Sync` configuration screen through the {+leftnav+} and then
   click the :guilabel:`Development Mode` tab.
 ---
 title: Select a Cluster to Sync
 ref: select-a-cluster-to-sync
 content: |
-  You can enable development mode sync for a single :term:`linked cluster` in
+  You can enable Development Mode sync for a single :term:`linked cluster` in
   your application. Determine which cluster you want to use and then select it
   from the :guilabel:`Select Cluster To Sync` dropdown menu.
 
@@ -19,7 +19,7 @@ content: |
 title: Choose a Target Database
 ref: choose-a-target-database
 content: |
-  While development mode is enabled, Realm maps every synced object type to its
+  While Development Mode is enabled, Realm maps every synced object type to its
   own collection in the linked cluster. The collections use the pluralized name
   of the object type and are located in a specific database.
 
@@ -53,12 +53,12 @@ content: |
 title: Turn On Development Mode
 ref: turn-on-development-mode
 content: |
-  Click :guilabel:`Turn Dev Mode On` to enable development mode.
+  Click :guilabel:`Turn Dev Mode On` to enable Development Mode.
 ---
 title: Deploy the Updated App
 ref: deploy-the-updated-app
 content: |
-  After you've enabled development mode, review your draft changes 
+  After you've enabled Development Mode, review your draft changes 
   and confirm that you want to deploy them. Press the :guilabel:`Review
   Draft & Deploy` button in the banner at the top of the UI. You'll see
   a summary of your changes. Click the :guilabel:`Deploy` button. 

--- a/source/includes/steps-disable-development-mode-cli.yaml
+++ b/source/includes/steps-disable-development-mode-cli.yaml
@@ -12,7 +12,7 @@ ref: disable-development-mode-in-cli
 content: |
   You can turn development mode on and off by setting a boolean value for
   ``development_mode_enabled`` in your app's ``sync/config.json`` file. To
-  disable dev mode, set the value to ``false``:
+  disable development mode, set the value to ``false``:
 
   .. code-block:: json
      :caption: sync/config.json

--- a/source/includes/steps-disable-development-mode-cli.yaml
+++ b/source/includes/steps-disable-development-mode-cli.yaml
@@ -10,9 +10,9 @@ content: |
 title: Disable Development Mode
 ref: disable-development-mode-in-cli
 content: |
-  You can turn development mode on and off by setting a boolean value for
+  You can turn Development Mode on and off by setting a boolean value for
   ``development_mode_enabled`` in your app's ``sync/config.json`` file. To
-  disable development mode, set the value to ``false``:
+  disable Development Mode, set the value to ``false``:
 
   .. code-block:: json
      :caption: sync/config.json
@@ -24,7 +24,7 @@ content: |
 title: Deploy the Updated App Configuration
 ref: deploy-development-mode-disabled-updated-app-configuration
 content: |
-  Now that you've configured development mode and specified that it's disabled,
+  Now that you've configured Development Mode and specified that it's disabled,
   you can deploy your changes to turn it off
 
   To deploy your changes, import your app configuration:

--- a/source/includes/steps-disable-development-mode-ui.yaml
+++ b/source/includes/steps-disable-development-mode-ui.yaml
@@ -1,20 +1,20 @@
 title: Navigate to the Sync Configuration Screen
 ref: navigate-to-the-sync-configuration-screen
 content: |
-  To configure and disable development mode for your application, navigate to to
+  To configure and disable Development Mode for your application, navigate to to
   the :guilabel:`Sync` configuration screen through the {+leftnav+} and then
   click the :guilabel:`Development Mode` tab.
 ---
 title: Turn Off Development Mode
 ref: turn-off-development-mode
 content: |
-  Click :guilabel:`Turn Dev Mode Off` to disable development mode, and then
+  Click :guilabel:`Turn Dev Mode Off` to disable Development Mode, and then
   press the :guilabel:`Close` button on the subsequent dialogue box.
 ---
 title: Deploy an Updated App Version
 ref: deploy-an-updated-app-version
 content: |
-  After you've disabled development mode, review your draft changes 
+  After you've disabled Development Mode, review your draft changes 
   and confirm that you want to deploy them. Press the :guilabel:`Review
   Draft & Deploy` button in the banner at the top of the UI. You'll see
   a summary of your changes. Click the :guilabel:`Deploy` button. 

--- a/source/includes/steps-disable-trigger-realm-ui.yaml
+++ b/source/includes/steps-disable-trigger-realm-ui.yaml
@@ -21,5 +21,5 @@ content: |
 title: Deploy Your Changes
 ref: deploy-your-changes
 content: |
-  If development mode is not enabled, press the
+  If Development Mode is not enabled, press the
   :guilabel:`review draft & deploy` button to release your changes.

--- a/source/logs/schema.txt
+++ b/source/logs/schema.txt
@@ -35,7 +35,7 @@ Fields
      - Important information about the schema update. This can include:
 
        - Whether the schema change originated in a client while
-         developer mode was enabled or from the {+backend+} backend.
+         development mode was enabled or from the {+backend+} backend.
 
        - The name of the table the schema change effected.
 

--- a/source/logs/schema.txt
+++ b/source/logs/schema.txt
@@ -35,7 +35,7 @@ Fields
      - Important information about the schema update. This can include:
 
        - Whether the schema change originated in a client while
-         development mode was enabled or from the {+backend+} backend.
+         Development Mode was enabled or from the {+backend+} backend.
 
        - The name of the table the schema change effected.
 

--- a/source/manage-apps/configure/config/sync.txt
+++ b/source/manage-apps/configure/config/sync.txt
@@ -72,7 +72,7 @@ app uses this Sync configuration:
 
    * - | ``development_mode_enabled``
        | Boolean
-     - If ``true``, :ref:`development mode <enable-development-mode>` is enabled
+     - If ``true``, :ref:`Development Mode <enable-development-mode>` is enabled
        for the application. While enabled, Realm automatically stores synced
        objects in a specific database (specified in ``database_name``) and
        mirrors objects types in that database's collection schemas.
@@ -80,7 +80,7 @@ app uses this Sync configuration:
    * - | ``database_name``
        | String
      - The name of a database in the synced cluster where Realm stores data in
-       :ref:`development mode <enable-development-mode>`. Realm automatically
+       :ref:`Development Mode <enable-development-mode>`. Realm automatically
        generates a schema for each synced type and maps each object type to a
        collection within the database.
 
@@ -187,7 +187,7 @@ Sync configuration:
 
    * - | ``development_mode_enabled``
        | Boolean
-     - If ``true``, :ref:`development mode <enable-development-mode>` is enabled
+     - If ``true``, :ref:`Development Mode <enable-development-mode>` is enabled
        for the application. While enabled, Realm automatically stores synced
        objects in a specific database (specified in ``database_name``) and
        mirrors objects types in that database's collection schemas.
@@ -200,7 +200,7 @@ Sync configuration:
    * - | ``database_name``
        | String
      - The name of a database in the synced cluster where Realm stores data in
-       :ref:`development mode <enable-development-mode>`. Realm automatically
+       :ref:`Development Mode <enable-development-mode>`. Realm automatically
        generates a schema for each synced type and maps each object type to a
        collection within the database.
 

--- a/source/manage-apps/deploy/automated/sdlc.txt
+++ b/source/manage-apps/deploy/automated/sdlc.txt
@@ -57,7 +57,7 @@ To develop new features for an existing app:
 
 2. Develop your application. This could involve updating or adding a client app
    screen, adding a new database trigger, or any other application features. You
-   can use :ref:`development mode <concept-development-mode>` if you need to
+   can use :ref:`Development Mode <concept-development-mode>` if you need to
    make changes to your synced Realm object model.
 
 3. Run automated tests locally to ensure that your code does not introduce any

--- a/source/sdk/android/examples/modify-an-object-schema.txt
+++ b/source/sdk/android/examples/modify-an-object-schema.txt
@@ -168,7 +168,7 @@ Modify an Object Schema - Android SDK
       .. note:: Development Mode: Only for Defining Your Initial Schema
 
          You can define the first version of your application's synced
-         schema using :ref:`development mode <concept-development-mode>`,
+         schema using :ref:`Development Mode <concept-development-mode>`,
          which automatically translates client models into
          JSON Schema on the backend. However, you should make subsequent
          changes to your schema through edits to the JSON Schema in your

--- a/source/sdk/android/quick-start-sync.txt
+++ b/source/sdk/android/quick-start-sync.txt
@@ -93,7 +93,7 @@ using classes in your mobile application code. To define your {+app+}'s
 object model in this way, you need to :ref:`enable Development Mode
 <enable-development-mode>`.
 
-Once you've enabled Developer Mode, add the following class
+Once you've enabled Development Mode, add the following class
 definitions to your application code:
 
 .. seealso::

--- a/source/sdk/android/quick-start-sync.txt
+++ b/source/sdk/android/quick-start-sync.txt
@@ -90,7 +90,7 @@ stored within {+client-database+} and synchronized to and from
 
 This quick start uses the latter approach, which defines your schema
 using classes in your mobile application code. To define your {+app+}'s
-object model in this way, you need to :ref:`enable Developer Mode
+object model in this way, you need to :ref:`enable Development Mode
 <enable-development-mode>`.
 
 Once you've enabled Developer Mode, add the following class

--- a/source/sdk/dotnet/quick-start-with-sync.txt
+++ b/source/sdk/dotnet/quick-start-with-sync.txt
@@ -66,10 +66,10 @@ define your object model directly in code.
 
 .. note::
 
-   If you have enabled {+sync-short+} but turned off Developer Mode,
+   If you have enabled {+sync-short+} but turned off Development Mode,
    you can copy and paste the object model definitions that
    {+backend-short+} generated for you from the :guilabel:`SDKs` tab
-   in the {+ui+}. You must re-enable Developer Mode if you want to make
+   in the {+ui+}. You must re-enable Development Mode if you want to make
    changes to the object model definition from client side code. See
    :ref:`Configure Your Data Model <configure-your-data-model>`.
 

--- a/source/sdk/dotnet/quick-start-with-sync.txt
+++ b/source/sdk/dotnet/quick-start-with-sync.txt
@@ -61,7 +61,7 @@ the data that you can store within {+client-database+} and synchronize
 to and from {+backend+}.
 
 If have not :ref:`enabled {+sync+} <enable-sync>` or you enabled
-{+sync-short+} with :term:`development mode` in the {+ui+}, you can
+{+sync-short+} with :term:`Development Mode` in the {+ui+}, you can
 define your object model directly in code.
 
 .. note::

--- a/source/sdk/node/quick-start.txt
+++ b/source/sdk/node/quick-start.txt
@@ -77,7 +77,7 @@ Define Your Object Model
 ------------------------
 
 If you have not :ref:`enabled {+sync+} <enable-sync>` or you enabled
-{+sync-short+} with :term:`development mode`, you can define your :ref:`object
+{+sync-short+} with :term:`Development Mode`, you can define your :ref:`object
 model <node-object-schemas>` directly in code.
 
 .. note::

--- a/source/sdk/react-native/quick-start.txt
+++ b/source/sdk/react-native/quick-start.txt
@@ -96,7 +96,7 @@ define your :ref:`object model <react-native-object-schemas>` directly in code.
 
 .. note::
 
-   If you have enabled {+sync-short+} but turned off Developer Mode, you can copy and paste the object model definitions that {+backend-short+} generated for you from the :guilabel:`SDKs` tab in the {+ui+}. You must re-enable Developer Mode if you want to make changes to the object model definition from client side code. See :ref:`Configure Your Data Model <configure-your-data-model>`.
+   If you have enabled {+sync-short+} but turned off Development Mode, you can copy and paste the object model definitions that {+backend-short+} generated for you from the :guilabel:`SDKs` tab in the {+ui+}. You must re-enable Development Mode if you want to make changes to the object model definition from client side code. See :ref:`Configure Your Data Model <configure-your-data-model>`.
 
 .. tabs-realm-languages::
 

--- a/source/sdk/react-native/quick-start.txt
+++ b/source/sdk/react-native/quick-start.txt
@@ -91,7 +91,7 @@ Define Your Object Model
 ------------------------
 
 If have not :ref:`enabled {+sync+} <enable-sync>` or you enabled
-{+sync-short+} with :term:`development mode` in the {+ui+}, you can
+{+sync-short+} with :term:`Development Mode` in the {+ui+}, you can
 define your :ref:`object model <react-native-object-schemas>` directly in code.
 
 .. note::

--- a/source/sdk/swift/quick-start-with-sync.txt
+++ b/source/sdk/swift/quick-start-with-sync.txt
@@ -55,7 +55,7 @@ Define Your Object Model
 ------------------------
 
 If have not :ref:`enabled {+sync+} <enable-sync>` or you enabled {+sync-short+} with
-:term:`development mode` in the {+ui+}, you can define your :ref:`object model
+:term:`Development Mode` in the {+ui+}, you can define your :ref:`object model
 <ios-realm-objects>` directly in code.
 
 .. note::

--- a/source/sdk/swift/quick-start-with-sync.txt
+++ b/source/sdk/swift/quick-start-with-sync.txt
@@ -60,7 +60,7 @@ If have not :ref:`enabled {+sync+} <enable-sync>` or you enabled {+sync-short+} 
 
 .. note::
 
-   If you have enabled {+sync-short+} but turned off Developer Mode, you can copy and paste the object model definitions that {+backend-short+} generated for you from the :guilabel:`SDKs` tab in the {+ui+}. You must re-enable Developer Mode if you want to make changes to the object model definition from client side code. See :ref:`Configure Your Data Model <configure-your-data-model>`.
+   If you have enabled {+sync-short+} but turned off Development Mode, you can copy and paste the object model definitions that {+backend-short+} generated for you from the :guilabel:`SDKs` tab in the {+ui+}. You must re-enable Development Mode if you want to make changes to the object model definition from client side code. See :ref:`Configure Your Data Model <configure-your-data-model>`.
 
 .. literalinclude:: /examples/generated/code/start/CompleteQuickStart.codeblock.model.swift
    :language: swift

--- a/source/sync/configure/enable-sync.txt
+++ b/source/sync/configure/enable-sync.txt
@@ -39,7 +39,7 @@ configure your data model and access {+sync-short+}, see:
    
    Before defining sync rules and enabling sync, you must specify at least
    one valid :ref:`schema <schemas>` for a collection in the synced cluster 
-   unless you are using :ref:`development mode <enable-development-mode>`.
+   unless you are using :ref:`Development Mode <enable-development-mode>`.
    
    At a minimum, the schema must define ``_id`` and the field that you intend to
    use as your :term:`partition key`. A partition key field may be a ``string``,

--- a/source/sync/data-model/development-mode.txt
+++ b/source/sync/data-model/development-mode.txt
@@ -80,7 +80,7 @@ database for every type of synced object.
 
 .. warning:: Specify Data Access Rules with Development Mode Enabled
 
-   By default, enabling development mode when you have not defined 
+   By default, enabling development mode before you have defined 
    permissions creates default permissions that allow any user to access 
    any data. However, if your application requires permissions during schema 
    development, you can :ref:`specify data access rules <sync-rules>` after 
@@ -90,7 +90,7 @@ database for every type of synced object.
 
    Specify a Development Mode database of ``myapp``. Your iOS client has a 
    ``Person`` model. You sync a {+realm+} that contains an instance of the 
-   ``Person`` object. Developer Mode creates a server-side schema associated 
+   ``Person`` object. Development Mode creates a server-side schema associated 
    with the model. The object syncs to the ``myapp.Person`` collection. 
 
    {+service-short+} continues creating new server-side schemas and collections 

--- a/source/sync/data-model/development-mode.txt
+++ b/source/sync/data-model/development-mode.txt
@@ -66,29 +66,6 @@ while {+backend+} updates the schema to match.
    For more information about modifying synced object schemas, including
    how to make destructive changes, see: :ref:`<synced-schema-overview>`.
 
-Bypass Rules and Validation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When you enable development mode, {+service-short+} bypasses data access 
-rules and schema validation. This lets developers iterate quickly to develop 
-new features or fix bugs. However, this aspect of development mode means 
-it's vital to disable it in production. Leaving development mode enabled 
-in production can expose your app to security vulnerabilities. 
-
-.. warning::
-
-   Ensure your development database does not contain production data. When 
-   you enable development mode, {+service-short+} does not enforce data access 
-   rules. If your development database contains production data, developer
-   mode would leave that data vulnerable to inadvertent or malicious access.
-   
-.. note:: Specify Data Access Rules with Development Mode Enabled
-
-   By default, enabling development mode disables all data access rules,
-   allowing any user to access any data. However, if your application requires
-   permissions during schema development, you can :ref:`specify data access
-   rules <sync-rules>` after enabling development mode.
-
 Key Concepts
 ------------
 
@@ -101,9 +78,13 @@ When you enable Development Mode, you specify a database to store synced
 objects. {+service-short+} creates new collections in this Development Mode 
 database for every type of synced object.
 
-{+service-short+} does not enforce data access rules while in Development 
-Mode. Your Development Mode Database should not contain any production 
-or user data.
+.. warning:: Specify Data Access Rules with Development Mode Enabled
+
+   By default, enabling development mode when you have not defined 
+   permissions creates default permissions that allow any user to access 
+   any data. However, if your application requires permissions during schema 
+   development, you can :ref:`specify data access rules <sync-rules>` after 
+   enabling development mode.
 
 .. example::
 

--- a/source/sync/data-model/development-mode.txt
+++ b/source/sync/data-model/development-mode.txt
@@ -20,13 +20,13 @@ give you language-specific tools to define and work with these objects.
 
 You can infer schemas from your client object models by enabling development 
 mode. Development mode is a {+sync+} configuration setting for your {+app+}.
-When you enable development mode, your {+app+} can create or update your 
+When you enable Development Mode, your {+app+} can create or update your 
 schema by reading your synced {+realm+} files.
 
 Why Use Development Mode?
 -------------------------
 
-{+sync+} development mode enables developers to develop faster, and design
+{+sync+} Development Mode enables developers to develop faster, and design
 :ref:`schemas <configure-your-data-model>` directly in client application 
 code.
 
@@ -34,9 +34,9 @@ Create Schemas
 ~~~~~~~~~~~~~~
 
 In practice, here's how the server-side document schema definition process 
-works with development mode:
+works with Development Mode:
 
-1. Enable development mode.
+1. Enable Development Mode.
 2. Sync {+realm+} files from your local {+client-database+}.
 3. The objects in the files become the definitions for your schema.
 
@@ -80,11 +80,11 @@ database for every type of synced object.
 
 .. warning:: Specify Data Access Rules with Development Mode Enabled
 
-   By default, enabling development mode before you have defined 
+   By default, enabling Development Mode before you have defined 
    permissions creates default permissions that allow any user to access 
    any data. However, if your application requires permissions during schema 
    development, you can :ref:`specify data access rules <sync-rules>` after 
-   enabling development mode.
+   enabling Development Mode.
 
 .. example::
 
@@ -106,7 +106,7 @@ Enable Development Mode
 .. important:: Disable Development Mode for Production Apps
    
    Development mode is a development utility that is not suitable for 
-   production use. Make sure that you turn off development mode before you 
+   production use. Make sure that you turn off Development Mode before you 
    make your app accessible in a production environment.
 
 .. tabs-realm-admin-interfaces::

--- a/source/sync/learn/overview.txt
+++ b/source/sync/learn/overview.txt
@@ -207,7 +207,7 @@ between synced realms and MongoDB Atlas.
 To define your synced object models, do one of the following for each object
 type:
 
-- **Sync object models from an SDK:** In :ref:`development mode
+- **Sync object models from an SDK:** In :ref:`Development Mode
   <concept-development-mode>`, Realm automatically generates a document schema
   for each synced object type and assigns that schema to a collection in the
   linked cluster with the same name as the object type. Development mode lets
@@ -216,7 +216,7 @@ type:
   you prefer a client-first approach that uses idiomatic object models in your
   preferred programming language.
   
-  For a walkthrough of how to turn on development mode, see :ref:`Enable
+  For a walkthrough of how to turn on Development Mode, see :ref:`Enable
   Development Mode <enable-development-mode>`.
   
   .. tip:: Partition-Based Sync


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-20605

### Staged Changes (Requires MongoDB Corp SSO)

While I was scouring the docs for Development Mode references, I found some places where naming was inconsistent (developer mode, dev mode) and have also updated those references in this PR.

Removed inaccurate info:
- [Development Mode Glossary entry](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20605/get-started/glossary/)
- [Application Configuration Files (Legacy)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20605/manage-apps/configure/config/legacy/#synced-cluster-configuration)
- [Enable or Disable Development Mode](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20605/sync/data-model/development-mode/)

Updated naming:
- [Enable or Disable Development Mode -> Enable Development Mode -> Realm CLI](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20605/sync/data-model/development-mode/#enable-development-mode)
- [Enable or Disable Development Mode -> Disable Development Mode -> Realm CLI](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20605/sync/data-model/development-mode/#disable-development-mode)
- [Schema Logs](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20605/logs/schema/)
- [.Net Quick Start with Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20605/sdk/dotnet/quick-start-with-sync/)
- [RN Quick Start with Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20605/sdk/react-native/quick-start/)
- [Swift Quick Start with Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20605/sdk/swift/quick-start-with-sync/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
