### PR TITLE
remove limits around arrays and clarify text - DOCSP-22050

### DIFF
--- a/source/reference/realm-query-language.txt
+++ b/source/reference/realm-query-language.txt
@@ -41,17 +41,11 @@ Unsupported Query Operators in Flexible Sync
    * - Operator Type
      - Unsupported Operators
 
-   * - Comparison Operators
-     - ``IN``
-
    * - String Operators
      - ``in``
 
    * - Aggregate Operators
      - ``@avg``, ``@count``, ``@max``, ``@min``, ``@sum``
-
-   * - Collection Operators
-     - ``ANY``, ``SOME``, ``ALL``, ``NONE``
 
    * - Query Suffixes
      - ``DISTINCT``, ``SORT``, ``LIMIT``

--- a/source/sync/data-access-patterns/flexible-sync.txt
+++ b/source/sync/data-access-patterns/flexible-sync.txt
@@ -66,8 +66,8 @@ Eligible Field Types
 ~~~~~~~~~~~~~~~~~~~~
 
 Any top-level primitive field with a scalar type can be a queryable field. 
-Flexible Sync does not currently support embedded objects as 
-queryable fields. Flexible Sync queries only support arrays of primitives, not objects.
+Flexible Sync does not currently support embedded objects or arrays of 
+objects as queryable fields, but does support arrays of primitives.
 
 .. seealso:: Realm Query Language - Flexible Sync Limitations
 

--- a/source/sync/data-access-patterns/flexible-sync.txt
+++ b/source/sync/data-access-patterns/flexible-sync.txt
@@ -64,10 +64,10 @@ control on individual collections.
 
 Eligible Field Types
 ~~~~~~~~~~~~~~~~~~~~
-
-Any top-level primitive field with a scalar type can be a queryable field. 
-Flexible Sync does not currently support embedded objects or arrays of 
-objects as queryable fields, but does support arrays of primitives.
+Flexible Sync only supports top-level primitive fields with a scalar type as 
+queryable fields. You can also include arrays of these primitives as queryable 
+fields. Flexible Sync does not support embedded objects or arrays of 
+objects as queryable fields.
 
 .. seealso:: Realm Query Language - Flexible Sync Limitations
 

--- a/tools/autobuilder/src/index.ts
+++ b/tools/autobuilder/src/index.ts
@@ -6,7 +6,8 @@ import {
 } from "mongodb-stitch-server-sdk";
 
 // Add expected errors here.
-const expectedErrors: RegExp[] = [/(WARNING|ERROR)\(sdk\/java\/api.*/];
+const expectedErrors: RegExp[] = [/(WARNING|ERROR)\(sdk\/java\/api.*/,
+ /ERROR #98124  WEBPACK/];
 
 const STITCH_APP_ID = "workerpool-boxgs";
 


### PR DESCRIPTION
## Pull Request Info

### Jira

https://jira.mongodb.org/browse/DOCSP-22050

### Staged Changes (Requires MongoDB Corp SSO)

https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22050/reference/realm-query-language/
and
https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-22050/sync/data-access-patterns/flexible-sync/#eligible-field-types

### Note
Change to autobuilder/src/index.ts is a work-around for a borked autobuilder. Change should only be needed for the short term, but does no harm being in there for ever.