### PR TITLE
(DOCSP-20436): Add Null Support for Optional Types in Realm Schema

### DIFF
--- a/source/schemas/enforce-a-schema.txt
+++ b/source/schemas/enforce-a-schema.txt
@@ -43,3 +43,21 @@ Procedure
       :tabid: cli
       
       .. include:: /includes/steps/enforce-a-schema-cli.rst
+
+.. _validate-null-types:
+
+Validate Null Types
+-------------------
+
+You can configure {+service-short+} to pass schema validation for any ``null`` values
+when their field types are set as optional in the schema. 
+
+If you do not enable null type schema validation, {+service-short+} rejects ``null``
+values passed to optional fields. 
+
+To enable null type schema validation: 
+
+#. In the left navigation menu, select :guilabel:`App Settings` beneath :guilabel:`Manage`.
+#. On the :guilabel:`General` tab, navigate to the :guilabel:`Null Type Schema Validation`
+   section. Toggle the switch to be :guilabel:`ON`.
+#. Click the :guilabel:`Save` button. 

--- a/source/schemas/enforce-a-schema.txt
+++ b/source/schemas/enforce-a-schema.txt
@@ -52,13 +52,13 @@ Validate Null Types
 You can configure {+service-short+} to pass schema validation for any ``null`` values
 when their field types are set as optional in the schema.
 Enabling null type validation allows the value for a field to be persisted as
-the type in the schema or :manual:`BSON null </reference/bson-types/>`.
+the type in the schema or the :manual:`BSON null </reference/bson-types/>` type.
 If you do not enable null type schema validation, {+service-short+} rejects ``null``
 values passed to optional fields. 
 
 .. note:: 
 
-   Schema fields are not nullable by default because null is a unique BSON type.
+   Schema fields are not nullable by default because ``null`` is a unique BSON type.
    The default schema behavior is to accept only a single type for a field.
 
 

--- a/source/schemas/enforce-a-schema.txt
+++ b/source/schemas/enforce-a-schema.txt
@@ -54,7 +54,7 @@ Schema fields are not nullable by default because ``null`` is a unique
 :manual:`BSON type </reference/bson-types/>`.
 
 You can configure {+service+} to pass schema validation when you use ``null`` 
-values with optional fieds.
+values with optional fields.
 Enabling null type validation allows the value for a field to be persisted as
 the type in the schema or the :manual:`BSON null </reference/bson-types/>` type.
 If you do not enable null type schema validation, {+service-short+} rejects ``null``

--- a/source/schemas/enforce-a-schema.txt
+++ b/source/schemas/enforce-a-schema.txt
@@ -53,8 +53,8 @@ Validate Null Types
 Schema fields are not nullable by default because ``null`` is a unique 
 :manual:`BSON type </reference/bson-types/>`.
 
-You can configure fields to pass schema validation for ``null`` values
-when their types are set as optional in the schema.
+You can configure {+service+} to pass schema validation when you use ``null`` 
+values with optional fieds.
 Enabling null type validation allows the value for a field to be persisted as
 the type in the schema or the :manual:`BSON null </reference/bson-types/>` type.
 If you do not enable null type schema validation, {+service-short+} rejects ``null``

--- a/source/schemas/enforce-a-schema.txt
+++ b/source/schemas/enforce-a-schema.txt
@@ -51,13 +51,12 @@ Validate Null Types
 
 You can configure {+service-short+} to pass schema validation for any ``null`` values
 when their field types are set as optional in the schema. 
-
 If you do not enable null type schema validation, {+service-short+} rejects ``null``
 values passed to optional fields. 
 
 To enable null type schema validation: 
 
-#. In the left navigation menu, select :guilabel:`App Settings` beneath :guilabel:`Manage`.
+#. In the left navigation menu, select :guilabel:`App Settings` below :guilabel:`Manage`.
 #. On the :guilabel:`General` tab, navigate to the :guilabel:`Null Type Schema Validation`
