### PR TITLE
(DOCSP-22031): Add client reset warning to docs that mention terminating sync

### DIFF
--- a/source/includes/warn-terminate-sync-client-reset.rst
+++ b/source/includes/warn-terminate-sync-client-reset.rst
@@ -1,0 +1,32 @@
+.. warning:: Recovering Unsynchronized Changes after Terminating Sync
+ 
+ Terminating and re-enabling {+sync+} prevents unsynchronized client changes
+ from automatically syncing. To recover any unsynchronized changes, implement a
+ manual client reset that handles this case in your client applications:
+
+ .. tabs-realm-sdks::
+
+   .. tab::
+      :tabid: android
+
+      Learn how to perform a :ref:`Client Reset using the Java SDK <java-client-resets>`.
+
+   .. tab::
+      :tabid: ios
+
+      Learn how to perform a :ref:`Client Reset using the Swift SDK <ios-client-resets>`.
+
+   .. tab::
+      :tabid: node
+      
+      Learn how to perform a :ref:`Client Reset using the Node SDK <node-client-resets>`.
+
+   .. tab::
+      :tabid: react-native
+      
+      Learn how to perform a :ref:`Client Reset using the React Native SDK <react-native-client-resets>`.
+
+   .. tab::
+      :tabid: dotnet
+
+      Learn how to perform a :ref:`Client Reset using the .NET SDK <dotnet-client-reset>`.

--- a/source/reference/upgrade-shared-cluster.txt
+++ b/source/reference/upgrade-shared-cluster.txt
@@ -25,6 +25,8 @@ Sync application by completing the following steps.
    To avoid data loss, upgrade to a dedicated tier cluster before releasing your
    application.
 
+.. include:: /includes/warn-terminate-sync-client-reset.rst
+
 Procedure
 ---------
 

--- a/source/sync/configure/pause-or-terminate-sync.txt
+++ b/source/sync/configure/pause-or-terminate-sync.txt
@@ -136,38 +136,7 @@ terminate and re-enable {+sync+} under a few different circumstances:
 - A paused {+sync+} session on a shared tier cluster due to infrequent usage 
 - Troubleshooting, at the request of MongoDB Support
 
-.. warning:: Recovering Unsynchronized Changes after Terminating Sync
- 
- Terminating and re-enabling {+sync+} prevents unsynchronized client changes
- from automatically syncing. To recover any unsynchronized changes, implement a
- manual client reset that handles this case in your client applications:
-
- .. tabs-realm-sdks::
-
-   .. tab::
-      :tabid: android
-
-      Learn how to perform a :ref:`Client Reset using the Java SDK <java-client-resets>`.
-
-   .. tab::
-      :tabid: ios
-
-      Learn how to perform a :ref:`Client Reset using the Swift SDK <ios-client-resets>`.
-
-   .. tab::
-      :tabid: node
-      
-      Learn how to perform a :ref:`Client Reset using the Node SDK <node-client-resets>`.
-
-   .. tab::
-      :tabid: react-native
-      
-      Learn how to perform a :ref:`Client Reset using the React Native SDK <react-native-client-resets>`.
-
-   .. tab::
-      :tabid: dotnet
-
-      Learn how to perform a :ref:`Client Reset using the .NET SDK <dotnet-client-reset>`.
+.. include:: /includes/warn-terminate-sync-client-reset.rst
 
 Procedure
 ~~~~~~~~~

--- a/source/sync/data-access-patterns/partitions.txt
+++ b/source/sync/data-access-patterns/partitions.txt
@@ -58,6 +58,8 @@ different field. If you need to change a partition key, you can terminate sync
 and then enable it with the new partition key; however, this requires all client
 applications to reset and sync data into new realms.
 
+.. include:: /includes/warn-terminate-sync-client-reset.rst
+
 Depending on your data model and the complexity of your app, your partition key
 could be either:
 

--- a/source/sync/data-model/migrate-schema-partner-collection.txt
+++ b/source/sync/data-model/migrate-schema-partner-collection.txt
@@ -34,6 +34,8 @@ If you need to make a breaking schema change, you have two choices:
   
   The remainder of this guide leads you through creating a partner collection.
 
+.. include:: /includes/warn-terminate-sync-client-reset.rst
+
 Partner Collections
 -------------------
 In the following procedure, the *initial* collection uses the JSON Schema below 

--- a/source/sync/error-handling/client-resets.txt
+++ b/source/sync/error-handling/client-resets.txt
@@ -35,14 +35,14 @@ with the client's history. The most common causes of client resets are:
   the earlier version and lose any changes that were saved on the client but not
   yet synced with the server.
 
-- **Disabling and re-enabling sync**: Turning Sync off then on again in
+- **Disabling and re-enabling sync**: Turning Sync off and then on again in
   the Realm UI causes all clients to require a client reset.
 
 - **Client/Backend schema mismatch**: If a client application attempts
   to synchronize with the backend while using a Realm Object schema that
   does not exist in the backend, that client must perform a client reset.
   This only applies in one direction: if the backend schema contains a
-  Realm Object class not used in a client, that client will *not*
+  Realm Object class not used in a client, that client does *not*
   need to client reset.
 
 - **Client maximum offline time**: When a client has not synchronized with
@@ -54,14 +54,20 @@ with the client's history. The most common causes of client resets are:
 
 - **Breaking schema changes**: A :ref:`breaking or destructive change
   <destructive-changes-synced-schema>`, like changing a property type or a
-  primary key, requires you to terminate and re-enable sync. This creates a new
+  primary key, requires you to terminate and re-enable Sync. This creates a new
   synced realm file with a version unrelated to the client's file. Because
   this scenario requires a new realm file, you can only handle client resets
   caused by breaking changes using the :ref:`manually recover unsynced changes
   <manually-recover-unsynced-changes>` strategy.
 
-- **Session role changes**: When using flexible sync, changes to a user's
-  :ref:`flexible sync session role <flex-sync-expansions-caveat>` result
+- **Upgrading from a Shared to Dedicated cluster**: When you :ref:`upgrade from 
+  a shared to a dedicated cluster <upgrade-shared-cluster>`, you must 
+  terminate Sync on the old cluster. After you upgrade, you can re-enable Sync.
+  Turning Sync off and then on again causes all clients to require a 
+  client reset.
+
+- **Session role changes**: When using Flexible Sync, changes to a user's
+  :ref:`Flexible Sync session role <flex-sync-expansions-caveat>` result
   in a client reset. The following scenarios all result in a client reset:
 
   - server-side modifications to the session role


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-22031

### Staged Changes (Requires MongoDB Corp SSO)

- [Upgrade a Shared Tier Cluster](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22031/reference/upgrade-shared-cluster/): Add an include w/details about terminating sync causing a client reset
- [Pause or Terminate Sync - Terminate Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22031/sync/configure/pause-or-terminate-sync/#terminate-sync): Move the content about terminating sync causing a client reset to an include
- [Partitions](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22031/sync/data-access-patterns/partitions/#partition-key): Add include to the partition page where we mention you can change a partition key when you terminate and re-enable sync
- [Make Breaking Schema Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22031/sync/data-model/migrate-schema-partner-collection/): Add include to describe _why_ we recommend not making breaking schema changes
- [Client Resets](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22031/sync/error-handling/client-resets/): Add a note about upgrading from a Shared to a Dedicated cluster causing a client reset, and fix some product/feature naming capitalization issues

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
