### PR TITLE
(DOCSP-20792): RN/Node "Sync Changes between Devices" page clarifications

### DIFF
--- a/source/sdk/node/examples/sync-changes-between-devices.txt
+++ b/source/sdk/node/examples/sync-changes-between-devices.txt
@@ -191,12 +191,12 @@ your :js-sdk:`Realm.App <Realm.App.html>`.
 Multiplex Sync Sessions
 -----------------------
 
-To enable session multiplexing, call :js-sdk:`Realm.App.Sync.enableSessionMultiplexing() <Realm.App.Sync.html#.enableSessionMultiplexing>` with your :js-sdk:`Realm.App <Realm.App.html>`. 
+Enable :wikipedia:`session multiplexing <Session_multiplexing>` for multiple sync sessions of a Realm app. 
+Only use session multiplexing if you see errors about reaching the file descriptor limit,
+and you know you are using many sync sessions.
 
-.. warning::
-
-   Only use session multiplexing if you see errors about reaching the file descriptor limit,
-   and you know you are using many sync sessions.
+To enable session multiplexing, call :js-sdk:`Realm.App.Sync.enableSessionMultiplexing()
+<Realm.App.Sync.html#.enableSessionMultiplexing>` with your :js-sdk:`Realm.App <Realm.App.html>`. 
 
 .. example::
    

--- a/source/sdk/node/examples/sync-changes-between-devices.txt
+++ b/source/sdk/node/examples/sync-changes-between-devices.txt
@@ -94,15 +94,6 @@ downloading any existing data from the server in the background.
 .. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-sync-changes-in-the-background-open-realm.js
       :language: javascript
 
-
-.. warning:: Read-only Realms Must Not Be Synced in the Background
-
-   If a {+realm+} has read-only {+realm+} level permissions, then you must
-   asynchronously open the {+realm+}. Opening a file-level read-only {+realm+}
-   without the asynchronous API will cause an error if your session is online.
-   Synced realms are opened asynchronously by default. Learn how to :ref:`open a
-   synced {+realm+} <node-partition-sync-open-realm>`.
-
 .. _node-pause-or-resume-a-sync-session:
 
 Pause or Resume a Sync Session

--- a/source/sdk/node/examples/sync-changes-between-devices.txt
+++ b/source/sdk/node/examples/sync-changes-between-devices.txt
@@ -191,7 +191,8 @@ your :js-sdk:`Realm.App <Realm.App.html>`.
 Multiplex Sync Sessions
 -----------------------
 
-Enable :wikipedia:`session multiplexing <Session_multiplexing>` for multiple sync sessions of a Realm app. 
+Enable :wikipedia:`session multiplexing <Session_multiplexing>` to consolidate
+multiple sync sessions of a Realm app. 
 Only use session multiplexing if you see errors about reaching the file descriptor limit,
 and you know you are using many sync sessions.
 

--- a/source/sdk/node/examples/sync-changes-between-devices.txt
+++ b/source/sdk/node/examples/sync-changes-between-devices.txt
@@ -124,9 +124,18 @@ notification using the :js-sdk:`syncSession.addProgressNotification() <Realm.App
 
 The ``syncSession.addProgressNotification()`` method takes in the following three parameters:
 
-- A ``direction`` parameter that can be set to ``"upload"`` or ``"download"`` to register notifications for either event.
-- A ``mode`` parameter that can be set to ``"reportIndefinitely"`` (for the notifications to continue until the callback is unregistered using the :js-sdk:`syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>` method), or ``"forCurrentlyOutstandingWork"`` (for the notifications to continue until only the currently transferable bytes are synced).
-- A callback parameter with the arguments ``transferred`` and ``transferable``, representing the current number of bytes already transferred and the number of transferable bytes (the number of bytes already transferred plus the number of bytes pending transfer), respectively.
+- A ``direction`` parameter. 
+  Set to ``"upload"`` to register notifications for uploading data. 
+  Set to ``"download"`` to register notifications for downloading data.
+- A ``mode`` parameter. Set to ``"reportIndefinitely"`` 
+  for the notifications to continue until the callback is unregistered using
+  :js-sdk:`syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
+  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
+  until only the currently transferable bytes are synced.
+- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
+  ``transferred`` is the current number of bytes already transferred.
+  ``transferable`` is the total number of bytes already transferred
+  plus the number of bytes pending transfer.
 
 .. example::
 

--- a/source/sdk/react-native/examples/sync-changes-between-devices.txt
+++ b/source/sdk/react-native/examples/sync-changes-between-devices.txt
@@ -190,12 +190,12 @@ your :js-sdk:`Realm.App <Realm.App.html>`.
 Multiplex Sync Sessions
 -----------------------
 
