### PR TITLE
(DOCSP-15678): Add more explicit guidance to compacting documentation

### DIFF
--- a/examples/ios/Examples/Compacting.swift
+++ b/examples/ios/Examples/Compacting.swift
@@ -21,4 +21,25 @@ class Compacting: XCTestCase {
         }
         // :code-block-end:
     }
+
+    // :code-block-start: async-compact
+    func testAsyncCompact() async {
+        let config = Realm.Configuration(shouldCompactOnLaunch: { totalBytes, usedBytes in
+            // totalBytes refers to the size of the file on disk in bytes (data + free space)
+            // usedBytes refers to the number of bytes used by data in the file
+
+            // Compact if the file is over 100MB in size and less than 50% 'used'
+            let oneHundredMB = 100 * 1024 * 1024
+            return (totalBytes > oneHundredMB) && (Double(usedBytes) / Double(totalBytes)) < 0.5
+        })
+
+        do {
+            // Realm is compacted asynchronously on the first open if the
+            // configuration block conditions were met.
+            let realm = try await Realm(configuration: config)
+        } catch {
+            // handle error compacting or opening Realm
+        }
+    }
+    // :code-block-end:
 }

--- a/source/examples/generated/code/start/Compacting.codeblock.async-compact.swift
+++ b/source/examples/generated/code/start/Compacting.codeblock.async-compact.swift
@@ -1,0 +1,18 @@
+func testAsyncCompact() async {
+    let config = Realm.Configuration(shouldCompactOnLaunch: { totalBytes, usedBytes in
+        // totalBytes refers to the size of the file on disk in bytes (data + free space)
+        // usedBytes refers to the number of bytes used by data in the file
+
+        // Compact if the file is over 100MB in size and less than 50% 'used'
+        let oneHundredMB = 100 * 1024 * 1024
+        return (totalBytes > oneHundredMB) && (Double(usedBytes) / Double(totalBytes)) < 0.5
+    })
+
+    do {
+        // Realm is compacted asynchronously on the first open if the
+        // configuration block conditions were met.
+        let realm = try await Realm(configuration: config)
+    } catch {
+        // handle error compacting or opening Realm
+    }
+}

--- a/source/sdk/android/fundamentals/realms.txt
+++ b/source/sdk/android/fundamentals/realms.txt
@@ -353,6 +353,11 @@ You can remove unused space by **compacting** the {+realm+} file:
   builder option when opening the first connection to a {+realm+} in your
   Android application
 
+.. tip:: Implement Compacting in Your Production Application
+
+   Every production application should implement compacting to 
+   periodically reduce the realm file size.
+
 .. _android-backup-and-restore-realms:
 
 Backup and Restore Realms

--- a/source/sdk/dotnet/advanced-guides/compact-realm.txt
+++ b/source/sdk/dotnet/advanced-guides/compact-realm.txt
@@ -28,7 +28,12 @@ Realm reduces the file size by writing a new (compact) version of the file, and
 then replacing the original with the newly-written file. Therefore, to compact, 
 you must have free storage space equivalent to the original realm file size. 
 
+.. tip:: Implement Compacting in Your Production Application
 
+   Every production application should implement :dotnet-sdk:`ShouldCompactOnLaunch 
+   <reference/Realms.RealmConfiguration.html#Realms_RealmConfiguration_ShouldCompactOnLaunch>` 
+   to periodically reduce the realm file size. For more information
+   about compacting a realm, see: :ref:`<dotnet-when-to-compact-a-realm>`.
 
 Compaction Options
 ------------------
@@ -62,3 +67,47 @@ method. The following example shows how to do this:
    :language: csharp
 
 The ``Compact`` method will return true if the operation is successful.
