### PR TITLE
WIP - Open and close a realm test fixes

### DIFF
--- a/examples/node/Examples/open-and-close-a-realm.js
+++ b/examples/node/Examples/open-and-close-a-realm.js
@@ -80,7 +80,7 @@ describe("Open and Close a Realm", () => {
     realm.close();
   });
 
-  test.skip("should open and close a synced realm with internet", async () => {
+  test("should open and close a synced realm with internet", async () => {
     const Car = {
       name: "Car",
       properties: {
@@ -118,7 +118,7 @@ describe("Open and Close a Realm", () => {
     // :snippet-end:xw
   });
 
-  test.skip("should open and close a sycned realm without internet", async () => {
+  test("should open and close a sycned realm without internet", async () => {
     const Car = {
       name: "Car",
       properties: {
@@ -180,7 +180,7 @@ describe("Open and Close a Realm", () => {
     nock.enableNetConnect();
   });
 
-  test.skip("Should open and close a realm with background sync", async () => {
+  test("Should open and close a realm with background sync", async () => {
     const Car = {
       name: "Car",
       properties: {

--- a/examples/node/Examples/open-and-close-a-realm.js
+++ b/examples/node/Examples/open-and-close-a-realm.js
@@ -252,7 +252,7 @@ describe("Convert Realm using writeCopyTo()", () => {
       await app.currentUser?.logOut();
     }
   });
-  test("Open local realm as synced realm with `writeCopyTo()`", async () => {
+  test.skip("Open local realm as synced realm with `writeCopyTo()`", async () => {
     // :snippet-start: open-local-as-synced
     const localConfig = {
       schema: [Car],

--- a/examples/node/Examples/open-and-close-a-realm.js
+++ b/examples/node/Examples/open-and-close-a-realm.js
@@ -370,7 +370,6 @@ describe("Convert Realm using writeCopyTo()", () => {
     // :snippet-end:
     expect(syncedEncryptedRealm.isClosed).toBe(false);
     expect(localUnencryptedRealm.isClosed).toBe(false);
-
     // clean up
     await syncedEncryptedRealm.syncSession.uploadAllLocalChanges();
     await syncedEncryptedRealm.syncSession.downloadAllServerChanges();


### PR DESCRIPTION
WIP 

In this PR: 

- I've unskipped some tests that don't need to be skipped
- I've skipped 'Open local realm as synced realm with `writeCopyTo()`' due to the error `zsh: segmentation fault  npm run test:js`. Note: this error is not present if I run the same code on a regular node file, outside of the jest unit test suite:

```
const Realm = require("realm");

const Car = {
    name: "Car",
    properties: {
      make: "string",
      model: "string",
      miles: "int",
      _id: "string",
    },
    primaryKey: "_id",
};

async function run(){
    const app = new Realm.App({ id: "demo_app-cicfi" });
    app.logIn(Realm.Credentials.anonymous());

    const localConfig = {
        schema: [Car],
        path: "localOnly.realm",
      };
      const localRealm = await Realm.open(localConfig);
  
      const syncedConfig = {
        schema: [Car], // predefined schema
        path: "copyLocalToSynced.realm", // must include in output configuration
        sync: {
          user: app.currentUser, // already logged in user
          partitionValue: "myPartition",
        },
      };
      localRealm.writeCopyTo(syncedConfig);
      const syncedRealm = await Realm.open(syncedConfig);
  
      // clean up
      localRealm.close();
      syncedRealm.close();
      Realm.deleteFile(localConfig);
      Realm.deleteFile(syncedConfig);
}
run().catch((err) => {
    console.log('an error occurred: ', err);
})
```
