### PR TITLE
(DOCSP-21579): [Java] Add note about ISRG Root X1 certificate w/Android 6 devices

### DIFF
--- a/source/includes/android-6-trusted-certificate.rst
+++ b/source/includes/android-6-trusted-certificate.rst
@@ -1,0 +1,8 @@
+.. important:: Android 6 and Below
+   
+   Realm Cloud Services use certificates signed with the 
+   `ISRG Root X1 certificate <https://letsencrypt.org/certificates/>`__. 
+   This may prevent Android devices at version 6 or below from connecting 
+   to Realm Cloud Services. To connect, ensure that any devices running 
+   Android 6 or lower have the ISRG Root X1 certificate in their trusted 
+   certificate store.

--- a/source/sdk/java/install.txt
+++ b/source/sdk/java/install.txt
@@ -22,6 +22,8 @@ Prerequisites
 - An emulated or hardware Android device for testing.
 - Android API Level 16 or higher (Android 4.1 and above).
 
+.. include:: /includes/android-6-trusted-certificate.rst
+
 Installation
 ------------
 

--- a/source/sdk/java/troubleshooting.txt
+++ b/source/sdk/java/troubleshooting.txt
@@ -142,3 +142,8 @@ Possible causes include:
 
 If you experience this error, check any recent updates to your schema for
 problems.
+
+Android 6 or Lower Devices Can't Connect to Realm Cloud Services
+----------------------------------------------------------------
+
+.. include:: /includes/android-6-trusted-certificate.rst


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-21579

### Staged Changes (Requires MongoDB Corp SSO)

(This is the same `/include` on two different pages)

- [Install](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21579/sdk/java/install/#prerequisites): Added as an include in Prerequisites
- [Troubleshooting](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21579/sdk/java/troubleshooting/#android-6-or-lower-devices-can-t-connect-to-realm-cloud-services): New section with this info

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
