### PR TITLE
(DOCSP-21981): Add note about to-one relationships being optional

### DIFF
--- a/source/sdk/swift/examples/define-a-realm-object-model.txt
+++ b/source/sdk/swift/examples/define-a-realm-object-model.txt
@@ -206,7 +206,7 @@ Index a Property
 
 Indexes make queries using equality and IN operators faster in exchange
 for slightly slower writes. Indexes take up more space in the realm
-file. It’s best to only add indexes when optimizing the read performance
+file. It's best to only add indexes when optimizing the read performance
 for specific situations.
 
 Realm supports indexing for string, integer, boolean, ``Date``, ``UUID``,
@@ -255,8 +255,8 @@ Realm supports indexing for string, integer, boolean, ``Date``, ``UUID``,
 Ignore a Property
 ~~~~~~~~~~~~~~~~~
 
-Ignored properties behave exactly like normal properties. They can’t be
-used in queries and won’t trigger Realm notifications. You can still
+Ignored properties behave exactly like normal properties. They can't be
+used in queries and won't trigger Realm notifications. You can still
 observe them using :apple:`KVO
 <library/archive/documentation/Cocoa/Conceptual/KeyValueObserving/KeyValueObserving.html>`.
 
@@ -272,7 +272,7 @@ observe them using :apple:`KVO
       .. deprecated:: 10.10.0 
          ``ignoredProperties()``
 
-      If you don’t want to save a field in your model to its realm,
+      If you don't want to save a field in your model to its realm,
       leave the ``@Persisted`` notation off the property attribute.
 
       Additionally, if you mix ``@Persisted`` and ``@objc dynamic`` 
@@ -285,7 +285,7 @@ observe them using :apple:`KVO
    .. tab:: Objective C
       :tabid: objective-c
 
-      If you don’t want to save a field in your model to its realm,
+      If you don't want to save a field in your model to its realm,
       override :objc-sdk:`+[RLMObject ignoredProperties]
       <Classes/RLMObject.html#/c:objc(cs)RLMObject(cm)ignoredProperties>`
       and return a list of ignored property names.
@@ -296,7 +296,7 @@ observe them using :apple:`KVO
    .. tab:: Swift pre-10.10.0
       :tabid: swift-pre-10.10.0
 
-      If you don’t want to save a field in your model to its realm,
+      If you don't want to save a field in your model to its realm,
       override `Object.ignoredProperties()
       <https://www.mongodb.com/docs/realm-sdks/swift/10.9.0/Extensions/Object.html#/c:@CM@RealmSwift@@objc(cs)RealmSwiftObject(cm)ignoredProperties>`_
       and return a list of ignored property names.
@@ -351,6 +351,12 @@ Define a To-One Relationship Property
 A **to-one** relationship maps one property to a single instance of
 another object type. For example, you can model a person having at most
 one companion dog as a to-one relationship.
+
+.. note:: To-one relationships must be optional
+
+   When you declare a to-one relationship in your object model, it must
+   be an optional property. If you try to make a to-one relationship
+   required, Realm throws an exception at runtime.
 
 .. tabs-realm-languages::
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-21981

### Staged Changes (Requires MongoDB Corp SSO)

- [Define a Realm Object Schema -> Define a To-One Relationship Property](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21981/sdk/swift/examples/define-a-realm-object-model/#define-a-to-one-relationship-property): Add a note about to-one relationships being optional

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
