### PR TITLE
(DOCSP-20221): [Swift SDK] Add docs for converting between non-synced and synced realms

### DIFF
--- a/examples/ios/Examples/ConvertSyncLocalRealms.swift
+++ b/examples/ios/Examples/ConvertSyncLocalRealms.swift
@@ -1,0 +1,294 @@
+import XCTest
+import RealmSwift
+
+class ConvertSyncAndLocalRealms: XCTestCase {
+    override func setUp() async throws {
+        // Populate data for synced realm examples
+        // This applies to the two examples that start with synced realms;
+        // the local to synced realm example populates its own data using
+        // a different partition value
+        let app = App(id: YOUR_REALM_APP_ID)
+
+        // Log in the user whose realm you want to open as a synced realm
+        let syncUser = try await app.login(credentials: Credentials.anonymous)
+
+        // Create a configuration to open the sync user's realm
+        var syncConfig = syncUser.configuration(partitionValue: "Some Partition Value")
+        syncConfig.objectTypes = [QsTask.self]
+
+        let syncedRealm = try await Realm(configuration: syncConfig, downloadBeforeOpen: .always)
+
+        let task1 = QsTask(value: ["name": "Keep it secret", "owner": "Frodo"])
+        let task2 = QsTask(value: ["name": "Keep it safe", "owner": "Frodo"])
+        let task3 = QsTask(value: ["name": "Journey to Bree", "owner": "Frodo"])
+
+        try! syncedRealm.write {
+            syncedRealm.add([task1, task2, task3])
+        }
+    }
+
+    override func tearDown() async throws {
+        // Delete synced realm tasks. This applies to the two
+        // examples that start with synced realms; the one that
+        // starts with a local realm deletes its own data and uses
+        // a different partition value
+        let app = App(id: YOUR_REALM_APP_ID)
+
+        // Log in the user whose realm you want to open as a synced realm
+        let syncUser = try await app.login(credentials: Credentials.anonymous)
+
+        // Create a configuration to open the sync user's realm
+        var syncConfig = syncUser.configuration(partitionValue: "Some Partition Value")
+        syncConfig.objectTypes = [QsTask.self]
+
+        let syncedRealm = try await Realm(configuration: syncConfig, downloadBeforeOpen: .always)
+        let syncedTasks = syncedRealm.objects(QsTask.self)
+
+        try syncedRealm.write {
+            syncedRealm.delete(syncedTasks)
+        }
+
+        print("Successfully deleted all synced tasks")
+    }
+
+    // :code-block-start: convert-local-to-sync
+    func testConvertLocalToSync() async throws {
+        let app = App(id: YOUR_REALM_APP_ID)
+
+        // Log in the user whose realm you want to open as a synced realm
+        let syncUser = try await app.login(credentials: Credentials.anonymous)
+
+        // Create a configuration to open the sync user's realm
+        var syncConfig = syncUser.configuration(partitionValue: "Your Partition Value")
+        syncConfig.objectTypes = [QsTask.self]
+        // Prepare the configuration for the user whose local realm you
+        // want to convert to a synced realm
+        let localConfig = Realm.Configuration()
+
+        // For this example, add some data to the local realm
+        // before copying it. No need to do this if you're
+        // copying a realm that already contains data.
+        let localRealm = bootstrapRealm(config: localConfig)
+
+        // Create a copy of the local realm that uses the
+        // sync configuration. All the data that is in the
+        // local realm is available in the synced realm.
+        try! localRealm.writeCopy(configuration: syncConfig)
+
+        // Open the synced realm we just created from the local realm
+        let syncedRealm = try await Realm(configuration: syncConfig)
+
+        // Access the Task objects in the synced realm to see
+        // that we have all the data we expect
+        let syncedTasks = syncedRealm.objects(QsTask.self)
+        var frodoSyncedTasks = syncedTasks.where { $0.owner == "Frodo" }
+        XCTAssertEqual(frodoSyncedTasks.count, 3)
+        print("Synced realm opens and contains this many tasks: \(frodoSyncedTasks.count)")
+
+        // Add a new task to the synced realm, and see it in the task count
+        let task4 = QsTask(value: ["name": "Send gift basket to Tom Bombadil", "owner": "Frodo"])
+
+        try! syncedRealm.write {
+            syncedRealm.add(task4)
+        }
+
+        frodoSyncedTasks = syncedTasks.where { $0.owner == "Frodo" }
+        XCTAssertEqual(frodoSyncedTasks.count, 4)
+        print("After adding a task, the synced realm contains this many tasks: \(frodoSyncedTasks.count)")
+
+        // Open the local realm, and confirm that it still only contains 3 tasks
+        let openedLocalRealm = try await Realm(configuration: localConfig)
+        let localTasks = openedLocalRealm.objects(QsTask.self)
+        var frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
+        XCTAssertEqual(frodoLocalTasks.count, 3)
+        print("Local realm opens and contains this many tasks: \(frodoLocalTasks.count)")
+
+        XCTAssertNotEqual(frodoLocalTasks.count, frodoSyncedTasks.count)
+
+        // :hide-start:
+        // Delete the tasks we added to avoid messing with future test runs
+        try! syncedRealm.write {
+            syncedRealm.delete(frodoSyncedTasks)
+        }
+        // :hide-end:
+
+        /// Populate the local realm with some data that we'll use in the synced realm.
+        func bootstrapRealm(config: Realm.Configuration) -> Realm {
+            // Prepare the configuration for the user whose local realm you
+            // want to convert to a synced realm
+            var localConfig = config
+            localConfig.objectTypes = [QsTask.self]
+            // :hide-start:
+            // Delete a local realm that may already exist
+            // avoid messing up future test runs.
+            if Realm.fileExists(for: localConfig) {
+                try! Realm.deleteFiles(for: localConfig)
+                print("Successfully deleted local realm")
+            } else {
+                print("No local realm currently exists")
+            }
+            // :hide-end:
+
+            // Open the local realm, and populate it with some data before returning it
+            let localRealm = try! Realm(configuration: localConfig)
+
+            let task1 = QsTask(value: ["name": "Keep it secret", "owner": "Frodo"])
+            let task2 = QsTask(value: ["name": "Keep it safe", "owner": "Frodo"])
+            let task3 = QsTask(value: ["name": "Journey to Bree", "owner": "Frodo"])
+
+            try! localRealm.write {
+                localRealm.add([task1, task2, task3])
+            }
+            return localRealm
+        }
+    }
+    // :code-block-end:
+
+    // :code-block-start: convert-sync-to-local
+    func testConvertSyncToLocal() async throws {
+        let app = App(id: YOUR_REALM_APP_ID)
+
+        // Log in the user whose realm you want to open as a local realm
+        let syncUser = try await app.login(credentials: Credentials.anonymous)
+
+        // Create a configuration to open the seed user's realm
+        var syncConfig = syncUser.configuration(partitionValue: "Some Partition Value")
+        syncConfig.objectTypes = [QsTask.self]
+
+        // Open the realm with the Sync user's config, downloading
+        // any remote changes before opening.
+        let syncedRealm = try await Realm(configuration: syncConfig, downloadBeforeOpen: .always)
+        print("Successfully opened realm: \(syncedRealm)")
+
+        // Verify the data we expect in the realm
+        // The synced realm we are copying contains 3 tasks whose owner is "Frodo"
+        let syncedTasks = syncedRealm.objects(QsTask.self)
+        var frodoSyncedTasks = syncedTasks.where { $0.owner == "Frodo" }
+        XCTAssertEqual(frodoSyncedTasks.count, 3)
+        print("Synced realm opens and contains this many tasks: \(frodoSyncedTasks.count)")
+
+        // Construct an output file path for the local Realm
+        guard let outputDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+
+        // Append a file name to complete the path
+        let localRealmFilePath = outputDir.appendingPathComponent("local.realm")
+
+        // Construct a local realm configuration
+        var localConfig = Realm.Configuration()
+        localConfig.objectTypes = [QsTask.self]
+        localConfig.fileURL = localRealmFilePath
+
+        // `realm_id` will be removed in the local realm, so we need to bump
+        // the schema version.
+        localConfig.schemaVersion = 1
+
+        // Check to see if there is already a realm at the local realm file path. If there
+        // is already a realm there, delete it.
+        if Realm.fileExists(for: localConfig) {
+            try Realm.deleteFiles(for: localConfig)
+            print("Successfully deleted existing realm at path: \(localRealmFilePath)")
+        } else {
+            print("No file currently exists at path")
+        }
+
+        // Make a copy of the synced realm that uses a local configuration
+        try syncedRealm.writeCopy(configuration: localConfig)
+
+        // Try opening the realm as a local realm
+        let localRealm = try await Realm(configuration: localConfig)
+
+        // Verify that the copied realm contains the data we expect
+        let localTasks = localRealm.objects(QsTask.self)
+        var frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
+        XCTAssertEqual(frodoLocalTasks.count, 3)
+        print("Local realm opens and contains this many tasks: \(frodoLocalTasks.count)")
+
+        let task = QsTask(value: ["name": "Send gift basket to Tom Bombadil", "owner": "Frodo"])
+
+        try! localRealm.write {
+            localRealm.add(task)
+        }
+
+        frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
+        XCTAssertEqual(frodoLocalTasks.count, 4)
+        print("After adding a task, the local realm contains this many tasks: \(frodoLocalTasks.count)")
+
+        frodoSyncedTasks = syncedTasks.where { $0.owner == "Frodo" }
+        XCTAssertEqual(frodoSyncedTasks.count, 3)
+        print("After writing to local realm, synced realm contains this many tasks: \(frodoSyncedTasks.count)")
+
+        XCTAssertNotEqual(frodoLocalTasks.count, frodoSyncedTasks.count)
+    }
+    // :code-block-end:
+
+    // :code-block-start: convert-sync-to-sync
+    func testConvertSyncToSync() async throws {
+        let app = App(id: YOUR_REALM_APP_ID)
+
+        // Log in the user whose realm you want to use with another sync user
+        let frodoBaggins = try await app.login(credentials: Credentials.anonymous)
+        var frodoConfig = frodoBaggins.configuration(partitionValue: "Some Partition Value")
+        frodoConfig.objectTypes = [QsTask.self]
+
+        // Open the synced realm, and confirm it contains the data we want
+        // the other user to be able to access.
+        let frodoRealm = try await Realm(configuration: frodoConfig, downloadBeforeOpen: .always)
+
+        let frodoRealmTasks = frodoRealm.objects(QsTask.self)
+        let frodoSyncedTasks = frodoRealmTasks.where { $0.owner == "Frodo" }
+        XCTAssertEqual(frodoSyncedTasks.count, 3)
+        print("Successfully opened frodo's realm and it contains this many tasks: \(frodoSyncedTasks.count)")
+
+        // Log in as the user who will work with frodo's synced realm
+        let samwiseGamgee = try await app.login(credentials: Credentials.anonymous)
+        var samConfig = samwiseGamgee.configuration(partitionValue: "Some Partition Value")
+        samConfig.objectTypes = [QsTask.self]
+
+        // Specify an output directory for the copied realm
+        // We're using FileManager here for tested code examples.
+        guard let outputDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+
+        // Append a file name to complete the path
+        let copiedRealmFilePath = outputDir.appendingPathComponent("copied.realm")
+
+        // Update the config file path to the path where you want to save the copied realm
+        samConfig.fileURL = copiedRealmFilePath
+
+        // :hide-start:
+        // If there is already a realm at the copy realm file path, delete it
+        // to avoid issues in future test runs.
+        if Realm.fileExists(for: samConfig) {
+            try Realm.deleteFiles(for: samConfig)
+            print("Successfully deleted existing realm at path")
+        } else {
+            print("No file currently exists at path")
+        }
+        // :hide-end:
+
+        // Make a copy of frodo's realm that uses sam's config
+        try frodoRealm.writeCopy(configuration: samConfig)
+
+        // Open sam's realm, and see that it contains the same data as frodo's realm
+        let samRealm = try await Realm(configuration: samConfig)
+        let samRealmTasks = samRealm.objects(QsTask.self)
+        var samSyncedTasks = samRealmTasks.where { $0.owner == "Frodo" }
+        print("Successfully opened sam's realm and it contains this many tasks: \(samSyncedTasks.count)")
+
+        XCTAssertEqual(frodoSyncedTasks.count, samSyncedTasks.count)
+
+        // Add a task to sam's realm
+        let task = QsTask(value: ["name": "Keep an eye on that Gollum", "owner": "Sam"])
+
+        try! samRealm.write {
+            samRealm.add(task)
+        }
+
+        // See that the new task reflects in sam's realm, but not frodo's
+        samSyncedTasks = samRealmTasks.where { $0.owner == "Sam" }
+        XCTAssertEqual(samSyncedTasks.count, 1)
+
+        let samTasksInFrodoRealm = frodoRealmTasks.where { $0.owner == "Sam" }
+        XCTAssertEqual(samTasksInFrodoRealm.count, 0)
+    }
+    // :code-block-end:
+}

