### PR TITLE
Update language to make it clear that all clients client reset after …

### DIFF
--- a/source/includes/destructive-schema-change-app-update.rst
+++ b/source/includes/destructive-schema-change-app-update.rst
@@ -1,6 +1,9 @@
 .. note:: Destructive Schema Changes Require an App Schema Update
 
-   After a destructive schema change, clients must update their local
-   object models before they can resume syncing. Only clients that use
-   models affected by that schema change need to update. All clients
-   must perform a client reset.
+   After a destructive schema change:
+
+   - All clients must perform a client reset.
+   - Clients that use models destructively affected by the schema
+     change must update local object models.
+
+

--- a/source/includes/destructive-schema-change-app-update.rst
+++ b/source/includes/destructive-schema-change-app-update.rst
@@ -2,5 +2,5 @@
 
    After a destructive schema change, clients must update their local
    object models before they can resume syncing. Only clients that use
-   models affected by that schema change need to update and perform
-   a client reset.
+   models affected by that schema change need to update. All clients
+   must perform a client reset.

--- a/source/sdk/android/examples/reset-a-client-realm.txt
+++ b/source/sdk/android/examples/reset-a-client-realm.txt
@@ -104,6 +104,8 @@ The following example implements this strategy:
 Discard Unsynced Changes after Destructive Schema Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. include:: /includes/destructive-schema-change-app-update.rst
+
 If your application experiences a destructive schema change, the "discard
 unsynced changes" strategy cannot handle the resulting client reset
 automatically. Instead, you must provide a manual client reset
@@ -126,8 +128,6 @@ discarding all unsynced changes:
        .. literalinclude:: /examples/generated/android/sync/ClientResetTest.codeblock.client-reset-discard-unsynced-changes-with-simple-manual-fallback.java
          :language: java
          :copyable: false
-
-.. include:: /includes/destructive-schema-change-app-update.rst
 
 .. _android-manually-recover-unsynced-changes:
 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -59,6 +59,8 @@ with the client's history. The most common causes of client resets are:
   this scenario requires a new realm file, you can only handle client resets
   caused by destructive changes using the :ref:`manually recover unsynced changes
   <manually-recover-unsynced-changes>` strategy.
+  
+  .. include:: /includes/destructive-schema-change-app-update.rst
 
 .. _handle-a-client-reset:
 


### PR DESCRIPTION
…a destructive change

## Pull Request Info

### Jira

- slack conversation

### Staged Changes (Requires MongoDB Corp SSO)

- [Reset a Client Realm - Android](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/client-reset-destructive-change-clarification/sdk/android/examples/reset-a-client-realm/#discard-unsynced-changes-after-destructive-schema-changes)
- [Client Resets](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/client-reset-destructive-change-clarification/sync/error-handling/client-resets/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
