### PR TITLE
(DOCSP-22032): Add details for Swift SDK offline login

### DIFF
--- a/examples/ios/Examples/Authenticate.swift
+++ b/examples/ios/Examples/Authenticate.swift
@@ -285,6 +285,39 @@ class Authenticate: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
+    func testShowOfflineLogin() async throws {
+        // :code-block-start: offline-login
+        // Log the user into the backend app.
+        // The first time you login, the user must have a network connection.
+        func getUser() async throws -> User {
+            // Check for an existing user.
+            // If the user is offline but credentials are
+            // cached, this returns the existing user.
+            if let user = app.currentUser {
+                return user
+            } else {
+                // If the device has no cached user
+                // credentials, log them in.
+                let app = App(id: YOUR_REALM_APP_ID)
+                let loggedInUser = try await app.login(credentials: Credentials.anonymous)
+                return loggedInUser
+            }
+        }
+
+        let user = try await getUser()
+        var configuration = user.configuration(partitionValue: "Some Partition Value")
+        // :hide-start:
+        configuration.objectTypes = [SyncExamples_Task.self]
+        // :hide-end:
+        // Open a Realm with this configuration.
+        // If you do not require the app to download updates
+        // before opening the realm, the realm just opens, even if
+        // offline.
+        let realm = try await Realm(configuration: configuration)
+        print("Successfully opened realm: \(realm)")
+        // :code-block-end:
+    }
+
     override func tearDown() {
         guard app.currentUser != nil else {
             return

--- a/source/examples/generated/code/start/Authenticate.codeblock.offline-login.swift
+++ b/source/examples/generated/code/start/Authenticate.codeblock.offline-login.swift
@@ -1,0 +1,25 @@
+// Log the user into the backend app.
+// The first time you login, the user must have a network connection.
+func getUser() async throws -> User {
+    // Check for an existing user.
+    // If the user is offline but credentials are
+    // cached, this returns the existing user.
+    if let user = app.currentUser {
+        return user
+    } else {
+        // If the device has no cached user
+        // credentials, log them in.
+        let app = App(id: YOUR_REALM_APP_ID)
+        let loggedInUser = try await app.login(credentials: Credentials.anonymous)
+        return loggedInUser
+    }
+}
+
+let user = try await getUser()
+var configuration = user.configuration(partitionValue: "Some Partition Value")
+// Open a Realm with this configuration.
+// If you do not require the app to download updates
+// before opening the realm, the realm just opens, even if
+// offline.
+let realm = try await Realm(configuration: configuration)
+print("Successfully opened realm: \(realm)")

--- a/source/includes/offline-login.rst
+++ b/source/includes/offline-login.rst
@@ -2,8 +2,9 @@ When your Realm application authenticates a user, it caches the user's
 credentials. You can check for existing user credentials to bypass the 
 login flow and access the cached user. Use this to open a {+realm+} offline. 
 
-.. note:: A user must have a network connection for first login
+.. note:: A user must have a network connection for first login on client
 
-   The first time the user logs in, they must have a network connection.
+   When a user signs up for your app or logs in for the first time with an 
+   existing account on a client, they must have a network connection.
    Checking for cached user credentials lets you open a realm offline, but
    only if the user has previously logged in while online.

--- a/source/includes/offline-login.rst
+++ b/source/includes/offline-login.rst
@@ -1,0 +1,9 @@
+When your Realm application authenticates a user, it caches the user's 
+credentials. You can check for existing user credentials to bypass the 
+login flow and access the cached user. Use this to open a {+realm+} offline. 
+
+.. note:: A user must have a network connection for first login
+
+   The first time the user logs in, they must have a network connection.
+   Checking for cached user credentials lets you open a realm offline, but
+   only if the user has previously logged in while online.

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -354,6 +354,19 @@ accepts a case from the ``OpenBehavior`` enum:
 
 .. include:: /examples/generated/code/start/Sync.codeblock.specify-download-behavior.swift.code-block.rst
 
+.. _ios-open-a-synced-realm-offline:
+
+Open a Synced Realm Offline
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/offline-login.rst
+
+This only works if you do not require your Realm app to ``always`` :ref:`download
+changes before opening the realm <ios-specify-download-behavior>`.
+
+.. literalinclude:: /examples/generated/code/start/Authenticate.codeblock.offline-login.swift
+   :language: swift
+
 .. _ios-close-a-realm:
 
 Close a Realm

--- a/source/sdk/swift/examples/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/examples/configure-and-open-a-realm.txt
@@ -361,8 +361,9 @@ Open a Synced Realm Offline
 
 .. include:: /includes/offline-login.rst
 
-This only works if you do not require your Realm app to ``always`` :ref:`download
-changes before opening the realm <ios-specify-download-behavior>`.
+You can only open a synced realm offline if you do not require your client 
+app to ``always`` :ref:`download changes before opening the realm 
+<ios-specify-download-behavior>`.
 
 .. literalinclude:: /examples/generated/code/start/Authenticate.codeblock.offline-login.swift
    :language: swift

--- a/source/sdk/swift/examples/users/authenticate-users.txt
+++ b/source/sdk/swift/examples/users/authenticate-users.txt
@@ -165,6 +165,16 @@ method asynchronously returns a User or Error.
 
 .. include:: /includes/swift-async-await-support.rst
 
+.. _ios-offline-login:
+
+Offline Login
+-------------
+
+.. include:: /includes/offline-login.rst
+
+.. literalinclude:: /examples/generated/code/start/Authenticate.codeblock.offline-login.swift
+   :language: swift
+
 .. _ios-logout:
 
 Log Out

--- a/source/sdk/swift/examples/work-with-users.txt
+++ b/source/sdk/swift/examples/work-with-users.txt
@@ -71,9 +71,9 @@ When you have a logged-in user, SDK methods enable you to:
   application
 - :ref:`Remove a user <ios-remove-a-user-from-the-device>` from the device
 
-{+service-short+} caches credentials on the device upon successful login in a 
-``sync_metadata.realm`` file. You can bypass the login flow and access the 
-cached user to open a {+realm+} or call a function upon subsequent app opens.
+On successful login, {+service-short+} caches credentials on the device. You 
+can bypass the login flow and access the cached user. Use this to open a 
+{+realm+} or call a function upon subsequent app opens. 
 
 User Sessions
 ~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Note for reviewer: the CI is broken due to GitHubActions not currently supporting macOS-12/Xcode 13.3. However, the tests pass locally:

> Test Suite 'All tests' passed at 2022-04-14 11:07:52.723.
	 Executed 214 tests, with 0 failures (0 unexpected) in 54.816 (54.964) seconds

### Jira

- https://jira.mongodb.org/browse/DOCSP-22032

### Staged Changes (Requires MongoDB Corp SSO)

- [Authenticate Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22032/sdk/swift/examples/users/authenticate-users/#offline-login): New "Offline Login" section w/include we can use across docs
- [Open and Configure a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22032/sdk/swift/examples/configure-and-open-a-realm/#open-a-synced-realm-offline): New "Open a Synced Realm Offline" section that uses the same include/code example from above, rather than telling the user to go look at it on another page. Also a Swift SDK-specific implementation detail.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
