### PR TITLE
(DOCSP-21503): Expand Open Realm docs for Flutter SDK

### DIFF
--- a/examples/dart/bin/models/car.dart
+++ b/examples/dart/bin/models/car.dart
@@ -5,7 +5,7 @@ part 'car.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late final String make;
+  late String make;
 
   late String? model;
   late int? miles;

--- a/examples/dart/bin/models/car.g.dart
+++ b/examples/dart/bin/models/car.g.dart
@@ -6,15 +6,15 @@ part of 'car.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Car extends _Car with RealmObject {
+class Car extends _Car with RealmEntity, RealmObject {
   Car(
     String make, {
     String? model,
     int? miles,
   }) {
     RealmObject.set(this, 'make', make);
-    this.model = model;
-    this.miles = miles;
+    RealmObject.set(this, 'model', model);
+    RealmObject.set(this, 'miles', miles);
   }
 
   Car._();
@@ -33,6 +33,10 @@ class Car extends _Car with RealmObject {
   int? get miles => RealmObject.get<int>(this, 'miles') as int?;
   @override
   set miles(int? value) => RealmObject.set(this, 'miles', value);
+
+  @override
+  Stream<RealmObjectChanges<Car>> get changes =>
+      RealmObject.getChanges<Car>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/examples/dart/test/define_realm_model_test.g.dart
+++ b/examples/dart/test/define_realm_model_test.g.dart
@@ -6,15 +6,15 @@ part of 'define_realm_model_test.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Car extends _Car with RealmObject {
+class Car extends _Car with RealmEntity, RealmObject {
   Car(
     String make, {
     String? model,
     int? miles,
   }) {
     RealmObject.set(this, 'make', make);
-    this.model = model;
-    this.miles = miles;
+    RealmObject.set(this, 'model', model);
+    RealmObject.set(this, 'miles', miles);
   }
 
   Car._();
@@ -33,6 +33,10 @@ class Car extends _Car with RealmObject {
   int? get miles => RealmObject.get<int>(this, 'miles') as int?;
   @override
   set miles(int? value) => RealmObject.set(this, 'miles', value);
+
+  @override
+  Stream<RealmObjectChanges<Car>> get changes =>
+      RealmObject.getChanges<Car>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/examples/dart/test/open_realm_test.dart
+++ b/examples/dart/test/open_realm_test.dart
@@ -15,5 +15,68 @@ void main() {
       // :snippet-end:
       expect(realm.isClosed, true);
     });
+
+    group('In-memory realm', () {
+      test('Configuration inMemory - no files after closing realm', () {
+        // :snippet-start: in-memory-realm
+        var config = Configuration([Car.schema], inMemory: true);
+        var realm = Realm(config);
+        // :snippet-end:
+        realm.write(() => realm.add(Car('Tesla')));
+        realm.close();
+        expect(Realm.existsSync(config.path), false);
+      });
+
+      test('Configuration inMemory can not be readOnly', () {
+        Configuration config = Configuration([Car.schema], inMemory: true);
+        var realm = Realm(config);
+
+        config.isReadOnly = true;
+        expect(
+            () => Realm(config),
+            throwsA(RealmException(
+                "Realm at path '${config.path}' already opened with different read permissions")));
+        realm.close();
+      });
+    });
+
+    group('Read-only realm', () {
+      test('Configuration readOnly - reading is possible', () {
+        Configuration initConfig = Configuration([Car.schema]);
+        var realm = Realm(initConfig);
+        realm.write(() => realm.add(Car("Mustang")));
+        realm.close();
+
+        // :snippet-start: read-only-realm
+        var config = Configuration([Car.schema], readOnly: true);
+        realm = Realm(config);
+        // :snippet-end:
+        var cars = realm.all<Car>();
+        expect(cars.isNotEmpty, true);
+        realm.close();
+      });
+
+      test('Configuration readOnly - writing on read-only Realms throws', () {
+        Configuration config = Configuration([Car.schema]);
+        var realm = Realm(config);
+        realm.close();
+
+        config = Configuration([Car.schema], readOnly: true);
+        realm = Realm(config);
+        expect(
+            () => realm.write(() {}),
+            throwsA(RealmException(
+                "Can't perform transactions on read-only Realms.")));
+        realm.close();
+      });
+    });
+    test('Configuration - FIFO files fallback path', () {
+      // :snippet-start: fifo-file
+      var config =
+          Configuration([Car.schema], fifoFilesFallbackPath: "./fifo_folder");
+      var realm = Realm(config);
+      // :snippet-end:
+      realm.close();
+    });
   });
 }

