### PR TITLE
Remove legacy links

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -15,8 +15,6 @@ Welcome to the MongoDB Realm Docs
    Realm Database SDKs </sdk>
    MongoDB Realm </cloud>
    Realm Studio </studio>
-   Realm (Legacy) </realm-legacy>
-   MongoDB Stitch (Legacy) </stitch>
    Release Notes </release-notes>
 
 

--- a/source/realm-legacy.txt
+++ b/source/realm-legacy.txt
@@ -9,15 +9,8 @@ documentation for earlier versions of {+client-database+} can be found
 on at `Realm documentation (legacy)
 <https://www.mongodb.com/docs/realm-legacy/docs/>`_.
 
-Legacy Realm, both self-hosted Realm Object Server and the Realm Cloud,
-is currently End of Life and will be shut down on November 1st 2021. See
-`Realm Legacy Migration Guide
-<https://docs.realm.io/realm-legacy-migration-guide/>`_ for migration
-instructions.
-
 .. toctree::
    :titlesonly:
    :hidden:
    
    Realm Database Documentation (Legacy) <https://www.mongodb.com/docs/realm-legacy/docs/>
-   Realm Legacy Migration Guide <https://docs.realm.io/realm-legacy-migration-guide/>

--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -94,3 +94,5 @@ and platforms. Each SDK is language-idiomatic and includes:
       :icon-alt: Futter icon
 
       Build Flutter applications with Dart. 
+
+For legacy (pre-v10) Realm Database Documentation, see https://www.mongodb.com/docs/realm-legacy/docs/.


### PR DESCRIPTION
Removes legacy links from sidebars for SEO.
See https://jira.mongodb.org/browse/DOP-2938 for context.

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/remove-legacy-links/ (see sidebar)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
