### PR TITLE
(DOCSP-21708): Use endpoints `response` object with  function returns as body

### DIFF
--- a/source/endpoints.txt
+++ b/source/endpoints.txt
@@ -187,6 +187,14 @@ The second argument of an endpoint function is a ``response`` object
 that represents HTTPS response sent back to the caller. The object
 includes methods that you can call to configure the response.
 
+.. note:: Difference in Response Converting from Webhooks to Endpoints
+
+   If you're :ref:`converting your webhooks to endpoints <convert-webhooks-to-endpoints>`, 
+   there can be slight differences in behavior for how your Realm function
+   handles the the HTTP response. For more information, refer to the documentation on 
+   :ref:`differences between webhooks and their converted endpoints 
+   <differences-webhooks-converted-endpoints>`.
+
 .. list-table::
    :header-rows: 1
    :widths: 40 60

--- a/source/includes/steps-create-an-endpoint-cli.yaml
+++ b/source/includes/steps-create-an-endpoint-cli.yaml
@@ -21,7 +21,7 @@ content: |
   To create a new endpoint, add an :ref:`endpoint configuration
   <appconfig-endpoints>` object to the array in
   :file:`/http_endpoints/config.json`.
-  
+
   The configuration file has the following form:
 
   .. code-block:: json
@@ -47,7 +47,7 @@ content: |
   An endpoint's route determines the URL used to call the endpoint. You
   can define at most one handler for a given route and HTTP method
   combination in your app.
-  
+
   1. Enter a name for the endpoint in ``route`` field. Route
      names must begin with a forward slash (``/``) and may contain
      additional forward slashes to indicate a nested path.
@@ -85,14 +85,15 @@ ref: configure-the-endpoint-response
 content: |
   To send an :mdn:`HTTP Response <Web/HTTP/Messages#HTTP_Responses>` to
   clients that call the endpoint, set ``respond_result`` to ``true``.
-  
+
   By default, the endpoint responds to incoming requests with a basic
   :mdn:`HTTP 200 <Web/HTTP/Status/200>` response that includes the
   endpoint function return value as its ``body`` field.
-  
+
   You can configure a custom HTTP response from within the endpoint
-  function using the ``response`` object. For more information, see
-  :ref:`endpoint-response-object`.
+  function using the ``response`` object. If you use ``response.setBody(value)``,
+  the endpoint returns that value, not the function return value.
+  For more information, see :ref:`endpoint-response-object`.
 ---
 title: Configure Request Authorization
 ref: configure-request-authorization
@@ -154,7 +155,7 @@ content: |
   it calls for each incoming request. You can either :ref:`define a new
   function <create-a-function>` or reference an existing function by
   name.
-  
+
   Endpoint functions have the following signature:
 
   .. code-block:: javascript
@@ -162,7 +163,7 @@ content: |
      exports = async function(request, response) {
        // ... your code here
      }
-  
+
   {+service-short+} calls endpoint functions with two arguments:
 
   .. list-table::
@@ -221,7 +222,7 @@ content: |
   function that they call. To configure an endpoint's user
   authentication, :ref:`modify the underlying function
   <create-a-function>`.
-  
+
   For more information on how to authenticate endpoint requests, see
   :ref:`Endpoint Authentication <endpoint-authentication>`.
 ---

--- a/source/includes/steps-create-an-endpoint-ui.yaml
+++ b/source/includes/steps-create-an-endpoint-ui.yaml
@@ -17,7 +17,7 @@ content: |
   An endpoint's route determines the URL used to call the endpoint. You
   can define at most one handler for a given route and HTTP method
   combination in your app.
-  
+
   1. Enter a name for the endpoint in the :guilabel:`Route` field. Route
      names must begin with a forward slash (``/``) and may contain
      additional forward slashes to indicate a nested path.
@@ -42,14 +42,15 @@ content: |
   To send an :mdn:`HTTP Response <Web/HTTP/Messages#HTTP_Responses>` to
   clients that call the endpoint, enable :guilabel:`Respond With
   Result`.
-  
+
   By default, the endpoint responds to incoming requests with a basic
   :mdn:`HTTP 200 <Web/HTTP/Status/200>` response that includes the
   endpoint function return value as its ``body`` field.
-  
+
   You can configure a custom HTTP response from within the endpoint
-  function using the ``response`` object. For more information, see
-  :ref:`endpoint-response-object`.
+  function using the ``response`` object. If you use ``response.setBody(value)``,
+  the endpoint returns that value, not the function return value.
+  For more information, see :ref:`endpoint-response-object`.
 ---
 title: Configure Request Authorization
 ref: configure-request-authorization
@@ -89,7 +90,7 @@ content: |
   Every endpoint is associated with a :ref:`function <functions>` that
   it calls for each incoming request. You can either :ref:`define a new
   function <create-a-function>` or reference an existing function by name.
-  
+
   Endpoint functions have the following signature:
 
   .. code-block:: javascript
@@ -97,7 +98,7 @@ content: |
      exports = async function(request, response) {
        // ... your code here
      }
-  
+
   {+service-short+} calls endpoint functions with two arguments:
 
   .. list-table::
@@ -156,7 +157,7 @@ content: |
   function that they call. To configure an endpoint's user
   authentication, :ref:`modify the underlying function configuration
   <create-a-function>`.
