### PR TITLE
(DOCSP-21980): [Swift SDK] Add section to docs about appending frozen objects to frozen collections

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "13.3.1"
+          xcode-version: "13.3.0"
       - name: Build
         env:
           scheme: ${{ 'default' }}

--- a/source/examples/generated/code/start/Threading.codeblock.append-to-frozen-collection.swift
+++ b/source/examples/generated/code/start/Threading.codeblock.append-to-frozen-collection.swift
@@ -1,0 +1,21 @@
+// Get a copy of frozen objects.
+// Here, we're getting them from a frozen realm,
+// but you might also be passing them across threads.
+let frozenTimmy = frozenRealm.objects(Person.self).where {
+    $0.name == "Timmy"
+}.first!
+let frozenLassie = frozenRealm.objects(Dog.self).where {
+    $0.name == "Lassie"
+}.first!
+// Confirm the objects are frozen.
+assert(frozenTimmy.isFrozen == true)
+assert(frozenLassie.isFrozen == true)
+// Thaw the frozen objects. You must thaw both the object
+// you want to append and the collection you want to append it to.
+let thawedTimmy = frozenTimmy.thaw()
+let thawedLassie = frozenLassie.thaw()
+let realm = try! Realm()
+try! realm.write {
+    thawedTimmy?.dogs.append(thawedLassie!)
+}
+XCTAssertEqual(thawedTimmy?.dogs.first?.name, "Lassie")

--- a/source/sdk/swift/advanced-guides/threading.txt
+++ b/source/sdk/swift/advanced-guides/threading.txt
@@ -394,7 +394,7 @@ In this example, we query for two objects in a frozen Realm:
   of Dog objects
 - A Dog object
 
-Then we must thaw both objects before we can append the Dog to 
+We must thaw both objects before we can append the Dog to 
 the Dog List collection on the Person. If we thaw only the Person object
 but not the Dog, Realm throws an error.
 

--- a/source/sdk/swift/advanced-guides/threading.txt
+++ b/source/sdk/swift/advanced-guides/threading.txt
@@ -379,7 +379,30 @@ on a live object, collection, or {+realm+} returns itself.
 Thawing an object or collection also thaws the {+realm+} it references.
 
 .. literalinclude:: /examples/generated/code/start/Threading.codeblock.thaw.swift
-         :language: swift
+   :language: swift
+
+.. _ios-append-to-frozen-collection:
+
+Append to a Frozen Collection
+`````````````````````````````
+
+When you append to a frozen collection, you must thaw both the collection 
+and the object that you want to append. In this example, we query for two 
+objects in a frozen Realm:
+
+- A Person object that has a List property of Dog objects
+- A Dog object
+
+Then we must thaw both objects before we can append the Dog to 
+the Dog List collection on the Person. If we thaw only the Person object
+but not the Dog, Realm throws an error.
+
+You might also be passing these objects across threads instead
+of querying for them. A common case might be calling a function on a 
+background thread to do some work instead of blocking the UI.
+
+.. literalinclude:: /examples/generated/code/start/Threading.codeblock.append-to-frozen-collection.swift
+   :language: swift
 
 .. _ios-mvcc:
 

--- a/source/sdk/swift/advanced-guides/threading.txt
+++ b/source/sdk/swift/advanced-guides/threading.txt
@@ -386,20 +386,21 @@ Thawing an object or collection also thaws the {+realm+} it references.
 Append to a Frozen Collection
 `````````````````````````````
 
-When you append to a frozen collection, you must thaw both the collection 
-and the object that you want to append. In this example, we query for two 
-objects in a frozen Realm:
+When you append to a frozen :ref:`collection <ios-client-collections>`, 
+you must thaw both the collection and the object that you want to append. 
+In this example, we query for two objects in a frozen Realm:
 
-- A Person object that has a List property of Dog objects
+- A Person object that has a :ref:`List <ios-list-collections>` property 
+  of Dog objects
 - A Dog object
 
 Then we must thaw both objects before we can append the Dog to 
 the Dog List collection on the Person. If we thaw only the Person object
 but not the Dog, Realm throws an error.
 
-You might also be passing these objects across threads instead
-of querying for them. A common case might be calling a function on a 
-background thread to do some work instead of blocking the UI.
+The same rule applies when passing frozen objects across threads. A common 
+case might be calling a function on a background thread to do some work 
+instead of blocking the UI.
 
 .. literalinclude:: /examples/generated/code/start/Threading.codeblock.append-to-frozen-collection.swift
    :language: swift


### PR DESCRIPTION
## Pull Request Info

Note for reviewer: yay, the CI is working again! But boo, now a test that is completely unrelated to this PR is failing in CI. It still passes locally, though:

> Test Suite 'All tests' passed at 2022-04-15 10:56:08.659.
	 Executed 214 tests, with 0 failures (0 unexpected) in 54.560 (54.706) seconds

I've made a Jira ticket to remind me to fix this later: https://jira.mongodb.org/browse/DOCSP-22067

### Jira

- https://jira.mongodb.org/browse/DOCSP-21980

### Staged Changes (Requires MongoDB Corp SSO)

- [Threading (Swift SDK) -> Append to a Frozen Collection](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-21980/sdk/swift/advanced-guides/threading/#append-to-a-frozen-collection): New subsection about appending a frozen object to a frozen collection

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
