### PR TITLE
(DOCSP-20777): Add Flexible Sync callouts for required subscription and object links

### DIFF
--- a/source/sdk/android/examples/flexible-sync.txt
+++ b/source/sdk/android/examples/flexible-sync.txt
@@ -154,6 +154,17 @@ new subscription to the client's Realm subscriptions.
          :language: java
          :copyable: false
 
+.. important:: Object Links
+
+   If your subscription results contain an object with a property that links 
+   to an object not contained in the results, the link appears to be nil.
+   There is no way to distinguish whether that property's value is 
+   legitimately nil, or whether the object it links to exists but is out of
+   view of the query subscription.
+   
+   You must add both the object and the linked object to the subscription 
+   set to see a linked object.
+
 .. _android-sync-check-subscription-state:
 .. _android-sync-react-to-subscription-changes:
 

--- a/source/sdk/dotnet/examples/flexible-sync.txt
+++ b/source/sdk/dotnet/examples/flexible-sync.txt
@@ -70,6 +70,17 @@ specific object type. In your Flexible Sync subscriptions, you can have
 subscriptions on several different object types or several queries on the same
 object type.
 
+.. important:: Object Links
+
+   If your subscription results contain an object with a property that links 
+   to an object not contained in the results, the link appears to be nil.
+   There is no way to distinguish whether that property's value is 
+   legitimately nil, or whether the object it links to exists but is out of
+   view of the query subscription.
+   
+   You must add both the object and the linked object to the subscription 
+   set to see a linked object.
+
 .. _dotnet-sync-get-subscription:
 
 Get Subscriptions

--- a/source/sdk/dotnet/examples/open-a-realm.txt
+++ b/source/sdk/dotnet/examples/open-a-realm.txt
@@ -133,6 +133,10 @@ to open a synced realm.
 .. literalinclude:: /examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.codeblock.open-a-flexible-synced-realm.cs
    :language: csharp
 
+.. important:: Flexible Sync Requires a Subscription
+
+   You can't use a Flexible Sync realm until you add at least one subscription.
+   To learn how to add subscriptions, see: :ref:`<dotnet-sync-add-subscription>`.
 
 Scoping the Realm
 -----------------

--- a/source/sdk/node/examples/flexible-sync.txt
+++ b/source/sdk/node/examples/flexible-sync.txt
@@ -92,6 +92,17 @@ object type.
   .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.create-queries-to-subscribe-to.js
      :language: javascript
 
+.. important:: Object Links
+
+   If your subscription results contain an object with a property that links 
+   to an object not contained in the results, the link appears to be nil.
+   There is no way to distinguish whether that property's value is 
+   legitimately nil, or whether the object it links to exists but is out of
+   view of the query subscription.
+   
+   You must add both the object and the linked object to the subscription 
+   set to see a linked object.
+
 Get Subscriptions
 ~~~~~~~~~~~~~~~~~
 When using a flexible synced realm, you can access a ``SubscriptionSet``, a
@@ -102,6 +113,8 @@ collection of subscriptions, through the ``realm.subscriptions`` property.
 
 You can use this snapshot to add queries to the list of subscriptions and
 update existing subscriptions, as shown in the examples below.
+
+.. _node-sync-add-subscription:
 
 Add a Query to the List Of Subscriptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/source/sdk/node/examples/open-and-close-a-realm.txt
+++ b/source/sdk/node/examples/open-and-close-a-realm.txt
@@ -37,6 +37,11 @@ In the SyncConfiguration, you must include include a ``user`` and ``flexible:tru
 .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.open-flexible-sync-realm.js
    :language: javascript
 
+.. important:: Flexible Sync Requires a Subscription
+
+   You can't use a Flexible Sync realm until you add at least one subscription.
+   To learn how to add subscriptions, see: :ref:`<node-sync-add-subscription>`.
+
 .. _node-partition-sync-open-realm:
 
 Open a Partition-Based Synced Realm

--- a/source/sdk/react-native/examples/flexible-sync.txt
+++ b/source/sdk/react-native/examples/flexible-sync.txt
@@ -92,6 +92,17 @@ object type.
   .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.create-queries-to-subscribe-to.js
      :language: javascript
 
+.. important:: Object Links
+
+   If your subscription results contain an object with a property that links 
+   to an object not contained in the results, the link appears to be nil.
+   There is no way to distinguish whether that property's value is 
+   legitimately nil, or whether the object it links to exists but is out of
+   view of the query subscription.
+   
+   You must add both the object and the linked object to the subscription 
+   set to see a linked object.
+
 Get Subscriptions
 ~~~~~~~~~~~~~~~~~
 To get a snapshot of current subscriptions, call ``getSubscriptions()`` method
@@ -102,6 +113,8 @@ on the {+realm+}.
 
 You can use this snapshot to add queries to the list of subscriptions and
 update existing subscriptions, as shown in the examples below.
+
+.. _react-native-sync-add-subscription:
 
 Add a Query to the List Of Subscriptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -37,6 +37,11 @@ In the SyncConfiguration, you must include include a ``user`` and ``flexible:tru
 .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.open-flexible-sync-realm.js
    :language: javascript
 
+.. important:: Flexible Sync Requires a Subscription
+
+   You can't use a Flexible Sync realm until you add at least one subscription.
+   To learn how to add subscriptions, see: :ref:`<react-native-sync-add-subscription>`.
+
 .. _react-native-partition-sync-open-realm:
 
 Open a Partition-Based Synced Realm

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -178,6 +178,11 @@ to open a synced realm.
 .. literalinclude:: /examples/generated/code/start/FlexibleSync.codeblock.flex-sync-open-realm.swift
    :language: swift
 
+.. important:: Flexible Sync Requires a Subscription
+
+   You can't use a Flexible Sync realm until you add at least one subscription.
+   To learn how to add subscriptions, see: :ref:`<ios-sync-add-subscription>`.
+
 .. _ios-specify-download-behavior:
 
 Download Changes Before Open

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -85,6 +85,17 @@ When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
 object types. You can also have multiple queries on the same object type.
 
+.. important:: Object Links
+
+   If your subscription results contain an object with a property that links 
+   to an object not contained in the results, the link appears to be nil.
+   There is no way to distinguish whether that property's value is 
+   legitimately nil, or whether the object it links to exists but is out of
+   view of the query subscription.
+   
+   You must add both the object and the linked object to the subscription 
+   set to see a linked object.
+
 .. example::
 
    You can create a subscription with an explicit name. Then, you can


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-20777

### Staged Changes (Requires MongoDB Corp SSO)

Configure/Open a Realm page across SDKs has gotten an "Important" callout about the requirement for at least one subscription to use a realm (except Android, which shows it in the code example):
- [Swift SDK - Configure & Open a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20777/sdk/swift/examples/configure-and-open-a-realm/#open-a-synced-realm-with-a-flexible-sync-configuration)
- [.Net - Open a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20777/sdk/dotnet/examples/open-a-realm/#open-a-synced-realm-with-a-flexible-sync-configuration)
- [Node.js - Open & Close a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20777/sdk/node/examples/open-and-close-a-realm/#open-a-flexible-synced-realm)
- [React Native -> Open & Close a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20777/sdk/react-native/examples/open-and-close-a-realm/#open-a-flexible-synced-realm)


### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
