### PR TITLE
(DOCSP-23439): Expo v45 not supported note

### DIFF
--- a/source/sdk/react-native/install.txt
+++ b/source/sdk/react-native/install.txt
@@ -32,12 +32,12 @@ meets the following prerequisites:
 - React Native v0.31.0 or later. Follow the `official React Native CLI Quickstart instructions <https://facebook.github.io/react-native/docs/getting-started.html>`__ to set up your environment.
 - `CocoaPods <https://cocoapods.org/>`__ 1.10.1 or later (recommended for building an iOS app with React Native v.60+).
 
-.. important:: Using Realm with Expo
+.. important:: Using Realm with Expo 
 
    `Expo <https://docs.expo.dev/>`_ now supports Realm with the Expo SDK version
-   44. To use Realm with Expo, upgrade to `Expo SDK version 44
+   44 **only**. To use Realm with Expo, upgrade to `Expo SDK version 44
    <https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/>`_.  Realm
-   does not work with earlier versions of Expo.
+   does not work with earlier versions of Expo, or with Expo version 45.
 
 .. note:: Realm JS version 10.6.0 Supports Mac Catalyst
    

--- a/source/sdk/react-native/install.txt
+++ b/source/sdk/react-native/install.txt
@@ -32,7 +32,7 @@ meets the following prerequisites:
 - React Native v0.31.0 or later. Follow the `official React Native CLI Quickstart instructions <https://facebook.github.io/react-native/docs/getting-started.html>`__ to set up your environment.
 - `CocoaPods <https://cocoapods.org/>`__ 1.10.1 or later (recommended for building an iOS app with React Native v.60+).
 
-.. important:: Using Realm with Expo 
+.. important:: Using Realm with Expo
 
    `Expo <https://docs.expo.dev/>`_ now supports Realm with the Expo SDK version
    44 **only**. To use Realm with Expo, upgrade to `Expo SDK version 44


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-23439

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23439-Expo-v45-not-supported/sdk/react-native/install/
### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
