### PR TITLE
(DOCSP-21443): Client reset + flex sync session role cause

### DIFF
--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -60,8 +60,14 @@ with the client's history. The most common causes of client resets are:
   caused by breaking changes using the :ref:`manually recover unsynced changes
   <manually-recover-unsynced-changes>` strategy.
 
-- **Session role changes**: If a user's :ref:`flexible sync session role <flexible-sync-roles>`
-  changes in between sync sessions, the client must perform a client reset.
+- **Session role changes**: When using flexible sync, changes to a user's
+  :ref:`flexible sync session role <flex-sync-expansions-caveat>` result
+  in a client reset. The following scenarios all result in a client reset:
+
+  - server-side modifications to the session role
+  - the value of any expansions in the "apply when", read, or
+    write expressions changes
+  - changes that qualify the user for a different session role
   
   .. include:: /includes/destructive-schema-change-app-update.rst
 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -59,6 +59,9 @@ with the client's history. The most common causes of client resets are:
   this scenario requires a new realm file, you can only handle client resets
   caused by breaking changes using the :ref:`manually recover unsynced changes
   <manually-recover-unsynced-changes>` strategy.
+
+- **Session role changes**: If a user's :ref:`flexible sync session role <flexible-sync-roles>`
+  changes in between sync sessions, the client must perform a client reset.
   
   .. include:: /includes/destructive-schema-change-app-update.rst
 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -65,8 +65,8 @@ with the client's history. The most common causes of client resets are:
   in a client reset. The following scenarios all result in a client reset:
 
   - server-side modifications to the session role
-  - the value of any expansions in the "apply when", read, or
-    write expressions changes
+  - changes to the value of any expansions in the "apply when", read, or
+    write expressions
   - changes that qualify the user for a different session role
   
   .. include:: /includes/destructive-schema-change-app-update.rst


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-21443

### Staged Changes (Requires MongoDB Corp SSO)

- [Client Resets](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21443/sync/error-handling/client-resets/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
