### PR TITLE
(DOCSP-21384): Update deprecated serverApiKey usage in JS examples to…

### DIFF
--- a/examples/node/Examples/authenticate.js
+++ b/examples/node/Examples/authenticate.js
@@ -66,7 +66,7 @@ describe("user authentication", () => {
       throw new Error("Could not find a Realm Server API Key.");
     }
     // Create an api key credential
-    const credentials = Realm.Credentials.serverApiKey(apiKey);
+    const credentials = Realm.Credentials.apiKey(apiKey);
     try {
       const user = await app.logIn(credentials);
       console.log("Successfully logged in!", user.id);

--- a/examples/node/Examples/authenticate.ts
+++ b/examples/node/Examples/authenticate.ts
@@ -62,7 +62,7 @@ describe("user authentication", () => {
       throw new Error("Could not find a Realm Server API Key.");
     }
     // Create an api key credential
-    const credentials = Realm.Credentials.serverApiKey(apiKey);
+    const credentials = Realm.Credentials.apiKey(apiKey);
     try {
       const user = await app.logIn(credentials);
       console.log("Successfully logged in!", user.id);

--- a/source/examples/generated/code/start/authenticate.codeblock.server-api-key-login.js
+++ b/source/examples/generated/code/start/authenticate.codeblock.server-api-key-login.js
@@ -4,7 +4,7 @@ if (!apiKey) {
   throw new Error("Could not find a Realm Server API Key.");
 }
 // Create an api key credential
-const credentials = Realm.Credentials.serverApiKey(apiKey);
+const credentials = Realm.Credentials.apiKey(apiKey);
 try {
   const user = await app.logIn(credentials);
   console.log("Successfully logged in!", user.id);

--- a/source/examples/generated/code/start/authenticate.codeblock.server-api-key-login.ts
+++ b/source/examples/generated/code/start/authenticate.codeblock.server-api-key-login.ts
@@ -4,7 +4,7 @@ if (!apiKey) {
   throw new Error("Could not find a Realm Server API Key.");
 }
 // Create an api key credential
-const credentials = Realm.Credentials.serverApiKey(apiKey);
+const credentials = Realm.Credentials.apiKey(apiKey);
 try {
   const user = await app.logIn(credentials);
   console.log("Successfully logged in!", user.id);

--- a/source/examples/generated/code/start/authenticate.js
+++ b/source/examples/generated/code/start/authenticate.js
@@ -75,7 +75,7 @@ describe("user authentication", () => {
       throw new Error("Could not find a Realm Server API Key.");
     }
     // Create an api key credential
-    const credentials = Realm.Credentials.serverApiKey(apiKey);
+    const credentials = Realm.Credentials.apiKey(apiKey);
     try {
       const user = await app.logIn(credentials);
       console.log("Successfully logged in!", user.id);

--- a/source/examples/generated/code/start/authenticate.ts
+++ b/source/examples/generated/code/start/authenticate.ts
@@ -74,7 +74,7 @@ describe("user authentication", () => {
       throw new Error("Could not find a Realm Server API Key.");
     }
     // Create an api key credential
-    const credentials = Realm.Credentials.serverApiKey(apiKey);
+    const credentials = Realm.Credentials.apiKey(apiKey);
     try {
       const user: Realm.User = await app.logIn(credentials);
       console.log("Successfully logged in!", user.id);


### PR DESCRIPTION
… apiKey() instead

## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-21384

### Staged Changes (Requires MongoDB Corp SSO)

- [Authenticate Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21384/sdk/node/examples/authenticate-users/#api-key-user)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
