### PR TITLE
(DOCSP-21350): Update additive and destructive changes to breaking and non-breaking

### DIFF
--- a/source/includes/realm-database.rst
+++ b/source/includes/realm-database.rst
@@ -227,9 +227,12 @@ and relations between object instances.
 
 Each {+realm+} uses a versioned schema. When that schema changes, you
 must define a migration to move object data between schema versions.
-Additive schema changes happen automatically, but your SDK may require
-you to increase the local schema version to begin using the updated
-schema in your app. Destructive changes require a migration function.
+Non-breaking schema changes, also referred to as additive schema changes, 
+happen automatically. However, your SDK may require you to increase the 
+local schema version to begin using the updated schema in your app. 
+Breaking schema changes, also called destructive schema changes, require 
+a migration function.
+
 See your SDK's documentation for more information on migrations.
 
 Persistent or In-Memory Realms

--- a/source/includes/realm-database.rst
+++ b/source/includes/realm-database.rst
@@ -228,10 +228,9 @@ and relations between object instances.
 Each {+realm+} uses a versioned schema. When that schema changes, you
 must define a migration to move object data between schema versions.
 Non-breaking schema changes, also referred to as additive schema changes, 
-happen automatically. However, your SDK may require you to increase the 
-local schema version to begin using the updated schema in your app. 
-Breaking schema changes, also called destructive schema changes, require 
-a migration function.
+do not require a migration. After you increment the local schema version, 
+you can begin using the updated schema in your app. Breaking schema 
+changes, also called destructive schema changes, require a migration function.
 
 See your SDK's documentation for more information on migrations.
 

--- a/source/includes/steps-github-deploy.yaml
+++ b/source/includes/steps-github-deploy.yaml
@@ -128,12 +128,12 @@ content: |
   reference pages for details on the structure and schema of your application
   directory.
 
-  .. important:: Do not make destructive schema changes via automated deploy
+  .. important:: Do not make breaking schema changes via automated deploy
 
