### PR TITLE
Get files in subdirectories

### DIFF
--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -5,7 +5,7 @@ name: Docusaurus Staging
 on:
   pull_request_target:
     paths:
-      - "docusaurus/*"
+      - "docusaurus/**"
 
 jobs:
   deploy:


### PR DESCRIPTION
Make Docusaurus staging action get files in subdirectories.

right now it only gets files in `docusaurus`, not `docusaurus/path/to/myfile.md`.

this should fix per https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet