### PR TITLE
(DOCSP-19777): Add size limit guidance to custom user data

### DIFF
--- a/source/users/enable-custom-user-data.txt
+++ b/source/users/enable-custom-user-data.txt
@@ -29,10 +29,11 @@ and their client application access token.
 
 .. note::
 
-   Because {+service+} stores the custom user data in the access token,
-   you should keep the custom user data payload small (less than 16KB).
-   Otherwise, the payload might exceed header size limits, depending on
-   your infrastructure.
+   Because {+service+} stores the custom user data in the access token
+   in the HTTP header, you should keep the custom user data payload
+   small (say, less than 16KB). Other services might limit the HTTP
+   header size, which means that large custom user data objects can
+   cause integration issues.
 
 {+service+} does not manage custom user documents so you are responsible for
 creating and deleting them. The underlying data is a regular MongoDB

--- a/source/users/enable-custom-user-data.txt
+++ b/source/users/enable-custom-user-data.txt
@@ -27,6 +27,13 @@ in their access token when they log in. You can access the data in the
 <context-get-user-information>`, the :json-expansion:`%%user` expansion,
 and their client application access token.
 
+.. note::
+
+   Because {+service+} stores the custom user data in the access token,
+   you should keep the custom user data payload small (less than 16KB).
+   Otherwise, the payload might exceed header size limits, depending on
+   your infrastructure.
+
 {+service+} does not manage custom user documents so you are responsible for
 creating and deleting them. The underlying data is a regular MongoDB
 document, so you can use standard CRUD operations through the


### PR DESCRIPTION
## Pull Request Info

Adds guidance around size limitations of custom user data since the data is stored in the access token.

However, not sure if this is actually a good change since any limitations/the meaning of "small" would depend on the other infrastructure of the user's site.

Is this a product issue? Should the custom user data be fetched in the access token at all?

Opening for discussion.


### Jira

- https://jira.mongodb.org/browse/DOCSP-19777

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/user-data-size/users/enable-custom-user-data/

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