-     Because :ref:`destructive schema changes 
+     Because :ref:`breaking - also called destructive - schema changes 
      <destructive-changes-synced-schema>` require special handling, Realm
-     does not support making destructive schema changes via automated deploy
-     with GitHub. Instead, you should make destructive changes from the
+     does not support making breaking schema changes via automated deploy
+     with GitHub. Instead, you should make breaking changes from the
      Realm UI.
 ---
 title: Commit and Push Your Changes

--- a/source/logs/schema.txt
+++ b/source/logs/schema.txt
@@ -14,10 +14,9 @@ Overview
 --------
 
 Events related to your {+app+}'s :term:`{+backend-schema+}` create schema logs.
-This includes both breaking and non-breaking schema updates (which may appear as
-additive and destructive changes in error messaging and log entries) to tables 
-and fields, as well as the collection scans used to automatically generate 
-schemas based on the form of existing documents.
+This includes both breaking (destructive) and non-breaking (additive) 
+schema updates to tables and fields, as well as the collection scans used 
+to automatically generate schemas based on the form of existing documents.
 
 Fields
 ~~~~~~

--- a/source/logs/schema.txt
+++ b/source/logs/schema.txt
@@ -14,9 +14,10 @@ Overview
 --------
 
 Events related to your {+app+}'s :term:`{+backend-schema+}` create schema logs.
-This includes both additive and destructive schema updates to tables and fields
-as well as the collection scans used to automatically generate schemas based on
-the form of existing documents.
+This includes both breaking and non-breaking schema updates (which may appear as
+additive and destructive changes in error messaging and log entries) to tables 
+and fields, as well as the collection scans used to automatically generate 
+schemas based on the form of existing documents.
 
 Fields
 ~~~~~~

--- a/source/sdk/flutter/realm-database.txt
+++ b/source/sdk/flutter/realm-database.txt
@@ -229,7 +229,10 @@ and relations between object instances.
 
 Each {+realm+} uses a versioned schema. When that schema changes, you
 must define a migration to move object data between schema versions.
-Additive schema changes happen automatically, but your SDK may require
-you to increase the local schema version to begin using the updated
-schema in your app. Destructive changes require a migration function.
+Non-breaking schema changes, also referred to as additive schema changes, 
+happen automatically. However, your SDK may require you to increase the 
+local schema version to begin using the updated schema in your app. 
+Breaking schema changes, also called destructive schema changes, require 
+a migration function.
+
 See your SDK's documentation for more information on migrations.

--- a/source/sdk/java/advanced-guides/manual-client-reset-data-recovery.txt
+++ b/source/sdk/java/advanced-guides/manual-client-reset-data-recovery.txt
@@ -20,11 +20,11 @@ Manual Client Reset Data Recovery - Java SDK
    :ref:`discard unsynced changes <java-discard-unsynced-changes>`
    client reset strategy instead.
 
-.. warning:: Avoid Making Destructive Schema Changes in Production
+.. warning:: Avoid Making Breaking Schema Changes in Production
 
-   Do not expect to recover all unsynced data after a destructive schema
+   Do not expect to recover all unsynced data after a breaking schema
    change. The best way to preserve user data is to never make a
-   destructive schema change at all.
+   breaking - also called destructive - schema change at all.
 
 .. include:: /includes/destructive-schema-change-app-update.rst
 

--- a/source/sdk/java/examples/modify-an-object-schema.txt
+++ b/source/sdk/java/examples/modify-an-object-schema.txt
@@ -18,7 +18,8 @@ Modify an Object Schema - Java SDK
 
       The following examples demonstrate how to add, delete, and modify 
       properties in a schema. First, make the required schema change.
-      Then, increment the schema version. Finally, if the change is destructive,
+      Then, increment the schema version. Finally, if the change is 
+      breaking - also called destructive -
       create a corresponding :ref:`migration function
       <java-migration-function>` to move data from the original schema
       to the updated schema.
@@ -166,9 +167,9 @@ Modify an Object Schema - Java SDK
       You can make changes to the schema of a synchronized {+realm+} by
       modifying the :ref:`JSON Schema <configure-your-data-model>`
       defined in your application's backend. Synchronized {+realm+}s do
-      not require migration functions, since destructive changes to
+      not require migration functions, since breaking changes to
       synchronized schemas cause synchronization errors. {+sync+}
-      handles additive changes to synchronized {+realm+} schemas
+      handles non-breaking changes to synchronized {+realm+} schemas
       automatically. As a result, both old versions of your schema and
       new versions can synchronize as users upgrade their applications.
 

--- a/source/sdk/java/examples/modify-an-object-schema.txt
+++ b/source/sdk/java/examples/modify-an-object-schema.txt
@@ -19,8 +19,7 @@ Modify an Object Schema - Java SDK
       The following examples demonstrate how to add, delete, and modify 
       properties in a schema. First, make the required schema change.
       Then, increment the schema version. Finally, if the change is 
-      breaking - also called destructive -
-      create a corresponding :ref:`migration function
+      breaking (destructive) create a corresponding :ref:`migration function
       <java-migration-function>` to move data from the original schema
       to the updated schema.
 

--- a/source/sdk/java/examples/reset-a-client-realm.txt
+++ b/source/sdk/java/examples/reset-a-client-realm.txt
@@ -55,8 +55,8 @@ synced to the backend.
 
 The "discard unsynced changes" strategy can handle every kind of client
 reset error *except* for client resets triggered by
-:ref:`destructive schema changes <destructive-changes-synced-schema>`.
-If your application experiences a destructive schema change, this strategy
+:ref:`breaking or destructive schema changes <destructive-changes-synced-schema>`.
+If your application experiences a breaking schema change, this strategy
 falls back to a mode that mimics the "manually recover unsynced changes"
 strategy.
 
@@ -76,9 +76,9 @@ methods:
   a live instance of the realm in a syncable state.
 - ``onError()``: mimics the "manually recover unsynced changes"
   strategy. The SDK only calls this method when your application
-  experiences a destructive schema change. For more information on
+  experiences a breaking schema change. For more information on
   how to handle this scenario, see
