### PR TITLE
(DOCSP-21139): Flutter Open & Close a Realm page

### DIFF
--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -9,7 +9,8 @@ Flutter SDK (Alpha)
    
    Install Realm for Flutter </sdk/flutter/install.txt>
    Quick Start </sdk/flutter/quick-start.txt>
-   Realm Database </sdk/flutter/realm-database.txt>
+   Realm Database Overview </sdk/flutter/realm-database.txt>
+   Open & Close a Realm </sdk/flutter/open-and-close-a-realm.txt>
    Flutter SDK Reference Manual <https://pub.dev/documentation/realm/latest/>
    Release Notes <https://github.com/realm/realm-dart/releases>
    

--- a/source/sdk/flutter/open-and-close-a-realm.txt
+++ b/source/sdk/flutter/open-and-close-a-realm.txt
@@ -1,4 +1,4 @@
-.. _flutter-install: 
+.. _flutter-open-close-realm: 
 
 ==================================
 Open & Close a Realm - Flutter SDK

--- a/source/sdk/flutter/open-and-close-a-realm.txt
+++ b/source/sdk/flutter/open-and-close-a-realm.txt
@@ -1,0 +1,40 @@
+.. _flutter-install: 
+
+==================================
+Open & Close a Realm - Flutter SDK
+==================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. _flutter-open-realm:
+
+Open a Realm
+------------
+
+Use the :flutter-sdk:`Configuration <realm/Configuration-class.html>` class
+to control the specifics of the {+realm+} you
+would like to open, including schema.
+
+Pass your configuration to the :flutter-sdk:`Realm constructor <realm/Realm-class.html>`
+to generate an instance of that {+realm+}:
+
+.. literalinclude:: /examples/generated/flutter/open_realm_test.codeblock.open-realm.dart
+   :language: dart
+
+You can now use that {+realm+} instance to work with objects in the database.
+
+.. _flutter-close-realm: 
+
+Close a Realm
+-------------
+
+Once you've finished working with a {+realm+}, close it to prevent memory leaks.  
+
+.. literalinclude:: /examples/generated/flutter/open_realm_test.codeblock.close-realm.dart
+   :language: dart


### PR DESCRIPTION
## Pull Request Info

Create Flutter 'Open & Close a Realm' page. 

note that for now the page largely duplicate of content on quickstart page, as there aren't yet advanced configuration options for Flutter realms. in the future, this page will grow with the SDK. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-21139

### Staged Changes (Requires MongoDB Corp SSO)

- [Open & Close a Realm (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21139/sdk/flutter/open-and-close-a-realm)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
