### PR TITLE
(DOCSP-21675): [Swift] Add info about only using realm on a serial queue

### DIFF
--- a/examples/ios/Examples/Threading.swift
+++ b/examples/ios/Examples/Threading.swift
@@ -259,14 +259,6 @@ class Threading: XCTestCase {
             let realm = try! Realm(configuration: .defaultConfiguration, queue: serialQueue)
             // Do something with Realm on the non-main thread
         }
-        // This does not work. Realm does not support concurrent
-        // queues, and 'global()' is a concurrent queue.
-        // DispatchQueue.global().async {
-        //     autoreleasepool{
-        //          try! Realm()
-        //          // Do something with Realm on the non-main thread
-        //     }
-        // }
         // :code-block-end:
     }
 }

--- a/examples/ios/Examples/Threading.swift
+++ b/examples/ios/Examples/Threading.swift
@@ -251,7 +251,6 @@ class Threading: XCTestCase {
     }
 
     func testCreateSerialQueueToUseRealm() {
-        let expectation = XCTestExpectation(description: "it completes")
         // :code-block-start: use-realm-with-serial-queue
         // Initialize a serial queue, and
         // perform realm operations on it
@@ -268,9 +267,7 @@ class Threading: XCTestCase {
         //          // Do something with Realm on the non-main thread
         //     }
         // }
-        expectation.fulfill() // :remove:
         // :code-block-end:
-        wait(for: [expectation], timeout: 10)
     }
 }
 

--- a/examples/ios/Examples/Threading.swift
+++ b/examples/ios/Examples/Threading.swift
@@ -249,6 +249,29 @@ class Threading: XCTestCase {
         // :code-block-end:
         wait(for: [expectation], timeout: 10)
     }
+
+    func testCreateSerialQueueToUseRealm() {
+        let expectation = XCTestExpectation(description: "it completes")
+        // :code-block-start: use-realm-with-serial-queue
+        // Initialize a serial queue, and
+        // perform realm operations on it
+        let serialQueue = DispatchQueue(label: "serial-queue")
+        serialQueue.async {
+            let realm = try! Realm(configuration: .defaultConfiguration, queue: serialQueue)
+            // Do something with Realm on the non-main thread
+        }
+        // This does not work. Realm does not support concurrent
+        // queues, and 'global()' is a concurrent queue.
+        // DispatchQueue.global().async {
+        //     autoreleasepool{
+        //          try! Realm()
+        //          // Do something with Realm on the non-main thread
+        //     }
+        // }
+        expectation.fulfill() // :remove:
+        // :code-block-end:
+        wait(for: [expectation], timeout: 10)
+    }
 }
 
 // :replace-end:

--- a/source/examples/generated/code/start/Threading.codeblock.use-realm-with-serial-queue.swift
+++ b/source/examples/generated/code/start/Threading.codeblock.use-realm-with-serial-queue.swift
@@ -5,11 +5,3 @@ serialQueue.async {
     let realm = try! Realm(configuration: .defaultConfiguration, queue: serialQueue)
     // Do something with Realm on the non-main thread
 }
-// This does not work. Realm does not support concurrent
-// queues, and 'global()' is a concurrent queue.
-// DispatchQueue.global().async {
-//     autoreleasepool{
-//          try! Realm()
-//          // Do something with Realm on the non-main thread
-//     }
-// }

--- a/source/examples/generated/code/start/Threading.codeblock.use-realm-with-serial-queue.swift
+++ b/source/examples/generated/code/start/Threading.codeblock.use-realm-with-serial-queue.swift
@@ -1,0 +1,15 @@
+// Initialize a serial queue, and
+// perform realm operations on it
+let serialQueue = DispatchQueue(label: "serial-queue")
+serialQueue.async {
+    let realm = try! Realm(configuration: .defaultConfiguration, queue: serialQueue)
+    // Do something with Realm on the non-main thread
+}
+// This does not work. Realm does not support concurrent
+// queues, and 'global()' is a concurrent queue.
+// DispatchQueue.global().async {
+//     autoreleasepool{
+//          try! Realm()
+//          // Do something with Realm on the non-main thread
+//     }
+// }

--- a/source/sdk/swift/advanced-guides/threading.txt
+++ b/source/sdk/swift/advanced-guides/threading.txt
@@ -122,6 +122,18 @@ several options depending on your use case:
 - To keep and share many read-only views of the object in your app, copy
   the object from the {+realm+}.
 
+.. _ios-use-serial-queues-for-non-main-threads:
+
+Create a Serial Queue to use Realm on a Background Thread
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using Realm on a background thread, create a serial queue. Realm Database 
+does not support using realms in concurrent queues, such as the ``global()`` 
+queue.
+
+.. literalinclude:: /examples/generated/code/start/Threading.codeblock.use-realm-with-serial-queue.swift
+   :language: swift
+
 .. _ios-thread-safe-reference:
 
 Pass Instances Across Threads


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-21675

### Staged Changes (Requires MongoDB Corp SSO)

- [Threading](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21675/sdk/swift/advanced-guides/threading/#create-a-serial-queue-to-use-realm-on-a-background-thread): Add section about Realm only supporting serial queues for background activity

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