-  
+
   For more information on how to authenticate endpoint requests, see
   :ref:`Endpoint Authentication <endpoint-authentication>`.
 ---
@@ -166,4 +167,3 @@ content: |
   You must save changes to your endpoint before they take effect. To do
   so, click :guilabel:`Save` from either the :guilabel:`Settings` screen
   or the :guilabel:`Function Editor`.
-...

--- a/source/services/convert-webhooks-to-endpoints.txt
+++ b/source/services/convert-webhooks-to-endpoints.txt
@@ -187,7 +187,9 @@ To migrate to the converted HTTPS endpoint URLs:
       
       https://data.mongodb-api.com/app/myapp-abcde/endpoint/myHttpService/handleIncomingEvent
 
-Differing Behavior between Webhooks and Their Converted Endpoints
+.. _differences-webhooks-converted-endpoints: 
+
+Differences between Webhooks and Their Converted Endpoints
 -----------------------------------------------------------------
 
 If you configured your converted HTTPS endpoint to use :ref:`Respond with Result <configure-endpoints>`

--- a/source/services/convert-webhooks-to-endpoints.txt
+++ b/source/services/convert-webhooks-to-endpoints.txt
@@ -190,9 +190,25 @@ To migrate to the converted HTTPS endpoint URLs:
 .. _differences-webhooks-converted-endpoints: 
 
 Differences between Webhooks and Their Converted Endpoints
------------------------------------------------------------------
+----------------------------------------------------------
 
 If you configured your converted HTTPS endpoint to use :ref:`Respond with Result <configure-endpoints>`
 and the webhook function it's based on returns a value but does not invoke ``response.setBody()``,
 the generated endpoint includes the function's return value as its response body.
 The webhook, in contrast, only returns a body specified by ``response.setBody()``.
+
+.. example:: 
+
+   .. code-block:: javascript
+
+      exports = function({ query, headers, body}, response){
+         response.setStatusCode(200);
+         return "Hello world";
+      };
+   
+   The webhook for this function only responds with status code ``200`` without a body.
+
+   For the endpoint, if you enable **Respond with Result**, the endpoint responds 
+   with status code ``200`` *and* the body ``"Hello world"``. 
+   If you don't enable **Respond with Result**, the endpoint only responds 
+   with status code ``200``. 

--- a/source/services/convert-webhooks-to-endpoints.txt
+++ b/source/services/convert-webhooks-to-endpoints.txt
@@ -186,3 +186,11 @@ To migrate to the converted HTTPS endpoint URLs:
       :caption: Converted HTTPS Endpoint URL
       
       https://data.mongodb-api.com/app/myapp-abcde/endpoint/myHttpService/handleIncomingEvent
+
+Differing Behavior between Webhooks and Their Converted Endpoints
+-----------------------------------------------------------------
+
+If you’ve configured your HTTPS endpoint to use :ref:`Respond with Result <configure-endpoints>`,
+and your webhook function returns a result but does not invoke ``response.setBody()``,
+the generated endpoint will return the function value.
+The webhook, in contrast, only returns values specified by ``response.setBody()``.

--- a/source/services/convert-webhooks-to-endpoints.txt
+++ b/source/services/convert-webhooks-to-endpoints.txt
@@ -190,7 +190,7 @@ To migrate to the converted HTTPS endpoint URLs:
 Differing Behavior between Webhooks and Their Converted Endpoints
 -----------------------------------------------------------------
 
-If you’ve configured your HTTPS endpoint to use :ref:`Respond with Result <configure-endpoints>`,
+If you’ve configured your converted HTTPS endpoint to use :ref:`Respond with Result <configure-endpoints>`
 and your webhook function returns a result but does not invoke ``response.setBody()``,
-the generated endpoint will return the function value.
-The webhook, in contrast, only returns values specified by ``response.setBody()``.
+the generated endpoint will return the function value as the response body.
+The webhook, in contrast, only returns a body specified by ``response.setBody()``.

--- a/source/services/convert-webhooks-to-endpoints.txt
+++ b/source/services/convert-webhooks-to-endpoints.txt
@@ -190,7 +190,7 @@ To migrate to the converted HTTPS endpoint URLs:
 Differing Behavior between Webhooks and Their Converted Endpoints
 -----------------------------------------------------------------
 
-If you’ve configured your converted HTTPS endpoint to use :ref:`Respond with Result <configure-endpoints>`
-and your webhook function returns a result but does not invoke ``response.setBody()``,
-the generated endpoint will return the function value as the response body.
+If you configured your converted HTTPS endpoint to use :ref:`Respond with Result <configure-endpoints>`
+and the webhook function it's based on returns a value but does not invoke ``response.setBody()``,
+the generated endpoint includes the function's return value as its response body.
 The webhook, in contrast, only returns a body specified by ``response.setBody()``.


### PR DESCRIPTION
## Pull Request Info

update docs to reflect the fact that users can use the endpoint function return value along with the function's `response` object methods. 

(previously it'd been only the response object or the endpoint function return value, not combo of both)

### Jira

- https://jira.mongodb.org/browse/DOCSP-21708

### Staged Changes (Requires MongoDB Corp SSO)

- [Create HTTPS Endpoint](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21708/endpoints/configure/#configure-the-endpoint-response)
- [Convert Webhooks to Endpoints](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21708/services/convert-webhooks-to-endpoints/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
