### PR TITLE
(DOCSP-21502): Query RealmList of RealmObjects - Flutter SDK

### DIFF
--- a/examples/dart/bin/models/car.g.dart
+++ b/examples/dart/bin/models/car.g.dart
@@ -6,15 +6,15 @@ part of 'car.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Car extends _Car with RealmObject {
+class Car extends _Car with RealmEntity, RealmObject {
   Car(
     String make, {
     String? model,
     int? miles,
   }) {
     RealmObject.set(this, 'make', make);
-    this.model = model;
-    this.miles = miles;
+    RealmObject.set(this, 'model', model);
+    RealmObject.set(this, 'miles', miles);
   }
 
   Car._();
@@ -33,6 +33,10 @@ class Car extends _Car with RealmObject {
   int? get miles => RealmObject.get<int>(this, 'miles') as int?;
   @override
   set miles(int? value) => RealmObject.set(this, 'miles', value);
+
+  @override
+  Stream<RealmObjectChanges<Car>> get changes =>
+      RealmObject.getChanges<Car>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/examples/dart/test/define_realm_model_test.g.dart
+++ b/examples/dart/test/define_realm_model_test.g.dart
@@ -6,15 +6,15 @@ part of 'define_realm_model_test.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Car extends _Car with RealmObject {
+class Car extends _Car with RealmEntity, RealmObject {
   Car(
     String make, {
     String? model,
     int? miles,
   }) {
     RealmObject.set(this, 'make', make);
-    this.model = model;
-    this.miles = miles;
+    RealmObject.set(this, 'model', model);
+    RealmObject.set(this, 'miles', miles);
   }
 
   Car._();
@@ -33,6 +33,10 @@ class Car extends _Car with RealmObject {
   int? get miles => RealmObject.get<int>(this, 'miles') as int?;
   @override
   set miles(int? value) => RealmObject.set(this, 'miles', value);
+
+  @override
+  Stream<RealmObjectChanges<Car>> get changes =>
+      RealmObject.getChanges<Car>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/examples/dart/test/read_write_data_test.dart
+++ b/examples/dart/test/read_write_data_test.dart
@@ -1,0 +1,46 @@
+// NOTE: most of the Read and Write Data page tests are currenty in the quick_start_test.dart
+// file, as the examples are the same.
+import 'package:test/test.dart';
+import 'package:realm_dart/realm.dart';
+
+part 'read_write_data_test.g.dart';
+
+@RealmModel()
+class _Person {
+  @PrimaryKey()
+  late String name;
+}
+
+@RealmModel()
+class _Team {
+  @PrimaryKey()
+  late String name;
+
+  late List<_Person> crew;
+}
+
+void main() {
+  group('Query Data', () {
+    test("Query List of Realm Objects", () {
+      // :snippet-start: query-realm-list
+      final config = Configuration([Person.schema, Team.schema]);
+      final realm = Realm(config);
+      final heroes = Team('Millenium Falcon Crew', crew: [
+        Person('Luke'),
+        Person('Leia'),
+        Person('Han'),
+        Person('Chewbacca')
+      ]);
+      realm.write(() => realm.add(heroes));
+
+      final lukeAndLeia = (heroes.crew).query(r'name BEGINSWITH $0', ['L']);
+      // :snippet-end:
+      expect(lukeAndLeia.length, 2);
+      expect(lukeAndLeia.query("name == 'Luke'").length, 1);
+      realm.write(() {
+        realm.deleteMany(realm.all<Person>());
+        realm.deleteMany(realm.all<Team>());
+      });
+    });
+  });
+}

--- a/examples/dart/test/read_write_data_test.g.dart
+++ b/examples/dart/test/read_write_data_test.g.dart
@@ -1,0 +1,74 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'read_write_data_test.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class Person extends _Person with RealmEntity, RealmObject {
+  Person(
+    String name,
+  ) {
+    RealmObject.set(this, 'name', name);
+  }
+
+  Person._();
+
+  @override
+  String get name => RealmObject.get<String>(this, 'name') as String;
+  @override
+  set name(String value) => throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<Person>> get changes =>
+      RealmObject.getChanges<Person>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(Person._);
+    return const SchemaObject(Person, [
+      SchemaProperty('name', RealmPropertyType.string, primaryKey: true),
+    ]);
+  }
+}
+
+class Team extends _Team with RealmEntity, RealmObject {
+  Team(
+    String name, {
+    Iterable<Person> crew = const [],
+  }) {
+    RealmObject.set(this, 'name', name);
+    RealmObject.set<RealmList<Person>>(this, 'crew', RealmList<Person>(crew));
+  }
+
+  Team._();
+
+  @override
+  String get name => RealmObject.get<String>(this, 'name') as String;
+  @override
+  set name(String value) => throw RealmUnsupportedSetError();
+
+  @override
+  RealmList<Person> get crew =>
+      RealmObject.get<Person>(this, 'crew') as RealmList<Person>;
+  @override
+  set crew(covariant RealmList<Person> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<Team>> get changes =>
+      RealmObject.getChanges<Team>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObject.registerFactory(Team._);
+    return const SchemaObject(Team, [
+      SchemaProperty('name', RealmPropertyType.string, primaryKey: true),
+      SchemaProperty('crew', RealmPropertyType.object,
+          linkTarget: 'Person', collectionType: RealmCollectionType.list),
+    ]);
+  }
+}

--- a/examples/dart/test/task_project_models_test.g.dart
+++ b/examples/dart/test/task_project_models_test.g.dart
@@ -6,7 +6,7 @@ part of 'task_project_models_test.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Task extends _Task with RealmObject {
+class Task extends _Task with RealmEntity, RealmObject {
   static var _defaultsSet = false;
 
   Task(
@@ -25,11 +25,11 @@ class Task extends _Task with RealmObject {
       });
     }
     RealmObject.set(this, 'id', id);
-    this.name = name;
-    this.isComplete = isComplete;
-    this.assignee = assignee;
-    this.priority = priority;
-    this.progressMinutes = progressMinutes;
+    RealmObject.set(this, 'name', name);
+    RealmObject.set(this, 'isComplete', isComplete);
+    RealmObject.set(this, 'assignee', assignee);
+    RealmObject.set(this, 'priority', priority);
+    RealmObject.set(this, 'progressMinutes', progressMinutes);
   }
 
   Task._();
@@ -66,6 +66,10 @@ class Task extends _Task with RealmObject {
   set progressMinutes(int value) =>
       RealmObject.set(this, 'progressMinutes', value);
 
+  @override
+  Stream<RealmObjectChanges<Task>> get changes =>
+      RealmObject.getChanges<Task>(this);
+
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
@@ -81,7 +85,7 @@ class Task extends _Task with RealmObject {
   }
 }
 
-class Project extends _Project with RealmObject {
+class Project extends _Project with RealmEntity, RealmObject {
   Project(
     int id,
     String name, {
@@ -89,9 +93,9 @@ class Project extends _Project with RealmObject {
     Iterable<Task> tasks = const [],
   }) {
     RealmObject.set(this, 'id', id);
-    this.name = name;
-    this.quota = quota;
-    RealmObject.set<List<Task>>(this, 'tasks', tasks.toList());
+    RealmObject.set(this, 'name', name);
+    RealmObject.set(this, 'quota', quota);
+    RealmObject.set<RealmList<Task>>(this, 'tasks', RealmList<Task>(tasks));
   }
 
   Project._();
@@ -107,14 +111,20 @@ class Project extends _Project with RealmObject {
   set name(String value) => RealmObject.set(this, 'name', value);
 
   @override
-  List<Task> get tasks => RealmObject.get<Task>(this, 'tasks') as List<Task>;
+  RealmList<Task> get tasks =>
+      RealmObject.get<Task>(this, 'tasks') as RealmList<Task>;
   @override
-  set tasks(covariant List<Task> value) => throw RealmUnsupportedSetError();
+  set tasks(covariant RealmList<Task> value) =>
+      throw RealmUnsupportedSetError();
 
   @override
   int? get quota => RealmObject.get<int>(this, 'quota') as int?;
   @override
   set quota(int? value) => RealmObject.set(this, 'quota', value);
+
+  @override
+  Stream<RealmObjectChanges<Project>> get changes =>
+      RealmObject.getChanges<Project>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;

--- a/source/examples/generated/flutter/read_write_data_test.codeblock.query-realm-list.dart
+++ b/source/examples/generated/flutter/read_write_data_test.codeblock.query-realm-list.dart
@@ -1,0 +1,11 @@
+final config = Configuration([Person.schema, Team.schema]);
+final realm = Realm(config);
+final heroes = Team('Millenium Falcon Crew', crew: [
+  Person('Luke'),
+  Person('Leia'),
+  Person('Han'),
+  Person('Chewbacca')
+]);
+realm.write(() => realm.add(heroes));
+
+final lukeAndLeia = (heroes.crew).query(r'name BEGINSWITH $0', ['L']);

--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -55,8 +55,6 @@ are specific configuration considerations:
 - The SDK doesn't have built-in functionality to interact with 
   :ref:`{+service+} application services<realm-cloud>`.
 
-- The SDK doesn't support Flutter on Linux desktop yet.
-
 Get Started
 -----------
 

--- a/source/sdk/flutter/read-and-write-data.txt
+++ b/source/sdk/flutter/read-and-write-data.txt
@@ -36,12 +36,24 @@ Retrieve a collection of all objects of a data model in the {+realm+} with the
 .. literalinclude:: /examples/generated/flutter/quick_start_test.codeblock.query-all-realm-objects.dart
    :language: dart
 
+.. _flutter-query-list-realm-objects:
+
+Query List of RealmObjects
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can query any list of :flutter-sdk:`RealmObjects <realm/RealmObject-mixin.html>`.
+You must cast the the list as a :flutter-sdk:`RealmList <realm/RealmList-class.html>` 
+See :ref:`Filter Results <flutter-filter-results>` for more information on querying a ``RealmList``.
+
+.. literalinclude:: /examples/generated/flutter/read_and_write_data.codeblock.query-realm-list.dart
+   :language: dart
+
 .. _flutter-filter-results:
 
 Filter Results
 ~~~~~~~~~~~~~~
 
-Filter a collection to retrieve a specific segment
+Filter a ``RealmList`` to retrieve a specific segment
 of objects with the :flutter-sdk:`Realm.query() <realm/Realm/query.html>` method.
 In the ``query()`` method's argument,
 use :ref:`Realm Query Language operators<flutter-query-language>` to perform filtering.

--- a/source/sdk/flutter/read-and-write-data.txt
+++ b/source/sdk/flutter/read-and-write-data.txt
@@ -42,8 +42,7 @@ Query List of RealmObjects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can query any list of :flutter-sdk:`RealmObjects <realm/RealmObject-mixin.html>`.
-You must cast the the list as a :flutter-sdk:`RealmList <realm/RealmList-class.html>` 
-See :ref:`Filter Results <flutter-filter-results>` for more information on querying a ``RealmList``.
+For more information on querying, see :ref:`Filter Results <flutter-filter-results>`.
 
 .. literalinclude:: /examples/generated/flutter/read_write_data_test.codeblock.query-realm-list.dart
    :language: dart

--- a/source/sdk/flutter/read-and-write-data.txt
+++ b/source/sdk/flutter/read-and-write-data.txt
@@ -45,7 +45,7 @@ You can query any list of :flutter-sdk:`RealmObjects <realm/RealmObject-mixin.ht
 You must cast the the list as a :flutter-sdk:`RealmList <realm/RealmList-class.html>` 
 See :ref:`Filter Results <flutter-filter-results>` for more information on querying a ``RealmList``.
 
-.. literalinclude:: /examples/generated/flutter/read_and_write_data.codeblock.query-realm-list.dart
+.. literalinclude:: /examples/generated/flutter/read_write_data_test.codeblock.query-realm-list.dart
    :language: dart
 
 .. _flutter-filter-results:


### PR DESCRIPTION
## Pull Request Info

Add docs for querying RealmList of RealmObjects.

also removed note about flutter for linux desktop not being supported 

### Jira

- https://jira.mongodb.org/browse/DOCSP-21502

### Staged Changes (Requires MongoDB Corp SSO)

- [Read and Write Data (Flutter SDK)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21502/sdk/flutter/read-and-write-data/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