+
+.. _dotnet-when-to-compact-a-realm:
+
+When to Compact a Realm
+-----------------------
+
+Compacting a realm can be an expensive operation that can block 
+the UI thread. Your application should not compact every time you open 
+a {+realm+}. Instead, try to optimize compacting so your application does 
+it just often enough to prevent the file size from growing too large. 
+If your application runs in a resource-constrained environment,
+you may want to compact when you reach a certain file size or when the 
+file size negatively impacts performance.
+
+These recommendations can help you start optimizing compaction for your 
+application:
+
+- Set the max file size to a multiple of your average realm state
+  size. If your average realm state size is 10MB, you might set the max 
+  file size to 20MB or 40MB, depending on expected usage and device
+  constraints.
+- As a starting point, compact realms when more than 50% of the realm file 
+  size is no longer in use. Divide the currently used bytes by the total 
+  file size to determine the percentage of space that is currently used. 
+  Then, check for that to be less than 50%. This means that greater than 
+  50% of your realm file size is unused space, and it is a good time to 
+  compact. After experimentation, you may find a different percentage 
+  works best for your application.
+
+These calculations might look like this in your delegate:
+
+.. code-block:: csharp
+
+   // Set a maxFileSize equal to 20MB in bytes
+   var maxFileSize = 20 * 1024 * 1024;
+
+   /* Check for the realm file size to be greater than the max file size, 
+    * and the amount of bytes currently used to be less than 50% of the
+    * total realm file size */
+   return (totalBytes > (double)maxFileSize) ||
+      ((double)usedBytes / totalBytes > 0.5);
+
+Experiment with conditions to find the right balance of how often to 
+compact {+realm+} files in your application.

--- a/source/sdk/dotnet/fundamentals/realms.txt
+++ b/source/sdk/dotnet/fundamentals/realms.txt
@@ -110,6 +110,13 @@ specify a path.
 The default realm file is named ``default.realm`` and is located where the OS 
 stores app-specific data.
 
+.. tip:: Implement Compacting in Your Production Application
+
+   Every production application should implement :dotnet-sdk:`ShouldCompactOnLaunch 
+   <reference/Realms.RealmConfiguration.html#Realms_RealmConfiguration_ShouldCompactOnLaunch>` 
+   to periodically reduce the realm file size. For more information
+   about compacting a realm, see: :ref:`<dotnet-compact-realm>`.
+
 .. note:: Auxiliary Realm Files
    
    Realm Database creates additional files for each {+realm+}.

--- a/source/sdk/node/fundamentals/realms.txt
+++ b/source/sdk/node/fundamentals/realms.txt
@@ -137,6 +137,11 @@ Realm Database stores a binary encoded version of every object and type in a
 realm in a single ``.realm`` file. The file is located at a specific path that
 you define when you open the realm.
 
+.. tip:: Implement Compacting in Your Production Application
+
+   Every production application should implement a ``shouldCompactOnLaunch`` 
+   callback to periodically reduce the realm file size.
+
 .. note:: Auxiliary Realm Files
    
    Realm Database creates additional files for each {+realm+}.

--- a/source/sdk/react-native/fundamentals/realms.txt
+++ b/source/sdk/react-native/fundamentals/realms.txt
@@ -137,6 +137,11 @@ Realm Database stores a binary encoded version of every object and type in a
 realm in a single ``.realm`` file. The file is located at a specific path that
 you define when you open the realm.
 
+.. tip:: Implement Compacting in Your Production Application
+
+   Every production application should implement a ``shouldCompactOnLaunch`` 
+   callback to periodically reduce the realm file size.
+
 .. note:: Auxiliary Realm Files
    
    Realm Database creates additional files for each {+realm+}.

--- a/source/sdk/swift/advanced-guides/compacting.txt
+++ b/source/sdk/swift/advanced-guides/compacting.txt
@@ -29,6 +29,13 @@ file. In some situations, unused space may comprise a significant
 portion of a {+realm+} file. If file size grows large enough to 
 negatively impact performance, compact the {+realm+}. 
 
+.. tip:: Implement Compacting in Your Productin Application
+
+   Every production application should implement a :swift-sdk:`shouldCompactOnLaunch 
+   <Structs/Realm/Configuration.html#/s:10RealmSwift0A0V13ConfigurationV21shouldCompactOnLaunchSbSi_SitcSgvp>` 
+   callback to periodically reduce the realm file size. For more information
+   about how often to compact a realm, see: :ref:`<ios-when-to-compact-a-realm>`.
+
 .. _ios-how-to-compact-a-realm:
 
 Compact a Realm
@@ -93,13 +100,53 @@ How Compacting Works
 
 If the file contains a lot of data, this can be an expensive operation.
 
