### PR TITLE
(DOCSP-21660): Increase external dependency size cap to 15MB

### DIFF
--- a/source/functions/add-external-dependencies.txt
+++ b/source/functions/add-external-dependencies.txt
@@ -79,7 +79,7 @@ Upload Zipped node_modules (Legacy)
 -----------------------------------
 
 You must first upload an archive of an npm ``node_modules`` folder. 
-Uploaded ``node_modules`` archive files are subject to a 10MB size cap.
+Uploaded ``node_modules`` archive files are subject to a 15MB size cap.
 
 .. important:: Overriding Existing Dependencies
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-21660

### Staged Changes (Requires MongoDB Corp SSO)

- [Add External Dependencies](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21660/functions/add-external-dependencies/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