--- a/examples/dart/test/task_project_models_test.g.dart
+++ b/examples/dart/test/task_project_models_test.g.dart
@@ -6,7 +6,7 @@ part of 'task_project_models_test.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Task extends _Task with RealmObject {
+class Task extends _Task with RealmEntity, RealmObject {
   static var _defaultsSet = false;
 
   Task(
@@ -25,11 +25,11 @@ class Task extends _Task with RealmObject {
       });
     }
     RealmObject.set(this, 'id', id);
-    this.name = name;
-    this.isComplete = isComplete;
-    this.assignee = assignee;
-    this.priority = priority;
-    this.progressMinutes = progressMinutes;
+    RealmObject.set(this, 'name', name);
+    RealmObject.set(this, 'isComplete', isComplete);
+    RealmObject.set(this, 'assignee', assignee);
+    RealmObject.set(this, 'priority', priority);
+    RealmObject.set(this, 'progressMinutes', progressMinutes);
   }
 
   Task._();
@@ -66,6 +66,10 @@ class Task extends _Task with RealmObject {
   set progressMinutes(int value) =>
       RealmObject.set(this, 'progressMinutes', value);
 
+  @override
+  Stream<RealmObjectChanges<Task>> get changes =>
+      RealmObject.getChanges<Task>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -81,7 +85,7 @@ class Task extends _Task with RealmObject {
   }
 }
 
