### PR TITLE
(DOCSP-21050): Sync roles updates

### DIFF
--- a/source/includes/non-sync-rules-note.txt
+++ b/source/includes/non-sync-rules-note.txt
@@ -1,0 +1,5 @@
+.. note::
+
+   The content in this section only applies when Realm Sync is not
+   enabled. For information about configuring permissions when using
+   Sync, see :ref:`sync-permissions`.

--- a/source/rules.txt
+++ b/source/rules.txt
@@ -17,6 +17,8 @@ Rules
    Filter Incoming Queries </mongodb/filter-incoming-queries>
    Configure Advanced Rules </mongodb/configure-advanced-rules>
 
+.. include:: /includes/non-sync-rules-note.rst
+
 In traditional applications, an application server exposes an API to client
 applications and handles database queries on their behalf. To prevent malicious,
 improper, or incorrect read and write operations, clients don't query the

--- a/source/rules/examples.txt
+++ b/source/rules/examples.txt
@@ -12,6 +12,8 @@ Rule Templates & Examples
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/non-sync-rules-note.rst
+
 Apply When Expressions
 ----------------------
 

--- a/source/rules/filters.txt
+++ b/source/rules/filters.txt
@@ -12,6 +12,8 @@ Filters
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/non-sync-rules-note.rst
+
 Overview
 --------
 

--- a/source/rules/roles.txt
+++ b/source/rules/roles.txt
@@ -13,6 +13,8 @@ Role-based Permissions
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/non-sync-rules-note.rst
+
 Overview
 --------
 

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -387,7 +387,7 @@ accidentally leak sensitive information.
 - Sync rules apply dynamically based on the value of the queryable field or 
   user metadata. One user may have full read & write access to a document 
   while another user has only read permissions or is unable to access the 
-  document entirely. You control these permissions by defining 
+  document. You control these permissions by defining 
   :ref:`JSON expressions <expressions>`.
 
 - There are no field-level permissions. Sync rules apply to all

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -377,9 +377,8 @@ You define a read and write rule expression pair for every session role.
 :ref:`Queryable fields <queryable-fields>` couple these rules to your app's data model.
 
 In response to a Flexible Sync subscription query, Realm evaluates the
-read and write rule expressions for each document that matches the query
-and only syncs to the client those documents where the rule expression
-evaluated to "true".
+read and write rule expressions for each document that matches the query.
+The client only receives documents where the rule expression evaluates to "true".
 
 Consider the following behavior when designing your schemas 
 to ensure that you have appropriate data access granularity and don't 

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -359,7 +359,7 @@ defined, session role resolution reverts to default session roles.
 
    Because session roles apply only at the session level and not on a
    per-document level, most apps only need one (default) session role
-   with more interesting per-document logic in that session role's read
+   with per-document logic in that session role's read
    and write rules. With Flexible Sync, session roles can be thought of
    as a way to group read and write rule expressions in order to manage
    your code.

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -374,8 +374,7 @@ Flexible Sync Rules
 
 You define a read and write rule expression pair for every session role.
 
-These rules are coupled to your app's data model by the :ref:`queryable
-field <queryable-fields>`.
+:ref:`Queryable fields <queryable-fields>` couple these rules to your app's data model.
 
 In response to a Flexible Sync subscription query, Realm evaluates the
 read and write rule expressions for each document that matches the query

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -254,8 +254,6 @@ other data from an authentication provider.
        partition if the partition value is listed in the
        ``data.writePartitions`` field of their user object.
 
-
-
 Function Rules
 ``````````````
 
@@ -306,8 +304,10 @@ cannot express solely in JSON expressions.
 Flexible Sync Session Roles and Rules
 -------------------------------------
 
-In flexible sync, a **session role** is a set of read and write
-permissions that Realm assigns to a user for the duration of a session.
+In flexible sync, a **session role** is a set of read and write rule
+expressions that Realm assigns to a user for the duration of a session.
+Realm evaluates these rule expressions to determine which permissions a
+user has for each document in a query result.
 
 A session role consists of:
 
@@ -334,9 +334,9 @@ they are defined in the configuration.
    because Realm only evaluates session roles at the start of a session
    -- that is, before any query for specific documents -- you can't
    refer to a document or its field values to determine whether the
-   session role applies. Therefore, most apps just use a main session
-   role and leave the per-document permission logic to that session
-   role's read and write rule expressions.
+   session role applies. Therefore, most apps just have one session role
+   and leave the per-document permission logic to that session role's
+   read and write rule expressions.
 
 The session role stays assigned for the duration of the session. If you
 make changes to an applied session role while a user is in the middle of
@@ -424,10 +424,11 @@ before and after it's modified.
 Flexible Sync Permission Strategies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These common flexible sync permission strategies rely on role names 
-stored in :ref:`custom user data <custom-user-data>`. When a logged-in 
-user's role name matches the name in the ``applyWhen`` rule, the user has 
-the corresponding read and write permissions for that role.
+These common flexible sync permission strategies rely on session role
+names stored in :ref:`custom user data <custom-user-data>`. When a
+logged-in user's session role name matches the name in the ``applyWhen``
+rule, the user has the corresponding read and write permissions for that
+session role.
 
 Admin Read/Write, User Write Self
 `````````````````````````````````