-Best Practices
-~~~~~~~~~~~~~~
+.. _ios-when-to-compact-a-realm:
+
+When to Compact a Realm
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Compacting a realm can be an expensive operation that can block 
+the UI thread. Your application should not compact every time you open 
+a {+realm+}. Instead, try to optimize compacting so your application does 
+it just often enough to prevent the file size from growing too large. 
+If your application runs in a resource-constrained environment,
+you may want to compact when you reach a certain file size, or when the 
+file size negatively impacts performance.
+
+These recommendations can help you start optimizing compaction for your 
+application:
+
+- Set the max file size to a multiple of your average realm state
+  size. If your average realm state size is 10MB, you might set the max 
+  file size to 20MB or 40MB, depending on expected usage and device
+  constraints.
+- As a starting point, compact realms when less than 50% of the realm file 
+  size is actually in use. After experimentation, you may find a different
+  percentage works best for your application.
+
+These calculations might look like this in your ``shouldCompactOnLaunch`` 
+callback:
+
+.. code-block:: Swift
+
+   // Set a maxFileSize equal to 20MB in bytes
+   let maxFileSize = 20 * 1024 * 1024
+   // Check for the realm file size to be greater than the max file size, 
+   // and the amount of bytes currently used to be less than 50% of the
+   // total realm file size
+   return (realmFileSizeInBytes > maxFileSize) && (Double(usedBytes) / Double(realmFileSizeInBytes)) < 0.5
 
 Experiment with conditions to find the right balance of how often to 
-compact a {+realm+} file. Because the operation can be 
-expensive, don't compact every time you open a {+realm+}. Do compact 
-often enough to prevent the file size from growing too large.
+compact {+realm+} files in your application.
+
+Compact a Realm Asynchronously
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you use the Swift async/await syntax to open a realm asynchronously,
+you can compact a realm in the background.
+
+.. literalinclude:: /examples/generated/code/start/Compacting.codeblock.async-compact.swift
+   :language: swift
 
 Summary
 -------
@@ -112,3 +159,5 @@ Summary
 - Define conditions for ``shouldCompactOnLaunch()`` to compact a {+realm+}.
 
 - Compacting cannot occur if another process is accessing the {+realm+}.
+
+- You can compact a realm asynchronously when you use async/await syntax.

--- a/source/sdk/swift/advanced-guides/compacting.txt
+++ b/source/sdk/swift/advanced-guides/compacting.txt
@@ -29,7 +29,7 @@ file. In some situations, unused space may comprise a significant
 portion of a {+realm+} file. If file size grows large enough to 
 negatively impact performance, compact the {+realm+}. 
 
-.. tip:: Implement Compacting in Your Productin Application
+.. tip:: Implement Compacting in Your Production Application
 
    Every production application should implement a :swift-sdk:`shouldCompactOnLaunch 
    <Structs/Realm/Configuration.html#/s:10RealmSwift0A0V13ConfigurationV21shouldCompactOnLaunchSbSi_SitcSgvp>` 
@@ -160,4 +160,4 @@ Summary
 
 - Compacting cannot occur if another process is accessing the {+realm+}.
 
-- You can compact a realm asynchronously when you use async/await syntax.
+- You can compact a realm in the background when you use async/await syntax.

--- a/source/sdk/swift/advanced-guides/compacting.txt
+++ b/source/sdk/swift/advanced-guides/compacting.txt
@@ -120,9 +120,13 @@ application:
   size. If your average realm state size is 10MB, you might set the max 
   file size to 20MB or 40MB, depending on expected usage and device
   constraints.
-- As a starting point, compact realms when less than 50% of the realm file 
-  size is actually in use. After experimentation, you may find a different
-  percentage works best for your application.
+- As a starting point, compact realms when more than 50% of the realm file 
+  size is no longer in use. Divide the currently used bytes by the total 
+  file size to determine the percentage of space that is currently used. 
+  Then, check for that to be less than 50%. This means that greater than 
+  50% of your realm file size is unused space, and it is a good time to 
+  compact. After experimentation, you may find a different percentage 
+  works best for your application.
 
 These calculations might look like this in your ``shouldCompactOnLaunch`` 
 callback:

--- a/source/sdk/swift/advanced-guides/compacting.txt
+++ b/source/sdk/swift/advanced-guides/compacting.txt
@@ -110,7 +110,7 @@ the UI thread. Your application should not compact every time you open
 a {+realm+}. Instead, try to optimize compacting so your application does 
 it just often enough to prevent the file size from growing too large. 
 If your application runs in a resource-constrained environment,
