### PR TITLE
(DOCSP-23116): [Swift] Update Flex Sync rerunOnOpen example to show re-computing vars

### DIFF
--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1256,7 +1256,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.28.0;
+				minimumVersion = 10.28.1;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/examples/ios/RealmExamples.xcodeproj/xcshareddata/xcschemes/RealmExamplesHostApp.xcscheme
+++ b/examples/ios/RealmExamples.xcodeproj/xcshareddata/xcschemes/RealmExamplesHostApp.xcscheme
@@ -37,6 +37,11 @@
                BlueprintName = "RealmExamples"
                ReferencedContainer = "container:RealmExamples.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "BundleRealms">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/source/examples/generated/code/start/FlexibleSync.snippet.add-initial-subscriptions-rerun-on-open.swift
+++ b/source/examples/generated/code/start/FlexibleSync.snippet.add-initial-subscriptions-rerun-on-open.swift
@@ -1,6 +1,12 @@
+// Set the date a week ago and the date a week from now, as those are the dates we'll use
+// in the Flexible Sync query. `rerunOnOpen` lets the app recalculate this query every
+// time the app opens.
+let secondsInAWeek: TimeInterval = 604800
+let dateLastWeek = (Date.now - secondsInAWeek)
+let dateNextWeek = (Date.now + secondsInAWeek)
 var flexSyncConfig = user.flexibleSyncConfiguration(initialSubscriptions: { subs in
     subs.append(
-       QuerySubscription<Team> {
-          $0.teamName == "Developer Education"
-       })
+        QuerySubscription<Task> {
+            $0.dueDate > dateLastWeek && $0.dueDate < dateNextWeek
+        })
 }, rerunOnOpen: true)

--- a/source/examples/generated/code/start/FlexibleSync.snippet.flexible-sync-models.swift
+++ b/source/examples/generated/code/start/FlexibleSync.snippet.flexible-sync-models.swift
@@ -1,14 +1,15 @@
 class Task: Object {
-   @Persisted(primaryKey: true) var _id: ObjectId
-   @Persisted var taskName: String
-   @Persisted var assignee: String?
-   @Persisted var completed: Bool
-   @Persisted var progressMinutes: Int
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var taskName: String
+    @Persisted var assignee: String?
+    @Persisted var completed: Bool
+    @Persisted var progressMinutes: Int
+    @Persisted var dueDate: Date
 }
 
 class Team: Object {
-   @Persisted(primaryKey: true) var _id: ObjectId
-   @Persisted var teamName: String
-   @Persisted var tasks: List<Task>
-   @Persisted var members: List<String>
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var teamName: String
+    @Persisted var tasks: List<Task>
+    @Persisted var members: List<String>
 }

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -49,10 +49,9 @@ About the Examples on This Page
 The examples on this page use a simple data set for a
 task list app. The two Realm object types are ``Team``
 and ``Task``. A ``Task`` has a ``taskName``, assignee's name, and
-completed flag. There is also an arbitrary number for
-priority -- higher is more important -- and a count of
-minutes spent working on it. A ``Team`` has a ``teamName``, 
-zero or more ``Tasks``, and a list of ``members``.
+completed flag. There is also a count of minutes spent working on it, and a 
+due date. A ``Team`` has a ``teamName``, zero or more ``Tasks``, and a list 
+of ``members``.
 
 .. literalinclude:: /examples/generated/code/start/FlexibleSync.snippet.flexible-sync-models.swift
    :language: swift
@@ -160,6 +159,13 @@ denotes whether the initial subscription should re-run every time the
 app starts. You might need to do this to re-run dynamic time ranges 
 or other queries that require a re-computation of static variables for the 
 subscription.
+
+In this example, we don't want users to be overwhelmed by irrelevant tasks,
+so we'll load only tasks that were due up to a week ago through next week.
+Tasks that were due more than a week ago are no longer relevant, and tasks
+that are due further out than the next week are also not relevant. With
+``rerunOnOpen`` here, the query dynamically recalculates the relevant 
+objects to sync based on the desired date range every time the app starts.
 
 .. literalinclude:: /examples/generated/code/start/FlexibleSync.snippet.add-initial-subscriptions-rerun-on-open.swift
    :language: swift

--- a/source/sdk/swift/examples/flexible-sync.txt
+++ b/source/sdk/swift/examples/flexible-sync.txt
@@ -161,7 +161,7 @@ or other queries that require a re-computation of static variables for the
 subscription.
 
 In this example, we don't want users to be overwhelmed by irrelevant tasks,
-so we'll load only tasks that were due up to a week ago through next week.
+so we'll load only tasks due within the previous 7 days and the next 7 days.
 Tasks that were due more than a week ago are no longer relevant, and tasks
 that are due further out than the next week are also not relevant. With
 ``rerunOnOpen`` here, the query dynamically recalculates the relevant 


### PR DESCRIPTION
## Pull Request Info

In addition to the Jira ticket linked below, this PR also updates a skipped (failing) test - instead of commenting the test, the unit test suite is now skipping it. I have a separate Jira ticket to fix that failing test.

### Jira

- https://jira.mongodb.org/browse/DOCSP-23116

### Staged Changes (Requires MongoDB Corp SSO)

- [Flexible Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23116/sdk/swift/examples/flexible-sync/#bootstrap-the-realm-with-initial-subscriptions): Update the second example in "Bootstrap the Realm with Initial Subscriptions" to show a more applicable `rerunOnOpen` example that re-computes date-related variables on app startup.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