@@ -481,12 +482,13 @@ Users cannot write, even to their own documents.
 Global Admin, Department Admin, Department Member
 `````````````````````````````````````````````````
 
-In this permission strategy, users with the ``globalAdmin`` role can read and 
-write to any document. Users with the ``departmentAdmin`` role can read any
-document, but can only write to documents in their department. Users with
-the ``departmentMember`` role can read any document in their department,
-but can't write to any documents. Members can only read documents in their
-own departments; they cannot read documents for other departments.
+In this permission strategy, users with the ``globalAdmin`` session role
+can read and write to any document. Users with the ``departmentAdmin``
+session role can read any document, but can only write to documents in
+their department. Users with the ``departmentMember`` session role can
+read any document in their department, but can't write to any documents.
+Members can only read documents in their own departments; they cannot
+read documents for other departments.
 
 .. code-block:: json
 

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -254,6 +254,8 @@ other data from an authentication provider.
        partition if the partition value is listed in the
        ``data.writePartitions`` field of their user object.
 
+
+
 Function Rules
 ``````````````
 

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -20,6 +20,9 @@ MongoDB Realm enforces data access rules for all requests to a :term:`synced
 cluster`. Sync rules are dynamic :ref:`JSON expressions <expressions>` that
 specify a given user's ability to view and modify synced data.
 
+The way Sync rules work depends on whether you are using Partition-Based
+Sync or Flexible Sync.
+
 .. important:: Non-Sync Rules
    
    This page describes data access rules for synced clusters. Non-synced cluster
@@ -296,18 +299,86 @@ cannot express solely in JSON expressions.
        data in the requested partition.
 
 .. _flexible-sync-rules-and-permissions:
+.. _flexible-sync-roles:
 
-Flexible Sync Rules and Permissions
------------------------------------
+Flexible Sync Session Roles and Rules
+-------------------------------------
 
-Flexible Sync Rule Behavior
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In flexible sync, a **session role** is a set of read and write
+permissions that Realm assigns to a user for the duration of a session.
 
-You define Flexible Sync rules on a per-collection basis. They are coupled to 
-your app's data model by the :ref:`queryable field <queryable-fields>` or 
-user metadata. Realm applies the per-collection rules to each document 
-when evaluating which documents to return in response to a Flexible Sync 
-subscription query.
+A session role consists of:
+
+- A name 
+- An "apply when" :ref:`rule expression <expressions>`
+- A set of :ref:`read <flexible-sync-read-permissions>` and :ref:`write 
+  <flexible-sync-write-permissions>` rule expressions
+
+You define Flexible Sync session roles on a per-collection basis. Each
+"collection" when using Realm Sync corresponds to a Realm Object type.
+
+When a user begins a session by opening a synced realm, Realm determines
+which session role applies for the user for each collection in play.
+Realm evaluates each session role's "apply when" expression until it
+finds a matching role. Realm evaluates session roles in the order that
+they are defined in the configuration.
+
+.. tip::
+
+   Your session role "apply when" expressions can use :ref:`JSON
+   expansions <expansions>` to refer to :ref:`user metadata
+   <configure-user-metadata-on-the-backend>` and :ref:`custom user data
+   <custom-user-data>` to determine the given user's role. However,
+   because Realm only evaluates session roles at the start of a session
+   -- that is, before any query for specific documents -- you can't
+   refer to a document or its field values to determine whether the
+   session role applies. Therefore, most apps just use a main session
+   role and leave the per-document permission logic to that session
+   role's read and write rule expressions.
+
+The session role stays assigned for the duration of the session. If you
+make changes to an applied session role while a user is in the middle of
+a session, {+service-short+} does not evaluate the updated session role
+until the next time the user starts a new session. Likewise, if
+something changes that would qualify the user for a different session
+role, the user's current session role does not change until the next
+session.
+
+.. _default-roles:
+
+Default Roles
+~~~~~~~~~~~~~
+
+You can create one or more default session roles that apply across all
+collections. If a collection does not have any custom session roles
+defined, session role resolution reverts to default session roles. 
+
+.. tip::
+
+   Because session roles apply only at the session level and not on a
+   per-document level, most apps only need one (default) session role
+   with more interesting per-document logic in that session role's read
+   and write rules. With Flexible Sync, session roles can be thought of
+   as a way to group read and write rule expressions in order to manage
+   your code.
+
+.. seealso::
+
+   :ref:`flexible-sync-custom-and-default-roles`
+
+
+Flexible Sync Rules
+~~~~~~~~~~~~~~~~~~~
+
+You define a read and write rule expression pair for every session role.
+
+These rules are coupled to your app's data model by the :ref:`queryable
+field <queryable-fields>`.
+
+In response to a Flexible Sync subscription query, Realm evaluates the
+read and write rule expressions for each document that matches the query
+and only syncs to the client those documents where the rule expression
+evaluated to "true".
 
 Consider the following behavior when designing your schemas 
 to ensure that you have appropriate data access granularity and don't 
@@ -319,85 +390,15 @@ accidentally leak sensitive information.
   document entirely. You control these permissions by defining 
   :ref:`JSON expressions <expressions>`.
 
-- Sync rules apply to all documents in a query on a per-collection basis. 
-  If a user has read or write permission for a given collection, then they 
-  can read or modify all synced fields of any document that matches the 
-  sync query in the collection.
+- There are no field-level permissions. Sync rules apply to all
+  documents in a query on a per-collection basis. If a user has read or
+  write permission for a given collection, then they can read or modify
+  all synced fields of any document that matches the sync query in the
+  collection.
 
 - Write permissions require read permissions, so a user with write access to a
   collection also has read access regardless of the defined read permission
   rules.
-
-Roles
-`````
-
-When a user submits a query to the {+app+}, Sync determines which role 
-applies for the user.
-
-A role consists of:
-
-- A name 
-- An Apply When rule :ref:`expression <expressions>`
-- A set of :ref:`read <flexible-sync-read-permissions>` and :ref:`write 
-  <flexible-sync-write-permissions>` permissions
-
-A role might also include a collection name, if it is a collection-specific
-role.
-
-A role applies for the duration of the session. If you make changes to an
-applied role while a user is in the middle of a session, {+service-short+}
-does not evaluate the updated role until the next time the user starts a 
-session.
-
-Because roles apply at the collection level, a user could have different roles
-for different collections.
-
-Roles resolve to a lower level of permissions until the user's metadata 
-evaluates to ``true`` for a given role. At that point, the user receives 
-the corresponding permissions for the duration of their session.
-
-.. _default-roles:
-
-Default Roles
-`````````````
-
-You can create one or more default roles that apply across all collections. 
-If a collection does not have any custom roles defined, role resolution 
-reverts to default roles. 
-
-.. seealso::
-
-   :ref:`flexible-sync-custom-and-default-roles`
-
-.. _flexible-sync-permissions:
-
-Flexible Sync Permissions
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Realm enforces dynamic, user-specific read and write permissions to secure the
-data in each collection and query. You define permissions with :ref:`JSON 
-rule expressions <expressions>` that control whether or not a given user has 
-read or write access to the data in a given collection and query. Realm 
-evaluates a user's permissions at the beginning of each session.
-
-.. tip::
-   
-   Your rule expressions can use :ref:`JSON expansions <expansions>` to 
-   dynamically determine a user's permissions based on the context of 
-   their request. However, the user can only use expansions that do not 
-   refer directly to a document or the document's values. 
-
-Configure Flexible Sync Permissions
-```````````````````````````````````
-
-Flexible Sync rules must be configured on either:
-
-- The values of :ref:`queryable fields <queryable-fields>`
-- User data, including :ref:`metadata <configure-user-metadata-on-the-backend>`
-  and :ref:`custom user data <custom-user-data>`
-
-If you configure rules on anything else, Flexible Sync cannot assign the 
-correct role.
 
 .. _flexible-sync-read-permissions:
 
