### PR TITLE
Remove support for `@avg` for Flexible Sync arrays

### DIFF
--- a/source/reference/realm-query-language.txt
+++ b/source/reference/realm-query-language.txt
@@ -60,7 +60,7 @@ Case insensitive queries (``[c]``) cannot use indexes effectively.
 As a result, case insensitive queries are not recommended, since they could lead to
 performance problems.
 
-Flexible Sync only supports ``@avg`` and ``@count`` for array fields.
+Flexible Sync only supports ``@count`` for array fields.
 
 Embedded or Linked Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

remove inaccuracy stating that RQL supports RQL `@avg` on arrays

### Jira

N/A 

### Staged Changes (Requires MongoDB Corp SSO)

- [RQL](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/rql_flex_sync_no_avg/reference/realm-query-language/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
