### PR TITLE
rephrase description of JS bulk update for accuracy

### DIFF
--- a/source/sdk/node/examples/read-and-write-data.txt
+++ b/source/sdk/node/examples/read-and-write-data.txt
@@ -177,8 +177,7 @@ Bulk Update a Collection
 
 To apply an update to a collection of objects, iterate through the collection
 (e.g. with :mdn:`for...of
-<Web/JavaScript/Reference/Statements/for...of>`). In the iterator
-callback, update each object individually:
+<Web/JavaScript/Reference/Statements/for...of>`). In the loop, update each object individually:
 
 .. literalinclude:: /examples/generated/node/read-and-write-data.codeblock.read-and-write-bulk-update.js
   :language: javascript

--- a/source/sdk/react-native/examples/read-and-write-data.txt
+++ b/source/sdk/react-native/examples/read-and-write-data.txt
@@ -177,8 +177,7 @@ Bulk Update a Collection
 
 To apply an update to a collection of objects, iterate through the collection
 (e.g. with :mdn:`for...of
-<Web/JavaScript/Reference/Statements/for...of>`). In the iterator
-callback, update each object individually:
+<Web/JavaScript/Reference/Statements/for...of>`). In the loop, update each object individually:
 
 .. literalinclude:: /examples/generated/node/read-and-write-data.codeblock.read-and-write-bulk-update.js
   :language: javascript


### PR DESCRIPTION
## Pull Request Info
rephrase language around JS bulk update for accuracy. the current phrasing is inaccurate reflecting a previous example using `Array.prototype.forEach()`. this has updated the phrasing to use the now recommended `for...of`.

### Jira

N/A

### Staged Changes (Requires MongoDB Corp SSO)

- [Read and Write Data (Node)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fix_change_object_js/sdk/node/examples/read-and-write-data/#bulk-update-a-collection)
- [Read and Write Data (RN)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fix_change_object_js/sdk/react-native/examples/read-and-write-data/#bulk-update-a-collection)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