--- a/examples/ios/Examples/ConvertSyncLocalRealms.swift
+++ b/examples/ios/Examples/ConvertSyncLocalRealms.swift
@@ -17,6 +17,10 @@ class ConvertSyncAndLocalRealms: XCTestCase {
         syncConfig.objectTypes = [QsTask.self]
 
         let syncedRealm = try await Realm(configuration: syncConfig, downloadBeforeOpen: .always)
+        
+        try! syncedRealm.write {
+            syncedRealm.delete(syncedRealm.objects(QsTask.self))
+        }
 
         let task1 = QsTask(value: ["name": "Keep it secret", "owner": "Frodo"])
         let task2 = QsTask(value: ["name": "Keep it safe", "owner": "Frodo"])
@@ -68,7 +72,7 @@ class ConvertSyncAndLocalRealms: XCTestCase {
         // For this example, add some data to the local realm
         // before copying it. No need to do this if you're
         // copying a realm that already contains data.
-        let localRealm = bootstrapRealm(config: localConfig)
+        let localRealm = addExampleData(config: localConfig)
 
         // Create a copy of the local realm that uses the
         // sync configuration. All the data that is in the
@@ -113,7 +117,7 @@ class ConvertSyncAndLocalRealms: XCTestCase {
         // :hide-end:
 
         /// Populate the local realm with some data that we'll use in the synced realm.
-        func bootstrapRealm(config: Realm.Configuration) -> Realm {
+        func addExampleData(config: Realm.Configuration) -> Realm {
             // Prepare the configuration for the user whose local realm you
             // want to convert to a synced realm
             var localConfig = config

--- a/examples/ios/Examples/ConvertSyncLocalRealms.swift
+++ b/examples/ios/Examples/ConvertSyncLocalRealms.swift
@@ -17,7 +17,7 @@ class ConvertSyncAndLocalRealms: XCTestCase {
         syncConfig.objectTypes = [QsTask.self]
 
         let syncedRealm = try await Realm(configuration: syncConfig, downloadBeforeOpen: .always)
-        
+
         try! syncedRealm.write {
             syncedRealm.delete(syncedRealm.objects(QsTask.self))
         }
@@ -67,7 +67,15 @@ class ConvertSyncAndLocalRealms: XCTestCase {
         syncConfig.objectTypes = [QsTask.self]
         // Prepare the configuration for the user whose local realm you
         // want to convert to a synced realm
-        let localConfig = Realm.Configuration()
+        var localConfig = Realm.Configuration()
+        localConfig.objectTypes = [QsTask.self]
+        // :hide-start:
+        // Set a custom fileURL to prevent other tests using
+        // a default realm from causing this test to fail
+        localConfig.fileURL!.deleteLastPathComponent()
+        localConfig.fileURL!.appendPathComponent("nonSync")
+        localConfig.fileURL!.appendPathExtension("realm")
+        // :hide-end:
 
         // For this example, add some data to the local realm
         // before copying it. No need to do this if you're
@@ -120,8 +128,7 @@ class ConvertSyncAndLocalRealms: XCTestCase {
         func addExampleData(config: Realm.Configuration) -> Realm {
             // Prepare the configuration for the user whose local realm you
             // want to convert to a synced realm
-            var localConfig = config
-            localConfig.objectTypes = [QsTask.self]
+            let localConfig = config
             // :hide-start:
             // Delete a local realm that may already exist
             // avoid messing up future test runs.
@@ -132,7 +139,6 @@ class ConvertSyncAndLocalRealms: XCTestCase {
                 print("No local realm currently exists")
             }
             // :hide-end:
-
             // Open the local realm, and populate it with some data before returning it
             let localRealm = try! Realm(configuration: localConfig)
 

--- a/examples/ios/Examples/ConvertSyncLocalRealms.swift
+++ b/examples/ios/Examples/ConvertSyncLocalRealms.swift
@@ -31,30 +31,6 @@ class ConvertSyncAndLocalRealms: XCTestCase {
         }
     }
 
-    override func tearDown() async throws {
-        // Delete synced realm tasks. This applies to the two
-        // examples that start with synced realms; the one that
-        // starts with a local realm deletes its own data and uses
-        // a different partition value
-        let app = App(id: YOUR_REALM_APP_ID)
-
-        // Log in the user whose realm you want to open as a synced realm
-        let syncUser = try await app.login(credentials: Credentials.anonymous)
-
-        // Create a configuration to open the sync user's realm
-        var syncConfig = syncUser.configuration(partitionValue: "Some Partition Value")
-        syncConfig.objectTypes = [QsTask.self]
-
-        let syncedRealm = try await Realm(configuration: syncConfig, downloadBeforeOpen: .always)
-        let syncedTasks = syncedRealm.objects(QsTask.self)
-
-        try syncedRealm.write {
-            syncedRealm.delete(syncedTasks)
-        }
-
-        print("Successfully deleted all synced tasks")
-    }
-
     // :code-block-start: convert-local-to-sync
     func testConvertLocalToSync() async throws {
         let app = App(id: YOUR_REALM_APP_ID)
@@ -111,7 +87,7 @@ class ConvertSyncAndLocalRealms: XCTestCase {
         // Open the local realm, and confirm that it still only contains 3 tasks
         let openedLocalRealm = try await Realm(configuration: localConfig)
         let localTasks = openedLocalRealm.objects(QsTask.self)
-        var frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
+        let frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
         XCTAssertEqual(frodoLocalTasks.count, 3)
         print("Local realm opens and contains this many tasks: \(frodoLocalTasks.count)")
 

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Realm (10.22.0):
-    - Realm/Headers (= 10.22.0)
-  - Realm/Headers (10.22.0)
-  - RealmSwift (10.22.0):
-    - Realm (= 10.22.0)
+  - Realm (10.23.0):
+    - Realm/Headers (= 10.23.0)
+  - Realm/Headers (10.23.0)
+  - RealmSwift (10.23.0):
+    - Realm (= 10.23.0)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - FBSDKLoginKit (= 8.1.0)
   - GoogleSignIn
-  - Realm (from `https://github.com/realm/realm-swift.git`, branch `master`)
-  - RealmSwift (from `https://github.com/realm/realm-swift.git`, branch `master`)
+  - Realm (= 10.23.0)
+  - RealmSwift (= 10.23.0)
   - SwiftLint
 
 SPEC REPOS:
@@ -44,6 +44,8 @@ SPEC REPOS:
     - GoogleSignIn
     - GTMAppAuth
     - GTMSessionFetcher
+    - Realm
+    - RealmSwift
     - SwiftLint
 
 EXTERNAL SOURCES:
@@ -74,6 +76,6 @@ SPEC CHECKSUMS:
   RealmSwift: 47d3e1a772f129bf998cfbfcb2cf45fd3da062f8
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 3514d0170bf545844f2bbaba98346040c027ad69
+PODFILE CHECKSUM: 0231a4dc93a0a6052ba58d48f47217eab55be6cf
 
 COCOAPODS: 1.10.1

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -7,11 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0090B72CEE8344EEB081EB2B /* Pods_RealmExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D4D3FCB7A0EB5AE975DF2B1 /* Pods_RealmExamples.framework */; };
 		228B6F9226166ED10075A6E0 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228B6F9026166ED10075A6E0 /* Errors.swift */; };
 		228B6F9326166ED10075A6E0 /* Errors.m in Sources */ = {isa = PBXBuildFile; fileRef = 228B6F9126166ED10075A6E0 /* Errors.m */; };
-		39DFFABB984AFC2A4429C5D7 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		3AFEF991672127C4DF1EBBD0 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		4803B327251068F800CCAF97 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4803B326251068F800CCAF97 /* AppDelegate.swift */; };
 		4803B329251068F800CCAF97 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4803B328251068F800CCAF97 /* SceneDelegate.swift */; };
 		4803B32B251068F800CCAF97 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4803B32A251068F800CCAF97 /* ContentView.swift */; };
@@ -66,6 +63,7 @@
 		48F38B5A252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */; };
 		48F38B5C2527A3FE00DDEB65 /* ManageApiKeys.m in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B5B2527A3FE00DDEB65 /* ManageApiKeys.m */; };
 		48FE4E8B2666A93600720F92 /* MapExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FE4E8A2666A93600720F92 /* MapExample.swift */; };
+		911366EB27BC0C6100DF865D /* ConvertSyncLocalRealms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911366EA27BC0C6100DF865D /* ConvertSyncLocalRealms.swift */; };
 		9136A4DB26409A7E00FFA03B /* AnyRealmValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9136A4DA26409A7E00FFA03B /* AnyRealmValue.swift */; };
 		914601F626A86B9100BC91EA /* Sync.m in Sources */ = {isa = PBXBuildFile; fileRef = 914601F426A86B9000BC91EA /* Sync.m */; };
 		914601F726A86B9100BC91EA /* Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914601F526A86B9000BC91EA /* Sync.swift */; };
