### PR TITLE
Fix card icons if no img provided

### DIFF
--- a/docusaurus/src/theme/DocCard/index.js
+++ b/docusaurus/src/theme/DocCard/index.js
@@ -29,11 +29,15 @@ function CardContainer({ href, children }) {
 }
 
 function CardLayout({ href, icon, title, description }) {
+  icon = "📄️🔗🗃️".includes(icon) ? (
+    icon
+  ) : (
+    <img src={useBaseUrl(`${icon}`)} style={{ height: 20, width: 20 }} />
+  );
   return (
     <CardContainer href={href}>
       <h2 className={clsx("text--truncate", styles.cardTitle)} title={title}>
-        <img src={useBaseUrl(`${icon}`)} style={{ height: 20, width: 20 }} />{" "}
-        {title}
+        {icon} {title}
       </h2>
       <div
         className={clsx("text--truncate", styles.cardDescription)}


### PR DESCRIPTION
## Pull Request Info

fix current bug where broken image appears if no img in static directory provided for homepage cards. now will default to emoji, as per original behavior. (see getting started page)
### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