@@ -517,17 +518,18 @@ own departments; they cannot read documents for other departments.
 Custom and Default Roles
 ````````````````````````
 
-This permission strategy combines custom and default roles. The custom role 
-applies to the ``Employees`` collection. The ``Items`` collection has no
-custom role, and therefore the default role applies. The ``Store`` collection
-is not listed in the configuration, and has no custom role, so it also 
-evaluates to the default role.
+This permission strategy combines custom and default roles. The custom
+session role applies to the ``Employees`` collection. The ``Items``
+collection has no custom session role, and therefore the default role
+applies. The ``Store`` collection is not listed in the configuration,
+and has no custom session role, so it also evaluates to the default
+role.
 
-Sync attempts to find a matching role by traversing the roles in descending
-order. List the most specific custom roles first, getting gradually more 
-general, so the user "falls through" to the correct role. If no role applies,
-and you have defined a default role, the user gets the default role 
-permissions.
+Sync attempts to find a matching session role by traversing the session
+roles in descending order. List the most specific custom session roles
+first, getting gradually more general, so the user "falls through" to
+the correct session role. If no role applies, and you have defined a
+default role, the user gets the default role permissions.
 
 .. code-block:: json
 
@@ -572,8 +574,3 @@ permissions.
          ]
    }
 
-Summary
--------
-
-- **Sync rules** allow you to control who can read and write data in a given :term:`{+realm+}`.
-- You can define rules in the {+ui+} or by importing them with :term:`{+cli+}`.

--- a/source/sync/data-access-patterns/permissions.txt
+++ b/source/sync/data-access-patterns/permissions.txt
@@ -361,7 +361,7 @@ defined, session role resolution reverts to default session roles.
    per-document level, most apps only need one (default) session role
    with per-document logic in that session role's read
    and write rules. With Flexible Sync, session roles can be thought of
-   as a way to group read and write rule expressions in order to manage
+   as a way to group read and write rule expressions to organize
    your code.
 
 .. seealso::

--- a/source/sync/learn/overview.txt
+++ b/source/sync/learn/overview.txt
@@ -291,8 +291,8 @@ access patterns.
 Flexible Sync Data Access Rules
 ```````````````````````````````
 
-Flexible Sync does not require you to define a partition strategy, but
-instead enables you to specify which data to sync by querying for
+Flexible Sync does not require you to define a partition strategy.
+Instead, you specify which data to sync through queries for
 matching objects in a client application. Realm then evaluates
 :ref:`session roles and rules <flexible-sync-roles>` to determine which
 of those matching objects a user can read and write.

--- a/source/sync/learn/overview.txt
+++ b/source/sync/learn/overview.txt
@@ -291,16 +291,17 @@ access patterns.
 Flexible Sync Data Access Rules
 ```````````````````````````````
 
-Flexible Sync does not require you to define a partition strategy, but instead
-enables you to specify which data to sync by querying for matching objects 
-in a client application. Realm then evaluates :ref:`rules and roles 
-<flexible-sync-permissions>` to determine which of those matching objects 
-a user can read and write.
+Flexible Sync does not require you to define a partition strategy, but
+instead enables you to specify which data to sync by querying for
+matching objects in a client application. Realm then evaluates
+:ref:`session roles and rules <flexible-sync-roles>` to determine which
+of those matching objects a user can read and write.
 
-You can define rules on specific collections. Default roles provide read and 
-write permissions when more specific rules do not apply. Default roles apply 
-to all collections a Realm app can access, but you can restrict a rule to a 
-specific collection by specifying the collection name.
+You can define session roles on specific collections. Default roles
+provide read and write permissions when more specific session roles do
+not apply. Default roles apply to all collections a Realm app can
+access, but you can restrict a session role to a specific collection by
+specifying the collection name.
 
 Configure and Enable Sync
 -------------------------


### PR DESCRIPTION
## Pull Request Info

Updates to clarify flexible sync roles
- Rename "role" to "session role" in the context of flexible sync
- Reorganize page to put session roles first, then rules
- Add note to non-sync rules and roles content

### Jira

- https://jira.mongodb.org/browse/DOCSP-21050

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/sync-roles/sync/data-access-patterns/permissions/

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