-class Project extends _Project with RealmObject {
+class Project extends _Project with RealmEntity, RealmObject {
   Project(
     int id,
     String name, {
@@ -89,9 +93,9 @@ class Project extends _Project with RealmObject {
     Iterable<Task> tasks = const [],
   }) {
     RealmObject.set(this, 'id', id);
-    this.name = name;
-    this.quota = quota;
-    RealmObject.set<List<Task>>(this, 'tasks', tasks.toList());
+    RealmObject.set(this, 'name', name);
+    RealmObject.set(this, 'quota', quota);
+    RealmObject.set<RealmList<Task>>(this, 'tasks', RealmList<Task>(tasks));
   }
 
   Project._();
@@ -107,14 +111,20 @@ class Project extends _Project with RealmObject {
   set name(String value) => RealmObject.set(this, 'name', value);
 
   @override
-  List<Task> get tasks => RealmObject.get<Task>(this, 'tasks') as List<Task>;
+  RealmList<Task> get tasks =>
+      RealmObject.get<Task>(this, 'tasks') as RealmList<Task>;
   @override
-  set tasks(covariant List<Task> value) => throw RealmUnsupportedSetError();
+  set tasks(covariant RealmList<Task> value) =>
+      throw RealmUnsupportedSetError();
 
   @override
   int? get quota => RealmObject.get<int>(this, 'quota') as int?;
   @override
   set quota(int? value) => RealmObject.set(this, 'quota', value);
+
+  @override
+  Stream<RealmObjectChanges<Project>> get changes =>
+      RealmObject.getChanges<Project>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/source/examples/generated/flutter/open_realm_test.codeblock.fifo-file.dart
+++ b/source/examples/generated/flutter/open_realm_test.codeblock.fifo-file.dart
@@ -1,0 +1,3 @@
+var config =
+    Configuration([Car.schema], fifoFilesFallbackPath: "./fifo_folder");
+var realm = Realm(config);

--- a/source/examples/generated/flutter/open_realm_test.codeblock.in-memory-realm.dart
+++ b/source/examples/generated/flutter/open_realm_test.codeblock.in-memory-realm.dart
@@ -1,0 +1,2 @@
+var config = Configuration([Car.schema], inMemory: true);
+var realm = Realm(config);

--- a/source/examples/generated/flutter/open_realm_test.codeblock.read-only-realm.dart
+++ b/source/examples/generated/flutter/open_realm_test.codeblock.read-only-realm.dart
@@ -1,0 +1,2 @@
+var config = Configuration([Car.schema], readOnly: true);
+realm = Realm(config);

--- a/source/sdk/flutter/open-and-close-a-realm.txt
+++ b/source/sdk/flutter/open-and-close-a-realm.txt
@@ -29,6 +29,53 @@ to generate an instance of that {+realm+}:
 
 You can now use that {+realm+} instance to work with objects in the database.
 
+.. _flutter-open-read-only-realm:
+
+Open a Read-Only Realm
+~~~~~~~~~~~~~~~~~~~~~~
+
+You can open an existing Realm in read-only mode. To open a read-only realm, 
+add ``readOnly: true`` to your ``Configuration`` object.
+
+
+You can only open *existing* realms in read-only mode. 
+If you try to write to a read-only realm, it throws an error. 
+
+.. literalinclude:: /examples/generated/flutter/open_realm_test.codeblock.read-only-realm.dart
+   :language: dart
+
+.. _flutter-open-in-memory-realm:
+
+Open an In-Memory Realm
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To create a realm that runs entirely in memory without being written to a file,
+add ``inMemory: true`` to your ``Configuration`` object. 
+In-memory realms **cannot** also be read-only.
+
+.. literalinclude:: /examples/generated/flutter/open_realm_test.codeblock.in-memory-realm.dart
+   :language: dart
+
+.. _flutter-set-custom-fifo:
+
+Set Custom FIFO Special Files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set a value for realm's `FIFO special files 
+<https://www.ibm.com/docs/en/zos/2.3.0?topic=csf-fifo-special-files>`_ location. 
+Opening a realm creates a number of lightweight FIFO special files 
+that coordinate access to the realm across threads and processes. 
+If the realm file is in a location that doesn't allow for the creation of 
+FIFO special files (e.g. FAT32 filesystems), then the realm cannot be opened.
+In this case, realm needs a different location to store these files. 
+Add ``fifoFilesFallbackPath: <Your Custom FIFO File Path>`` to your ``Configuration`` object.
+
+This property is ignored if the directory for the realm database file allows
+FIFO special files.
+
+.. literalinclude:: /examples/generated/flutter/open_realm_test.codeblock.fifo-file.dart
+   :language: dart
+
 .. _flutter-close-realm: 
 
 Close a Realm

--- a/source/sdk/flutter/open-and-close-a-realm.txt
+++ b/source/sdk/flutter/open-and-close-a-realm.txt
@@ -34,7 +34,7 @@ You can now use that {+realm+} instance to work with objects in the database.
 Open a Read-Only Realm
 ~~~~~~~~~~~~~~~~~~~~~~
 
-You can open an existing Realm in read-only mode. To open a read-only realm, 
+You can open an existing realm in read-only mode. To open a read-only realm, 
 add ``readOnly: true`` to your ``Configuration`` object.
 
 
@@ -61,16 +61,16 @@ In-memory realms **cannot** also be read-only.
 Set Custom FIFO Special Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Set a value for realm's `FIFO special files 
+Set a value for Realm's `FIFO special files 
 <https://www.ibm.com/docs/en/zos/2.3.0?topic=csf-fifo-special-files>`_ location. 
 Opening a realm creates a number of lightweight FIFO special files 
 that coordinate access to the realm across threads and processes. 
 If the realm file is in a location that doesn't allow for the creation of 
-FIFO special files (e.g. FAT32 filesystems), then the realm cannot be opened.
-In this case, realm needs a different location to store these files. 
+FIFO special files (such as FAT32 filesystems), then the realm cannot be opened.
+In this case, Realm needs a different location to store these files. 
 Add ``fifoFilesFallbackPath: <Your Custom FIFO File Path>`` to your ``Configuration`` object.
 
-This property is ignored if the directory for the realm database file allows
+This property is ignored if the directory for the realm file allows
 FIFO special files.
 
 .. literalinclude:: /examples/generated/flutter/open_realm_test.codeblock.fifo-file.dart


### PR DESCRIPTION
## Pull Request Info

add sections for:
* open read-only realm
* open in-memory realm
* set custom FIFO special file path

### Jira

- https://jira.mongodb.org/browse/DOCSP-21503

### Staged Changes (Requires MongoDB Corp SSO)

- [Open and Close a Realm (Flutter SDK)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21503/sdk/flutter/open-and-close-a-realm/#open-a-read-only-realm)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