-To enable session multiplexing, call :js-sdk:`Realm.App.Sync.enableSessionMultiplexing() <Realm.App.Sync.html#.enableSessionMultiplexing>` with your :js-sdk:`Realm.App <Realm.App.html>`. 
+Enable :wikipedia:`session multiplexing <Session_multiplexing>` for multiple sync sessions of a Realm app. 
+Only use session multiplexing if you see errors about reaching the file descriptor limit,
+and you know you are using many sync sessions.
 
-.. warning::
-
-   Only use session multiplexing if you see errors about reaching the file descriptor limit,
-   and you know you are using many sync sessions.
+To enable session multiplexing, call :js-sdk:`Realm.App.Sync.enableSessionMultiplexing()
+<Realm.App.Sync.html#.enableSessionMultiplexing>` with your :js-sdk:`Realm.App <Realm.App.html>`. 
 
 .. example::
    

--- a/source/sdk/react-native/examples/sync-changes-between-devices.txt
+++ b/source/sdk/react-native/examples/sync-changes-between-devices.txt
@@ -190,7 +190,8 @@ your :js-sdk:`Realm.App <Realm.App.html>`.
 Multiplex Sync Sessions
 -----------------------
 
-Enable :wikipedia:`session multiplexing <Session_multiplexing>` for multiple sync sessions of a Realm app. 
+Enable :wikipedia:`session multiplexing <Session_multiplexing>` to consolidate
+multiple sync sessions of a Realm app.
 Only use session multiplexing if you see errors about reaching the file descriptor limit,
 and you know you are using many sync sessions.
 

--- a/source/sdk/react-native/examples/sync-changes-between-devices.txt
+++ b/source/sdk/react-native/examples/sync-changes-between-devices.txt
@@ -93,15 +93,6 @@ downloading any existing data from the server in the background.
 .. literalinclude:: /examples/generated/node/sync-changes-between-devices.codeblock.sync-changes-between-devices-sync-changes-in-the-background-open-realm.js
       :language: javascript
 
-
-.. warning:: Read-only Realms Must Not Be Synced in the Background
-
-   If a {+realm+} has read-only {+realm+} level permissions, then you must
-   asynchronously open the {+realm+}. Opening a file-level read-only {+realm+}
-   without the asynchronous API will cause an error if your session is online.
-   Synced realms are opened asynchronously by default. Learn how to :ref:`open a
-   synced {+realm+} <react-native-partition-sync-open-realm>`.
-
 .. _react-native-pause-or-resume-a-sync-session:
 
 Pause or Resume a Sync Session

--- a/source/sdk/react-native/examples/sync-changes-between-devices.txt
+++ b/source/sdk/react-native/examples/sync-changes-between-devices.txt
@@ -123,9 +123,18 @@ notification using the :js-sdk:`syncSession.addProgressNotification() <Realm.App
 
 The ``syncSession.addProgressNotification()`` method takes in the following three parameters:
 
-- A ``direction`` parameter that can be set to ``"upload"`` or ``"download"`` to register notifications for either event.
-- A ``mode`` parameter that can be set to ``"reportIndefinitely"`` (for the notifications to continue until the callback is unregistered using the :js-sdk:`syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>` method), or ``"forCurrentlyOutstandingWork"`` (for the notifications to continue until only the currently transferable bytes are synced).
-- A callback parameter with the arguments ``transferred`` and ``transferable``, representing the current number of bytes already transferred and the number of transferable bytes (the number of bytes already transferred plus the number of bytes pending transfer), respectively.
+- A ``direction`` parameter. 
+  Set to ``"upload"`` to register notifications for uploading data. 
+  Set to ``"download"`` to register notifications for downloading data.
+- A ``mode`` parameter. Set to ``"reportIndefinitely"`` 
+  for the notifications to continue until the callback is unregistered using
+  :js-sdk:`syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
+  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
+  until only the currently transferable bytes are synced.
+- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
+  ``transferred`` is the current number of bytes already transferred.
+  ``transferable`` is the total number of bytes already transferred
+  plus the number of bytes pending transfer.
 
 .. example::
 


### PR DESCRIPTION
## Pull Request Info

Couple of small clarifications to the RN and Node "Sync Changes between Devices" page:

1. bit of clarification regarding what session multiplexing is and when to use
2. remove unclear note abt deprecated `new Realm()` method to open realms
3. clarify description of parameters for `syncSession.addProgressNotification()`
 

### Jira

- https://jira.mongodb.org/browse/DOCSP-20792

### Staged Changes (Requires MongoDB Corp SSO)

- [Sync Changes between Devices (Node)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20792/sdk/node/examples/sync-changes-between-devices/)
- [Sync Changes between Devices (RN)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20792/sdk/react-native/examples/sync-changes-between-devices/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
