### PR TITLE
(DOCSP-20829): Fix Flex Sync JS, waitForSync rturns a promise + cleanup add a query

### DIFF
--- a/source/sdk/node/examples/flexible-sync.txt
+++ b/source/sdk/node/examples/flexible-sync.txt
@@ -123,17 +123,6 @@ You can add queries to your subscriptions list. To do so, perform the following:
 #. Create a transaction by passing a callback function to the ``update()`` method of your subscriptions snapshot. The callback function provides a ``MutableSubscriptionSet`` as an argument. 
 #. Within the callback function, call the ``add()`` method on the ``MutableSubscriptionSet`` to add a query to the subscription.
 
-The ``add()`` method on the ``MutableSubscriptionSet`` takes a ``query`` and a
-subscription options object. The subscription options include:
-
-- a ``name`` string field
-- a ``throwOnUpdate`` boolean field.
-
-If ``throwOnUpdate`` is false or undefined, adding a subscription with an
-existing name will replace the existing query with the new query. However, if
-you set ``throwOnUpdate`` to true, adding a subscription with an existing name
-but a different query throws an exception.
-
 You can asynchronously add a single query, or multiple queries within a ``subscription.update``
 transaction. In the example below, we subscribe to the queries we created
 earlier. 
@@ -148,6 +137,18 @@ method, but this requires you to call the :ref:`waitForSynchronization
 .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.subscribe-to-queryable-fields.js
     :language: javascript
 
+The ``add()`` method on the ``MutableSubscriptionSet`` takes a ``query`` and a
+subscription options object. The subscription options include:
+
+- a ``name`` string field
+- a ``throwOnUpdate`` boolean field.
+
+If ``throwOnUpdate`` is false or undefined, adding a subscription with an
+existing name will replace the existing query with the new query. However, if
+you set ``throwOnUpdate`` to true, adding a subscription with an existing name
+but a different query throws an exception.
+
+
 .. _node-flexible-sync-wait-for-sync:
 
 Check the Status of Subscriptions
@@ -158,13 +159,9 @@ set of subscriptions and return the matching objects:
 
 The ``waitForSynchronization()`` method returns a promise that resolves when
 synchronization is complete or rejects if there is an error during
-synchronization.
-
-.. note::
- 
-   The ``waitForSynchronization()`` method throws if there is an error, so we
-   recommend wrapping it in a :mdn:`try...catch
-   <Web/JavaScript/Reference/Statements/try...catch>` statement.
+synchronization. Wrap the method call in a :mdn:`try...catch
+<Web/JavaScript/Reference/Statements/try...catch>` statement to handle any
+exceptions that are thrown.
 
 .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.wait-for-synchronization.js
     :language: javascript

--- a/source/sdk/node/examples/flexible-sync.txt
+++ b/source/sdk/node/examples/flexible-sync.txt
@@ -123,19 +123,28 @@ You can add queries to your subscriptions list. To do so, perform the following:
 #. Create a transaction by passing a callback function to the ``update()`` method of your subscriptions snapshot. The callback function provides a ``MutableSubscriptionSet`` as an argument. 
 #. Within the callback function, call the ``add()`` method on the ``MutableSubscriptionSet`` to add a query to the subscription.
 
-You can asynchronously add a single query, or multiple queries within a ``subscription.update``
-transaction. In the example below, we subscribe to the queries we created
-earlier. 
+.. tabs::
 
-.. literalinclude:: /examples/generated/node/flexible-sync.codeblock.subscribe-to-queryable-fields-await-form.js
-    :language: javascript
+   .. tab:: Asynchronously Add a Query
+      :tabid: asynchronous-add-a-query-to-subscriptions
 
-Alternatively, you can synchronously call the ``subscriptions.update()``
-method, but this requires you to call the :ref:`waitForSynchronization
-<node-flexible-sync-wait-for-sync>` method afterward.
+      You can asynchronously add a single query, or multiple queries within a ``subscription.update``
+      transaction. In the example below, we subscribe to the queries we created
+      earlier. 
+  
+      .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.subscribe-to-queryable-fields-await-form.js
+          :language: javascript
 
-.. literalinclude:: /examples/generated/node/flexible-sync.codeblock.subscribe-to-queryable-fields.js
-    :language: javascript
+   
+   .. tab:: Synchronously Add a Query
+      :tabid: synchronous-add-a-query-to-subscriptions
+
+      You can synchronously add a single query, or multiple queries within a ``subscriptions.update()``
+      transaction. If you synchronously add queries, you must call the :ref:`waitForSynchronization
+      <node-flexible-sync-wait-for-sync>` method afterward.
+      
+      .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.subscribe-to-queryable-fields.js
+          :language: javascript      
 
 The ``add()`` method on the ``MutableSubscriptionSet`` takes a ``query`` and a
 subscription options object. The subscription options include:

--- a/source/sdk/react-native/examples/flexible-sync.txt
+++ b/source/sdk/react-native/examples/flexible-sync.txt
@@ -123,6 +123,29 @@ You can add queries to your subscriptions list. To do so, perform the following:
 #. Create a transaction by passing a callback function to the ``update()`` method of your subscriptions snapshot. The callback function provides a mutable instance of the subscriptions as an argument. 
 #. Within the callback function, call the ``add()`` method on the mutable subscription instance to add a query to the subscription.
 
+.. tabs::
+
+   .. tab:: Asynchronously Add a Query to the List Of Subscriptions
+      :tabid: asynchronous-add-a-query-to-subscriptions
+
+      You can asynchronously add a single query, or multiple queries within a ``subscription.update``
+      transaction. In the example below, we subscribe to the queries we created
+      earlier. 
+  
+      .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.subscribe-to-queryable-fields-await-form.js
+          :language: javascript
+
+   
+   .. tab:: Synchronously Add a Query to the List Of Subscriptions
+      :tabid: synchronous-add-a-query-to-subscriptions
+
+      Alternatively, you can synchronously call the ``subscriptions.update()``
+      method, but this requires you to call the :ref:`waitForSynchronization
+      <node-flexible-sync-wait-for-sync>` method afterward.
+      
+      .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.subscribe-to-queryable-fields.js
+          :language: javascript      
+
 The ``add()`` method on the mutable subscription instance takes a ``query`` and a
 subscription options object. The subscription options include:
 
@@ -134,13 +157,6 @@ existing name will replace the existing query with the new query. However, if
 you set ``throwOnUpdate`` to true, adding a subscription with an existing name
 but a different query throws an exception.
 
-You can add a single query, or multiple queries within a ``subscription.update``
-transaction. In the example below, we subscribe to the queries we created
-earlier. 
-
-.. literalinclude:: /examples/generated/node/flexible-sync.codeblock.subscribe-to-queryable-fields.js
-    :language: javascript
-
 Check the Status of Subscriptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can use the ``waitForSynchronization()`` method to wait for the server to
@@ -148,13 +164,9 @@ acknowledge this set of subscriptions and return the matching objects:
 
 The ``waitForSynchronization()`` method returns a promise that resolves when
 synchronization is complete or rejects if there is an error during
-synchronization.
-
-.. note::
- 
-   The ``waitForSynchronization()`` method throws if there is an error, so we
-   recommend wrapping it in a :mdn:`try...catch
-   <Web/JavaScript/Reference/Statements/try...catch>` statement.
+synchronization. Wrap the method call in a :mdn:`try...catch
+<Web/JavaScript/Reference/Statements/try...catch>` statement to handle any
+exceptions that are thrown.
 
 .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.wait-for-synchronization.js
     :language: javascript

--- a/source/sdk/react-native/examples/flexible-sync.txt
+++ b/source/sdk/react-native/examples/flexible-sync.txt
@@ -125,7 +125,7 @@ You can add queries to your subscriptions list. To do so, perform the following:
 
 .. tabs::
 
-   .. tab:: Asynchronously Add a Query to the List Of Subscriptions
+   .. tab:: Asynchronously Add a Query
       :tabid: asynchronous-add-a-query-to-subscriptions
 
       You can asynchronously add a single query, or multiple queries within a ``subscription.update``
@@ -136,12 +136,12 @@ You can add queries to your subscriptions list. To do so, perform the following:
           :language: javascript
 
    
-   .. tab:: Synchronously Add a Query to the List Of Subscriptions
+   .. tab:: Synchronously Add a Query
       :tabid: synchronous-add-a-query-to-subscriptions
 
-      Alternatively, you can synchronously call the ``subscriptions.update()``
-      method, but this requires you to call the :ref:`waitForSynchronization
-      <node-flexible-sync-wait-for-sync>` method afterward.
+      You can synchronously add a single query, or multiple queries within a ``subscriptions.update()``
+      transaction. If you synchronously add queries, you must call the :ref:`waitForSynchronization
+      <react-native-flexible-sync-wait-for-sync>` method afterward.
       
       .. literalinclude:: /examples/generated/node/flexible-sync.codeblock.subscribe-to-queryable-fields.js
           :language: javascript      
@@ -156,6 +156,8 @@ If ``throwOnUpdate`` is false or undefined, adding a subscription with an
 existing name will replace the existing query with the new query. However, if
 you set ``throwOnUpdate`` to true, adding a subscription with an existing name
 but a different query throws an exception.
+
+.. _react-native-flexible-sync-wait-for-sync:
 
 Check the Status of Subscriptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-20829

### Staged Changes (Requires MongoDB Corp SSO)

- [Node.js > Usage Examples > Flexible Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-20829-flex-sync-js-additional-ex/sdk/node/examples/flexible-sync/#add-a-query-to-the-list-of-subscriptions)
- [React Native > Usage Examples > Flexible Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-20829-flex-sync-js-additional-ex/sdk/react-native/examples/flexible-sync/#flexible-sync---react-native-sdk)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
