### PR TITLE
Fix type mistakes because of renaming

### DIFF
--- a/source/sdk/dotnet/fundamentals/device-sync.txt
+++ b/source/sdk/dotnet/fundamentals/device-sync.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 Atlas Device Sync automatically synchronizes data between client applications and 
-a :ref:`Atlas App Services backend <realm-cloud>`. When a client 
+an :ref:`Atlas App Services backend <realm-cloud>`. When a client 
 device is online, {+sync-short+} asynchronously synchronizes data in a 
 background thread between the device and your backend {+app+}. 
 

--- a/source/sdk/flutter/app-services.txt
+++ b/source/sdk/flutter/app-services.txt
@@ -29,7 +29,7 @@ backend using the Flutter SDK. Backend functionality includes:
 The Realm App Client
 --------------------
 
-To connect to your Atlas App Services backend, start with a
+To connect to your Atlas App Services backend, start with an
 :flutter-sdk:`App <realm/App-class.html>` object.
 This object provides all other functionality related to
 the backend. Initialize an App with the Realm app ID, which you can

--- a/source/sdk/flutter/sync.txt
+++ b/source/sdk/flutter/sync.txt
@@ -12,7 +12,7 @@ Device Sync - Flutter SDK
    Manage Sync Session </sdk/flutter/sync/manage-sync-session>
 
 {+sync+} automatically synchronizes data between client applications and
-a :ref:`Atlas App Services backend application <realm-cloud>`. When a client
+an :ref:`Atlas App Services backend application <realm-cloud>`. When a client
 device is online, {+sync-short+} asynchronously synchronizes data in the
 background between the device and your App Services backend.
 

--- a/source/sdk/flutter/users/multiple-users.txt
+++ b/source/sdk/flutter/users/multiple-users.txt
@@ -52,7 +52,7 @@ The following states describe an on-device user at any given time:
 - **Logged Out:** any user that authenticated on the device but
   has since logged out or had their session revoked.
 
-The following diagram shows how users within a App Services client app
+The following diagram shows how users within an App Services client app
 transition between states when certain events occur:
 
 .. figure:: /images/multi-user.png

--- a/source/sdk/java/api/io/realm/mongodb/AppConfiguration.txt
+++ b/source/sdk/java/api/io/realm/mongodb/AppConfiguration.txt
@@ -22,11 +22,11 @@ io.realm.mongodb
  | 		io.realm.mongodb.AppConfiguration
 
 
-A AppConfiguration is used to setup a MongoDB Realm application.Instances of a AppConfiguration can only created by using the :ref:`AppConfiguration.Builder <io_realm_mongodb_AppConfiguration_Builder>`  and calling its :ref:`AppConfiguration.Builder.build() <io_realm_mongodb_AppConfiguration_Builder_build__>`  method.
+An AppConfiguration is used to setup a MongoDB Realm application.Instances of a AppConfiguration can only created by using the :ref:`AppConfiguration.Builder <io_realm_mongodb_AppConfiguration_Builder>` and calling its :ref:`AppConfiguration.Builder.build() <io_realm_mongodb_AppConfiguration_Builder_build__>`  method.
 
 
 
-Configuring a App is only required if the default settings are not enough. Otherwise calling ``new App("app-id")``  is sufficient.
+Configuring an App is only required if the default settings are not enough. Otherwise calling ``new App("app-id")`` is sufficient.
 
 
 

--- a/source/sdk/java/fundamentals/device-sync.txt
+++ b/source/sdk/java/fundamentals/device-sync.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 Atlas Device Sync automatically synchronizes data between client applications and 
-a :ref:`Atlas App Services backend <realm-cloud>`. When a client 
+an :ref:`Atlas App Services backend <realm-cloud>`. When a client 
 device is online, {+sync-short+} asynchronously synchronizes data in a 
 background thread between the device and your backend {+app+}. 
 

--- a/source/sdk/kotlin/app-services/overview.txt
+++ b/source/sdk/kotlin/app-services/overview.txt
@@ -26,7 +26,7 @@ backend using the SDK. Backend functionality includes:
 The Realm App Client
 --------------------
 
-To connect to your {+service-short+} backend, start with a 
+To connect to your {+service-short+} backend, start with an 
 :kotlin-sdk:`App <{+kotlin-sync-prefix+}io.realm.mongodb/-app/index.html>` object.
 This object provides all other functionality related to 
 the backend. Initialize an App with the {+app+} ID, which you can 

--- a/source/sdk/kotlin/sync/overview.txt
+++ b/source/sdk/kotlin/sync/overview.txt
@@ -18,7 +18,7 @@ Overview
 --------
 
 Atlas Device Sync automatically synchronizes data between client applications and 
-a :ref:`Atlas App Services backend <realm-cloud>`. When a client 
+an :ref:`Atlas App Services backend <realm-cloud>`. When a client 
 device is online, {+sync-short+} asynchronously synchronizes data in a 
 background thread between the device and your backend {+app+}. 
 

--- a/source/sdk/node/fundamentals/device-sync.txt
+++ b/source/sdk/node/fundamentals/device-sync.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 Atlas Device Sync automatically synchronizes data between client applications and 
-a :ref:`Atlas App Services backend <realm-cloud>`. When a client 
+an :ref:`Atlas App Services backend <realm-cloud>`. When a client 
 device is online, {+sync-short+} asynchronously synchronizes data in a 
 background thread between the device and your backend {+app+}. 
 

--- a/source/sdk/react-native/fundamentals/device-sync.txt
+++ b/source/sdk/react-native/fundamentals/device-sync.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 Atlas Device Sync automatically synchronizes data between client applications and 
-a :ref:`Atlas App Services backend <realm-cloud>`. When a client 
+an :ref:`Atlas App Services backend <realm-cloud>`. When a client 
 device is online, {+sync-short+} asynchronously synchronizes data in a 
 background thread between the device and your backend {+app+}. 
 

--- a/source/sdk/swift/fundamentals/device-sync.txt
+++ b/source/sdk/swift/fundamentals/device-sync.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 Atlas Device Sync automatically synchronizes data between client applications and 
-a :ref:`Atlas App Services backend <realm-cloud>`. When a client 
+an :ref:`Atlas App Services backend <realm-cloud>`. When a client 
 device is online, {+sync-short+} asynchronously synchronizes data in a 
 background thread between the device and your backend {+app+}. 
 


### PR DESCRIPTION
Changed to "an" instead of "a" where it is needed.
