### PR TITLE
Update Static Hosting to be onlyUI enabled

### DIFF
--- a/source/hosting/enable-hosting.txt
+++ b/source/hosting/enable-hosting.txt
@@ -16,10 +16,13 @@ Overview
 --------
 
 You need to enable static hosting for your application before you can
-upload and access content. You can allow static hosting from the {+ui+}
-or by :doc:`importing </manage-apps/deploy/manual/deploy-cli>` an
-application directory that enables hosting in its configuration file.
-Select the tab below that corresponds to the method you want to use.
+upload and access content. You can enable static hosting from the {+ui+}.
+
+.. TODO(DOCSP-19662): when enable cli hosting functionality restored,
+.. add the following text back in:
+.. or by :doc:`importing </manage-apps/deploy/manual/deploy-cli>` an
+.. application directory that enables hosting in its configuration file.
+.. Select the tab below that corresponds to the method you want to use.
 
 
 Procedure


### PR DESCRIPTION
## Pull Request Info

clarify that can't use the CLI with static hosting at the moment due to a known bug. Updated this paragraph to align with rest of the docs. 

### Jira

N/A

### Staged Changes (Requires MongoDB Corp SSO)

- [Enable Static Hosting](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/remove_import_hosting_text/hosting/enable-hosting/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