-   section. Toggle the switch to be :guilabel:`ON`.
+   section. Toggle the switch to :guilabel:`ON`.
 #. Click the :guilabel:`Save` button. 

--- a/source/schemas/enforce-a-schema.txt
+++ b/source/schemas/enforce-a-schema.txt
@@ -49,12 +49,12 @@ Procedure
 Validate Null Types
 -------------------
 
-{+service+}'s default behavior is to only accept a single :manual:`BSON type
-</reference/bson-types/>` for each field. 
-Schema fields are not nullable by default because ``null`` is a unique BSON type.
+{+service+}'s default behavior is to only accept a single type for each field. 
+Schema fields are not nullable by default because ``null`` is a unique 
+:manual:`BSON type </reference/bson-types/>`.
 
-You can configure {+service-short+} to pass schema validation for ``null`` values
-when their field types are set as optional in the schema.
+You can configure fields to pass schema validation for ``null`` values
+when their types are set as optional in the schema.
 Enabling null type validation allows the value for a field to be persisted as
 the type in the schema or the :manual:`BSON null </reference/bson-types/>` type.
 If you do not enable null type schema validation, {+service-short+} rejects ``null``

--- a/source/schemas/enforce-a-schema.txt
+++ b/source/schemas/enforce-a-schema.txt
@@ -49,22 +49,22 @@ Procedure
 Validate Null Types
 -------------------
 
-You can configure {+service-short+} to pass schema validation for any ``null`` values
+{+service+}'s default behavior is to only accept a single :manual:`BSON type
+</reference/bson-types/>` for each field. 
+Schema fields are not nullable by default because ``null`` is a unique BSON type.
+
+You can configure {+service-short+} to pass schema validation for ``null`` values
 when their field types are set as optional in the schema.
 Enabling null type validation allows the value for a field to be persisted as
 the type in the schema or the :manual:`BSON null </reference/bson-types/>` type.
 If you do not enable null type schema validation, {+service-short+} rejects ``null``
-values passed to optional fields. 
-
-.. note:: 
-
-   Schema fields are not nullable by default because ``null`` is a unique BSON type.
-   The default schema behavior is to accept only a single type for a field.
+values passed to optional fields. Even if you enable null type validation,
+required fields are never nullable.
 
 
 To enable null type schema validation: 
 
-#. In the left navigation menu, select :guilabel:`App Settings` below :guilabel:`Manage`.
+#. In the left navigation menu below the :guilabel:`Manage` header, select :guilabel:`App Settings`.
 #. On the :guilabel:`General` tab, navigate to the :guilabel:`Null Type Schema Validation`
    section. Toggle the switch to :guilabel:`ON`.
 #. Click the :guilabel:`Save` button. 

--- a/source/schemas/enforce-a-schema.txt
+++ b/source/schemas/enforce-a-schema.txt
@@ -50,9 +50,17 @@ Validate Null Types
 -------------------
 
 You can configure {+service-short+} to pass schema validation for any ``null`` values
-when their field types are set as optional in the schema. 
+when their field types are set as optional in the schema.
+Enabling null type validation allows the value for a field to be persisted as
+the type in the schema or :manual:`BSON null </reference/bson-types/>`.
 If you do not enable null type schema validation, {+service-short+} rejects ``null``
 values passed to optional fields. 
+
+.. note:: 
+
+   Schema fields are not nullable by default because null is a unique BSON type.
+   The default schema behavior is to accept only a single type for a field.
+
 
 To enable null type schema validation: 
 


### PR DESCRIPTION
## Pull Request Info

Document how to add null support for optional types in a realm schema

### Jira

- https://jira.mongodb.org/browse/DOCSP-20436

### Staged Changes (Requires MongoDB Corp SSO)

- [Enforce a Schema page > Validate Null Types section](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-20436/schemas/enforce-a-schema#validate-null-types)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