-  :ref:`Discard Unsynced Changes after Destructive Schema Changes
+  :ref:`Discard Unsynced Changes after Breaking Schema Changes
   <java-discard-unsynced-changes-after-destructive-schema-changes>`.
 
 The following example implements this strategy:
@@ -101,12 +101,12 @@ The following example implements this strategy:
 
 .. _java-discard-unsynced-changes-after-destructive-schema-changes:
 
-Discard Unsynced Changes after Destructive Schema Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Discard Unsynced Changes after Breaking Schema Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/destructive-schema-change-app-update.rst
 
-If your application experiences a destructive schema change, the "discard
+If your application experiences a breaking schema change, the "discard
 unsynced changes" strategy cannot handle the resulting client reset
 automatically. Instead, you must provide a manual client reset
 implementation in the ``onError()`` method. The following

--- a/source/sdk/kotlin/realm-database/overview.txt
+++ b/source/sdk/kotlin/realm-database/overview.txt
@@ -238,9 +238,12 @@ and relations between object instances.
 
 Each {+realm+} uses a versioned schema. When that schema changes, you
 must define a migration to move object data between schema versions.
-Additive schema changes happen automatically, but your SDK may require
-you to increase the local schema version to begin using the updated
-schema in your app. Destructive changes require a migration function.
+Non-breaking schema changes, also referred to as additive schema changes, 
+happen automatically. However, your SDK may require you to increase the 
+local schema version to begin using the updated schema in your app. 
+Breaking schema changes, also called destructive schema changes, require 
+a migration function.
+
 See your SDK's documentation for more information on migrations.
 
 

--- a/source/sdk/node/examples/modify-an-object-schema.txt
+++ b/source/sdk/node/examples/modify-an-object-schema.txt
@@ -127,11 +127,13 @@ property, and then delete the old property.
 
 .. important:: Synced Realms
 
-   :ref:`Synced realms <sync>` only support additive changes to ensure that
-   older clients can sync with newer clients. Because full renames require you
-   to delete the old property, you cannot rename a synchronized property without
-   requiring a client reset. Instead, consider adding
-   the renamed property without deleting the old property.
+   :ref:`Synced realms <sync>` only support non-breaking - also called additive
+   - changes to ensure that older clients can sync with newer clients. 
+   Because full renames require you to delete the old property, you cannot 
+   rename a synchronized property without requiring a client reset. Instead, 
+   consider adding the renamed property without deleting the old property.
+   Alternately, use :ref:`mapTo <node-remap-a-property>` to store data using 
+   the existing internal name, but let your code use a different name.  
 
 Modify a Property Type
 ----------------------
@@ -142,7 +144,7 @@ callback function of the :js-sdk:`realm's configuration Object
 
 .. note::
 
-   :doc:`Synchronized realms </sync/>` only support additive changes,
+   :doc:`Synchronized realms </sync/>` only support non-breaking changes,
    to ensure that older clients can sync with newer clients. This means that
    synchronized realms do not support modifying the type of a property of a
    schema. 

--- a/source/sdk/node/fundamentals/schema-versions-and-migrations.txt
+++ b/source/sdk/node/fundamentals/schema-versions-and-migrations.txt
@@ -18,7 +18,7 @@ Schema Versions & Migrations - Node.js SDK
    Synced {+realm+}s do not have schema versions and automatically migrate
    objects to the latest schema.
    
-   Synced {+realm+}s only support additive schema changes. Destructive changes
+   Synced {+realm+}s only support non-breaking schema changes. Breaking changes
    require a client reset.
 
 .. _node-schema-version:

--- a/source/sdk/react-native/examples/modify-an-object-schema.txt
+++ b/source/sdk/react-native/examples/modify-an-object-schema.txt
@@ -125,11 +125,14 @@ property, and then delete the old property.
 
 .. important:: Synced Realms
 
-   :ref:`Synced realms <sync>` only support additive changes to ensure that
+   :ref:`Synced realms <sync>` only support non-breaking - also called additive
+   - changes to ensure that
    older clients can sync with newer clients. Because full renames require you
    to delete the old property, you cannot rename a synchronized property without
    requiring a client reset. Instead, consider adding
-   the renamed property without deleting the old property.
+   the renamed property without deleting the old property. Alternately, use 
+   :ref:`mapTo <react-native-remap-a-property>` to store data using the existing 
+   internal name, but let your code use a different name.  
 
 Modify a Property Type
 ----------------------
