### PR TITLE
(DOCSP-23563): Expo V45 not compatible with Android

### DIFF
--- a/source/sdk/react-native/install.txt
+++ b/source/sdk/react-native/install.txt
@@ -39,8 +39,8 @@ meets the following prerequisites:
    <https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/>`_. Realm
    does not work with earlier versions of Expo or with Expo version 45 on
    **Android**. To follow progress on its compatibility with Expo v45 on
-   Android, check out the :github:` GitHub issue<realm/realm-js/issues/4639>`.
-   
+   Android, check out the :github:`GitHub issue<realm/realm-js/issues/4639>`.
+
 .. note:: Realm JS version 10.6.0 Supports Mac Catalyst
    
    For `React Native version 0.64 and below

--- a/source/sdk/react-native/install.txt
+++ b/source/sdk/react-native/install.txt
@@ -35,10 +35,12 @@ meets the following prerequisites:
 .. important:: Using Realm with Expo
 
    `Expo <https://docs.expo.dev/>`_ now supports Realm with the Expo SDK version
-   44 **only**. To use Realm with Expo, upgrade to `Expo SDK version 44
-   <https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/>`_.  Realm
-   does not work with earlier versions of Expo, or with Expo version 45.
-
+   44. To use Realm with Expo, upgrade to `Expo SDK version 44
+   <https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/>`_. Realm
+   does not work with earlier versions of Expo or with Expo version 45 on
+   **Android**. To follow progress on its compatibility with Expo v45 on
+   Android, check out the :github:` GitHub issue<realm/realm-js/issues/4639>`.
+   
 .. note:: Realm JS version 10.6.0 Supports Mac Catalyst
    
    For `React Native version 0.64 and below


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-23563

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23563-Expo-SDK-v45-github-issue-tracking/sdk/react-native/install/

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
