### PR TITLE
Only attempt to deploy from upstream

### DIFF
--- a/.github/workflows/docusaurus-push-to-production.yml
+++ b/.github/workflows/docusaurus-push-to-production.yml
@@ -10,7 +10,8 @@ on:
       - "docusaurus/**"
 
 jobs:
-  deploy:
+  production-deploy:
+    if: github.repository == 'mongodb/docs-realm'
     runs-on: ubuntu-latest
     env:
       DOCUSAURUS_URL: "http://realm-io.s3-website-us-east-1.amazonaws.com"


### PR DESCRIPTION
## Pull Request Info

Previously always failed in forks due to missing access key for S3.

Based on https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