@@ -89,8 +87,8 @@
 		91CEF606260E325000A029E0 /* Compacting.m in Sources */ = {isa = PBXBuildFile; fileRef = 91CEF605260E325000A029E0 /* Compacting.m */; };
 		91FBD320279865080005C10C /* DeleteUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FBD31F279865080005C10C /* DeleteUsers.swift */; };
 		91FDC13B261E5DE3006A6E13 /* MutableSetExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FDC13A261E5DE3006A6E13 /* MutableSetExample.swift */; };
-		9693C7E1A0EB364049783775 /* Pods_SwiftUIExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C6EAFA4554E3F8917F6DAC1 /* Pods_SwiftUIExamples.framework */; };
-		AF99F5877D8B6A122C53FC08 /* Pods_QuickStartSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A56BE659D55DD6B9972241E4 /* Pods_QuickStartSwiftUI.framework */; };
+		CD46CBF44F213919D71CE51B /* Pods_SwiftUIExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6559AECCE875E84046891CB8 /* Pods_SwiftUIExamples.framework */; };
+		E8BF762E7FB80B02CA362538 /* Pods_QuickStartSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 748E89E9725E4E5AF0811858 /* Pods_QuickStartSwiftUI.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,11 +102,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0C6EAFA4554E3F8917F6DAC1 /* Pods_SwiftUIExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftUIExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1D4D3FCB7A0EB5AE975DF2B1 /* Pods_RealmExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1FF72F810238D24734ABE294 /* Pods-SwiftUIExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUIExamples.release.xcconfig"; path = "Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples.release.xcconfig"; sourceTree = "<group>"; };
 		228B6F9026166ED10075A6E0 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		228B6F9126166ED10075A6E0 /* Errors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Errors.m; sourceTree = "<group>"; };
+		266DEBFAA901C3906409A265 /* Pods-QuickStartSwiftUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartSwiftUI.release.xcconfig"; path = "Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI.release.xcconfig"; sourceTree = "<group>"; };
 		4803B324251068F800CCAF97 /* RealmExamplesHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RealmExamplesHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4803B326251068F800CCAF97 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		4803B328251068F800CCAF97 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -160,6 +156,7 @@
 		48C072032511B5D5004B02BB /* ManageEmailPasswordUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageEmailPasswordUsers.swift; sourceTree = "<group>"; };
 		48C072052511B6DB004B02BB /* ManageEmailPasswordUsers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ManageEmailPasswordUsers.m; sourceTree = "<group>"; };
 		48C5BC3125A4CDE70004DA3D /* Migrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migrations.swift; sourceTree = "<group>"; };
+		48E21560F1F653C702A9C1B3 /* Pods-SwiftUIExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUIExamples.debug.xcconfig"; path = "Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples.debug.xcconfig"; sourceTree = "<group>"; };
 		48E63FB7252646A700F883B1 /* Authenticate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authenticate.swift; sourceTree = "<group>"; };
 		48F38B4F2527806600DDEB65 /* AccessMongoDB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessMongoDB.swift; sourceTree = "<group>"; };
 		48F38B512527843B00DDEB65 /* CustomUserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomUserData.swift; sourceTree = "<group>"; };
@@ -169,9 +166,12 @@
 		48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymouslyLoggedInTestCase.swift; sourceTree = "<group>"; };
 		48F38B5B2527A3FE00DDEB65 /* ManageApiKeys.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ManageApiKeys.m; sourceTree = "<group>"; };
 		48FE4E8A2666A93600720F92 /* MapExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapExample.swift; sourceTree = "<group>"; };
-		582A61F6F341821B0C632B0C /* Pods-RealmExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExamples.debug.xcconfig"; path = "Target Support Files/Pods-RealmExamples/Pods-RealmExamples.debug.xcconfig"; sourceTree = "<group>"; };
-		5CF772D6D27E64F6EADF7006 /* Pods-RealmExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExamples.release.xcconfig"; path = "Target Support Files/Pods-RealmExamples/Pods-RealmExamples.release.xcconfig"; sourceTree = "<group>"; };
-		613FAD387146D4ABC57E754B /* Pods-QuickStartSwiftUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartSwiftUI.debug.xcconfig"; path = "Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI.debug.xcconfig"; sourceTree = "<group>"; };
+		5E9D90C5E5B129BD9E69E45A /* Pods-RealmExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExamples.release.xcconfig"; path = "Target Support Files/Pods-RealmExamples/Pods-RealmExamples.release.xcconfig"; sourceTree = "<group>"; };
+		6559AECCE875E84046891CB8 /* Pods_SwiftUIExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftUIExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		748E89E9725E4E5AF0811858 /* Pods_QuickStartSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStartSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8893EDCF16E443992955F004 /* Pods-QuickStartSwiftUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartSwiftUI.debug.xcconfig"; path = "Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI.debug.xcconfig"; sourceTree = "<group>"; };
+		8E9701CFF7101F33CDED214C /* Pods_RealmExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		911366EA27BC0C6100DF865D /* ConvertSyncLocalRealms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvertSyncLocalRealms.swift; sourceTree = "<group>"; };
 		9136A4DA26409A7E00FFA03B /* AnyRealmValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyRealmValue.swift; sourceTree = "<group>"; };
 		914601F426A86B9000BC91EA /* Sync.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Sync.m; sourceTree = "<group>"; };
 		914601F526A86B9000BC91EA /* Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sync.swift; sourceTree = "<group>"; };
@@ -193,9 +193,8 @@
 		91CEF605260E325000A029E0 /* Compacting.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Compacting.m; sourceTree = "<group>"; };
 		91FBD31F279865080005C10C /* DeleteUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteUsers.swift; sourceTree = "<group>"; };
 		91FDC13A261E5DE3006A6E13 /* MutableSetExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutableSetExample.swift; sourceTree = "<group>"; };
-		9A2E9352D426560510A7F487 /* Pods-SwiftUIExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUIExamples.debug.xcconfig"; path = "Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples.debug.xcconfig"; sourceTree = "<group>"; };
-		A56BE659D55DD6B9972241E4 /* Pods_QuickStartSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStartSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F031E02203B6F069E8E3A216 /* Pods-QuickStartSwiftUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartSwiftUI.release.xcconfig"; path = "Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI.release.xcconfig"; sourceTree = "<group>"; };
+		C4C8F0336074D4B933736D0B /* Pods-RealmExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmExamples.debug.xcconfig"; path = "Target Support Files/Pods-RealmExamples/Pods-RealmExamples.debug.xcconfig"; sourceTree = "<group>"; };
+		E0DA23BA577113A89C231A22 /* Pods-SwiftUIExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUIExamples.release.xcconfig"; path = "Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,8 +209,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				39DFFABB984AFC2A4429C5D7 /* (null) in Frameworks */,
-				AF99F5877D8B6A122C53FC08 /* Pods_QuickStartSwiftUI.framework in Frameworks */,
+				E8BF762E7FB80B02CA362538 /* Pods_QuickStartSwiftUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -219,8 +217,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3AFEF991672127C4DF1EBBD0 /* (null) in Frameworks */,
-				0090B72CEE8344EEB081EB2B /* Pods_RealmExamples.framework in Frameworks */,
+				91E00573D8F9F23459E44AD5 /* Pods_RealmExamples.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,23 +225,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9693C7E1A0EB364049783775 /* Pods_SwiftUIExamples.framework in Frameworks */,
+				CD46CBF44F213919D71CE51B /* Pods_SwiftUIExamples.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		25659AAC46A872278D314C5C /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				1D4D3FCB7A0EB5AE975DF2B1 /* Pods_RealmExamples.framework */,
-				0C6EAFA4554E3F8917F6DAC1 /* Pods_SwiftUIExamples.framework */,
-				A56BE659D55DD6B9972241E4 /* Pods_QuickStartSwiftUI.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		4803B325251068F800CCAF97 /* HostApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -301,6 +288,7 @@
 				91CEF605260E325000A029E0 /* Compacting.m */,
 				91CEF5FD260E308100A029E0 /* Compacting.swift */,
 				48BF3415251076E4004139AF /* CompleteQuickStart.swift */,
