### PR TITLE
Upgrade actions/checkout to v3

### DIFF
--- a/.github/workflows/bluehawk.yml
+++ b/.github/workflows/bluehawk.yml
@@ -7,7 +7,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: 15.x

--- a/.github/workflows/check-autobuilder.yml
+++ b/.github/workflows/check-autobuilder.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: [14.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/docusaurus-push-to-production.yml
+++ b/.github/workflows/docusaurus-push-to-production.yml
@@ -16,7 +16,7 @@ jobs:
       DOCUSAURUS_URL: "http://realm-io.s3-website-us-east-1.amazonaws.com"
       DOCUSAURUS_BASE_URL: "docs"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: 16.x

--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -17,6 +17,8 @@ jobs:
       - run: |
           echo "DOCUSAURUS_BASE_URL=${DOCUSAURUS_BASE_URL}"
       - uses: actions/checkout@v3
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - uses: actions/setup-node@v1
         with:
           node-version: 16.x

--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -34,7 +34,7 @@ jobs:
           SOURCE_DIR: "docusaurus/build/"
           DEST_DIR: "$DOCUSAURUS_BASE_URL"
       - run: |
-          echo "(Probably) hosted at: ${DOCUSAURUS_URL}/${DOCUSAURUS_BASE_URL}/index.html"
+          echo "Hosted at: ${DOCUSAURUS_URL}/${DOCUSAURUS_BASE_URL}/index.html"
       - name: Comment on PR
         uses: actions/github-script@0.3.0
         with:

--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - run: |
           echo "DOCUSAURUS_BASE_URL=${DOCUSAURUS_BASE_URL}"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: 16.x

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '13.2.1'

--- a/.github/workflows/java_local.yml
+++ b/.github/workflows/java_local.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: set up JDK 11
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/java_sync.yml
+++ b/.github/workflows/java_sync.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: set up JDK 11
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: run jvm commonTests
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: [14.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/push-to-artifact-repos.yml
+++ b/.github/workflows/push-to-artifact-repos.yml
@@ -12,7 +12,7 @@ jobs:
     name: Bluehawk Check Tutorials
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: 15.x
@@ -21,7 +21,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: React Native
         uses: ./.github/actions/push-to-artifact-repo
         with:


### PR DESCRIPTION
Checking if v3 supports the pull_request_target event to actually check out the PR branch by default