### PR TITLE
(DOCSP-21093): Make Jest work with Realm Sync

### DIFF
--- a/examples/node/Examples/data-types.js
+++ b/examples/node/Examples/data-types.js
@@ -54,10 +54,12 @@ const PetOwnerSchema = {
 
 describe("Node.js Data Types", () => {
   afterEach(() => {
-    realm?.write(() => {
-      realm.deleteAll();
-    });
-    realm?.close();
+    if (realm && !realm.isClosed) {
+      realm.write(() => {
+        realm.deleteAll();
+      });
+      realm.close();
+    }
   });
   test("should create, update and query Realm dictionaries", async () => {
     // :code-block-start: define-dictionary-in-schema
@@ -524,7 +526,8 @@ describe("Node.js Data Types", () => {
     // :uncomment-start:
     // const realm = await Realm.open({
     // :uncomment-end:
-    realm = await Realm.open({ // :remove:
+    realm = await Realm.open({
+      // :remove:
       schema: [characterSchema],
     });
     realm.write(() => {

--- a/examples/node/Examples/data-types.js
+++ b/examples/node/Examples/data-types.js
@@ -526,8 +526,9 @@ describe("Node.js Data Types", () => {
     // :uncomment-start:
     // const realm = await Realm.open({
     // :uncomment-end:
+    // :remove-start:
     realm = await Realm.open({
-      // :remove:
+      // :remove-end:
       schema: [characterSchema],
     });
     realm.write(() => {

--- a/examples/node/Examples/mongodb.js
+++ b/examples/node/Examples/mongodb.js
@@ -1,6 +1,8 @@
 import Realm from "realm";
 import BSON from "bson";
 
+jest.useFakeTimers();
+
 // const alphabetized = (fieldName, arr) =>
 //   arr.sort((l, r) => (l[fieldName][0] < r[fieldName][0] ? -1 : 1));
 const ObjectId = (value) => new Realm.BSON.ObjectId(value);

--- a/examples/node/Examples/realm-query-language.js
+++ b/examples/node/Examples/realm-query-language.js
@@ -24,7 +24,6 @@ describe("Realm Query Language Reference", () => {
   beforeEach(async () => {
     realm = await Realm.open({
       schema: [Project, Task],
-      inMemory: true,
     });
 
     // populate test objects
@@ -63,10 +62,12 @@ describe("Realm Query Language Reference", () => {
 
   afterEach(() => {
     // After the test, delete the objects and close the realm
-    realm.write(() => {
-      realm.deleteAll();
-    });
-    realm.close();
+    if (realm && !realm.isClosed) {
+      realm.write(() => {
+        realm.deleteAll();
+      });
+      // realm.close();
+    }
   });
 
   test("comparison queries", () => {

--- a/examples/node/jest.config.js
+++ b/examples/node/jest.config.js
@@ -9,7 +9,10 @@ module.exports = {
       moduleFileExtensions: ["js"],
       testMatch: ["<rootDir>/Examples/**/*.js"],
       setupFilesAfterEnv: ["<rootDir>/testSetup.js"],
-      modulePathIgnorePatterns: ["<rootDir>/Examples/rn"],
+      modulePathIgnorePatterns: [
+        "<rootDir>/Examples/rn",
+        "<rootDir>/Examples/server_google_auth",
+      ],
     },
     {
       displayName: "TypeScript",

--- a/examples/node/testSetup.js
+++ b/examples/node/testSetup.js
@@ -1,4 +1,3 @@
-// jest.useFakeTimers();
 jest.setTimeout(10000);
 global.console = {
   ...global.console,

--- a/examples/node/testSetup.js
+++ b/examples/node/testSetup.js
@@ -1,7 +1,8 @@
-jest.useFakeTimers();
+// jest.useFakeTimers();
+jest.setTimeout(10000);
 global.console = {
   ...global.console,
-  // "log": jest.fn(),
+  log: jest.fn(),
   error: jest.fn(),
   warn: jest.fn(),
 };


### PR DESCRIPTION
## Pull Request Info

Make Jest work with Realm Sync. Also included a couple of other Jest-related tweaks that make the unit tests work more consistently with Jest.

### Jira

- https://jira.mongodb.org/browse/DOCSP-21093

### Staged Changes (Requires MongoDB Corp SSO)

N/A

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