+				911366EA27BC0C6100DF865D /* ConvertSyncLocalRealms.swift */,
 				48F38B5325278ECB00DDEB65 /* CustomUserData.m */,
 				48F38B512527843B00DDEB65 /* CustomUserData.swift */,
 				91FBD31F279865080005C10C /* DeleteUsers.swift */,
@@ -366,8 +354,8 @@
 				A485B1FDFCAD54FE9AB803CD /* Pods */,
 				48DBFAD725101C3100391E2B /* Products */,
 				489180092534E33500D53F19 /* QuickStartSwiftUI */,
-				25659AAC46A872278D314C5C /* Frameworks */,
 				91C68806274D8B34001A5DBE /* SwiftUIExamples */,
+				9C951D8D9D38B892BB6892F5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -400,15 +388,25 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
+		9C951D8D9D38B892BB6892F5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				748E89E9725E4E5AF0811858 /* Pods_QuickStartSwiftUI.framework */,
+				8E9701CFF7101F33CDED214C /* Pods_RealmExamples.framework */,
+				6559AECCE875E84046891CB8 /* Pods_SwiftUIExamples.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		A485B1FDFCAD54FE9AB803CD /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				613FAD387146D4ABC57E754B /* Pods-QuickStartSwiftUI.debug.xcconfig */,
-				F031E02203B6F069E8E3A216 /* Pods-QuickStartSwiftUI.release.xcconfig */,
-				582A61F6F341821B0C632B0C /* Pods-RealmExamples.debug.xcconfig */,
-				5CF772D6D27E64F6EADF7006 /* Pods-RealmExamples.release.xcconfig */,
-				9A2E9352D426560510A7F487 /* Pods-SwiftUIExamples.debug.xcconfig */,
-				1FF72F810238D24734ABE294 /* Pods-SwiftUIExamples.release.xcconfig */,
+				8893EDCF16E443992955F004 /* Pods-QuickStartSwiftUI.debug.xcconfig */,
+				266DEBFAA901C3906409A265 /* Pods-QuickStartSwiftUI.release.xcconfig */,
+				C4C8F0336074D4B933736D0B /* Pods-RealmExamples.debug.xcconfig */,
+				5E9D90C5E5B129BD9E69E45A /* Pods-RealmExamples.release.xcconfig */,
+				48E21560F1F653C702A9C1B3 /* Pods-SwiftUIExamples.debug.xcconfig */,
+				E0DA23BA577113A89C231A22 /* Pods-SwiftUIExamples.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -437,11 +435,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 489180192534E33600D53F19 /* Build configuration list for PBXNativeTarget "QuickStartSwiftUI" */;
 			buildPhases = (
-				BFCB87F7EA653E49095F9963 /* [CP] Check Pods Manifest.lock */,
+				4D17B2D795E8D22C7D997DFB /* [CP] Check Pods Manifest.lock */,
 				489180042534E33500D53F19 /* Sources */,
 				489180052534E33500D53F19 /* Frameworks */,
 				489180062534E33500D53F19 /* Resources */,
-				1273F631E6A85AAAA1C76DC7 /* [CP] Embed Pods Frameworks */,
+				3CA90004F1A7BA6E2DCCC3C6 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -456,13 +454,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4896EE512510514B00D1FABF /* Build configuration list for PBXNativeTarget "RealmExamples" */;
 			buildPhases = (
-				8BB4FC66D2F1B5405CFD4676 /* [CP] Check Pods Manifest.lock */,
+				2759F6E55FB84225FE482FED /* [CP] Check Pods Manifest.lock */,
 				48FA32DE25B7979C00715468 /* Swiftlint */,
 				4896EE482510514B00D1FABF /* Sources */,
 				4896EE492510514B00D1FABF /* Frameworks */,
 				4896EE4A2510514B00D1FABF /* Resources */,
-				6A14EBA462439E721CF795AB /* [CP] Embed Pods Frameworks */,
-				14BD3A2F84F7961E2E33D722 /* [CP] Copy Pods Resources */,
+				52C6D5D257B7726AE0EDEC25 /* [CP] Embed Pods Frameworks */,
+				86E0CCD4E1DBEC2A04107C4D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -478,11 +476,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 91C68801274D8AFE001A5DBE /* Build configuration list for PBXNativeTarget "SwiftUIExamples" */;
 			buildPhases = (
-				91C687F7274D8AFE001A5DBE /* [CP] Check Pods Manifest.lock */,
+				F8F03B3311C5A3E17CFB3304 /* [CP] Check Pods Manifest.lock */,
 				91C687F8274D8AFE001A5DBE /* Sources */,
 				91C687FA274D8AFE001A5DBE /* Frameworks */,
 				91C687FC274D8AFE001A5DBE /* Resources */,
-				91C68800274D8AFE001A5DBE /* [CP] Embed Pods Frameworks */,
+				06BDF26DDC3F510B5B857FC6 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -581,76 +579,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1273F631E6A85AAAA1C76DC7 /* [CP] Embed Pods Frameworks */ = {
+		06BDF26DDC3F510B5B857FC6 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		14BD3A2F84F7961E2E33D722 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		48FA32DE25B7979C00715468 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" autocorrect && \"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
-		};
-		6A14EBA462439E721CF795AB /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8BB4FC66D2F1B5405CFD4676 /* [CP] Check Pods Manifest.lock */ = {
+		2759F6E55FB84225FE482FED /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -672,7 +618,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		91C687F7274D8AFE001A5DBE /* [CP] Check Pods Manifest.lock */ = {
+		3CA90004F1A7BA6E2DCCC3C6 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-QuickStartSwiftUI/Pods-QuickStartSwiftUI-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		48FA32DE25B7979C00715468 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -680,38 +643,17 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "[CP] Check Pods Manifest.lock";
+			name = Swiftlint;
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-SwiftUIExamples-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" autocorrect && \"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
 		};
-		91C68800274D8AFE001A5DBE /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftUIExamples/Pods-SwiftUIExamples-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BFCB87F7EA653E49095F9963 /* [CP] Check Pods Manifest.lock */ = {
+		4D17B2D795E8D22C7D997DFB /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -727,6 +669,62 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-QuickStartSwiftUI-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		52C6D5D257B7726AE0EDEC25 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		86E0CCD4E1DBEC2A04107C4D /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RealmExamples/Pods-RealmExamples-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F8F03B3311C5A3E17CFB3304 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SwiftUIExamples-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -776,6 +774,7 @@
 				48924BBB2515309F00CC9567 /* MultipleUsers.m in Sources */,
 				916AC598273036C100270C64 /* ClassProjection.swift in Sources */,
 				917E73E726B8A9F80068242A /* MongoDBRemoteAccess.swift in Sources */,
+				911366EB27BC0C6100DF865D /* ConvertSyncLocalRealms.swift in Sources */,
 				228B6F9326166ED10075A6E0 /* Errors.m in Sources */,
 				4898DDB025A3768600416375 /* Threading.swift in Sources */,
 				487F77CD253F9A4900BDC8CE /* Models.swift in Sources */,
@@ -903,7 +902,7 @@
 		};
 		4891801A2534E33600D53F19 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 613FAD387146D4ABC57E754B /* Pods-QuickStartSwiftUI.debug.xcconfig */;
+			baseConfigurationReference = 8893EDCF16E443992955F004 /* Pods-QuickStartSwiftUI.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -924,7 +923,7 @@
 		};
 		4891801B2534E33600D53F19 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F031E02203B6F069E8E3A216 /* Pods-QuickStartSwiftUI.release.xcconfig */;
+			baseConfigurationReference = 266DEBFAA901C3906409A265 /* Pods-QuickStartSwiftUI.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -945,7 +944,7 @@
 		};
 		4896EE522510514B00D1FABF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 582A61F6F341821B0C632B0C /* Pods-RealmExamples.debug.xcconfig */;
+			baseConfigurationReference = C4C8F0336074D4B933736D0B /* Pods-RealmExamples.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
@@ -970,7 +969,7 @@
 		};
 		4896EE532510514B00D1FABF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5CF772D6D27E64F6EADF7006 /* Pods-RealmExamples.release.xcconfig */;
+			baseConfigurationReference = 5E9D90C5E5B129BD9E69E45A /* Pods-RealmExamples.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
@@ -1114,7 +1113,7 @@
 		};
 		91C68802274D8AFE001A5DBE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9A2E9352D426560510A7F487 /* Pods-SwiftUIExamples.debug.xcconfig */;
+			baseConfigurationReference = 48E21560F1F653C702A9C1B3 /* Pods-SwiftUIExamples.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -1135,7 +1134,7 @@
 		};
 		91C68803274D8AFE001A5DBE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1FF72F810238D24734ABE294 /* Pods-SwiftUIExamples.release.xcconfig */;
+			baseConfigurationReference = E0DA23BA577113A89C231A22 /* Pods-SwiftUIExamples.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;

--- a/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-local-to-sync.swift
+++ b/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-local-to-sync.swift
@@ -14,7 +14,7 @@ func testConvertLocalToSync() async throws {
     // For this example, add some data to the local realm
     // before copying it. No need to do this if you're
     // copying a realm that already contains data.
-    let localRealm = bootstrapRealm(config: localConfig)
+    let localRealm = addExampleData(config: localConfig)
 
     // Create a copy of the local realm that uses the
     // sync configuration. All the data that is in the
@@ -53,7 +53,7 @@ func testConvertLocalToSync() async throws {
 
 
     /// Populate the local realm with some data that we'll use in the synced realm.
-    func bootstrapRealm(config: Realm.Configuration) -> Realm {
+    func addExampleData(config: Realm.Configuration) -> Realm {
         // Prepare the configuration for the user whose local realm you
         // want to convert to a synced realm
         var localConfig = config

--- a/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-local-to-sync.swift
+++ b/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-local-to-sync.swift
@@ -46,7 +46,7 @@ func testConvertLocalToSync() async throws {
     // Open the local realm, and confirm that it still only contains 3 tasks
     let openedLocalRealm = try await Realm(configuration: localConfig)
     let localTasks = openedLocalRealm.objects(QsTask.self)
-    var frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
+    let frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
     XCTAssertEqual(frodoLocalTasks.count, 3)
     print("Local realm opens and contains this many tasks: \(frodoLocalTasks.count)")
 

--- a/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-local-to-sync.swift
+++ b/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-local-to-sync.swift
@@ -9,7 +9,8 @@ func testConvertLocalToSync() async throws {
     syncConfig.objectTypes = [QsTask.self]
     // Prepare the configuration for the user whose local realm you
     // want to convert to a synced realm
-    let localConfig = Realm.Configuration()
+    var localConfig = Realm.Configuration()
+    localConfig.objectTypes = [QsTask.self]
 
     // For this example, add some data to the local realm
     // before copying it. No need to do this if you're
@@ -56,9 +57,7 @@ func testConvertLocalToSync() async throws {
     func addExampleData(config: Realm.Configuration) -> Realm {
         // Prepare the configuration for the user whose local realm you
         // want to convert to a synced realm
-        var localConfig = config
-        localConfig.objectTypes = [QsTask.self]
-
+        let localConfig = config
         // Open the local realm, and populate it with some data before returning it
         let localRealm = try! Realm(configuration: localConfig)
 

--- a/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-local-to-sync.swift
+++ b/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-local-to-sync.swift
@@ -1,0 +1,74 @@
+func testConvertLocalToSync() async throws {
+    let app = App(id: YOUR_REALM_APP_ID)
+
+    // Log in the user whose realm you want to open as a synced realm
+    let syncUser = try await app.login(credentials: Credentials.anonymous)
+
+    // Create a configuration to open the sync user's realm
+    var syncConfig = syncUser.configuration(partitionValue: "Your Partition Value")
+    syncConfig.objectTypes = [QsTask.self]
+    // Prepare the configuration for the user whose local realm you
+    // want to convert to a synced realm
+    let localConfig = Realm.Configuration()
+
+    // For this example, add some data to the local realm
+    // before copying it. No need to do this if you're
+    // copying a realm that already contains data.
+    let localRealm = bootstrapRealm(config: localConfig)
+
+    // Create a copy of the local realm that uses the
+    // sync configuration. All the data that is in the
+    // local realm is available in the synced realm.
+    try! localRealm.writeCopy(configuration: syncConfig)
+
+    // Open the synced realm we just created from the local realm
+    let syncedRealm = try await Realm(configuration: syncConfig)
+
+    // Access the Task objects in the synced realm to see
+    // that we have all the data we expect
+    let syncedTasks = syncedRealm.objects(QsTask.self)
+    var frodoSyncedTasks = syncedTasks.where { $0.owner == "Frodo" }
+    XCTAssertEqual(frodoSyncedTasks.count, 3)
+    print("Synced realm opens and contains this many tasks: \(frodoSyncedTasks.count)")
+
+    // Add a new task to the synced realm, and see it in the task count
+    let task4 = QsTask(value: ["name": "Send gift basket to Tom Bombadil", "owner": "Frodo"])
+
+    try! syncedRealm.write {
+        syncedRealm.add(task4)
+    }
+
+    frodoSyncedTasks = syncedTasks.where { $0.owner == "Frodo" }
+    XCTAssertEqual(frodoSyncedTasks.count, 4)
+    print("After adding a task, the synced realm contains this many tasks: \(frodoSyncedTasks.count)")
+
+    // Open the local realm, and confirm that it still only contains 3 tasks
+    let openedLocalRealm = try await Realm(configuration: localConfig)
+    let localTasks = openedLocalRealm.objects(QsTask.self)
+    var frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
+    XCTAssertEqual(frodoLocalTasks.count, 3)
+    print("Local realm opens and contains this many tasks: \(frodoLocalTasks.count)")
+
+    XCTAssertNotEqual(frodoLocalTasks.count, frodoSyncedTasks.count)
+
+
+    /// Populate the local realm with some data that we'll use in the synced realm.
+    func bootstrapRealm(config: Realm.Configuration) -> Realm {
+        // Prepare the configuration for the user whose local realm you
+        // want to convert to a synced realm
+        var localConfig = config
+        localConfig.objectTypes = [QsTask.self]
+
+        // Open the local realm, and populate it with some data before returning it
+        let localRealm = try! Realm(configuration: localConfig)
+
+        let task1 = QsTask(value: ["name": "Keep it secret", "owner": "Frodo"])
+        let task2 = QsTask(value: ["name": "Keep it safe", "owner": "Frodo"])
+        let task3 = QsTask(value: ["name": "Journey to Bree", "owner": "Frodo"])
+
+        try! localRealm.write {
+            localRealm.add([task1, task2, task3])
+        }
+        return localRealm
+    }
+}

--- a/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-sync-to-local.swift
+++ b/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-sync-to-local.swift
@@ -1,0 +1,74 @@
+func testConvertSyncToLocal() async throws {
+    let app = App(id: YOUR_REALM_APP_ID)
+
+    // Log in the user whose realm you want to open as a local realm
+    let syncUser = try await app.login(credentials: Credentials.anonymous)
+
+    // Create a configuration to open the seed user's realm
+    var syncConfig = syncUser.configuration(partitionValue: "Some Partition Value")
+    syncConfig.objectTypes = [QsTask.self]
+
+    // Open the realm with the Sync user's config, downloading
+    // any remote changes before opening.
+    let syncedRealm = try await Realm(configuration: syncConfig, downloadBeforeOpen: .always)
+    print("Successfully opened realm: \(syncedRealm)")
+
+    // Verify the data we expect in the realm
+    // The synced realm we are copying contains 3 tasks whose owner is "Frodo"
+    let syncedTasks = syncedRealm.objects(QsTask.self)
+    var frodoSyncedTasks = syncedTasks.where { $0.owner == "Frodo" }
+    XCTAssertEqual(frodoSyncedTasks.count, 3)
+    print("Synced realm opens and contains this many tasks: \(frodoSyncedTasks.count)")
+
+    // Construct an output file path for the local Realm
+    guard let outputDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+
+    // Append a file name to complete the path
+    let localRealmFilePath = outputDir.appendingPathComponent("local.realm")
+
+    // Construct a local realm configuration
+    var localConfig = Realm.Configuration()
+    localConfig.objectTypes = [QsTask.self]
+    localConfig.fileURL = localRealmFilePath
+
+    // `realm_id` will be removed in the local realm, so we need to bump
+    // the schema version.
+    localConfig.schemaVersion = 1
+
+    // Check to see if there is already a realm at the local realm file path. If there
+    // is already a realm there, delete it.
+    if Realm.fileExists(for: localConfig) {
+        try Realm.deleteFiles(for: localConfig)
+        print("Successfully deleted existing realm at path: \(localRealmFilePath)")
+    } else {
+        print("No file currently exists at path")
+    }
+
+    // Make a copy of the synced realm that uses a local configuration
+    try syncedRealm.writeCopy(configuration: localConfig)
+
+    // Try opening the realm as a local realm
+    let localRealm = try await Realm(configuration: localConfig)
+
+    // Verify that the copied realm contains the data we expect
+    let localTasks = localRealm.objects(QsTask.self)
+    var frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
+    XCTAssertEqual(frodoLocalTasks.count, 3)
+    print("Local realm opens and contains this many tasks: \(frodoLocalTasks.count)")
+
+    let task = QsTask(value: ["name": "Send gift basket to Tom Bombadil", "owner": "Frodo"])
+
+    try! localRealm.write {
+        localRealm.add(task)
+    }
+
+    frodoLocalTasks = localTasks.where { $0.owner == "Frodo" }
+    XCTAssertEqual(frodoLocalTasks.count, 4)
+    print("After adding a task, the local realm contains this many tasks: \(frodoLocalTasks.count)")
+
+    frodoSyncedTasks = syncedTasks.where { $0.owner == "Frodo" }
+    XCTAssertEqual(frodoSyncedTasks.count, 3)
+    print("After writing to local realm, synced realm contains this many tasks: \(frodoSyncedTasks.count)")
+
+    XCTAssertNotEqual(frodoLocalTasks.count, frodoSyncedTasks.count)
+}

--- a/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-sync-to-sync.swift
+++ b/source/examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-sync-to-sync.swift
@@ -1,0 +1,58 @@
+func testConvertSyncToSync() async throws {
+    let app = App(id: YOUR_REALM_APP_ID)
+
+    // Log in the user whose realm you want to use with another sync user
+    let frodoBaggins = try await app.login(credentials: Credentials.anonymous)
+    var frodoConfig = frodoBaggins.configuration(partitionValue: "Some Partition Value")
+    frodoConfig.objectTypes = [QsTask.self]
+
+    // Open the synced realm, and confirm it contains the data we want
+    // the other user to be able to access.
+    let frodoRealm = try await Realm(configuration: frodoConfig, downloadBeforeOpen: .always)
+
+    let frodoRealmTasks = frodoRealm.objects(QsTask.self)
+    let frodoSyncedTasks = frodoRealmTasks.where { $0.owner == "Frodo" }
+    XCTAssertEqual(frodoSyncedTasks.count, 3)
+    print("Successfully opened frodo's realm and it contains this many tasks: \(frodoSyncedTasks.count)")
+
+    // Log in as the user who will work with frodo's synced realm
+    let samwiseGamgee = try await app.login(credentials: Credentials.anonymous)
+    var samConfig = samwiseGamgee.configuration(partitionValue: "Some Partition Value")
+    samConfig.objectTypes = [QsTask.self]
+
+    // Specify an output directory for the copied realm
+    // We're using FileManager here for tested code examples.
+    guard let outputDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+
+    // Append a file name to complete the path
+    let copiedRealmFilePath = outputDir.appendingPathComponent("copied.realm")
+
+    // Update the config file path to the path where you want to save the copied realm
+    samConfig.fileURL = copiedRealmFilePath
+
+
+    // Make a copy of frodo's realm that uses sam's config
+    try frodoRealm.writeCopy(configuration: samConfig)
+
+    // Open sam's realm, and see that it contains the same data as frodo's realm
+    let samRealm = try await Realm(configuration: samConfig)
+    let samRealmTasks = samRealm.objects(QsTask.self)
+    var samSyncedTasks = samRealmTasks.where { $0.owner == "Frodo" }
+    print("Successfully opened sam's realm and it contains this many tasks: \(samSyncedTasks.count)")
+
+    XCTAssertEqual(frodoSyncedTasks.count, samSyncedTasks.count)
+
+    // Add a task to sam's realm
+    let task = QsTask(value: ["name": "Keep an eye on that Gollum", "owner": "Sam"])
+
+    try! samRealm.write {
+        samRealm.add(task)
+    }
+
+    // See that the new task reflects in sam's realm, but not frodo's
+    samSyncedTasks = samRealmTasks.where { $0.owner == "Sam" }
+    XCTAssertEqual(samSyncedTasks.count, 1)
+
+    let samTasksInFrodoRealm = frodoRealmTasks.where { $0.owner == "Sam" }
+    XCTAssertEqual(samTasksInFrodoRealm.count, 0)
+}

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -15,17 +15,66 @@ Configure & Open a Realm - Swift SDK
 A **{+realm+}** is the core data structure used to organize data in
 {+client-database+}. For more information, see :ref:`ios-realms`.
 
-.. seealso::
+When you open a realm, you can pass a :swift-sdk:`Realm.Configuration 
+<Structs/Realm/Configuration.html>` that specifies additional details 
+about how to configure the realm file. This includes things like:
 
-   This page explains how to configure and open a local 
-   {+client-database+}. For information about opening a synced {+realm+},
-   including how to open a synced realm offline or online-only, see:
-   :ref:`Sync Changes Between Devices <ios-sync-changes-between-devices>`.
+- Whether the file should open at a specific fileURL or in-memory
+- Providing a logged-in user to use Sync with the realm
+- Specifying the realm use only a subset of your app's classes
+
+Synced Realms vs. Non-Synced Realms
+-----------------------------------
+
+Synced {+realms+} differ from non-synced local {+client-database+} in a 
+few ways:
+
+- Synced {+realms+} attempt to sync changes with your backend {+app+},
+  whereas non-synced {+realms+} do not.
+- Synced {+realms+} can be accessed by authenticated users, while non-synced 
+  {+realms+} have no concept of users or authentication.
+- With synced {+realms+}, you can :ref:`specify the download behavior 
+  <ios-specify-download-behavior>` to download updates before opening a 
+  {+realm+}. However, requiring changes to download before opening the 
+  realm requires the user to be online. Non-synced {+realms+} can always 
+  be used offline.
+
+You can copy data from a non-synced {+client-database+} to a synced {+realm+}, 
+but you cannot sync a non-synced {+client-database+}.
+
+.. _convert-realm-sync:
+
+Convert Between Synced and Non-Synced Realms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Realm does not have a direct mechanism to add sync to a non-synced realm, 
+or to permanently stop Sync for a synced realm. However, the Swift SDK does 
+provide methods that enable you to copy a realm file for use with a different 
+configuration. With these methods, you can easily duplicate a realm's data, 
+which you can then open with a sync or non-sync configuration. This lets
+you indirectly add Sync to a non-synced realm, or permanently stop a realm
+from syncing. See:
+
+- :ref:`<ios-open-non-synced-as-synced-realm>`
+- :ref:`<ios-open-synced-realm-as-non-sync>`
 
 .. _ios-open-a-local-realm:
 
-Open a Local Realm
-------------------
+Open a Realm Without Sync
+-------------------------
+
+You can open a non-synced local realm with several different configuration 
+options:
+
+- No configuration - i.e. default configuration
+- Specify a file URL for the realm
+- Open the realm only in memory, without saving a file to the file system
+- Copy a synced realm to use without Sync
+
+.. _ios-default-and-file-url-realm:
+
+Open a Default Realm or Realm at a File URL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. tabs-realm-languages::
    
@@ -36,9 +85,7 @@ Open a Local Realm
       <Structs/Realm.html#/s:10RealmSwift0A0V13configuration5queueA2C13ConfigurationV_So012OS_dispatch_D0CSgtKcfc>`.
       If you omit the :swift-sdk:`Realm.Configuration
       <Structs/Realm/Configuration.html>` parameter, you will open the
-      default realm. You can use the configuration object to open a
-      realm at a specific file URL, in memory, or with :ref:`{+sync+}
-      <sync>`.
+      default realm.
 
       You can set the default realm configuration by assigning a new
       Realm.Configuration instance to the
@@ -71,6 +118,75 @@ Open a Local Realm
       .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.codeblock.open-local-realm.m
          :language: objectivec
 
+.. _ios-open-an-in-memory-realm:
+
+Open an In-Memory Realm
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You can open a realm entirely in memory, which will not create a
+``.realm`` file or its associated :ref:`auxiliary files
+<ios-realm-file>`. Instead the SDK stores objects in memory while the
+{+realm+} is open and discards them immediately when all instances are
+closed.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: swift
+
+      Set the :swift-sdk:`inMemoryIdentifier
+      <Structs/Realm/Configuration.html#/s:10RealmSwift0A0V13ConfigurationV18inMemoryIdentifierSSSgvp>`
+      property of the realm configuration. Note that this property
+      cannot be combined with ``fileURL`` or ``syncConfiguration``.
+
+      .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.codeblock.open-in-memory-realm.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      Set the :objc-sdk:`inMemoryIdentifier
+      <Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)inMemoryIdentifier>`
+      property of the realm configuration. Note that this property
+      cannot be combined with ``fileURL`` or ``syncConfiguration``.
+
+      .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.codeblock.open-in-memory-realm.m
+         :language: objectivec
+
+.. important::
+
+   When all *in-memory* {+realm+} instances with a particular identifier
+   go out of scope, {+client-database+} deletes **all data** in that
+   {+realm+}. To avoid this, hold onto a strong reference to any
+   in-memory {+realms+} during your app's lifetime. 
+
+.. _ios-open-synced-realm-as-non-sync:
+
+Open a Synced Realm as a Non-Synced Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tip::
+
+   You may temporarily pause a Sync session if you do not want to permanently
+   change a synced realm to a non-synced realm. See: :ref:`Suspend or Resume 
+   a Sync Session <ios-suspend-or-resume-a-sync-session>`.
+
+If you want to permanently stop a realm from syncing to your backend Realm app,
+you can make a copy of a synced realm for use with a non-sync configuration.
+The example below creates a copy of the realm file, with all of its existing 
+data, at a file URL you specify. 
+
+This process removes the `realm_id` in the local realm. You must :ref:`increment 
+the schema version as if you had deleted a property <ios-delete-a-property>`.
+
+After you copy the realm for use without Sync, you can open the copy as a 
+non-synced realm. Any changes you make to the non-synced realm reflect 
+only in the local realm file. No changes propogate to other devices or
+the backend Realm application.
+
+.. literalinclude:: /examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-sync-to-local.swift
+   :language: swift
+
 .. _ios-login-and-open-realm:
 
 Open a Synced Realm
@@ -96,27 +212,10 @@ With cached credentials, you can:
 - Open a synced {+realm+} after downloading changes from your {+app+}. 
   This requires the user to have an active internet connection.
 
-Synced Realms vs. Local Realms
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Synced {+realms+} differ from local {+client-database+} in a few ways:
-
-- Synced {+realms+} attempt to sync changes with your backend {+app+},
-  whereas local {+realms+} do not.
-- Synced {+realms+} can be accessed by authenticated users, while local 
-  {+realms+} have no concept of users or authentication.
-- With synced {+realms+}, you can :ref:`specify the download behavior 
-  <ios-specify-download-behavior>` to download updates before opening a 
-  {+realm+}. However, this requires users to be online. Local {+realms+} - 
-  with no sync capability - can always be used offline.
-
-You can copy data from a :ref:`local {+client-database+} <ios-open-a-local-realm>` 
-to a synced {+realm+}, but you cannot sync a local {+client-database+}.
-
 .. _ios-partition-based-sync-open-realm:
 
-Open a Synced Realm with Partition-Based Sync
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Open a Synced Realm for Partition-Based Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Initialize a synced {+realm+} with a :swift-sdk:`sync configuration <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE13configuration14partitionValueAC0B0V13ConfigurationVx_tAC4BSONRzlF>`.
 This enables you to specify a partition value whose data should sync to the realm.
@@ -167,8 +266,8 @@ This enables you to specify a partition value whose data should sync to the real
 
 .. _ios-flexible-sync-open-realm:
 
-Open a Synced Realm with a Flexible Sync Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Open a Synced Realm for Flexible Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 10.22.0
 
@@ -182,11 +281,45 @@ to open a synced realm.
 
    You can't use a Flexible Sync realm until you add at least one subscription.
    To learn how to add subscriptions, see: :ref:`<ios-sync-add-subscription>`.
+.. _ios-open-synced-realm-as-different-sync-user:
+
+Open a Synced Realm as a Different Sync User
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to open a synced realm as a different Sync user, you can make 
+a copy of the synced realm for use with the new user's sync configuration. 
+The example below creates a copy of the synced realm, with all of its 
+existing data, that you can use with a different sync configuration.
+
+After you copy the realm for the new Sync user's configuration, you can 
+open the copy as a synced realm for that user. 
+
+.. literalinclude:: /examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-sync-to-sync.swift
+   :language: swift
+
+.. _ios-open-non-synced-as-synced-realm:
+
+Open Non-Synced Realm as a Synced Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want a non-synced realm to start syncing with other devices and your 
+backend Realm application, you can make a copy of the non-synced realm 
+for use with a sync configuration. The example below creates a copy of a 
+non-synced realm file, with all of its existing data, that you can use with 
+a sync configuration.
+
+After you copy the realm for use with Sync, you can open the copy as a 
+synced realm. Any changes you make to the synced realm will reflect 
+in the synced realm file, and they will also propogate to other devices and
+the backend Realm application.
+
+.. literalinclude:: /examples/generated/code/start/ConvertSyncLocalRealms.codeblock.convert-local-to-sync.swift
+   :language: swift
 
 .. _ios-specify-download-behavior:
 
 Download Changes Before Open
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 10.15.0
 
@@ -242,49 +375,6 @@ Handle Errors
 
       .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.codeblock.handle-error.m
          :language: objectivec
-
-
-.. _ios-open-an-in-memory-realm:
-
-Open an In-Memory Realm
------------------------
-
-You can open a realm entirely in memory, which will not create a
-``.realm`` file or its associated :ref:`auxiliary files
-<ios-realm-file>`. Instead the SDK stores objects in memory while the
-{+realm+} is open and discards them immediately when all instances are
-closed.
-
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: swift
-
-      Set the :swift-sdk:`inMemoryIdentifier
-      <Structs/Realm/Configuration.html#/s:10RealmSwift0A0V13ConfigurationV18inMemoryIdentifierSSSgvp>`
-      property of the realm configuration. Note that this property
-      cannot be combined with ``fileURL`` or ``syncConfiguration``.
-
-      .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.codeblock.open-in-memory-realm.swift
-         :language: swift
-
-   .. tab::
-      :tabid: objective-c
-
-      Set the :objc-sdk:`inMemoryIdentifier
-      <Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)inMemoryIdentifier>`
-      property of the realm configuration. Note that this property
-      cannot be combined with ``fileURL`` or ``syncConfiguration``.
-
-      .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.codeblock.open-in-memory-realm.m
-         :language: objectivec
-
-.. important::
-
-   When all *in-memory* {+realm+} instances with a particular identifier
-   go out of scope, {+client-database+} deletes **all data** in that
-   {+realm+}. To avoid this, hold onto a strong reference to any
-   in-memory {+realms+} during your app's lifetime. 
 
 .. _ios-provide-a-subset-of-classes-to-a-realm:
 
@@ -357,7 +447,7 @@ instance of ``SomeSwiftType`` before
 To avoid such issues, consider doing one of the following:
 
 - Defer instantiation of any type that eagerly initializes properties using {+client-database+} APIs until after your app has completed setting up its {+realm+} configurations. 
-- Define your properties using Swift’s ``lazy`` keyword. This allows you to safely instantiate such types at any time during your application’s lifecycle, as long as you do not attempt to access your ``lazy`` properties until after your app has set up its {+realm+} configurations.
+- Define your properties using Swift's ``lazy`` keyword. This allows you to safely instantiate such types at any time during your application’s lifecycle, as long as you do not attempt to access your ``lazy`` properties until after your app has set up its {+realm+} configurations.
 - Only initialize your properties using Realm APIs that explicitly take in user-defined configurations. You can be sure that the configuration values you are using have been set up properly before they are used to open {+realms+}.
 
 .. _use-realm-when-the-device-is-locked:

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -165,6 +165,8 @@ closed.
 Open a Synced Realm as a Non-Synced Realm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 10.23.0
+
 .. tip::
 
    You may temporarily pause a Sync session if you do not want to permanently
@@ -172,7 +174,9 @@ Open a Synced Realm as a Non-Synced Realm
    a Sync Session <ios-suspend-or-resume-a-sync-session>`.
 
 If you want to permanently stop a realm from syncing to your backend Realm app,
-you can make a copy of a synced realm for use with a non-sync configuration.
+you can use the :swift-sdk:`writeCopy(configuration: ) 
+<Structs/Realm.html#/s:10RealmSwift0A0V9writeCopy13configurationyAC13ConfigurationV_tKF>` 
+method to make a copy of a synced realm for use with a non-sync configuration.
 The example below creates a copy of the realm file, with all of its existing 
 data, at a file URL you specify. 
 
@@ -286,10 +290,15 @@ to open a synced realm.
 Open a Synced Realm as a Different Sync User
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to open a synced realm as a different Sync user, you can make 
-a copy of the synced realm for use with the new user's sync configuration. 
-The example below creates a copy of the synced realm, with all of its 
-existing data, that you can use with a different sync configuration.
+.. versionadded:: 10.23.0
+
+If you want to open a synced realm as a different Sync user, you can use 
+the :swift-sdk:`writeCopy(configuration: ) 
+<Structs/Realm.html#/s:10RealmSwift0A0V9writeCopy13configurationyAC13ConfigurationV_tKF>` 
+method to make a copy of the synced realm for use with the new user's 
+sync configuration. The example below creates a copy of the synced realm, 
+with all of its existing data, that you can use with a different sync 
+configuration.
 
 After you copy the realm for the new Sync user's configuration, you can 
 open the copy as a synced realm for that user. 
@@ -302,11 +311,14 @@ open the copy as a synced realm for that user.
 Open Non-Synced Realm as a Synced Realm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 10.23.0
+
 If you want a non-synced realm to start syncing with other devices and your 
-backend Realm application, you can make a copy of the non-synced realm 
-for use with a sync configuration. The example below creates a copy of a 
-non-synced realm file, with all of its existing data, that you can use with 
-a sync configuration.
+backend Realm application, you can use the :swift-sdk:`writeCopy(configuration: ) 
+<Structs/Realm.html#/s:10RealmSwift0A0V9writeCopy13configurationyAC13ConfigurationV_tKF>` 
+method to make a copy of the non-synced realm for use with a sync configuration. 
+The example below creates a copy of a non-synced realm file, with all of 
+its existing data, that you can use with a sync configuration.
 
 After you copy the realm for use with Sync, you can open the copy as a 
 synced realm. Any changes you make to the synced realm will reflect 

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -176,7 +176,7 @@ you can make a copy of a synced realm for use with a non-sync configuration.
 The example below creates a copy of the realm file, with all of its existing 
 data, at a file URL you specify. 
 
-This process removes the `realm_id` in the local realm. You must :ref:`increment 
+This process removes the ``realm_id`` in the local realm. You must :ref:`increment 
 the schema version as if you had deleted a property <ios-delete-a-property>`.
 
 After you copy the realm for use without Sync, you can open the copy as a 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-20221

### Staged Changes (Requires MongoDB Corp SSO)

- [Configure & Open a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20221/sdk/swift/examples/configure-and-open-a-realm/): The linked Jira ticket only mentions converting a local realm to a synced realm, but updates to writeCopy provide three conversion options, each of which gets a new section:
  - [Open a Synced Realm as a Non-Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20221/sdk/swift/examples/configure-and-open-a-realm/#open-a-synced-realm-as-a-non-synced-realm)
  - [Open a Synced Realm as a Different Sync User](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20221/sdk/swift/examples/configure-and-open-a-realm/#open-a-synced-realm-as-a-different-sync-user)
  - [Open a Non-Synced Realm as a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20221/sdk/swift/examples/configure-and-open-a-realm/#open-non-synced-realm-as-a-synced-realm)

I've also moved some things around on the page and updated the language to discuss "Synced" and "Non-Synced" realms vs. synced and local realms. However, I did intentionally leave "local" in several places to aid search for folks who might be already familiar with the "local" terminology.

### Before merging:
- [x] Add `..versionadded` for the new writeCopy options to reflect the release version
- [x] Update Podfile to point to release version
- [x] Add links from ``writeCopy`` to generated SDK reference for the new writeCopy options

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