@@ -140,7 +143,7 @@ callback function of the :js-sdk:`realm's configuration Object
 
 .. note::
 
-   :doc:`Synchronized realms </sync/>` only support additive changes,
+   :doc:`Synchronized realms </sync/>` only support non-breaking changes,
    to ensure that older clients can sync with newer clients. This means that
    synchronized realms do not support modifying the type of a property of a
    schema. 

--- a/source/sdk/react-native/fundamentals/schema-versions-and-migrations.txt
+++ b/source/sdk/react-native/fundamentals/schema-versions-and-migrations.txt
@@ -18,7 +18,7 @@ Schema Versions & Migrations - React Native SDK
    Synced {+realm+}s do not have schema versions and automatically migrate
    objects to the latest schema.
    
-   Synced {+realm+}s only support additive schema changes. Destructive changes
+   Synced {+realm+}s only support non-breaking schema changes. Breaking changes
    require a client reset.
 
 .. _react-native-schema-version:

--- a/source/studio/modify-schema.txt
+++ b/source/studio/modify-schema.txt
@@ -15,7 +15,7 @@ Modify Schema in a Realm Studio
 Overview
 --------
 
-Realm Studio gives you tools to make additive changes to your schema. You 
+Realm Studio gives you tools to make non-breaking changes to your schema. You 
 can:
 
 - :ref:`Add classes to the schema<realm-studio-add-class-to-schema>`

--- a/source/sync/data-model/development-mode.txt
+++ b/source/sync/data-model/development-mode.txt
@@ -48,7 +48,7 @@ Update Schemas
 ~~~~~~~~~~~~~~
 
 Schemas change as applications evolve. Development mode isn't just for 
-creating schemas. You can also make additive changes to schemas in the 
+creating schemas. You can also make non-breaking changes to schemas in the 
 same way. 
 
 When you sync a {+realm+} file, {+backend+} maps every synced object type 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -57,7 +57,7 @@ with the client's history. The most common causes of client resets are:
   primary key, requires you to terminate and re-enable sync. This creates a new
   synced realm file with a version unrelated to the client's file. Because
   this scenario requires a new realm file, you can only handle client resets
-  caused by destructive changes using the :ref:`manually recover unsynced changes
+  caused by breaking changes using the :ref:`manually recover unsynced changes
   <manually-recover-unsynced-changes>` strategy.
   
   .. include:: /includes/destructive-schema-change-app-update.rst


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-21350

### Staged Changes (Requires MongoDB Corp SSO)

- [Schema Logs](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/logs/schema/): Updated intro with new language
- [Flutter Realm DB Overview](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sdk/flutter/realm-database/#schemas): Updated Schemas section with new language
- [Java SDK - Manual Client Reset Data Recovery](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sdk/java/advanced-guides/manual-client-reset-data-recovery/): Updated destructive/additive language
- [Java SDK - Modify an Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sdk/java/examples/modify-an-object-schema/): Update for new language
- [Java SDK - Reset a Client Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sdk/java/examples/reset-a-client-realm/): Update for new language
- [Kotlin SDK - Realm DB Overview](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sdk/kotlin/realm-database/overview/#schemas): Updated Schemas section with new language
- [Node SDK - Modify an Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sdk/node/examples/modify-an-object-schema/#rename-a-property): Update language around breaking/non-breaking, and add to info about renaming a property using mapTo
- [Node SDK - Schema Versions and Migrations](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sdk/node/fundamentals/schema-versions-and-migrations/): Update note to use new language
- [RN SDK - Modify an Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sdk/react-native/examples/modify-an-object-schema/): Update language around breaking/non-breaking, and add to info about renaming a property using mapTo
- [RN SDK - Schema Versions and Migrations](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sdk/react-native/fundamentals/schema-versions-and-migrations/): Update note to use new language
- [Realm Studio - Modify Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/studio/modify-schema/): Change language from "additive" to "non-breaking"
- [Sync/Development Mode -> Update Schemas](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sync/data-model/development-mode/#update-schemas): Update language in section to non-breaking
- [Sync/Client Resets](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21350/sync/error-handling/client-resets/): Update "destructive" to "breaking"

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
