### PR TITLE
DOCSP-22389: Update Node/RN open existing realm with new configuration behavior info

### DIFF
--- a/examples/node/Examples/open-and-close-a-realm.js
+++ b/examples/node/Examples/open-and-close-a-realm.js
@@ -262,11 +262,60 @@ describe("Convert Realm using writeCopyTo()", () => {
 
     // clean up
     localRealm.close();
-    // await syncedRealm.syncSession.uploadAllLocalChanges();
-    // await syncedRealm.syncSession.downloadAllServerChanges();
     syncedRealm.close();
     Realm.deleteFile(localConfig);
     Realm.deleteFile(syncedConfig);
+  });
+  test("writing over realm doesn't replace data", async () => {
+    const Car = {
+      name: "Car",
+      properties: {
+        make: "string",
+        model: "string",
+        miles: "int",
+        _id: "string",
+      },
+      primaryKey: "_id",
+    };
+    const realm1Config = { schema: [Car], path: "realm1.realm" };
+    const realm1 = await Realm.open(realm1Config);
+    realm1.write(() => {
+      realm1.create("Car", { _id: "1", model: "Model X", make: "a", miles: 1 });
+      realm1.create("Car", { _id: "2", model: "Model Y", make: "a", miles: 1 });
+    });
+    realm1.close();
+
+    const OtherCar = {
+      name: "Car2",
+      properties: {
+        seats: "int",
+        model: "string",
+        miles: "int",
+        _id: "string",
+      },
+      primaryKey: "_id",
+    };
+    const realm2Config = { schema: [Car, OtherCar], path: "realm2.realm" };
+    const realm2 = await Realm.open(realm2Config);
+    realm2.write(() => {
+      realm2.create("Car2", { _id: "3", model: "Model A", miles: 1, seats: 1 });
+      realm2.create("Car2", { _id: "4", model: "Model B", miles: 1, seats: 1 });
+      realm2.create("Car", { _id: "3", model: "Model A", miles: 1, make: "a" });
+      realm2.create("Car", { _id: "4", model: "Model B", miles: 1, make: "a" });
+    });
+    realm2.writeCopyTo(realm1Config);
+
+    const combinedRealm = await Realm.open(realm1Config);
+    expect(combinedRealm.objects("Car").length).toBe(4);
+    expect(() => combinedRealm.objects("Car2")).toThrow(
+      "Object type 'Car2' not found in schema."
+    );
+
+    // clean up
+    realm2.close();
+    combinedRealm.close();
+    Realm.deleteFile(realm1Config);
+    Realm.deleteFile(realm2Config);
   });
   test("sync encrypted to local unencrypted", async () => {
     const Car = {

--- a/source/sdk/node/examples/open-and-close-a-realm.txt
+++ b/source/sdk/node/examples/open-and-close-a-realm.txt
@@ -154,7 +154,11 @@ To open an existing realm with a different configuration, pass the new
 to :js-sdk:`Realm.writeCopyTo() <Realm.html#writeCopyTo>`. 
 ``Realm.writeCopyTo()`` copies the realm's data to a new realm, but adds different configuration options. 
 In the output realm's configuration, you *must* specify the ``path``. 
-A realm file cannot already exist at that path. 
+
+If you write to a realm file that already exists, the data is written object by object
+without replacing the objects that are already there. The schemas of the realm you
+copy and the realm you are writing to must be compatible for the copy operation
+to succeed. Only objects in the schemas of both configurations are copied over.
 
 The configuration change can include modifications to :js-sdk:`SyncConfiguration
 <Realm.App.Sync.html#~SyncConfiguration>`: 

--- a/source/sdk/node/examples/open-and-close-a-realm.txt
+++ b/source/sdk/node/examples/open-and-close-a-realm.txt
@@ -155,7 +155,7 @@ to :js-sdk:`Realm.writeCopyTo() <Realm.html#writeCopyTo>`.
 ``Realm.writeCopyTo()`` copies the realm's data to a new realm, but adds different configuration options. 
 In the output realm's configuration, you *must* specify the ``path``. 
 
-If you write to a realm file that already exists, the data is written object by object
+If you write the copied realm to a realm file that already exists, the data is written object by object
 without replacing the objects that are already there. The schemas of the realm you
 copy and the realm you are writing to must be compatible for the copy operation
 to succeed. Only objects in the schemas of both configurations are copied over.

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -154,7 +154,11 @@ To open an existing realm with a different configuration, pass the new
 to :js-sdk:`Realm.writeCopyTo() <Realm.html#writeCopyTo>`. 
 ``Realm.writeCopyTo()`` copies the realm's data to a new realm, but adds different configuration options. 
 In the output realm's configuration, you *must* specify the ``path``. 
-A realm file cannot already exist at that path. 
+
+If you write to a realm file that already exists, the data is written object by object
+without replacing the objects that are already there. The schemas of the realm you
+copy and the realm you are writing to must be compatible for the copy operation
+to succeed. Only objects in the schemas of both configurations are copied over.
 
 The configuration change can include modifications to :js-sdk:`SyncConfiguration
 <Realm.App.Sync.html#~SyncConfiguration>`: 

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -155,7 +155,7 @@ to :js-sdk:`Realm.writeCopyTo() <Realm.html#writeCopyTo>`.
 ``Realm.writeCopyTo()`` copies the realm's data to a new realm, but adds different configuration options. 
 In the output realm's configuration, you *must* specify the ``path``. 
 
-If you write to a realm file that already exists, the data is written object by object
+If you write the copied realm to a realm file that already exists, the data is written object by object
 without replacing the objects that are already there. The schemas of the realm you
 copy and the realm you are writing to must be compatible for the copy operation
 to succeed. Only objects in the schemas of both configurations are copied over.


### PR DESCRIPTION
## Pull Request Info

update docs on 'update existing realm with new configuration' to make clear that you can write over a file, and what that behavior is, per https://github.com/realm/realm-core/blob/f1152a77475a17fa54025bd983013200230fd707/src/realm.h#L872 

### Jira

- https://jira.mongodb.org/browse/DOCSP-22389

### Staged Changes (Requires MongoDB Corp SSO)

- [Open and Close a Realm (RN)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22389/sdk/react-native/open-and-close-a-realm)
- [Open and Close a Realm (Node)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22389/sdk/node/open-and-close-a-realm)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
