### PR TITLE
Update Apple deployment targets and minimum Xcode version

### DIFF
--- a/source/sdk/swift.txt
+++ b/source/sdk/swift.txt
@@ -204,7 +204,7 @@ Integration Guides
 
 - :doc:`Build for tvOS </sdk/swift/integrations/tvos>`
 
-OS Support
+OS Support (Xcode 13)
 ----------
 
 .. list-table::
@@ -223,12 +223,40 @@ OS Support
    * - macOS 10.9+ (macOS 10.10+ if using Swift Package Manager)
      - X
      - X
-   
+
    * - tvOS 9.0+
      - X
      - X
 
    * - watchOS 2.0+
+     - X
+     - 
+
+OS Support (Xcode 14)
+----------
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :class: index-table
+
+   * - Supported OS
+     - Realm Database
+     - Realm Apps
+
+   * - iOS 11.0+
+     - X
+     - X
+
+   * - macOS 10.13+
+     - X
+     - X
+
+   * - tvOS 11.0+
+     - X
+     - X
+
+   * - watchOS 4.0+
      - X
      - 
 

--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -27,9 +27,10 @@ Prerequisites
 Before getting started, ensure your development environment
 meets the following prerequisites:
 
-- `Xcode <https://developer.apple.com/xcode/>`__ version 12.4 or higher.
-- Target of iOS 9.0 or higher, macOS 10.9 or higher, tvOS 9.0 or higher, or watchOS 2.0 or higher.
-- If using Swift Package Manager, target of iOS 11+ or macOS 10.10+ is required.
+- `Xcode <https://developer.apple.com/xcode/>`__ version 13.1 or higher.
+- When using Xcode 13, a target of iOS 9.0 or higher, macOS 10.9 or higher, tvOS 9.0 or higher, or watchOS 2.0 or higher.
+- If using Swift Package Manager with Xcode 13, target of iOS 11+ or macOS 10.10+ is required.
+- When using Xcode 14, a target of iOS 11.0 or higher, macOS 10.13 or higher, tvOS 11.0 or higher, or watchOS 4.0 or higher.
 
 .. important::
 


### PR DESCRIPTION
We now require Xcode 13, and when using Xcode 14 the minimum OS versions are higher.