-you may want to compact when you reach a certain file size, or when the 
+you may want to compact when you reach a certain file size or when the 
 file size negatively impacts performance.
 
 These recommendations can help you start optimizing compaction for your 
@@ -127,7 +127,7 @@ application:
 These calculations might look like this in your ``shouldCompactOnLaunch`` 
 callback:
 
-.. code-block:: Swift
+.. code-block:: swift
 
    // Set a maxFileSize equal to 20MB in bytes
    let maxFileSize = 20 * 1024 * 1024

--- a/source/sdk/swift/fundamentals/realms.txt
+++ b/source/sdk/swift/fundamentals/realms.txt
@@ -178,7 +178,7 @@ Generally, {+client-database+} takes less space on disk than a
 comparable SQLite database. Unexpected file growth may be related to the 
 {+backend-short+} referring to outdated data.
 
-.. tip:: Implement Compacting in Your Productin Application
+.. tip:: Implement Compacting in Your Production Application
 
    Every production application should implement a :swift-sdk:`shouldCompactOnLaunch 
    <Structs/Realm/Configuration.html#/s:10RealmSwift0A0V13ConfigurationV21shouldCompactOnLaunchSbSi_SitcSgvp>` 

--- a/source/sdk/swift/fundamentals/realms.txt
+++ b/source/sdk/swift/fundamentals/realms.txt
@@ -178,10 +178,12 @@ Generally, {+client-database+} takes less space on disk than a
 comparable SQLite database. Unexpected file growth may be related to the 
 {+backend-short+} referring to outdated data.
 
-.. seealso::
+.. tip:: Implement Compacting in Your Productin Application
 
-   If file size negatively impacts performance, you may want to compact the file:
-   :ref:`Compact a Realm <ios-client-compact-a-realm>`.
+   Every production application should implement a :swift-sdk:`shouldCompactOnLaunch 
+   <Structs/Realm/Configuration.html#/s:10RealmSwift0A0V13ConfigurationV21shouldCompactOnLaunchSbSi_SitcSgvp>` 
+   callback to periodically reduce the realm file size. For more information
+   about compacting a realm, see: :ref:`<ios-client-compact-a-realm>`.
 
 Avoid Pinning Transactions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

After a reviewer weighs in on the wording/value of these additions, I'll port the relevant bits to the other SDKs.

### Jira

- https://jira.mongodb.org/browse/DOCSP-15678

### Staged Changes (Requires MongoDB Corp SSO)

- [Swift SDK - Compact a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-15678/sdk/swift/advanced-guides/compacting/#std-label-ios-when-to-compact-a-realm): Renamed "Best Practices" to "When to Compact a Realm", added Swift async compact example
- [Swift SDK - Realms: File Size](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-15678/sdk/swift/fundamentals/realms/#file-size): Add a callout that all production applications should implement compacting, with a link to compacting docs
- [Android SDK - Realms: File Size/Compact a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-15678/sdk/android/fundamentals/realms/#compact-a-realm): Add a Tip callout to point out that apps should implement compacting in production. I created a Jira ticket to add a "Compact a Realm" page to the Android SDK and link to it from here
- [Node.js SDK - Realms: File Size](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-15678/sdk/node/fundamentals/realms/#realm-files): Add a Tip callout to point out that apps should implement compacting in production. I created a Jira ticket to add a "Compact a Realm" page to the Node.js SDK and link to it from here
- [Node.js SDK - Realms: File Size](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-15678/sdk/react-native/fundamentals/realms/#realm-files): Add a Tip callout to point out that apps should implement compacting in production. The Jira ticket I created for Node to add a "Compact a Realm" page mentions to add it here, too
- [.Net SDK - Realms: File Size](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-15678/sdk/dotnet/fundamentals/realms/#realm-files): Add a Tip callout to point out that apps should implement compacting in production that links to the "Compact a Realm" page
- [.Net SDK - Compact a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-15678/sdk/dotnet/advanced-guides/compact-realm/): Add a Tip callout to point out that apps should implement compacting in production, and add a "When to Compact a Realm" section with more guidance

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
