### PR TITLE
(DOCSP-19614): Java and Kotlin SDK cleanup

### DIFF
--- a/source/includes/destructive-schema-change-app-update.rst
+++ b/source/includes/destructive-schema-change-app-update.rst
@@ -1,4 +1,4 @@
-.. note:: Breaking Schema Changes Require an App Schema Update
+.. important:: Breaking Schema Changes Require an App Schema Update
 
    After a breaking schema change:
 

--- a/source/includes/java-initialize-realm.rst
+++ b/source/includes/java-initialize-realm.rst
@@ -30,11 +30,11 @@ application runs.
          :language: kotlin
          :copyable: false
 
-.. note:: Register Your Application Subclass in the Android Manifest
+.. tip:: Register Your Application Subclass in the Android Manifest
    
    If you create your own ``Application`` subclass, you must add it to your
    application's ``AndroidManifest.xml`` to execute your custom
-   application code. Set the ``android.name`` property of your manifest's
+   application logic. Set the ``android.name`` property of your manifest's
    application definition to ensure that Android instantiates your ``Application``
    subclass before any other class when a user launches your application.
    

--- a/source/includes/kotlin-install-prerequisites.rst
+++ b/source/includes/kotlin-install-prerequisites.rst
@@ -2,6 +2,6 @@ Prerequisites
 -------------
 
 - :android:`Android Studio <studio/index.html>` Bumblebee 2021.1.1 or higher.
-- JDK 11 or higher
+- JDK 11 or higher.
 - Kotlin Plugin for Android Studio, version 1.6.10 or higher.
 - An Android Virtual Device (AVD) using a supported CPU architecture.

--- a/source/includes/note-store-user-api-key-value.rst
+++ b/source/includes/note-store-user-api-key-value.rst
@@ -1,4 +1,4 @@
-.. important:: Store the API Key Value
+.. warning:: Store the API Key Value
    
    The SDK only returns the value of the user API key when you create it. Make
    sure to store the ``key`` value securely so that you can use it to log in.

--- a/source/includes/note-to-one-relationships-must-be-optional.rst
+++ b/source/includes/note-to-one-relationships-must-be-optional.rst
@@ -1,4 +1,4 @@
-.. note:: To-one relationships must be optional
+.. important:: To-one relationships must be optional
 
    When you declare a to-one relationship in your object model, it must
    be an optional property. If you try to make a to-one relationship

--- a/source/includes/note-unsupported-flex-sync-rql-operators.rst
+++ b/source/includes/note-unsupported-flex-sync-rql-operators.rst
@@ -1,4 +1,4 @@
-.. important::
+.. note::
 
    Flexible Sync does not support all the operators available in Realm 
    Query Language. See :ref:`Flexible Sync RQL Limitations 

--- a/source/includes/see-also-define-relationship-in-app-services-ui.rst
+++ b/source/includes/see-also-define-relationship-in-app-services-ui.rst
@@ -1,4 +1,4 @@
-.. seealso:: Define a Relationship in the App Services UI
+.. seealso::
 
-   If you're using {+sync+}, you can also :ref:`define your relationships 
+   With Device Sync, you can also :ref:`define your relationships 
    <define-a-relationship>` in the App Services UI.

--- a/source/includes/tip-realm-query-language-reference-examples.rst
+++ b/source/includes/tip-realm-query-language-reference-examples.rst
@@ -1,4 +1,4 @@
-.. tip:: Realm Query Language Reference & Examples
+.. seealso:: Realm Query Language Reference & Examples
 
    Refer to the :ref:`Realm Query Language Reference <realm-query-language>`
    for more information about syntax, usage and limitations. 

--- a/source/includes/use-custom-data-note.rst
+++ b/source/includes/use-custom-data-note.rst
@@ -1,4 +1,4 @@
-.. note::
+.. important::
 
    To use custom user data, you must first :ref:`Enable Custom User Data
    <enable-custom-user-data-procedure>`.

--- a/source/sdk/java/advanced-guides/custom-user-data.txt
+++ b/source/sdk/java/advanced-guides/custom-user-data.txt
@@ -79,22 +79,22 @@ Create a User's Custom Data Document
    To create, update, or delete custom user data, you will need the following
    information from your custom user data configuration:
 
-   - the :term:`custom user data cluster`
+   - the custom user data cluster
 
-   - the :term:`custom user data database`
+   - the custom user data database
 
-   - the :term:`custom user data collection` in which custom
+   - the custom user data collection in which custom
      user data documents are stored
 
-   - the :term:`user ID field` used to map custom user data documents
-     to users (via :term:`user ID`)
+   - the user ID field used to map custom user data documents
+     to users (via user ID)
 
    You can find this information in the App Services UI on the
    :guilabel:`App Users` page under the :guilabel:`Custom User Data` tab.
 
 To create custom user data for a user, create a MongoDB document in the
 custom user data collection. The user ID field of the document should
-contain the the user's :term:`user ID`. The following example uses
+contain the the user's user ID. The following example uses
 :ref:`MongoDB Data Access <java-mongodb-data-access>` to insert a
 document containing the user ID of the currently logged in user and a
 ``favoriteColor`` value into the custom user data collection:

--- a/source/sdk/java/advanced-guides/custom-user-data.txt
+++ b/source/sdk/java/advanced-guides/custom-user-data.txt
@@ -54,13 +54,13 @@ method on the ``User`` object of a logged in user:
 
 .. warning:: Custom Data May Be Stale
    
-   {+backend+} does not dynamically update the value of
+   App Services does not dynamically update the value of
    :java-sdk:`User.customData() <io/realm/mongodb/User.html#getCustomData-->`
-   immediately when underlying data changes. Instead, {+backend+}
+   immediately when underlying data changes. Instead, App Services
    fetches the most recent version of custom user data whenever a user
    refreshes their :ref:`access token <user-sessions>`, which occurs
-   during most SDK operations that contact the {+backend+} back end.
-   {+service-short+} refreshes access tokens every 30 minutes, so custom
+   during most SDK operations that contact the App Services back end.
+   Realm refreshes access tokens every 30 minutes, so custom
    user data can be stale for no more than 30 minutes.
 
    If you require the most recent version of custom user data, use the
@@ -130,7 +130,7 @@ Update a User's Custom Data
 ---------------------------
 
 You can update custom user data using :ref:`MongoDB Data Access
-<java-mongodb-data-access>`, {+service-short+} :ref:`Sync
+<java-mongodb-data-access>`, Realm :ref:`Sync
 <java-sync-data>`, :compass:`MongoDB Compass </>`, 
 or the :atlas:`MongoDB Atlas Data
 Explorer </data-explorer/>`.
@@ -140,7 +140,7 @@ MongoDB document whose user ID field contains the user ID of the user.
 
 .. tip::
    
-   To determine a user's ID, access the ``User.id`` property or find the user in the {+ui+}
+   To determine a user's ID, access the ``User.id`` property or find the user in the App Services UI
    on the :guilabel:`App Users` page under the :guilabel:`Users` tab.
 
 The following example uses :ref:`MongoDB Data Access

--- a/source/sdk/java/advanced-guides/custom-user-data.txt
+++ b/source/sdk/java/advanced-guides/custom-user-data.txt
@@ -63,8 +63,6 @@ method on the ``User`` object of a logged in user:
    {+service-short+} refreshes access tokens every 30 minutes, so custom
    user data can be stale for no more than 30 minutes.
 
-.. note::
-
    If you require the most recent version of custom user data, use the
    :java-sdk:`User.refreshCustomData()
    <io/realm/mongodb/User.html#refreshCustomData-->` method to request
@@ -76,23 +74,23 @@ method on the ``User`` object of a logged in user:
 Create a User's Custom Data Document
 ------------------------------------
 
-To create, update, or delete custom user data, you will need the following
-information from your custom user data configuration:
-
-- the :term:`custom user data cluster`
-
-- the :term:`custom user data database`
-
-- the :term:`custom user data collection` in which custom
-  user data documents are stored
-
-- the :term:`user ID field` used to map custom user data documents
-  to users (via :term:`user ID`)
-
 .. tip::
-   
-   You can find this information in the {+ui+} on the :guilabel:`App Users` page
-   under the :guilabel:`Custom User Data` tab.
+
+   To create, update, or delete custom user data, you will need the following
+   information from your custom user data configuration:
+
+   - the :term:`custom user data cluster`
+
+   - the :term:`custom user data database`
+
+   - the :term:`custom user data collection` in which custom
+     user data documents are stored
+
+   - the :term:`user ID field` used to map custom user data documents
+     to users (via :term:`user ID`)
+
+   You can find this information in the App Services UI on the
+   :guilabel:`App Users` page under the :guilabel:`Custom User Data` tab.
 
 To create custom user data for a user, create a MongoDB document in the
 custom user data collection. The user ID field of the document should
@@ -139,6 +137,12 @@ Explorer </data-explorer/>`.
 
 To update a user's custom user data with MongoDB Data Access, edit the
 MongoDB document whose user ID field contains the user ID of the user.
+
+.. tip::
+   
+   To determine a user's ID, access the ``User.id`` property or find the user in the {+ui+}
+   on the :guilabel:`App Users` page under the :guilabel:`Users` tab.
+
 The following example uses :ref:`MongoDB Data Access
 <java-mongodb-data-access>` to update the ``favoriteColor`` field of
 the the document containing the user ID of the currently logged in user
@@ -161,8 +165,3 @@ in the custom user data collection:
          :language: java
          :emphasize-lines: 11,12
          :copyable: false
-
-.. tip::
-   
-   To determine a user's ID, access the ``User.id`` property or find the user in the {+ui+}
-   on the :guilabel:`App Users` page under the :guilabel:`Users` tab.

--- a/source/sdk/java/advanced-guides/debugging.txt
+++ b/source/sdk/java/advanced-guides/debugging.txt
@@ -18,19 +18,19 @@ Android Studio Debugging
 .. important::
 
    The Android Studio debugger can provide misleading values for
-   {+service-short+} object fields. For correct values, you can watch
-   accessor values instead, or use the {+service-short+} object
+   Realm object fields. For correct values, you can watch
+   accessor values instead, or use the Realm object
    ``toString()`` method to see the latest field values.
 
 This section details information you should keep in mind when debugging
-{+service-short+} applications with Android Studio to avoid incorrect
-value reporting. When you watch a {+service-short+} object,
+Realm applications with Android Studio to avoid incorrect
+value reporting. When you watch a Realm object,
 you'll see values displayed in the object's fields. These values 
 are incorrect because the field values themselves are not used. This is
-because {+service-short+} creates a :ref:`proxy object
+because Realm creates a :ref:`proxy object
 <java-realm-proxy>` behind the scenes, overriding
 the getters and setters to access the persisted data in the
-{+realm+}. To see the correct values, add a watch on the accessors.
+realm. To see the correct values, add a watch on the accessors.
 See the image below:
 
 .. figure:: /images/android-studio-debugging.png
@@ -51,7 +51,7 @@ the *accessors* report values that are correct.
 NDK Debugging
 -------------
 
-The {+service-short+} Java SDK library contains native code. 
+The Realm Java SDK library contains native code. 
 Debugging NDK crashes can be cumbersome, as the default stack trace
 provides minimal information. 
 

--- a/source/sdk/java/advanced-guides/debugging.txt
+++ b/source/sdk/java/advanced-guides/debugging.txt
@@ -15,8 +15,8 @@ Debugging - Java SDK
 Android Studio Debugging
 ------------------------
 
-.. warning::
-   
+.. important::
+
    The Android Studio debugger can provide misleading values for
    {+service-short+} object fields. For correct values, you can watch
    accessor values instead, or use the {+service-short+} object

--- a/source/sdk/java/advanced-guides/encryption.txt
+++ b/source/sdk/java/advanced-guides/encryption.txt
@@ -12,39 +12,39 @@ Encrypt a Realm - Java SDK
    :depth: 2
    :class: singlecol
 
-You can encrypt the {+realm+} database file on disk with AES-256 +
+You can encrypt the realm database file on disk with AES-256 +
 SHA-2 by supplying a 64-byte encryption key when :ref:`opening a
-{+realm+} <java-open-a-local-realm>`.
+realm <java-open-a-local-realm>`.
 
 Realm transparently encrypts and decrypts data with standard
 :wikipedia:`AES-256 encryption <Advanced_Encryption_Standard>` using the
-first 256 bits of the given 512-bit encryption key. {+service-short+}
+first 256 bits of the given 512-bit encryption key. Realm
 uses the other 256 bits of the 512-bit encryption key to validate
 integrity using a :wikipedia:`hash-based message authentication code
 (HMAC) <HMAC>`.
 
 .. note:: Performance Impact
 
-   Reads and writes on encrypted {+realm+}s can be up to 10%
-   slower than equivalent reads and writes to unencrypted {+realm+}s.
+   Reads and writes on encrypted realms can be up to 10%
+   slower than equivalent reads and writes to unencrypted realms.
 
 .. important:: Encryption and Atlas Device Sync
 
    You can encrypt a :ref:`synced realm <java-sync-data>`, but
-   {+service+} only encrypts the data on the device. {+service+} stores
+   Realm only encrypts the data on the device. Realm stores
    the data unencrypted in your :term:`data source`.
 
 Store & Reuse Keys
 ------------------
 
-To repeatedly access an encrypted {+realm+}, you must pass the same
+To repeatedly access an encrypted realm, you must pass the same
 encryption key to :java-sdk:`RealmConfiguration.Builder.encryptionKey()
 <io/realm/RealmConfiguration.Builder.html#encryptionKey-byte:A->` each
-time you open the {+realm+}. Apps should store the encryption key in the
+time you open the realm. Apps should store the encryption key in the
 :android:`Android KeyStore <training/articles/keystore.html>` so
 that other apps cannot read the key. The following steps describe the
 recommended way to use the KeyStore for encryption with
-{+service-short+}:
+Realm:
 
 1. Generate an asymmetric RSA key that Android can securely store and
    retrieve using the Android KeyStore.
@@ -54,19 +54,19 @@ recommended way to use the KeyStore for encryption with
       Versions M and above require user PIN or fingerprint to unlock
       the KeyStore.
 
-#. Generate a symmetric key (AES) you can use to encrypt the {+realm+}.
+#. Generate a symmetric key (AES) you can use to encrypt the realm.
 
 #. Encrypt the symmetric AES key using your private RSA key.
 
 #. Store the encrypted AES key on filesystem (in a
    ``SharedPreferences``, for example).
 
-When you need to use your encrypted {+realm+}:
+When you need to use your encrypted realm:
 
 1. Retrieve your encrypted AES key.
 #. Decrypt your encrypted AES key using the public RSA key.
 #. Use the decrypted AES key in the ``RealmConfiguration`` to open the
-   encrypted {+realm+}.
+   encrypted realm.
 
 .. seealso::
 
@@ -80,7 +80,7 @@ Generate and Store an Encryption Key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following code demonstrates how to securely generate and store an
-encryption key for a {+realm+}:
+encryption key for a realm:
 
 .. tabs-realm-languages::
    
@@ -102,7 +102,7 @@ Access an Existing Encryption Key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following code demonstrates how to access and decrypt a securely
-stored encryption key for a {+realm+}:
+stored encryption key for a realm:
 
 .. tabs-realm-languages::
    
@@ -123,7 +123,7 @@ stored encryption key for a {+realm+}:
 Open an Encrypted Realm
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The following code demonstrates how to open an encrypted {+realm+} with
+The following code demonstrates how to open an encrypted realm with
 the :java-sdk:`encryptionKey() <io/realm/mongodb/sync/SyncConfiguration.Builder.html#encryptionKey-byte:A->`
 method:
 

--- a/source/sdk/java/advanced-guides/encryption.txt
+++ b/source/sdk/java/advanced-guides/encryption.txt
@@ -32,7 +32,7 @@ integrity using a :wikipedia:`hash-based message authentication code
 
    You can encrypt a :ref:`synced realm <java-sync-data>`, but
    Realm only encrypts the data on the device. Realm stores
-   the data unencrypted in your :term:`data source`.
+   the data unencrypted in your data source.
 
 Store & Reuse Keys
 ------------------

--- a/source/sdk/java/advanced-guides/link-user-identities.txt
+++ b/source/sdk/java/advanced-guides/link-user-identities.txt
@@ -19,7 +19,7 @@ Realm lets you merge multiple credentials into one user identity.
 Example
 -------
 
-Consider an application that offers :ref:`anonymous login 
+Consider an application that offers :ref:`anonymous login
 <anonymous-authentication>`, which allows users to explore the app without 
 registering. If a user wants to continue using the application, they can create 
 a permanent account by using another Authentication provider. {+service-short+} 
@@ -30,7 +30,7 @@ current User.
 
    Depending on how you have configured email/password authentication, there may 
    be additional steps (confirming the email address, for example) before the 
-   new account is created and can be linked to. 
+   new account is created and can be linked.
 
 You link identities using
 :java-sdk:`linkCredentials() <io/realm/mongodb/User.html#linkCredentials-io.realm.mongodb.Credentials->`

--- a/source/sdk/java/advanced-guides/link-user-identities.txt
+++ b/source/sdk/java/advanced-guides/link-user-identities.txt
@@ -22,7 +22,7 @@ Example
 Consider an application that offers :ref:`anonymous login
 <anonymous-authentication>`, which allows users to explore the app without 
 registering. If a user wants to continue using the application, they can create 
-a permanent account by using another Authentication provider. {+service-short+} 
+a permanent account by using another Authentication provider. Realm 
 creates a new ``User`` object. The app can then link the new identity with the 
 current User.
 

--- a/source/sdk/java/advanced-guides/manual-client-reset-data-recovery.txt
+++ b/source/sdk/java/advanced-guides/manual-client-reset-data-recovery.txt
@@ -12,7 +12,7 @@ Manual Client Reset Data Recovery - Java SDK
    :depth: 2
    :class: singlecol
 
-.. note:: Manual Recovery is Manual
+.. important:: Manual Recovery is Manual
 
    Manual recovery requires significant amounts of code, schema concessions,
    and custom conflict resolution logic. If your application can accommodate

--- a/source/sdk/java/advanced-guides/multi-user-applications.txt
+++ b/source/sdk/java/advanced-guides/multi-user-applications.txt
@@ -18,8 +18,8 @@ in the context of a single active user even if multiple users are logged in
 simultaneously. You can quickly switch between authenticated users without
 requiring them to log in again.
 
-.. important::
-   
+.. warning::
+
    **Any logged in user may become the active user without re-authenticating.**
    Depending on your app, this may be a security vulnerability. For example, a
    user on a shared device may switch to a coworker's logged in account without

--- a/source/sdk/java/advanced-guides/multi-user-applications.txt
+++ b/source/sdk/java/advanced-guides/multi-user-applications.txt
@@ -13,7 +13,7 @@ Multi-User Applications - Java SDK
    :class: singlecol
 
 The Realm SDK allows multiple :ref:`users <user-accounts>` to be logged in to an
-app simultaneously on a given device. {+service-short+} client applications run
+app simultaneously on a given device. Realm client applications run
 in the context of a single active user even if multiple users are logged in
 simultaneously. You can quickly switch between authenticated users without
 requiring them to log in again.
@@ -31,7 +31,7 @@ requiring them to log in again.
 User Account States
 -------------------
 
-When a user first logs in through a {+service-short+} SDK on a given device or
+When a user first logs in through a Realm SDK on a given device or
 browser, the SDK saves the user's information and keeps track of the user's
 state on the device. The user's data remains on the device, even if they log
 out, unless you actively :ref:`remove the user <java-remove-a-user-from-the-device>`.
@@ -43,7 +43,7 @@ The following states describe an on-device user at any given time:
   
   - **Active**: a single authenticated user that is currently using the
     app on a given device. The SDK associates this user with outgoing
-    requests and {+backend-short+} evaluates data access permissions and runs
+    requests and App Services evaluates data access permissions and runs
     functions in this user's context. See :ref:`active user <active-user>` for
     more information.
    
@@ -54,7 +54,7 @@ The following states describe an on-device user at any given time:
 - **Logged Out:** any user that authenticated on the device but
   has since logged out or had its session revoked.
 
-The following diagram shows how users within a {+service-short+} client app
+The following diagram shows how users within a Realm client app
 transition between states when certain events occur:
 
 .. figure:: /images/multi-user.png
@@ -65,7 +65,7 @@ transition between states when certain events occur:
 Add a New User to the Device
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The {+service-short+} SDK automatically adds users to a device when they log in
+The Realm SDK automatically adds users to a device when they log in
 for the first time on that device. When a user logs in, they immediately become
 the application's :ref:`active user <active-user>`.
 

--- a/source/sdk/java/advanced-guides/testing.txt
+++ b/source/sdk/java/advanced-guides/testing.txt
@@ -18,8 +18,8 @@ You can test your application using unit tests or integration tests.
 writes, and calls to your application's backend, if you have one. Unit tests
 run on your development machine using the JVM, while integration tests
 run on a physical or emulated Android device. You can run integration
-tests by communicating with actual instances of {+client-database+}
-or an {+app+} backend using Android's built-in instrumented tests.
+tests by communicating with actual instances of Realm Database
+or an App backend using Android's built-in instrumented tests.
 
 Android uses specific file paths and folder names in Android projects
 for unit tests and instrumented tests:
@@ -39,24 +39,24 @@ for unit tests and instrumented tests:
 
 Because the SDK uses C++ code via Android Native for data
 storage, unit testing requires you to entirely mock interactions with
-{+client-database+}. Prefer integration tests for logic that requires
+Realm Database. Prefer integration tests for logic that requires
 extensive interaction with the database.
 
 Integration Tests
 -----------------
 
 This section shows how to integration test an application that uses
-the {+service-short+} SDK. It covers the following concepts in the test
+the Realm SDK. It covers the following concepts in the test
 environment:
 
 - acquiring an application context
 - executing logic on a ``Looper`` thread
 - how to delay test execution while asynchronous method calls complete
 
-Applications that use {+sync+} or a backend {+app+} also require (not
+Applications that use Sync or a backend App also require (not
 covered here):
 
-- a separate {+app+} backend for testing, with separate user accounts
+- a separate App backend for testing, with separate user accounts
   and data
 - a separate Atlas cluster containing test-only data
 
@@ -88,7 +88,7 @@ should :ref:`block your test from executing further
 
 The following example uses an ``ActivityScenario``, an empty testing
 activity, and a ``CountDownLatch`` to demonstrate how to set up an
-environment where you can test your {+service-short+} application:
+environment where you can test your Realm application:
 
 .. tabs-realm-languages::
    
@@ -109,7 +109,7 @@ environment where you can test your {+service-short+} application:
 Looper Thread
 ~~~~~~~~~~~~~
 
-{+client-database+} functionality such as 
+Realm Database functionality such as 
 :ref:`Live objects <java-live-object>` and change notifications only
 work on :android:`Looper <reference/android/os/Looper>` threads.
 Threads configured with a ``Looper`` object pass events over a message
@@ -189,7 +189,7 @@ thread:
 Testing Backend
 ~~~~~~~~~~~~~~~
 
-Applications that use an {+app+} backend should not connect to the
+Applications that use an App backend should not connect to the
 production backend for testing purposes for the following reasons:
 
 - you should always keep test users and production users separate
@@ -204,7 +204,7 @@ apps for testing and production.
 Testing Atlas Cluster
 ~~~~~~~~~~~~~~~~~~~~~
 
-Applications that use {+sync+} or :ref:`MongoDB queries
+Applications that use Sync or :ref:`MongoDB queries
 <java-mongodb-data-access>` may read, write, update, or delete data
 stored in connected Atlas clusters. For security purposes, you shouldn't
 store production data and testing data on the same cluster. Additionally,
@@ -216,7 +216,7 @@ Full Example
 ~~~~~~~~~~~~
 
 The following example shows a full Junit instrumented ``androidTest``
-example running {+client-database+} in integration tests:
+example running Realm Database in integration tests:
 
 .. tabs-realm-languages::
    
@@ -236,15 +236,15 @@ example running {+client-database+} in integration tests:
 
 .. seealso::
 
-   See the :github:`{+service-short+} Documentation Examples App
+   See the :github:`Realm Documentation Examples App
    <mongodb/docs-realm/tree/master/examples/java>` for an example
    of integration testing the SDK locally and with a live backend.
 
 Unit Tests
 ----------
 
-To unit test {+service-short+} applications that use {+service-short+},
-you must :wikipedia:`mock <Mock_object>` {+client-database+} (and your
+To unit test Realm applications that use Realm,
+you must :wikipedia:`mock <Mock_object>` Realm Database (and your
 application backend, if you use one). Use the following libraries to
 mock SDK functionality:
 
@@ -270,7 +270,7 @@ add the following to the ``dependencies`` block of your application
 
    Mocking the SDK in unit tests requires Robolectric, Mockito, and
    Powermock because the SDK uses Android Native C++ method calls to
-   interact with {+client-database+}. Because the frameworks required to
+   interact with Realm Database. Because the frameworks required to
    override these method calls can be delicate, you should use the
    versions listed above to ensure that your mocking is successful. Some
    recent version updates (particularly Robolectric version 4.2+) can
@@ -337,7 +337,7 @@ Once you've completed the setup required for mocking, you can start
 mocking components and wiring up behavior for your tests. You can also
 configure PowerMockito to return specific objects when new objects of
 a type are instantiated, so even code that references the default
-{+realm+} in your application won't break your tests:
+realm in your application won't break your tests:
 
 .. tabs-realm-languages::
    
@@ -355,7 +355,7 @@ a type are instantiated, so even code that references the default
          :language: java
          :copyable: false
 
-After mocking a {+realm+}, you'll have to configure data for your test
+After mocking a realm, you'll have to configure data for your test
 cases. See the full example below for some examples of how you can
 provide testing data in unit tests.
 
@@ -363,8 +363,8 @@ Full Example
 ~~~~~~~~~~~~
 
 The following example shows a full JUnit ``test``
-example mocking {+client-database+} in unit tests. This example tests
-an activity that performs some basic {+client-database+} operations.
+example mocking Realm Database in unit tests. This example tests
+an activity that performs some basic Realm Database operations.
 The tests use mocking to simulate those operations when that activity is
 started during a unit test:
 
@@ -397,4 +397,4 @@ started during a unit test:
    See the :github:`Unit Testing Example App
    <realm/realm-java/tree/master/examples/unitTestExample>`
    for an example of unit testing an application that uses
-   {+service-short+}.
+   Realm.

--- a/source/sdk/java/advanced-guides/threading.txt
+++ b/source/sdk/java/advanced-guides/threading.txt
@@ -215,7 +215,7 @@ auto-refresh disabled. To refresh a {+realm+}, call
          :language: java
          :copyable: false
 
-.. note:: Refresh on Write
+.. tip:: Refresh on Write
 
    Realms also automatically refresh after completing a write transaction.
 

--- a/source/sdk/java/advanced-guides/threading.txt
+++ b/source/sdk/java/advanced-guides/threading.txt
@@ -29,34 +29,34 @@ regardless of the size of the workload.
 Three Rules to Keep in Mind
 ---------------------------
 
-{+service+} enables simple and safe multithreaded code when you
+Realm enables simple and safe multithreaded code when you
 follow these three rules:
 
 Avoid writes on the UI thread if you write on a background thread:
   You can :ref:`write <java-realm-database-writes>` to a
-  {+realm+} from any thread, but there can be only one
+  realm from any thread, but there can be only one
   writer at a time. Consequently, write transactions block
   each other. A write on the UI thread may result in your
   app appearing unresponsive while it waits for a write on a
   background thread to complete. If you are using
-  :ref:`{+sync+} <sync>`, avoid writing on
-  the UI thread as {+sync-short+} writes on a background
+  :ref:`Sync <sync>`, avoid writing on
+  the UI thread as Sync writes on a background
   thread.
 
-Don't pass live objects, collections, or {+realms+} to other threads:
-  Live objects, collections, and {+realm+} instances are
+Don't pass live objects, collections, or realms to other threads:
+  Live objects, collections, and realm instances are
   **thread-confined**: that is, they are only valid on the
   thread on which they were created. Practically speaking,
   this means you cannot pass live instances to other
-  threads. However, {+client-database+} offers several mechanisms for
+  threads. However, Realm Database offers several mechanisms for
   :ref:`sharing objects across threads
   <java-communication-across-threads>`.
 
 Don't lock to read:
-  {+client-database+}'s :ref:`Multiversion Concurrency Control (MVCC)
+  Realm Database's :ref:`Multiversion Concurrency Control (MVCC)
   <java-mvcc>` architecture eliminates the need to lock for read operations. The
   values you read will never be corrupted or in a
-  partially-modified state. You can freely read from {+realms+}
+  partially-modified state. You can freely read from realms
   on any thread without the need for locks or mutexes.
   Unnecessarily locking would be a performance bottleneck
   since each thread might need to wait its turn before
@@ -67,9 +67,9 @@ Don't lock to read:
 Communication Across Threads
 ----------------------------
 
-Live objects, collections, and {+realm+}s are **thread-confined**. If
+Live objects, collections, and realms are **thread-confined**. If
 you need to work with the same data across multiple threads, you should
-open the same {+realm+} on multiple threads as separate {+realm+}
+open the same realm on multiple threads as separate realm
 instances. The Java SDK :ref:`consolidates underlying connections across
 threads where possible <java-realm-lifecycle>` to make this pattern
 more efficient.
@@ -85,13 +85,13 @@ several options depending on your use case:
   :ref:`freeze <java-frozen-objects>` the object.
 
 - To keep and share many read-only views of the object in your app, copy
-  the object from the {+realm+}.
+  the object from the realm.
 
 - To react to changes made on any thread, use
   :ref:`notifications <java-client-notifications>`.
 
-- To see changes from other threads in the {+realm+} on the current
-  thread, :ref:`refresh <java-refreshing-realms>` your {+realm+}
+- To see changes from other threads in the realm on the current
+  thread, :ref:`refresh <java-refreshing-realms>` your realm
   instance (:term:`event loop` threads refresh automatically).
 
 .. _java-intents:
@@ -103,9 +103,9 @@ Intents
 not thread-safe or ``Parcelable``, so you cannot pass them between
 activities or threads via an ``Intent``. Instead, you can pass an object
 identifier, like a :ref:`primary key <java-primary-key-fundamentals>`,
-in the ``Intent`` extras bundle, and then open a new {+realm+} instance
+in the ``Intent`` extras bundle, and then open a new realm instance
 in the separate thread to query for that identifier. Alternatively, you
-can :ref:`freeze <java-frozen-objects>` {+service-short+} objects.
+can :ref:`freeze <java-frozen-objects>` Realm objects.
 
 .. seealso::
 
@@ -124,23 +124,23 @@ Live, thread-confined objects work fine in most cases.
 However, some apps -- those based on reactive, event
 stream-based architectures, for example -- need to send
 immutable copies across threads. In this case,
-you can **freeze** objects, collections, and {+realms+}.
+you can **freeze** objects, collections, and realms.
 
 Freezing creates an immutable view of a specific object,
-collection, or {+realm+} that still exists on disk and does not
+collection, or realm that still exists on disk and does not
 need to be deeply copied when passed around to other
 threads. You can freely share a frozen object across threads
 without concern for thread issues.
 
 Frozen objects are not live and do not automatically update. They are
 effectively snapshots of the object state at the time of freezing. When
-you freeze a {+realm+} all child objects and collections also become
+you freeze a realm all child objects and collections also become
 frozen. You can't modify frozen objects, but you can read the primary
-key from a frozen object, query a live {+realm+} for the underlying
+key from a frozen object, query a live realm for the underlying
 object, and then update that live object instance.
 
-Frozen objects remain valid for as long as the {+realm+} that
-spawned them stays open. Avoid closing {+realm+}s that contain frozen
+Frozen objects remain valid for as long as the realm that
+spawned them stays open. Avoid closing realms that contain frozen
 objects until all threads are done working with those frozen objects.
 
 .. warning:: Frozen Object Exceptions
@@ -148,15 +148,15 @@ objects until all threads are done working with those frozen objects.
    When working with frozen objects, an attempt to do any of
    the following throws an exception:
 
-   - Opening a write transaction on a frozen {+realm+}.
+   - Opening a write transaction on a frozen realm.
    - Modifying a frozen object.
-   - Adding a change listener to a frozen {+realm+}, collection, or object.
+   - Adding a change listener to a frozen realm, collection, or object.
 
 Once frozen, you cannot unfreeze an object. You
 can use ``isFrozen()`` to check if an object is frozen.
 This method is always thread-safe.
 
-To freeze an object, collection, or {+realm+}, use the
+To freeze an object, collection, or realm, use the
 :java-sdk:`freeze() <io/realm/RealmObject.html#freeze-->` method:
 
 .. tabs-realm-languages::
@@ -177,26 +177,26 @@ To freeze an object, collection, or {+realm+}, use the
 
 .. important:: Frozen Objects and Realm Size
 
-   Frozen objects preserve an entire copy of the {+realm+} that contains
+   Frozen objects preserve an entire copy of the realm that contains
    them at the moment they were frozen. As a result, freezing a large
-   number of objects can cause a {+realm+} to consume more memory and
+   number of objects can cause a realm to consume more memory and
    storage than it might have without frozen objects. If you need to
    separately freeze a large number of objects for long periods of time,
-   consider copying what you need out of the {+realm+} instead.
+   consider copying what you need out of the realm instead.
 
 .. _java-refreshing-realms:
 
 Refreshing Realms
 -----------------
 
-When you open a {+realm+}, it reflects the most recent successful write
+When you open a realm, it reflects the most recent successful write
 commit and remains on that version until it is **refreshed**. This means
-that the {+realm+} will not see changes that happened on another thread
+that the realm will not see changes that happened on another thread
 until the next refresh. Realms on any :term:`event loop` thread 
 (including the UI thread) automatically refresh themselves at the
 beginning of that thread's loop. However, you must manually refresh
-{+realm+} instances that are tied to non-looping threads or that have
-auto-refresh disabled. To refresh a {+realm+}, call
+realm instances that are tied to non-looping threads or that have
+auto-refresh disabled. To refresh a realm, call
 :java-sdk:`Realm.refresh() <io/realm/Realm.html#refresh-->`:
 
 .. tabs-realm-languages::
@@ -224,7 +224,7 @@ auto-refresh disabled. To refresh a {+realm+}, call
 Realm's Threading Model in Depth
 --------------------------------
 
-{+client-database+} provides safe, fast, lock-free, and concurrent access
+Realm Database provides safe, fast, lock-free, and concurrent access
 across threads with its :wikipedia:`Multiversion Concurrency
 Control (MVCC) <Multiversion_concurrency_control>`
 architecture.
@@ -240,31 +240,31 @@ elements of Git are:
 - Commits, which are atomic writes.
 - Branches, which are different versions of the commit history.
 
-Similarly, {+client-database+} has atomically-committed writes in the form
-of :ref:`transactions <java-realm-database-writes>`. {+client-database+} also has many
+Similarly, Realm Database has atomically-committed writes in the form
+of :ref:`transactions <java-realm-database-writes>`. Realm Database also has many
 different versions of the history at any given time, like
 branches.
 
 Unlike Git, which actively supports distribution and
-divergence through forking, a {+realm+} only has one true latest
+divergence through forking, a realm only has one true latest
 version at any given time and always writes to the head of
-that latest version. {+client-database+} cannot write to a previous
+that latest version. Realm Database cannot write to a previous
 version. This makes sense: your data should converge on one
 latest version of the truth.
 
 Internal Structure
 ~~~~~~~~~~~~~~~~~~
 
-A {+realm+} is implemented using a :wikipedia:`B+ tree
+A realm is implemented using a :wikipedia:`B+ tree
 <B%2B_tree>` data structure. The top-level node represents a
-version of the {+realm+}; child nodes are objects in that
-version of the {+realm+}. The {+realm+} has a pointer to its latest
+version of the realm; child nodes are objects in that
+version of the realm. The realm has a pointer to its latest
 version, much like how Git has a pointer to its HEAD commit.
 
-{+client-database+} uses a copy-on-write technique to ensure
+Realm Database uses a copy-on-write technique to ensure
 :wikipedia:`isolation <Isolation_(database_systems)>` and
 :wikipedia:`durability <Durability_(database_systems)>`.
-When you make changes, {+client-database+} copies the relevant part of the
+When you make changes, Realm Database copies the relevant part of the
 tree for writing, then commits the changes in two phases:
 
 - Write changes to disk and verify success.
@@ -273,44 +273,44 @@ tree for writing, then commits the changes in two phases:
 This two-step commit process guarantees that even if the
 write failed partway, the original version is not corrupted
 in any way because the changes were made to a copy of the
-relevant part of the tree. Likewise, the {+realm+}'s root
+relevant part of the tree. Likewise, the realm's root
 pointer will point to the original version until the new
 version is guaranteed to be valid.
 
 .. include:: /includes/commit-process-diagram.rst
 
-{+client-database+} uses :term:`zero-copy` techniques
+Realm Database uses :term:`zero-copy` techniques
 like memory mapping to handle data. When you read a value
-from the {+realm+}, you are virtually looking at the value on
+from the realm, you are virtually looking at the value on
 the actual disk, not a copy of it. This is the basis for
-:ref:`live objects <java-live-object>`. This is also why a {+realm+}
+:ref:`live objects <java-live-object>`. This is also why a realm
 head pointer can be set to point to the new version after
 the write to disk has been validated.
 
 Summary
 -------
 
-- {+service+} enables simple and safe multithreaded code when you follow
+- Realm enables simple and safe multithreaded code when you follow
   three rules:
 
   - Avoid writes on the UI thread if you write on background threads or
-    use :ref:`{+sync+} <sync>`.
+    use :ref:`Sync <sync>`.
 
   - Don't pass live objects to other threads.
 
   - Don't lock to read.
 
-- In order to see changes made on other threads in your {+realm+}
-  instance, you must manually **refresh** {+realm+} instances that do
+- In order to see changes made on other threads in your realm
+  instance, you must manually **refresh** realm instances that do
   not exist on "loop" threads or that have auto-refresh disabled.
 
 - For apps based on reactive, event-stream-based architectures, you can
-  **freeze** objects, collections, and {+realms+} in order to pass
+  **freeze** objects, collections, and realms in order to pass
   copies around efficiently to different threads for processing.
 
-- {+client-database+}'s multiversion concurrency control (MVCC)
-  architecture is similar to Git's. Unlike Git, {+client-database+} has
-  only one true latest version for each {+realm+}.
+- Realm Database's multiversion concurrency control (MVCC)
+  architecture is similar to Git's. Unlike Git, Realm Database has
+  only one true latest version for each realm.
 
-- {+client-database+} commits in two stages to guarantee isolation and
+- Realm Database commits in two stages to guarantee isolation and
   durability.

--- a/source/sdk/java/advanced-guides/threading.txt
+++ b/source/sdk/java/advanced-guides/threading.txt
@@ -92,7 +92,7 @@ several options depending on your use case:
 
 - To see changes from other threads in the realm on the current
   thread, :ref:`refresh <java-refreshing-realms>` your realm
-  instance (:term:`event loop` threads refresh automatically).
+  instance (event loop threads refresh automatically).
 
 .. _java-intents:
 
@@ -192,7 +192,7 @@ Refreshing Realms
 When you open a realm, it reflects the most recent successful write
 commit and remains on that version until it is **refreshed**. This means
 that the realm will not see changes that happened on another thread
-until the next refresh. Realms on any :term:`event loop` thread 
+until the next refresh. Realms on any event loop thread 
 (including the UI thread) automatically refresh themselves at the
 beginning of that thread's loop. However, you must manually refresh
 realm instances that are tied to non-looping threads or that have
@@ -279,7 +279,7 @@ version is guaranteed to be valid.
 
 .. include:: /includes/commit-process-diagram.rst
 
-Realm Database uses :term:`zero-copy` techniques
+Realm Database uses zero-copy` techniques
 like memory mapping to handle data. When you read a value
 from the realm, you are virtually looking at the value on
 the actual disk, not a copy of it. This is the basis for

--- a/source/sdk/java/data-types/collections.txt
+++ b/source/sdk/java/data-types/collections.txt
@@ -18,14 +18,14 @@ object that contains zero or more instances of one
 are homogenous, i.e. all objects in a collection are of the
 same type.
 
-You can filter and sort any collection using {+client-database+}'s
+You can filter and sort any collection using Realm Database's
 :ref:`query engine <java-client-query-engine>`. Collections are
 :ref:`live <java-live-object>`, so they always reflect the
 current state of the :term:`realm instance` on the current
 thread. You can also listen for changes in the collection by subscribing
 to :ref:`collection notifications <java-collection-notifications>`.
 
-{+client-database+} has two kinds of collections: **lists** and **results**.
+Realm Database has two kinds of collections: **lists** and **results**.
 
 .. _java-field-relationships-lists:
 
@@ -97,7 +97,7 @@ iterate over a collection. You can use
 Adapters
 --------
 
-{+client-database+} offers adapters to help bind data
+Realm Database offers adapters to help bind data
 to standard UI widgets. These classes work with any class that
 implements the ``OrderedRealmCollection`` interface, which includes
 the built-in ``RealmResults`` and ``RealmList`` classes. For more
@@ -106,7 +106,7 @@ information on adapters, see the documentation on
 
 .. important:: Adapters Require Managed Objects
 
-   The {+client-database+} adapters only accept *managed*
+   The Realm Database adapters only accept *managed*
    Realm object instances tied to an instance of a realm.
    To display non-managed objects, use the general-use Android
    ``RecyclerView.Adapter`` for recycler views or ``ArrayAdapter`` for
@@ -149,7 +149,7 @@ validate that it is up-to-date.
 Results are Lazily Evaluated
 ----------------------------
 
-{+client-database+} only runs a query when you actually request the
+Realm Database only runs a query when you actually request the
 results of that query, e.g. by accessing elements of the
 results collection. This lazy evaluation enables you to
 write elegant, highly performant code for handling large
@@ -161,7 +161,7 @@ Limiting Query Results
 ~~~~~~~~~~~~~~~~~~~~~~
 
 As a result of lazy evaluation, you do not need any special
-mechanism to limit query results with {+client-database+}. For example, if
+mechanism to limit query results with Realm Database. For example, if
 your query matches thousands of objects, but you only want
 to load the first ten, simply access only the first ten
 elements of the results collection.
@@ -212,7 +212,7 @@ are determined by a query.
    you to add or remove Persons directly to the resulting
    collection. The contents of that collection only change
    when the query matches a different set of Persons.
-   Therefore, {+client-database+} gives you a **results** collection.
+   Therefore, Realm Database gives you a **results** collection.
 
 .. _java-collection-type-for-implicit-inverse-relationships:
 

--- a/source/sdk/java/data-types/collections.txt
+++ b/source/sdk/java/data-types/collections.txt
@@ -12,16 +12,16 @@ Collections - Java SDK
    :depth: 2
    :class: singlecol
 
-A {+service-short+} collection is an
+A Realm collection is an
 object that contains zero or more instances of one
-:ref:`{+service-short+} type <java-realm-objects>`. {+service-short+} collections
+:ref:`type <java-realm-objects>`. Realm collections
 are homogenous, i.e. all objects in a collection are of the
 same type.
 
 You can filter and sort any collection using {+client-database+}'s
 :ref:`query engine <java-client-query-engine>`. Collections are
 :ref:`live <java-live-object>`, so they always reflect the
-current state of the :term:`{+realm+} instance` on the current
+current state of the :term:`realm instance` on the current
 thread. You can also listen for changes in the collection by subscribing
 to :ref:`collection notifications <java-collection-notifications>`.
 
@@ -32,7 +32,7 @@ to :ref:`collection notifications <java-collection-notifications>`.
 Lists
 -----
 
-Realm objects can contain lists of non-{+service-short+}-object data
+Realm objects can contain lists of non-Realm-object data
 types. You can model these collections with the type ``RealmList<T>``,
 where ``T`` can be the following types:
 
@@ -59,7 +59,7 @@ List Collections
 ~~~~~~~~~~~~~~~~
 
 A **list collection** represents a :ref:`to-many
-relationship <java-to-many-relationship>` between two {+service-short+}
+relationship <java-to-many-relationship>` between two Realm
 types. Lists are mutable: within a write transaction, you
 can add and remove elements on a list. Lists are not
 associated with a query.
@@ -88,7 +88,7 @@ in a write transaction.
 Iteration
 ---------
 
-Because {+service-short+} collections are live, objects may move as you
+Because Realm collections are live, objects may move as you
 iterate over a collection. You can use
 :ref:`snapshots <java-iteration>` to iterate over collections safely.
 
@@ -104,10 +104,10 @@ the built-in ``RealmResults`` and ``RealmList`` classes. For more
 information on adapters, see the documentation on
 :ref:`Displaying Collections <java-adapters>`.
 
-.. note:: Adapters Require Managed Objects
+.. important:: Adapters Require Managed Objects
 
    The {+client-database+} adapters only accept *managed*
-   {+service-short+} object instances tied to an instance of a {+realm+}.
+   Realm object instances tied to an instance of a realm.
    To display non-managed objects, use the general-use Android
    ``RecyclerView.Adapter`` for recycler views or ``ArrayAdapter`` for
    list views.
@@ -117,15 +117,15 @@ information on adapters, see the documentation on
 Collections are Live
 --------------------
 
-Like :ref:`live objects <java-live-object>`, {+service-short+} collections
+Like :ref:`live objects <java-live-object>`, Realm collections
 are usually **live**:
 
 - Live results collections always reflect the current results of the associated query.
-- Live lists always reflect the current state of the relationship on the {+realm+} instance.
+- Live lists always reflect the current state of the relationship on the realm instance.
 
 There are three cases when a collection is **not** live:
 
-- The collection is unmanaged, e.g. a List property of a {+service-short+} object that has not been added to a {+realm+} yet or that has been copied from a {+realm+}.
+- The collection is unmanaged, e.g. a List property of a Realm object that has not been added to a realm yet or that has been copied from a realm.
 - The collection is :ref:`frozen <java-frozen-objects>`.
 - The collection is part of a snapshot.
 
@@ -137,13 +137,12 @@ collection in your view class, then read the results
 collection as needed without having to refresh it or
 validate that it is up-to-date.
 
-.. important:: Indexes may change
+.. warning:: Indexes may change
 
-   Since results update themselves automatically, do not
-   store the positional index of an object in the collection
-   or the count of objects in a collection. The stored index
-   or count value could be outdated by the time you use
-   it.
+   Results update themselves automatically. If you
+   store the positional index of an object in a collection
+   or the count of objects in a collection, the stored index
+   or count value could be outdated by the time you use it.
 
 .. _java-lazy-evaluated-results:
 
@@ -175,7 +174,7 @@ Pagination
 Thanks to lazy evaluation, the common task of pagination
 becomes quite simple. For example, suppose you have a
 results collection associated with a query that matches
-thousands of objects in your {+realm+}. You display one hundred
+thousands of objects in your realm. You display one hundred
 objects per page. To advance to any page, simply access the
 elements of the results collection starting at the index
 that corresponds to the target page.
@@ -189,7 +188,7 @@ When you need a collection, you can use the following rule
 of thumb to determine whether a list or a results collection
 is appropriate:
 
-- When you define the properties of your {+service-short+} objects, use lists to define :ref:`to-many relationships <java-to-many-relationship>` except :ref:`implicit inverse relationships <java-inverse-relationship>`.
+- When you define the properties of your Realm objects, use lists to define :ref:`to-many relationships <java-to-many-relationship>` except :ref:`implicit inverse relationships <java-inverse-relationship>`.
 - Use results everywhere else.
 
 To understand these different use cases, consider whether
@@ -201,14 +200,14 @@ are determined by a query.
 
 .. example::
 
-   Consider a {+service-short+} type called Person with a field called
+   Consider a Realm type called Person with a field called
    ``emails`` that is a collection of strings representing
    email addresses. You control this data. Your application
    needs to add and remove email addresses from your Person
    instances. Therefore, use a **list** to define the field
    type of ``emails``.
 
-   On the other hand, when you query the {+realm+} for all
+   On the other hand, when you query the realm for all
    Persons over the age of 25, it would not make sense for
    you to add or remove Persons directly to the resulting
    collection. The contents of that collection only change
@@ -217,30 +216,11 @@ are determined by a query.
 
 .. _java-collection-type-for-implicit-inverse-relationships:
 
-.. note:: Inverse one-to-many relationship property exception
+.. note:: Inverse one-to-many relationships
 
-   Since {+client-database+} automatically determines the contents of
+   Since Realm automatically determines the contents of
    :ref:`implicit inverse relationship
    <java-inverse-relationship>` collections, you may not add
-   or remove objects from such a collection directly.
+   or remove objects from such a collection.
    Therefore, the type of such a one-to-many relationship
    property is actually a results collection, not a list.
-
-Summary
--------
-
-- A {+service-short+} **collection** is a homogenous container of zero
-  or more instances of one
-  :ref:`{+service-short+} type <java-realm-objects>`.
-
-- Collections are :ref:`live <java-live-object>`, i.e. auto-updating, unless
-  you have :ref:`frozen <java-frozen-objects>` them or they are not part of a {+realm+}.
-
-- Lazy evaluation of results collections means there is no need to
-  design a special query to get limited or paginated results. Perform
-  the query and read from the results collection as needed.
-
-- There are two main kinds of collection: **lists** and **results**.
-  Lists define the :ref:`to-many relationships <java-to-many-relationship>`
-  of your {+service-short+} types, while results represent the
-  lazily-loaded output of a :ref:`read operation <java-realm-database-reads>`.

--- a/source/sdk/java/data-types/collections.txt
+++ b/source/sdk/java/data-types/collections.txt
@@ -21,7 +21,7 @@ same type.
 You can filter and sort any collection using Realm Database's
 :ref:`query engine <java-client-query-engine>`. Collections are
 :ref:`live <java-live-object>`, so they always reflect the
-current state of the :term:`realm instance` on the current
+current state of the realm instance on the current
 thread. You can also listen for changes in the collection by subscribing
 to :ref:`collection notifications <java-collection-notifications>`.
 

--- a/source/sdk/java/data-types/counters.txt
+++ b/source/sdk/java/data-types/counters.txt
@@ -60,7 +60,7 @@ counts the number of ghosts found in a haunted house:
    ``RealmResults`` and ``RealmList``. This means the value contained
    inside the ``MutableRealmInteger`` can change when a {+realm+} is
    written to. For this reason ``MutableRealmInteger`` fields must be
-   marked final.
+   marked final in Java and ``val`` in Kotlin.
 
 Usage
 -----

--- a/source/sdk/java/data-types/counters.txt
+++ b/source/sdk/java/data-types/counters.txt
@@ -12,12 +12,12 @@ Counters - Java SDK
    :depth: 2
    :class: singlecol
 
-{+client-database+} offers :java-sdk:`MutableRealmInteger
+Realm Database offers :java-sdk:`MutableRealmInteger
 <io/realm/MutableRealmInteger.html>`, a wrapper around numeric values,
 to help better synchronize numeric changes across multiple clients.
 
 Typically, incrementing or decrementing a
-``byte``, ``short``, ``int``, or ``long`` field of a {+service-short+}
+``byte``, ``short``, ``int``, or ``long`` field of a Realm
 object looks something like this:
 
 1. Read the current value of the field.
@@ -58,7 +58,7 @@ counts the number of ghosts found in a haunted house:
 
    ``MutableRealmInteger`` is a live object like ``RealmObject``,
    ``RealmResults`` and ``RealmList``. This means the value contained
-   inside the ``MutableRealmInteger`` can change when a {+realm+} is
+   inside the ``MutableRealmInteger`` can change when a realm is
    written to. For this reason ``MutableRealmInteger`` fields must be
    marked final in Java and ``val`` in Kotlin.
 

--- a/source/sdk/java/data-types/embedded-objects.txt
+++ b/source/sdk/java/data-types/embedded-objects.txt
@@ -26,7 +26,7 @@ exist as an independent Realm object. Realm automatically deletes
 embedded objects if their parent object is deleted or when overwritten
 by a new embedded object instance.
 
-.. note:: Realm Uses Cascading Deletes for Embedded Objects
+.. warning:: Realm Uses Cascading Deletes for Embedded Objects
 
    When you delete a Realm object, Realm automatically deletes any
    embedded objects referenced by that object. Any objects that your
@@ -43,7 +43,7 @@ composable. You can use the same embedded object type in multiple parent
 object types and you can embed objects inside of other embedded objects.
 
 .. important::
-   
+
    Embedded objects cannot have a primary key.
 
 Realm Object Models

--- a/source/sdk/java/data-types/enums.txt
+++ b/source/sdk/java/data-types/enums.txt
@@ -14,12 +14,12 @@ Enumerations - Java SDK
 
 Enumerations, also known as enums, are not supported natively in the
 Java SDK. However, you can use Java and Kotlin enums in your
-{+service-short+} objects if you follow these steps.
+Realm objects if you follow these steps.
 
 Usage
 -----
 
-To use an enum in a {+service-short+} object class, define a field
+To use an enum in a Realm object class, define a field
 with a type matching the underlying data type of your enum. Create
 getters and setters for the field that convert the field value between
 the underlying value and the enum type. You can use the Java's built-in

--- a/source/sdk/java/data-types/field-types.txt
+++ b/source/sdk/java/data-types/field-types.txt
@@ -13,7 +13,7 @@ Field Types - Java SDK
    :depth: 2
    :class: singlecol
 
-{+client-database+} supports the following field data types:
+Realm Database supports the following field data types:
 
 - ``Boolean`` or ``boolean``
 - ``Integer`` or ``int``
@@ -35,10 +35,10 @@ Field Types - Java SDK
 
 The ``Byte``, ``Short``, ``Integer``, and ``Long`` types and their
 lowercase primitive alternatives are all stored as ``Long`` values
-within {+client-database+}. Similarly, {+client-database+} stores objects
+within Realm Database. Similarly, Realm Database stores objects
 of the ``Float`` and ``float`` types as type ``Double``.
 
-{+service-short+} does not support fields with modifiers ``final`` and
+Realm does not support fields with modifiers ``final`` and
 ``volatile``, though you can use fields with those modifiers if you
 :ref:`ignore <java-ignore-field>` them. If you choose to provide custom
 constructors, you must declare a public constructor with no arguments.
@@ -46,7 +46,7 @@ constructors, you must declare a public constructor with no arguments.
 Updating Strings and Byte Arrays
 --------------------------------
 
-Since {+client-database+} operates on fields as a whole, it's not possible
+Since Realm Database operates on fields as a whole, it's not possible
 to directly update individual elements of strings or byte arrays. Instead,
 you'll need to read the whole field, make your modification to individual
 elements, and then write the entire field back again in a transaction block.

--- a/source/sdk/java/data-types/field-types.txt
+++ b/source/sdk/java/data-types/field-types.txt
@@ -54,8 +54,6 @@ elements, and then write the entire field back again in a transaction block.
 Object IDs and UUIDs
 --------------------
 
-.. note:: UUID type -- *new to version 10.6.0*
-
 ``ObjectId`` and ``UUID`` (Universal Unique Identifier) both provide
 unique values that can be used as identifiers for objects.
 ``ObjectId`` is a :manual:`MongoDB-specific </reference/method/ObjectId/>`

--- a/source/sdk/java/data-types/realmany.txt
+++ b/source/sdk/java/data-types/realmany.txt
@@ -46,7 +46,7 @@ value. ``RealmAny`` instances are immutable just like ``String`` or
 ``Integer`` instances; if you want to assign a new value to a
 ``RealmAny`` field, you must create a new ``RealmAny`` instance.
 
-.. important:: Null ``RealmAny`` Values
+.. warning:: Two Possible Null ``RealmAny`` Values
 
    ``RealmAny`` instances are always :ref:`nullable
    <java-optionality>`. Additionally, instances can contain a value

--- a/source/sdk/java/data-types/realmany.txt
+++ b/source/sdk/java/data-types/realmany.txt
@@ -16,11 +16,11 @@ RealmAny - Java SDK
 .. versionadded:: 10.6.0
 
 You can use the :java-sdk:`RealmAny <io/realm/RealmAny.html>` data type to create
-{+service-short+} object fields that can contain any of several
+Realm object fields that can contain any of several
 underlying types. You can store multiple ``RealmAny`` instances in
 ``RealmList``, ``RealmDictionary``, or ``RealmSet`` fields. To change
 the value of a ``RealmAny`` field, assign a new ``RealmAny`` instance
-with a different underlying value. In {+sync+} backend
+with a different underlying value. In Sync backend
 :ref:`object schemas <object-schema>`, the ``RealmAny``
 data type is called **mixed**. ``RealmAny`` fields are indexable, but
 cannot be used as primary keys.

--- a/source/sdk/java/data-types/realmany.txt
+++ b/source/sdk/java/data-types/realmany.txt
@@ -20,7 +20,7 @@ Realm object fields that can contain any of several
 underlying types. You can store multiple ``RealmAny`` instances in
 ``RealmList``, ``RealmDictionary``, or ``RealmSet`` fields. To change
 the value of a ``RealmAny`` field, assign a new ``RealmAny`` instance
-with a different underlying value. In Sync backend
+with a different underlying value. In App Services backend
 :ref:`object schemas <object-schema>`, the ``RealmAny``
 data type is called **mixed**. ``RealmAny`` fields are indexable, but
 cannot be used as primary keys.

--- a/source/sdk/java/data-types/realmdictionary.txt
+++ b/source/sdk/java/data-types/realmdictionary.txt
@@ -19,9 +19,9 @@ You can use the :java-sdk:`RealmDictionary
 unique ``String`` keys paired with values. ``RealmDictionary``
 implements Java's ``Map`` interface, so it works just like the built-in
 ``HashMap`` class, except managed ``RealmDictionary`` instances persist
-their contents to a {+realm+}. ``RealmDictionary`` instances that
-contain {+service-short+} objects store references to those objects.
-When you delete a {+service-short+} object from a {+realm+}, any
+their contents to a realm. ``RealmDictionary`` instances that
+contain Realm objects store references to those objects.
+When you delete a Realm object from a realm, any
 references to that object in a ``RealmDictionary`` become ``null``
 values.
 

--- a/source/sdk/java/data-types/realmdictionary.txt
+++ b/source/sdk/java/data-types/realmdictionary.txt
@@ -33,18 +33,27 @@ of type ``RealmDictionary<T>``, where ``T`` defines the values you would
 like to store in your ``RealmDictionary``. Currently, ``RealmDictionary``
 instances can only use keys of type ``String``.
 
-- Add an object to a ``RealmDictionary`` with
-  :java-sdk:`RealmDictionary.put() <io/realm/RealmDictionary.html#put-E->`
-  (or the ``[]`` operator in Kotlin)
+The following table shows which methods you can use to complete common
+collection tasks with ``RealmDictionary``:
 
-- Add multiple objects to a ``RealmDictionary`` with
-  :java-sdk:`RealmDictionary.putAll() <io/realm/RealmDictionary.html#putAll-Map->`
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
 
-- Check if the dictionary contains an specific key with
-  :java-sdk:`RealmDictionary.containsKey() <io/realm/RealmDictionary.html#containsKey-String->`
+   * - Task
+     - Method
 
-- Check if the dictionary contains a specific value with
-  :java-sdk:`RealmDictionary.containsValue() <io/realm/RealmDictionary.html#containsValue-Object->`
+   * - Add an object to a ``RealmDictionary``
+     - :java-sdk:`put() <io/realm/RealmDictionary.html#put-E->` (or the ``[]`` operator in Kotlin)
+
+   * - Add multiple objects to a ``RealmDictionary``
+     - :java-sdk:`putAll() <io/realm/RealmDictionary.html#putAll-Map->`
+
+   * - Check if the dictionary contains an specific key
+     - :java-sdk:`containsKey() <io/realm/RealmDictionary.html#containsKey-String->`
+
+   * - Check if the dictionary contains a specific value
+     - :java-sdk:`containsValue() <io/realm/RealmDictionary.html#containsValue-Object->`
 
 .. tabs-realm-languages::
    

--- a/source/sdk/java/data-types/realmset.txt
+++ b/source/sdk/java/data-types/realmset.txt
@@ -18,9 +18,9 @@ You can use the :java-sdk:`RealmSet <io/realm/RealmSet.html>` data type
 to manage a collection of unique keys. ``RealmSet`` implements Java's
 ``Set`` interface, so it works just like the built-in ``HashSet`` class,
 except managed ``RealmSet`` instances persist their contents to a
-{+realm+}. ``RealmSet`` instances that contain {+service-short+} objects
+realm. ``RealmSet`` instances that contain Realm objects
 actually only store references to those objects, so deleting a
-{+service-short+} object from a {+realm+} also deletes that object from
+Realm object from a realm also deletes that object from
 any ``RealmSet`` instances that contain the object.
 
 Because ``RealmSet`` implements ``RealmCollection``, it has some useful

--- a/source/sdk/java/data-types/realmset.txt
+++ b/source/sdk/java/data-types/realmset.txt
@@ -28,17 +28,18 @@ mathematical methods, such as ``sum``, ``min``, and ``max``. For a complete
 list of available ``RealmSet`` methods, see: :java-sdk:`the RealmSet API 
 reference <io/realm/RealmSet.html>`.
 
-.. note:: ``RealmSet`` Limitations
+Method Limitations
+------------------
 
-   Objects containing ``RealmSet`` fields currently cannot use the
-   following ``Realm`` methods:
+You cannot use the following ``Realm`` methods on objects that contain
+a field of type ``RealmSet``:
 
-   - ``Realm.insert()``
-   - ``Realm.insertOrUpdate()``
-   - ``Realm.createAllFromJson()``
-   - ``Realm.createObjectFromJson()``
-   - ``Realm.createOrUpdateAllFromJson()``
-   - ``Realm.createOrUpdateObjectFromJson()``
+- ``Realm.insert()``
+- ``Realm.insertOrUpdate()``
+- ``Realm.createAllFromJson()``
+- ``Realm.createObjectFromJson()``
+- ``Realm.createOrUpdateAllFromJson()``
+- ``Realm.createOrUpdateObjectFromJson()``
 
 Usage
 -----

--- a/source/sdk/java/examples/adapters.txt
+++ b/source/sdk/java/examples/adapters.txt
@@ -15,12 +15,12 @@ Display Collections - Java SDK
 Android apps often populate the UI using
 :android:`RecyclerView <reference/androidx/recyclerview/widget/RecyclerView.html>`
 or :android:`ListView <reference/android/widget/ListView>` components.
-{+service-short+} offers **adapters** to display {+realm+} object 
+Realm offers **adapters** to display {+realm+} object 
 :ref:`collections <java-client-collections>`. These collections implement 
 the ``OrderedRealmCollections`` interface. :ref:`RealmResults <java-results-collections>`
 and :ref:`RealmList <java-list-collections>` are examples of these adaptors. 
 With these adapters, UI components update when your app changes 
-{+service-short+} objects.
+Realm objects.
 
 Install Adapters
 ----------------
@@ -35,7 +35,7 @@ Add these dependencies to your application level ``build.gradle`` file:
       implementation 'androidx.recyclerview:recyclerview:1.1.0'
    }
 
-{+service-short+} hosts these adapters on the
+Realm hosts these adapters on the
 `JCenter <https://mvnrepository.com/repos/jcenter>`_
 artifact repository. To use ``jcenter`` in your Android app, add it to your 
 project-level ``build.gradle`` file:
@@ -65,7 +65,7 @@ project-level ``build.gradle`` file:
 Example Models
 --------------
 
-The examples on this page use a {+service-short+} object named ``Item``. 
+The examples on this page use a Realm object named ``Item``. 
 This class contains a string named "name" and an identifier number named 
 "id":
 
@@ -90,13 +90,13 @@ This class contains a string named "name" and an identifier number named
 Display Collections in a ListView
 ---------------------------------
 
-Display {+service-short+} objects in a
+Display Realm objects in a
 :android:`ListView <reference/android/widget/ListView>` by extending
 :github:`RealmBaseAdapter
 <realm/realm-android-adapters/blob/master/adapters/src/main/java/io/realm/RealmBaseAdapter.java>`.
 The adapter uses the ``ListAdapter`` interface. Implementation works
 like any ``ListAdapter``. This provides support for automatically-updating 
-{+service-short+} objects.
+Realm objects.
 
 Subclass ``RealmBaseAdapter`` to display
 :ref:`Item <java-adapters-model-item>` objects in a ``ListView``:
@@ -135,13 +135,13 @@ Subclass ``RealmBaseAdapter`` to display
 Display Collections in a RecyclerView
 -------------------------------------
 
-Display {+service-short+} objects in a
+Display Realm objects in a
 :android:`RecyclerView <reference/androidx/recyclerview/widget/RecyclerView.html>`
 by extending :github:`RealmRecyclerViewAdapter
 <realm/realm-android-adapters/blob/master/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java>`.
 The adapter extends ``RecyclerView.Adapter``. Implementation works like any 
 ``RecyclerView`` adapter. This provides support
-for automatically-updating {+service-short+} objects.
+for automatically-updating Realm objects.
 
 Subclass ``RealmRecyclerViewAdapter`` to display
 :ref:`Item <java-adapters-model-item>` objects in a ``RecyclerView``:

--- a/source/sdk/java/examples/adapters.txt
+++ b/source/sdk/java/examples/adapters.txt
@@ -15,7 +15,7 @@ Display Collections - Java SDK
 Android apps often populate the UI using
 :android:`RecyclerView <reference/androidx/recyclerview/widget/RecyclerView.html>`
 or :android:`ListView <reference/android/widget/ListView>` components.
-Realm offers **adapters** to display {+realm+} object 
+Realm offers **adapters** to display realm object 
 :ref:`collections <java-client-collections>`. These collections implement 
 the ``OrderedRealmCollections`` interface. :ref:`RealmResults <java-results-collections>`
 and :ref:`RealmList <java-list-collections>` are examples of these adaptors. 

--- a/source/sdk/java/examples/authenticate-users.txt
+++ b/source/sdk/java/examples/authenticate-users.txt
@@ -13,7 +13,7 @@ Authenticate Users - Java SDK
    :depth: 2
    :class: singlecol
 
-{+service+} provides an API for authenticating users using any enabled
+Realm provides an API for authenticating users using any enabled
 authentication provider. Instantiate a ``Credentials`` object and pass
 it to either of the  ``app.login()`` or ``app.loginAsync()`` methods to
 authenticate a user login and create a ``User`` object. Each
@@ -169,7 +169,7 @@ Custom Function User
 
 The :ref:`Custom Function authentication provider <custom-function-authentication>`
 enables users to log in to your application using a
-:ref:`Realm Function <functions>` defined in your {+app+}. To log in with custom 
+:ref:`Realm Function <functions>` defined in your App. To log in with custom 
 function authentication, create a credential by calling 
 ``Credentials.customFunction()``. The :java-sdk:`customFunction()
 <io/realm/mongodb/Credentials.html#customFunction-Document->` method expects a 
@@ -229,8 +229,8 @@ Follow the official :facebook:`Facebook Login for Android Quickstart
 application. In the login completion handler, get the logged in user's access
 token from the Facebook :facebook:`LoginResult
 <docs/reference/android/current/class/LoginResult>`. Use the access token to
-create a {+service-short+} Facebook credential and then log the user into your
-{+service-short+} app.
+create a Realm Facebook credential and then log the user into your
+Realm app.
 
 .. tabs-realm-languages::
    
@@ -268,7 +268,7 @@ To set up your application for Google User authentication:
    <https://console.cloud.google.com/apis/credentials>`__, create an
    OAuth 2.0 client ID of type "Web application".
 
-#. Configure your backend {+app+} to use that client ID and the associated
+#. Configure your backend App to use that client ID and the associated
    client secret.
 
 #. Enable OpenID Connect on the backend.
@@ -435,7 +435,7 @@ methods. Both methods:
 
 - delete locally stored user credentials from the device
 
-- immediately halt any synchronization to and from the user's {+realm+}s
+- immediately halt any synchronization to and from the user's realms
 
 Because logging out halts synchronization, you should only log out after
 all local Realm updates have uploaded to the server.

--- a/source/sdk/java/examples/bundle-a-realm.txt
+++ b/source/sdk/java/examples/bundle-a-realm.txt
@@ -14,15 +14,15 @@ Bundle a Realm File - Java SDK
 
 .. note:: Bundle Synchronized Realms
 
-   SDK version 10.9.0 introduced the ability to bundle synchronized {+realm+}s.
-   Before version 10.9.0, you could only bundle local {+realm+}s.
+   SDK version 10.9.0 introduced the ability to bundle synchronized realms.
+   Before version 10.9.0, you could only bundle local realms.
 
-{+service-short+} supports **bundling** {+realm+} files. When you bundle
-a {+realm+} file, you include a database and all of its data in your
+Realm supports **bundling** realm files. When you bundle
+a realm file, you include a database and all of its data in your
 application download.
 
 This allows users to start applications for the first time with a set of
-initial data. For synced {+realm+}s, bundling can avoid a lengthy
+initial data. For synced realms, bundling can avoid a lengthy
 initial download the first time a user opens your application. Instead,
 users must only download the synced changes that occurred since you
 generated the bundled file.
@@ -33,56 +33,56 @@ generated the bundled file.
    <advanced-backend-compaction>` by configuring a
    :ref:`client maximum offline time <client-maximum-offline-time>`,
    users could experience a client reset the first time they open the
-   bundled {+realm+} file. This can happen if:
+   bundled realm file. This can happen if:
 
-   - the bundled {+realm+} file was generated more than
+   - the bundled realm file was generated more than
      **client maximum offline time** days before the user syncs the
-     {+realm+} for the first time.
+     realm for the first time.
 
    Users experiencing a client reset download the full state of the
-   {+realm+} from the application backend. This negates the
-   advantages of bundling a {+realm+} file. To prevent client resets and
-   preserve the advantages of {+realm+} file bundling:
+   realm from the application backend. This negates the
+   advantages of bundling a realm file. To prevent client resets and
+   preserve the advantages of realm file bundling:
 
    - Avoid using a client maximum offline time in applications that
-     bundle a synchronized {+realm+}.
+     bundle a synchronized realm.
 
    - If your application does use a client maximum offline time, ensure
      that your application download always includes a recently synced
-     {+realm+} file. Generate a new file each application version,
+     realm file. Generate a new file each application version,
      and ensure that no version ever stays current for more than
      **client maximum offline time** number of days.
 
 Overview
 --------
 
-To create and bundle a {+realm+} file with your application:
+To create and bundle a realm file with your application:
 
-1. :ref:`Create a {+realm+} file <java-create-a-realm-for-bundling>` that
+1. :ref:`Create a realm file <java-create-a-realm-for-bundling>` that
    contains the data you'd like to bundle.
 
-#. :ref:`Bundle the {+realm+} file <java-bundle-realm-file>` in the
+#. :ref:`Bundle the realm file <java-bundle-realm-file>` in the
    :file:`/<app name>/src/main/assets` folder of your production
    application.
 
 #. In your production application,
-   :ref:`open the {+realm+} from the bundled asset file
+   :ref:`open the realm from the bundled asset file
    <java-open-a-realm-from-a-bundled-realm-file>`. For synced
-   {+realm+}s, you must supply the partition key.
+   realms, you must supply the partition key.
 
 .. _java-create-a-realm-for-bundling:
 
 Create a Realm File for Bundling
 --------------------------------
 
-1. Build a temporary {+realm+} app that shares the data model of your
+1. Build a temporary realm app that shares the data model of your
    application.
 
-#. Open a {+realm+} and add the data you wish to bundle. If using a
-   synchronized {+realm+}, allow time for the {+realm+} to fully sync.
+#. Open a realm and add the data you wish to bundle. If using a
+   synchronized realm, allow time for the realm to fully sync.
 
 #. Use the :java-sdk:`writeCopyTo() <io/realm/Realm.html#writeCopyTo-java.io.File->` 
-   method to copy the {+realm+} to a new file:
+   method to copy the realm to a new file:
 
    .. tabs-realm-languages::
 
@@ -96,13 +96,13 @@ Create a Realm File for Bundling
 
          .. include:: /examples/generated/java/sync/BundleTest.snippet.copy-a-realm-file.java.rst
 
-   ``writeCopyTo()`` automatically compacts your {+realm+} to the smallest
+   ``writeCopyTo()`` automatically compacts your realm to the smallest
    possible size before copying.
 
    .. tip:: Differences Between Synced Realms and Local-only Realms
 
       The above example uses a ``SyncConfiguration`` to configure a synchronized
-      {+realm+}. To create a copy of a local {+realm+}, configure your {+realm+}
+      realm. To create a copy of a local realm, configure your realm
       with ``RealmConfiguration`` instead.
 
 .. _java-bundle-realm-file:
@@ -110,10 +110,10 @@ Create a Realm File for Bundling
 Bundle a Realm File in Your Production Application
 ----------------------------------------------------
 
-Now that you have a copy of the {+realm+} that contains the initial data,
+Now that you have a copy of the realm that contains the initial data,
 bundle it with your production application.
 
-1. Search your application logs to find the location of the {+realm+} file
+1. Search your application logs to find the location of the realm file
    copy you just created.
 
 #. Using the "Device File Explorer" widget in the bottom right of your
@@ -121,7 +121,7 @@ bundle it with your production application.
 
 #. Right click on the file and select "Save As". Navigate to the
    :file:`/<app name>/src/main/assets` folder of your production application.
-   Save a copy of the {+realm+} file there.
+   Save a copy of the realm file there.
 
 .. tip:: Asset Folders
 
@@ -135,10 +135,10 @@ bundle it with your production application.
 Open a Realm from a Bundled Realm File
 --------------------------------------
 
-Now that you have a copy of the {+realm+} included with your production
+Now that you have a copy of the realm included with your production
 application, you need to add code to use it. Use the :java-sdk:`assetFile()
 <io/realm/RealmConfiguration.Builder.html#assetFile-java.lang.String->`
-method when configuring your {+realm+} to open the realm
+method when configuring your realm to open the realm
 from the bundled file:
 
 .. tabs-realm-languages::
@@ -156,5 +156,5 @@ from the bundled file:
 .. tip:: Differences Between Synced Realms and Local-only Realms
 
    The above example uses a ``SyncConfiguration`` to configure a synchronized
-   {+realm+}. To create a copy of a local {+realm+}, configure your {+realm+}
+   realm. To create a copy of a local realm, configure your realm
    with ``RealmConfiguration`` instead.

--- a/source/sdk/java/examples/bundle-a-realm.txt
+++ b/source/sdk/java/examples/bundle-a-realm.txt
@@ -99,7 +99,7 @@ Create a Realm File for Bundling
    ``writeCopyTo()`` automatically compacts your {+realm+} to the smallest
    possible size before copying.
 
-   .. note:: Differences Between Synced Realms and Local-only Realms
+   .. tip:: Differences Between Synced Realms and Local-only Realms
 
       The above example uses a ``SyncConfiguration`` to configure a synchronized
       {+realm+}. To create a copy of a local {+realm+}, configure your {+realm+}
@@ -123,7 +123,7 @@ bundle it with your production application.
    :file:`/<app name>/src/main/assets` folder of your production application.
    Save a copy of the {+realm+} file there.
 
-.. note:: Asset Folders
+.. tip:: Asset Folders
 
    If your application does not already contain an asset folder, you can
    create one by right clicking on your top-level application
@@ -153,7 +153,7 @@ from the bundled file:
 
       .. include:: /examples/generated/java/sync/BundleTest.snippet.use-bundled-realm-file.java.rst
 
-.. note:: Differences Between Synced Realms and Local-only Realms
+.. tip:: Differences Between Synced Realms and Local-only Realms
 
    The above example uses a ``SyncConfiguration`` to configure a synchronized
    {+realm+}. To create a copy of a local {+realm+}, configure your {+realm+}

--- a/source/sdk/java/examples/call-a-function.txt
+++ b/source/sdk/java/examples/call-a-function.txt
@@ -32,7 +32,7 @@ To execute a function from the SDK, use the
 :java-sdk:`getFunctions() <io/realm/mongodb/App.html#getFunctions-io.realm.mongodb.User->`
 method of the your :java-sdk:`App <io/realm/mongodb/App.html>`
 to retrieve a :java-sdk:`Functions manager <>`. Pass the name and
-parameters of the :term:`function <{+service-short+} Function>` you would like to call to
+parameters of the :term:`function <Realm Function>` you would like to call to
 :java-sdk:`callFunction() <io/realm/mongodb/functions/Functions.html#callFunction-java.lang.String-java.util.List-->`
 or :java-sdk:`callFunctionAsync() <io/realm/mongodb/functions/Functions.html#callFunctionAsync-java.lang.String-java.util.List--io.realm.mongodb.App.Callback->`:
 

--- a/source/sdk/java/examples/call-a-function.txt
+++ b/source/sdk/java/examples/call-a-function.txt
@@ -28,8 +28,6 @@ The examples in this section demonstrate calling a simple function named
 Call a Function by Name
 -----------------------
 
-.. include:: /includes/important-sanitize-client-data-in-functions.rst
-
 To execute a function from the SDK, use the
 :java-sdk:`getFunctions() <io/realm/mongodb/App.html#getFunctions-io.realm.mongodb.User->`
 method of the your :java-sdk:`App <io/realm/mongodb/App.html>`

--- a/source/sdk/java/examples/call-a-function.txt
+++ b/source/sdk/java/examples/call-a-function.txt
@@ -32,7 +32,7 @@ To execute a function from the SDK, use the
 :java-sdk:`getFunctions() <io/realm/mongodb/App.html#getFunctions-io.realm.mongodb.User->`
 method of the your :java-sdk:`App <io/realm/mongodb/App.html>`
 to retrieve a :java-sdk:`Functions manager <>`. Pass the name and
-parameters of the :term:`function <Realm Function>` you would like to call to
+parameters of the function you would like to call to
 :java-sdk:`callFunction() <io/realm/mongodb/functions/Functions.html#callFunction-java.lang.String-java.util.List-->`
 or :java-sdk:`callFunctionAsync() <io/realm/mongodb/functions/Functions.html#callFunctionAsync-java.lang.String-java.util.List--io.realm.mongodb.App.Callback->`:
 

--- a/source/sdk/java/examples/connect-to-app-services-backend.txt
+++ b/source/sdk/java/examples/connect-to-app-services-backend.txt
@@ -13,7 +13,7 @@ Connect to an Atlas App Services backend - Java SDK
    :depth: 2
    :class: singlecol
 
-The {+app+} client is the interface to the {+backend+}
+The App client is the interface to the App Services
 backend. It provides access to the :ref:`authentication functionality
 <java-authenticate>`, :ref:`functions <java-call-a-function>`, and
 :ref:`sync management <java-sync-data>`.
@@ -25,7 +25,7 @@ backend. It provides access to the :ref:`authentication functionality
 Access the App Client
 ---------------------
 
-Pass the {+app+} ID for your {+app+}, which you can :ref:`find in the Realm UI
+Pass the App ID for your App, which you can :ref:`find in the Realm UI
 <find-your-app-id>`.
   
 .. tabs-realm-languages::
@@ -46,13 +46,13 @@ Pass the {+app+} ID for your {+app+}, which you can :ref:`find in the Realm UI
 
 .. important:: Initialize the App before Creating an Instance
 
-   You must initialize your {+service-short+} app connection with
+   You must initialize your Realm app connection with
    ``Realm.init()`` before creating any instance of an ``App``.
 
 .. note::
 
    You can create multiple ``App`` instances to connect to multiple
-   {+app+}s or to the same {+app+} with different configurations. All
+   Apps or to the same App with different configurations. All
    ``App`` instances that share the same App ID use the same underlying
    connection.
 
@@ -85,4 +85,4 @@ Builder to control details of your ``App``:
 .. note:: 
 
    For most use cases, you only need your application's App ID to connect
-   to {+service+}. The other settings demonstrated here are optional.
+   to Realm. The other settings demonstrated here are optional.

--- a/source/sdk/java/examples/connect-to-app-services-backend.txt
+++ b/source/sdk/java/examples/connect-to-app-services-backend.txt
@@ -13,7 +13,7 @@ Connect to an Atlas App Services backend - Java SDK
    :depth: 2
    :class: singlecol
 
-The App client is the interface to the App Services
+The App client is the interface for the App Services
 backend. It provides access to the :ref:`authentication functionality
 <java-authenticate>`, :ref:`functions <java-call-a-function>`, and
 :ref:`sync management <java-sync-data>`.

--- a/source/sdk/java/examples/connect-to-app-services-backend.txt
+++ b/source/sdk/java/examples/connect-to-app-services-backend.txt
@@ -46,7 +46,7 @@ Pass the App ID for your App, which you can :ref:`find in the Realm UI
 
 .. important:: Initialize the App before Creating an Instance
 
-   You must initialize your Realm app connection with
+   You must initialize your App connection with
    ``Realm.init()`` before creating any instance of an ``App``.
 
 .. note::

--- a/source/sdk/java/examples/define-a-realm-object-model.txt
+++ b/source/sdk/java/examples/define-a-realm-object-model.txt
@@ -263,7 +263,7 @@ Define an Embedded Object Field
 Realm Database provides the ability to nest objects within other
 objects. This has several advantages:
 
-- If using Sync, objects will translate into MongoDB documents that
+- If using Sync, objects translate into MongoDB documents that
   follow a :manual:`denormalized data model </core/data-modeling-introduction/>`.
 
 - When you delete an object that contains another object, the delete

--- a/source/sdk/java/examples/define-a-realm-object-model.txt
+++ b/source/sdk/java/examples/define-a-realm-object-model.txt
@@ -13,91 +13,79 @@ Define a Realm Object Schema - Java SDK
    :depth: 2
    :class: singlecol
 
-.. tip::
+.. seealso::
 
    For conceptual information about schemas, as well as details about
-   types and constraints, see :ref:`Fundametals: Object Models & Schemas
+   types and constraints, see :ref:`Fundamentals: Object Models & Schemas
    <java-object-models-and-schemas>`.
 
 Define a Realm Object
 ---------------------
 
-To define a {+service-short+} object in your application,
+To define a Realm object in your application,
 create a subclass of :java-sdk:`RealmObject <io/realm/RealmObject.html>`
 or implement :java-sdk:`RealmModel <io/realm/RealmModel.html>`.
 
 .. important::
 
-   All {+service-short+} objects must provide an empty constructor.
+   - All Realm objects must provide an empty constructor.
+   - All Realm objects must use the ``public`` visibility modifier in Java
+     or the ``open`` visibility modifier in Kotlin.
 
 Extend ``RealmObject``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. example::
+The following code block shows a Realm object that
+describes a Frog. This Frog class can be stored in
+{+client-database+} because it ``extends`` the ``RealmObject`` class.
 
-   The following code block shows a {+service-short+} object that
-   describes a Frog. This Frog class can be stored in
-   {+client-database+} because it ``extends`` the ``RealmObject`` class.
+.. tabs-realm-languages::
 
-   .. tabs-realm-languages::
+   .. tab::
+      :tabid: kotlin
 
-      .. tab::
-         :tabid: kotlin
+      .. include:: /examples/generated/java/local/FrogObjectExampleKt.snippet.complete.kt.rst
 
-         .. include:: /examples/generated/java/local/FrogObjectExampleKt.snippet.complete.kt.rst
+   .. tab::
+      :tabid: java
 
-         .. important::
-
-            All {+service-short+} objects defined must use the
-            ``open`` visibility modifier.
-
-      .. tab::
-         :tabid: java
-
-         .. include:: /examples/generated/java/local/FrogObjectExample.snippet.complete.java.rst
-
-         .. important::
-
-            All {+service-short+} objects must use the ``public``
-            visibility modifier.
+      .. include:: /examples/generated/java/local/FrogObjectExample.snippet.complete.java.rst
 
 Implement ``RealmModel``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. example::
+The following code block shows a Realm object that
+describes a Frog. This Frog class can
+be stored in {+client-database+} because it ``implements`` the
+``RealmModel`` class and uses the ``@RealmClass`` annotation:
 
-   The following code block shows a {+service-short+} object that
-   describes a Frog. This Frog class can
-   be stored in {+client-database+} because it ``implements`` the
-   ``RealmModel`` class and uses the ``@RealmClass`` annotation:
+.. tabs-realm-languages::
 
-   .. tabs-realm-languages::
+   .. tab::
+      :tabid: kotlin
 
-      .. tab::
-         :tabid: kotlin
+      .. include:: /examples/generated/java/local/FrogRealmModelExampleKt.snippet.complete.kt.rst
 
-         .. include:: /examples/generated/java/local/FrogRealmModelExampleKt.snippet.complete.kt.rst
+      .. important::
 
-         .. important::
+         All Realm objects must use the ``open``
+         visibility modifier.
 
-            All {+service-short+} objects must use the ``open``
-            visibility modifier.
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
+      .. include:: /examples/generated/java/local/FrogRealmModelExample.snippet.complete.java.rst
 
-         .. include:: /examples/generated/java/local/FrogRealmModelExample.snippet.complete.java.rst
+      .. important::
 
-         .. important::
-
-            All {+service-short+} objects must use the ``public``
-            visibility modifier.
+         All Realm objects must use the ``public``
+         visibility modifier.
 
 .. tip:: Using ``RealmObject`` Methods
 
-   When you create a {+service-short+} object by extending the ``RealmObject``
+   When you create a Realm object by extending the ``RealmObject``
    class, you can access ``RealmObject`` class methods dynamically on
-   instances of your {+service-short+} object. {+service-short+} objects
+   instances of your Realm object. Realm objects
    created by implementing ``RealmModel`` can access those same methods
    statically through the ``RealmObject`` class:
 
@@ -120,7 +108,7 @@ Implement ``RealmModel``
 Lists
 -----
 
-{+service-short+} objects can contain lists of non-{+service-short+}-object data
+Realm objects can contain lists of non-Realm-object data
 types:
 
 .. tabs-realm-languages::
@@ -133,7 +121,7 @@ types:
    .. tab::
       :tabid: java
 
-      Unlike lists of {+service-short+} objects, these lists can contain
+      Unlike lists of Realm objects, these lists can contain
       null values. If null values shouldn't be allowed, use the
       :ref:`@Required <java-required-field>` annotation.
 
@@ -152,11 +140,11 @@ Define a Relationship Field
 
 .. include:: /includes/see-also-define-relationship-in-app-services-ui.rst
 
-.. warning:: Always Define Accessors and Mutators for Client-Modified Fields
+.. warning:: Always Define Accessors and Mutators for Modifiable Fields
 
-   {+service-short+} objects use getters and setters to persist updated
-   field values to your {+realm+}s. Always use getters and setters when
-   changing fields of a {+service-short+} object.
+   Realm objects use getters and setters to persist updated
+   field values to your realms. Always use getters and setters for
+   updates.
 
 .. seealso::
 
@@ -168,7 +156,7 @@ Many-to-One
 ~~~~~~~~~~~
 
 To set up a many-to-one or one-to-one relationship, create a field
-whose type is a {+service-short+} object in your application:
+whose type is a Realm object in your application:
 
 .. tabs-realm-languages::
 
@@ -279,8 +267,8 @@ objects. This has several advantages:
   follow a :manual:`denormalized data model </core/data-modeling-introduction/>`.
 
 - When you delete an object that contains another object, the delete
-  operation removes both objects from the {+realm+}, so unused objects
-  don't accumulate in your {+realm+} file, taking up valuable space on
+  operation removes both objects from the realm, so unused objects
+  don't accumulate in your realm file, taking up valuable space on
   user's mobile devices.
 
 To embed an object, set the ``embedded`` property of the
@@ -325,7 +313,7 @@ class, as in the following example:
 Annotations
 -----------
 
-Use annotations to customize your {+service-short+} object models.
+Use annotations to customize your Realm object models.
 
 .. _java-primary-key:
 
@@ -451,10 +439,10 @@ annotation:
 Ignore a Field
 ~~~~~~~~~~~~~~
 
-If you don't want to save a field in your model to a {+realm+}, you can
+If you don't want to save a field in your model to a realm, you can
 ignore a field.
 
-Ignore a field from a {+service-short+} object model with the
+Ignore a field from a Realm object model with the
 :java-sdk:`@Ignore <io/realm/annotations/Ignore.html>` annotation:
 
 .. tabs-realm-languages::
@@ -469,7 +457,7 @@ Ignore a field from a {+service-short+} object model with the
 
       .. include:: /examples/generated/java/local/FrogIgnoreExample.snippet.complete.java.rst
 
-.. note:: Ignoring ``static`` and ``transient`` Fields
+.. note:: The SDK ignores ``static`` and ``transient`` Fields
 
    Fields marked ``static`` or ``transient`` are always ignored, and do
    not need the ``@Ignore`` annotation.
@@ -578,11 +566,11 @@ annotation to rename a class:
 Omit Classes from your Realm Schema
 -----------------------------------
 
-By default, your application's {+service-short+} Schema includes all
+By default, your application's Realm Schema includes all
 classes that extend ``RealmObject``. If you only want to include a
-subset of classes that extend ``RealmObject`` in your {+service-short+}
+subset of classes that extend ``RealmObject`` in your Realm
 Schema, you can include that subset of classes in a module and open
-your {+realm+} using that module:
+your realm using that module:
 
 .. tabs-realm-languages::
 

--- a/source/sdk/java/examples/define-a-realm-object-model.txt
+++ b/source/sdk/java/examples/define-a-realm-object-model.txt
@@ -37,7 +37,7 @@ Extend ``RealmObject``
 
 The following code block shows a Realm object that
 describes a Frog. This Frog class can be stored in
-{+client-database+} because it ``extends`` the ``RealmObject`` class.
+Realm Database because it ``extends`` the ``RealmObject`` class.
 
 .. tabs-realm-languages::
 
@@ -56,7 +56,7 @@ Implement ``RealmModel``
 
 The following code block shows a Realm object that
 describes a Frog. This Frog class can
-be stored in {+client-database+} because it ``implements`` the
+be stored in Realm Database because it ``implements`` the
 ``RealmModel`` class and uses the ``@RealmClass`` annotation:
 
 .. tabs-realm-languages::
@@ -212,7 +212,7 @@ like a regular collection. You can use the same object in multiple
 Inverse Relationships
 ~~~~~~~~~~~~~~~~~~~~~
 
-By default, {+client-database+} relationships are unidirectional. You
+By default, Realm Database relationships are unidirectional. You
 can follow a link from one class to a referenced class, but not in the
 opposite direction. Consider the following class defining a ``Toad`` with
 a list of ``frogFriends``:
@@ -260,10 +260,10 @@ annotation on a ``final`` (in Java) or ``val`` (in Kotlin) field of type
 Define an Embedded Object Field
 -------------------------------
 
-{+client-database+} provides the ability to nest objects within other
+Realm Database provides the ability to nest objects within other
 objects. This has several advantages:
 
-- If using {+sync+}, objects will translate into MongoDB documents that
+- If using Sync, objects will translate into MongoDB documents that
   follow a :manual:`denormalized data model </core/data-modeling-introduction/>`.
 
 - When you delete an object that contains another object, the delete
@@ -289,7 +289,7 @@ another class:
       .. include:: /examples/generated/java/local/FlyEmbeddedExample.snippet.complete.java.rst
 
 Then, any time you reference that class from another class,
-{+client-database+} will embed the referenced class within the enclosing
+Realm Database will embed the referenced class within the enclosing
 class, as in the following example:
 
 .. tabs-realm-languages::
@@ -467,7 +467,7 @@ Ignore a field from a Realm object model with the
 Rename a Field
 ~~~~~~~~~~~~~~
 
-By default, {+client-database+} uses the name defined in the model class
+By default, Realm Database uses the name defined in the model class
 to represent fields internally. In some cases you might want to change
 this behavior:
 
@@ -496,7 +496,7 @@ annotation to rename a field:
       .. include:: /examples/generated/java/local/FrogRenameAFieldExample.snippet.complete.java.rst
 
 Alternatively, you can also assign a naming policy at the module or
-class levels to change the way that {+client-database+} interprets field
+class levels to change the way that Realm Database interprets field
 names.
 
 You can define a
@@ -537,13 +537,13 @@ at the class level, which overrides module level settings:
 Rename a Class
 ~~~~~~~~~~~~~~
 
-By default, {+client-database+} uses the name defined in the model class
+By default, Realm Database uses the name defined in the model class
 to represent classes internally. In some cases you might want to change
 this behavior:
 
 - To support multiple model classes with the same simple name in different packages.
 - To make it easier to work across platforms, since naming conventions differ.
-- To use a class name that is longer than the 57 character limit enforced by {+client-database+}.
+- To use a class name that is longer than the 57 character limit enforced by Realm Database.
 - To change a class name in Kotlin without forcing a migration.
 
 Use the :java-sdk:`@RealmClass <io/realm/annotations/RealmClass.html>`

--- a/source/sdk/java/examples/email-password-users.txt
+++ b/source/sdk/java/examples/email-password-users.txt
@@ -13,7 +13,7 @@ Manage Email/Password Users - Java SDK
    :class: singlecol
 
 When you have enabled the :ref:`email/password provider
-<email-password-authentication>` in your {+app+}, you can register a new
+<email-password-authentication>` in your App, you can register a new
 account, confirm an email address, and reset a user's password from
 client code.
 
@@ -26,7 +26,7 @@ To register a new user, pass a user-provided email and password to the
 :java-sdk:`registerUser() <io/realm/mongodb/auth/EmailPasswordAuth.html#registerUser-java.lang.String-java.lang.String->`
 or :java-sdk:`registerUserAsync()
 <io/realm/mongodb/auth/EmailPasswordAuth.html#registerUserAsync-java.lang.String-java.lang.String-io.realm.mongodb.App.Callback->`
-methods of your {+service-short+} ``App``'s :java-sdk:`EmailPasswordAuth <io/realm/mongodb/auth/EmailPasswordAuth.html>`
+methods of your Realm ``App``'s :java-sdk:`EmailPasswordAuth <io/realm/mongodb/auth/EmailPasswordAuth.html>`
 instance:
 
 .. tabs-realm-languages::
@@ -53,7 +53,7 @@ Confirm a New User's Email Address
 To confirm a newly-created user, pass a confirmation ``token`` and
 ``tokenId`` to the :java-sdk:`confirmUser() <io/realm/mongodb/auth/EmailPasswordAuth.html#confirmUser-java.lang.String-java.lang.String->`
 or :java-sdk:`confirmUserAsync() <io/realm/mongodb/auth/EmailPasswordAuth.html#confirmUserAsync-java.lang.String-java.lang.String-io.realm.mongodb.App.Callback->`
-methods of your {+service-short+} ``App``'s :java-sdk:`EmailPasswordAuth <io/realm/mongodb/auth/EmailPasswordAuth.html>`
+methods of your Realm ``App``'s :java-sdk:`EmailPasswordAuth <io/realm/mongodb/auth/EmailPasswordAuth.html>`
 instance:
 
 .. tabs-realm-languages::
@@ -84,14 +84,14 @@ instance:
 Reset a User's Password
 -----------------------
 
-To reset a user password in {+sync+}, you can either:
+To reset a user password in Sync, you can either:
 
 - Send a password reset email
 - Run a password reset function
 
 Select your preferred password reset method by going to:
 
-1. Your {+app+}
+1. Your App
 #. :guilabel:`Authentication`
 #. :guilabel:`Authentication Providers`
 #. :guilabel:`Email/Password` - and press the :guilabel:`EDIT` button
@@ -122,7 +122,7 @@ or :java-sdk:`sendResetPasswordEmailAsync() <io/realm/mongodb/auth/EmailPassword
 Password reset emails contain two values, ``token`` and ``tokenId``.
 To complete the password reset flow, prompt the user to enter a new
 password and pass the ``token`` and ``tokenId`` values along with the
-new password value to your {+service-short+} ``App``'s
+new password value to your Realm ``App``'s
 :java-sdk:`EmailPasswordAuth <io/realm/mongodb/auth/EmailPasswordAuth.html>`
 instance's :java-sdk:`resetPassword() <io/realm/mongodb/auth/EmailPasswordAuth.html#resetPassword-java.lang.String-java.lang.String-java.lang.String->`
 or :java-sdk:`resetPasswordAsync()

--- a/source/sdk/java/examples/email-password-users.txt
+++ b/source/sdk/java/examples/email-password-users.txt
@@ -72,7 +72,7 @@ instance:
          :language: java
          :copyable: false
 
-.. note::
+.. tip::
 
    To access the ``token`` and ``tokenId`` values sent in the user
    confirmation email, you can use a :ref:`custom confirmation email subject
@@ -145,7 +145,7 @@ methods:
          :language: java
          :copyable: false
 
-.. note::
+.. tip::
 
    To access the ``token`` and ``tokenId`` values sent in the password
    reset email, you can use a :ref:`custom password reset email subject
@@ -172,8 +172,7 @@ than email.
 .. seealso::
 
    For more information on how to define a custom password reset function
-   in the {+sync+} backend, including how to structure it and examples 
-   of implementing custom flows, see: :ref:`Run a Password Reset Function 
+   in your App, see: :ref:`Run a Password Reset Function 
    <auth-run-a-password-reset-function>`.
 
 .. tabs-realm-languages::

--- a/source/sdk/java/examples/filter-data.txt
+++ b/source/sdk/java/examples/filter-data.txt
@@ -154,7 +154,7 @@ Sort Results
 
 .. important::
 
-   {+client-database+} applies the ``distinct()``, ``sort()`` and
+   Realm Database applies the ``distinct()``, ``sort()`` and
    ``limit()`` methods in the order you specify. Depending on the
    data set this can alter the query result. Generally, you should
    apply ``limit()`` last to avoid unintended result sets.
@@ -183,7 +183,7 @@ Sorts organize results in ascending order by default. To organize results
 in descending order, pass ``Sort.DESCENDING`` as a second argument.
 You can resolve sort order ties between identical property values
 by passing an array of properties instead of a single property: in the
-event of a tie, {+client-database+} sorts the tied objects by subsequent
+event of a tie, Realm Database sorts the tied objects by subsequent
 properties in order.
 
 .. note:: String Sorting Limitations
@@ -191,7 +191,7 @@ properties in order.
    Realm uses non-standard sorting for upper and lowercase
    letters, sorting them together rather than sorting uppercase first.
    As a result, ``'- !"#0&()*,./:;?_+<=>123aAbBcC...xXyYzZ`` is the
-   actual sorting order in {+client-database+}. Additionally, sorting
+   actual sorting order in Realm Database. Additionally, sorting
    strings only supports the ``Latin Basic``, ``Latin Supplement``,
    ``Latin Extended A``, and ``Latin Extended B (UTF-8 range 0–591)``
    character sets.
@@ -225,13 +225,13 @@ Limited result collections automatically update like any other query
 result. Consequently, objects might drop out of the collection as
 underlying data changes.
 
-.. tip:: Pagination is Not Necessary for {+client-database+} Optimization
+.. tip:: Pagination is Not Necessary for Realm Database Optimization
 
    Some databases encourage paginating results with limits to avoid
    reading unnecessary data from disk or using too much memory.
 
-   Since {+client-database+} queries are lazy, there is no need to
-   take such measures. {+client-database+} only loads objects from query
+   Since Realm Database queries are lazy, there is no need to
+   take such measures. Realm Database only loads objects from query
    results when they are explicitly accessed.
 
 .. tip:: Deleted Notifications in Limited Results

--- a/source/sdk/java/examples/filter-data.txt
+++ b/source/sdk/java/examples/filter-data.txt
@@ -92,7 +92,7 @@ containing teachers with the name "Ms. Langtree" or "Mrs. Jacobs".
   returns immediately and finds the first object that meets the query
   conditions asynchronously on a background thread
 
-Queries return a list of references to the matching {+service-short+}
+Queries return a list of references to the matching Realm
 objects using the :ref:`RealmResults <java-results-collections>` type.
 
 .. seealso::
@@ -152,6 +152,13 @@ You can even use dot notation to query inverse relationships:
 Sort Results
 ------------
 
+.. important::
+
+   {+client-database+} applies the ``distinct()``, ``sort()`` and
+   ``limit()`` methods in the order you specify. Depending on the
+   data set this can alter the query result. Generally, you should
+   apply ``limit()`` last to avoid unintended result sets.
+
 You can define the order of query results using the
 :java-sdk:`sort() <io/realm/RealmQuery.html#sort-java.lang.String->`
 method:
@@ -179,16 +186,9 @@ by passing an array of properties instead of a single property: in the
 event of a tie, {+client-database+} sorts the tied objects by subsequent
 properties in order.
 
-.. important::
+.. note:: String Sorting Limitations
 
-   {+client-database+} applies the ``distinct()``, ``sort()`` and
-   ``limit()`` methods in the order you specify. Depending on the
-   data set this can alter the query result. Generally, you should
-   apply ``limit()`` last to avoid unintended result sets.
-
-.. important:: String Sorting Limitations
-
-   {+service-short+} uses non-standard sorting for upper and lowercase
+   Realm uses non-standard sorting for upper and lowercase
    letters, sorting them together rather than sorting uppercase first.
    As a result, ``'- !"#0&()*,./:;?_+<=>123aAbBcC...xXyYzZ`` is the
    actual sorting order in {+client-database+}. Additionally, sorting
@@ -225,7 +225,7 @@ Limited result collections automatically update like any other query
 result. Consequently, objects might drop out of the collection as
 underlying data changes.
 
-.. important:: Pagination is Not Necessary for {+client-database+} Optimization
+.. tip:: Pagination is Not Necessary for {+client-database+} Optimization
 
    Some databases encourage paginating results with limits to avoid
    reading unnecessary data from disk or using too much memory.
@@ -234,12 +234,12 @@ underlying data changes.
    take such measures. {+client-database+} only loads objects from query
    results when they are explicitly accessed.
 
-.. warning:: Deleted Notifications in Limited Results
+.. tip:: Deleted Notifications in Limited Results
 
    :ref:`Collection notifications <java-collection-notifications>`
    report objects as deleted when they drop out of the result set.
    This does not necessarily mean that they have been deleted from the
-   underlying {+realm+}, just that they are no longer part of the
+   underlying realm, just that they are no longer part of the
    query result.
 
 .. _java-unique-results:
@@ -309,7 +309,7 @@ Query with Realm Query Language
 
 You can use :java-sdk:`RealmQuery.rawPredicate()
 <io/realm/RealmQuery.html#rawPredicate-java.lang.String->` to query
-{+realm+}s using :ref:`Realm Query Language <realm-query-language>`.
+realms using :ref:`Realm Query Language <realm-query-language>`.
 
 Realm Query Language can use either the class and property names defined
 in your Realm Model classes or the internal names defined with ``@RealmField``.

--- a/source/sdk/java/examples/flexible-sync.txt
+++ b/source/sdk/java/examples/flexible-sync.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 Flexible Sync uses subscriptions and permissions to determine which
-data to sync with your {+app+}.
+data to sync with your App.
 
 To use Flexible Sync in the SDK:
 
@@ -173,10 +173,10 @@ Writing an update to the subscription set locally is only one component
 of changing a subscription. After the local subscription change, the client
 synchronizes with the server to resolve any updates to the data due to 
 the subscription change. This could mean adding or removing data from the 
-synced {+realm+}. Use the :java-sdk:`waitForInitialRemoteData()
+synced realm. Use the :java-sdk:`waitForInitialRemoteData()
 <io/realm/mongodb/sync/SyncConfiguration.Builder.html#waitForInitialRemoteData(long,java.util.concurrent.TimeUnit)>`
 builder method to force your application to block until client subscription
-data synchronizes to the backend before opening the {+realm+}:
+data synchronizes to the backend before opening the realm:
 
 .. tabs-realm-languages::
    

--- a/source/sdk/java/examples/flexible-sync.txt
+++ b/source/sdk/java/examples/flexible-sync.txt
@@ -36,9 +36,9 @@ syncs to the client device.
 
    For general information about using Atlas Device Sync with the SDK,
    such as how to sync changes in the background or pause a sync session,
-   see: :ref:`Sync Changes Between Devices <java-sync-changes-between-devices>`.
+   check out :ref:`Sync Changes Between Devices <java-sync-changes-between-devices>`.
 
-   For information about setting up permissions for Flexible Sync, see:
+   For information about setting up permissions for Flexible Sync, check out
    :ref:`Flexible Sync Rules & Permissions <flexible-sync-rules-and-permissions>`.
 
 .. _java-sync-subscribe-to-queryable-fields:
@@ -66,7 +66,7 @@ permissions, syncs between clients and the backend application.
 
 You can specify an optional string name for your subscription.
 
-.. note:: Always Specify a Subscription Name
+.. tip:: Always Specify a Subscription Name
 
    Always specify a subscription name if your application uses multiple
    subscriptions. This makes your subscriptions easier to look up,
@@ -76,46 +76,45 @@ When you create a subscription, Realm looks for data matching a query on a
 specific object type. You can have multiple subscription sets on different 
 object types. You can also have multiple queries on the same object type.
 
-.. example::
 
-   You can create a subscription with an explicit name. Then, you can
-   search for that subscription by name to update or remove it.
+You can create a subscription with an explicit name. Then, you can
+search for that subscription by name to update or remove it.
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-         .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.explicitly-named-subscription.kt
-            :language: kotlin
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.explicitly-named-subscription.kt
+         :language: kotlin
+         :copyable: false
 
-      .. tab::
-         :tabid: java
+   .. tab::
+      :tabid: java
 
-         .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.explicitly-named-subscription.java
-            :language: java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.explicitly-named-subscription.java
+         :language: java
+         :copyable: false
 
-   You can also search subscriptions by query. If you omit the name when
-   creating a subscription, this is the only way to look up your
-   subscription.
+You can also search subscriptions by query. If you omit the name when
+creating a subscription, this is the only way to look up your
+subscription.
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-         .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.implicitly-named-subscription.kt
-            :language: kotlin
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.implicitly-named-subscription.kt
+         :language: kotlin
+         :copyable: false
 
-      .. tab::
-         :tabid: java
+   .. tab::
+      :tabid: java
 
-         .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.implicitly-named-subscription.java
-            :language: java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.implicitly-named-subscription.java
+         :language: java
+         :copyable: false
 
 .. note:: Duplicate subscriptions
 
@@ -153,15 +152,15 @@ new subscription to the client's Realm subscriptions.
           :language: java
           :copyable: false
 
-.. important:: Object Links
+.. note:: Object Links
 
-   You must add both an object and its linked object to the subscription 
+   You must add both an object and its linked object to the subscription
    set to see a linked object.
    
-   If your subscription results contain an object with a property that links 
-   to an object not contained in the results, the link appears to be nil.
-   There is no way to distinguish whether that property's value is 
-   legitimately nil, or whether the object it links to exists but is out of
+   If your subscription results contain an object with a property that links
+   to an object not contained in the results, the link appears to be null.
+   There is no way to distinguish whether that property's value is
+   legitimately null, or whether the object it links to exists but is out of
    view of the query subscription.
 
 .. _java-sync-check-subscription-state:
@@ -343,7 +342,7 @@ To remove all subscriptions from the subscription set, use
 :java-sdk:`removeAll() <io/realm/mongodb/sync/MutableSubscriptionSet.html#removeAll()>`
 with no arguments:
 
-.. important::
+.. warning::
 
    If you remove all subscriptions and do not add a new one, you'll 
    get an error. A realm opened with a flexible sync configuration needs

--- a/source/sdk/java/examples/manage-user-api-keys.txt
+++ b/source/sdk/java/examples/manage-user-api-keys.txt
@@ -21,7 +21,7 @@ User API keys are always associated with a user object created by another
 non-anonymous authentication provider. Each user can associate up to 20
 user keys with their account.
 
-.. note::
+.. tip::
 
    User API keys are not the same as **server API keys**, which allow a
    user or service to directly authenticate with {+service+} using the
@@ -71,10 +71,6 @@ method or asynchronous :java-sdk:`fetchAll()
 <io/realm/mongodb/auth/ApiKeyAuth.html#fetchAll-io.realm.mongodb.App.Callback->` method of a
 logged in user's :java-sdk:`ApiKeyAuth <io/realm/mongodb/auth/ApiKeyAuth.html>` instance.
 
-.. include:: /includes/note-store-user-api-key-value.rst
-
-.. include:: /includes/note-store-user-api-key-value.rst
-
 .. tabs-realm-languages::
    
    .. tab::
@@ -96,10 +92,6 @@ key's id to the :java-sdk:`fetch() <io/realm/mongodb/auth/ApiKeyAuth.html#fetch-
 or :java-sdk:`fetchAsync() <io/realm/mongodb/auth/ApiKeyAuth.html#fetchAsync-ObjectId-io.realm.mongodb.App.Callback->`
 methods of a logged in user's
 :java-sdk:`ApiKeyAuth <io/realm/mongodb/auth/ApiKeyAuth.html>` instance.
-
-.. include:: /includes/note-store-user-api-key-value.rst
-
-.. include:: /includes/note-store-user-api-key-value.rst
 
 .. tabs-realm-languages::
    

--- a/source/sdk/java/examples/manage-user-api-keys.txt
+++ b/source/sdk/java/examples/manage-user-api-keys.txt
@@ -13,7 +13,7 @@ Manage User API Keys - Java SDK
    :class: singlecol
 
 Application users can generate user API keys with the SDK. You
-can allow devices or services to communicate with {+service+}
+can allow devices or services to communicate with Realm
 on behalf of a user by associating a unique user API key with each
 device or service.
 
@@ -24,7 +24,7 @@ user keys with their account.
 .. tip::
 
    User API keys are not the same as **server API keys**, which allow a
-   user or service to directly authenticate with {+service+} using the
+   user or service to directly authenticate with Realm using the
    :ref:`API Key authentication provider <java-login-api-key>`. To learn
    more about server API keys, see :ref:`API Key Authentication
    <api-key-authentication>`.
@@ -39,7 +39,7 @@ To create a new user API key, call the :java-sdk:`create()
 :java-sdk:`createAsync() <io/realm/mongodb/auth/ApiKeyAuth.html#createAsync-java.lang.String-io.realm.mongodb.App.Callback->`
 methods of a logged in user's :java-sdk:`apiKeyAuth <io/realm/mongodb/auth/ApiKeyAuth.html>`
 instance. The user API key will be associated with the logged in user
-and can be used to interact with {+service+} on their behalf. You cannot
+and can be used to interact with Realm on their behalf. You cannot
 create user API keys for anonymous users.
 
 .. include:: /includes/note-store-user-api-key-value.rst

--- a/source/sdk/java/examples/modify-an-object-schema.txt
+++ b/source/sdk/java/examples/modify-an-object-schema.txt
@@ -28,11 +28,11 @@ Modify an Object Schema - Java SDK
          Assume that each schema change shown in the following example
          occurs after the application has used the existing schema. The
          new schema version numbers apply only after you open the
-         {+realm+} and explicitly specify the new version number.
+         realm and explicitly specify the new version number.
          In other words, you can't specify version 3 without previously
          specifying and using versions 0, 1, and 2.
 
-      A {+realm+} using schema version ``0`` has a ``Person`` object type:
+      A realm using schema version ``0`` has a ``Person`` object type:
 
       .. tabs-realm-languages::
        
@@ -136,8 +136,8 @@ Modify an Object Schema - Java SDK
       D. Migration Functions
       ----------------------
 
-      To migrate the {+realm+} to conform to the updated
-      ``Person`` schema, set the {+realm+}'s
+      To migrate the realm to conform to the updated
+      ``Person`` schema, set the realm's
       :ref:`schema version <java-schema-version>` to ``3``
       and define a migration function to set the value of
       ``fullName`` based on the existing ``firstName`` and
@@ -163,16 +163,16 @@ Modify an Object Schema - Java SDK
    .. tab:: Synchronized Realms
       :tabid: sync
 
-      You can make changes to the schema of a synchronized {+realm+} by
+      You can make changes to the schema of a synchronized realm by
       modifying the :ref:`JSON Schema <configure-your-data-model>`
-      defined in your application's backend. Synchronized {+realm+}s do
+      defined in your application's backend. Synchronized realms do
       not require migration functions, since breaking changes to
-      synchronized schemas cause synchronization errors. {+sync+}
-      handles non-breaking changes to synchronized {+realm+} schemas
+      synchronized schemas cause synchronization errors. Sync
+      handles non-breaking changes to synchronized realm schemas
       automatically. As a result, both old versions of your schema and
       new versions can synchronize as users upgrade their applications.
 
-      To learn more about schema changes to synchronized {+realm+}s,
+      To learn more about schema changes to synchronized realms,
       see :ref:`synced schema changes <synced-schema-overview>`.
 
       .. note:: Development Mode: Only for Defining Your Initial Schema
@@ -182,7 +182,7 @@ Modify an Object Schema - Java SDK
          which automatically translates client models into
          JSON Schema on the backend. However, you should make subsequent
          changes to your schema through edits to the JSON Schema in your
-         {+app+}.
+         App.
 
 .. seealso::
 
@@ -193,6 +193,6 @@ Modify an Object Schema - Java SDK
    You can use the
    :java-sdk:`RealmConfiguration.shouldDeleteRealmIfMigrationNeeded()
    <io/realm/RealmConfiguration.html#shouldDeleteRealmIfMigrationNeeded-->`
-   builder method when constructing a {+realm+} to delete the {+realm+}
+   builder method when constructing a realm to delete the realm
    instead of performing a migration when a migration is required. This
    can come in handy during development when schemas often change.

--- a/source/sdk/java/examples/mongodb-remote-access.txt
+++ b/source/sdk/java/examples/mongodb-remote-access.txt
@@ -11,7 +11,7 @@ Query MongoDB - Java SDK
    :class: singlecol
 
 The following actions enable access to a linked MongoDB Atlas cluster
-from an Android application using the {+service-short+} SDK.
+from an Android application using the Realm SDK.
 
 .. include:: /includes/mongodb-data-access-query-filter-indeterminate-order-note.rst
 

--- a/source/sdk/java/examples/open-and-close-a-realm.txt
+++ b/source/sdk/java/examples/open-and-close-a-realm.txt
@@ -207,7 +207,7 @@ To open a Dynamic Realm with a mutable schema, use
 Synced Realms
 -------------
 
-Synced realms use Sync to store data both on the client device
+Synced realms use :ref:`Atlas Device Sync <sync>` to store data both on the client device
 and in your synced data source. Opening a synced realm works exactly
 like opening a local realm, except you use ``SyncConfiguration``
 to customize the settings for synced realms.

--- a/source/sdk/java/examples/open-and-close-a-realm.txt
+++ b/source/sdk/java/examples/open-and-close-a-realm.txt
@@ -12,12 +12,12 @@ Open & Close a Realm - Java SDK
    :depth: 2
    :class: singlecol
 
-Interacting with :ref:`{+realm+}s <java-realms>` in an Android
+Interacting with :ref:`realms <java-realms>` in an Android
 application uses the following high-level series of steps:
 
-#. Create a configuration for the {+realm+} you want to open.
-#. Open the {+realm+} using the config.
-#. :ref:`Close the {+realm+} <java-close-a-realm>` to free up
+#. Create a configuration for the realm you want to open.
+#. Open the realm using the config.
+#. :ref:`Close the realm <java-close-a-realm>` to free up
    resources when you're finished.
 
 The Default Realm
@@ -45,7 +45,7 @@ You can then use
 :java-sdk:`getDefaultConfiguration() <io/realm/Realm.html#getDefaultConfiguration-->`
 to access that configuration, or
 :java-sdk:`getDefaultInstance() <io/realm/Realm.html#getDefaultInstance-->`
-to open a {+realm+} with that configuration:
+to open a realm with that configuration:
 
 .. tabs-realm-languages::
    
@@ -62,23 +62,23 @@ to open a {+realm+} with that configuration:
 Local Realms
 ------------
 
-Local {+realm+}s store data only on the client device. You can customize
-the settings for a local {+realm+} with ``RealmConfiguration``.
+Local realms store data only on the client device. You can customize
+the settings for a local realm with ``RealmConfiguration``.
 
 .. _java-local-realm-configuration:
 
 Local Realm Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To configure settings for a {+realm+}, create a
+To configure settings for a realm, create a
 :java-sdk:`RealmConfiguration <io/realm/RealmConfiguration.html>` with a
 :java-sdk:`RealmConfiguration.Builder <io/realm/RealmConfiguration.Builder.html>`.
-The following example configures a local {+realm+} with:
+The following example configures a local realm with:
 
 - the file name "alternate-realm"
 - synchronous reads explicitly allowed on the UI thread
 - synchronous writes explicitly allowed on the UI thread
-- automatic compaction when launching the {+realm+} to save file space
+- automatic compaction when launching the realm to save file space
 
 .. tabs-realm-languages::
    
@@ -106,7 +106,7 @@ The following example configures a local {+realm+} with:
 Open a Local Realm
 ~~~~~~~~~~~~~~~~~~
 
-To open a {+realm+}, create a
+To open a realm, create a
 :java-sdk:`RealmConfiguration <io/realm/RealmConfiguration.html>` with
 :java-sdk:`RealmConfiguration.Builder <io/realm/RealmConfiguration.Builder.html>` and 
 pass the resulting ``RealmConfiguration`` to
@@ -137,7 +137,7 @@ Read-Only Realms
 ~~~~~~~~~~~~~~~~
 
 Use the :java-sdk:`readOnly() <io/realm/RealmConfiguration.Builder.html#readOnly-->`
-method when configuring your {+realm+} to make it read-only:
+method when configuring your realm to make it read-only:
 
 .. tabs-realm-languages::
    
@@ -160,7 +160,7 @@ method when configuring your {+realm+} to make it read-only:
 In-Memory Realms
 ~~~~~~~~~~~~~~~~
 
-To create a {+realm+} that runs entirely in memory without being written
+To create a realm that runs entirely in memory without being written
 to a file, use :java-sdk:`inMemory() <io/realm/RealmConfiguration.Builder.html#inMemory()>`
 when configuring your realm:
 
@@ -207,27 +207,27 @@ To open a Dynamic Realm with a mutable schema, use
 Synced Realms
 -------------
 
-Synced {+realm+}s use {+sync+} to store data both on the client device
-and in your synced data source. Opening a synced {+realm+} works exactly
-like opening a local {+realm+}, except you use ``SyncConfiguration``
-to customize the settings for synced {+realm+}s.
+Synced realms use Sync to store data both on the client device
+and in your synced data source. Opening a synced realm works exactly
+like opening a local realm, except you use ``SyncConfiguration``
+to customize the settings for synced realms.
 
 .. _java-synced-realm-configuration:
 
 Synced Realm Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To configure settings for a {+realm+}, create a
+To configure settings for a realm, create a
 :java-sdk:`SyncConfiguration <io/realm/mongodb/sync/SyncConfiguration.html>` with a
 :java-sdk:`SyncConfiguration.Builder <io/realm/mongodb/sync/SyncConfiguration.Builder.html>`.
-The following example configures a synced {+realm+} with:
+The following example configures a synced realm with:
 
-- partition-based {+sync+}
+- partition-based Sync
 - synchronous reads explicitly allowed on the UI thread
 - synchronous writes explicitly allowed on the UI thread
 - explicit waiting for all backend changes to synchronize to the device
-  before returning an open {+realm+}
-- automatic compaction when launching the {+realm+} to save file space
+  before returning an open realm
+- automatic compaction when launching the realm to save file space
 
 .. warning:: Production Applications Should Handle Client Resets
 
@@ -268,7 +268,7 @@ Open a Synced Realm While Online
 Open a Synced Realm While Offline
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can open a synced {+realm+} when offline with the exact same syntax
+You can open a synced realm when offline with the exact same syntax
 that you use to :ref:`open a synced realm while online
 <java-open-a-synced-realm-while-online>`. Not all SDKs follow this
 pattern, so cross-platform developers should consult the documentation
@@ -325,7 +325,7 @@ Close a Realm
 
 It is important to remember to call the :java-sdk:`close()
 <io/realm/Realm.html#close-->` method when done with a 
-{+realm+} instance to free resources. Neglecting to close {+realm+}s can lead to an
+realm instance to free resources. Neglecting to close realms can lead to an
 ``OutOfMemoryError``.
 
 .. tabs-realm-languages::
@@ -354,16 +354,16 @@ It is important to remember to call the :java-sdk:`close()
 Configure Which Classes to Include in Your Realm Schema
 -------------------------------------------------------
 
-{+service-short+} modules are collections of {+service-short+} object
-models. Specify a module or modules when opening a {+realm+} to control
-which classes {+client-database+} should include in your schema. If you
-do not specify a module, {+service-short+} uses the default module,
-which includes all {+service-short+} objects defined in your
+Realm modules are collections of Realm object
+models. Specify a module or modules when opening a realm to control
+which classes Realm Database should include in your schema. If you
+do not specify a module, Realm uses the default module,
+which includes all Realm objects defined in your
 application.
 
 .. note::
    
-   Libraries that include {+client-database+} must expose and use their
+   Libraries that include Realm Database must expose and use their
    schema through a module. Doing so prevents the library from
    generating the default ``RealmModule``, which would conflict with
    the default ``RealmModule`` used by any app that includes the library.

--- a/source/sdk/java/examples/open-and-close-a-realm.txt
+++ b/source/sdk/java/examples/open-and-close-a-realm.txt
@@ -15,7 +15,7 @@ Open & Close a Realm - Java SDK
 Interacting with :ref:`{+realm+}s <java-realms>` in an Android
 application uses the following high-level series of steps:
 
-1. Create a configuration for the {+realm+} you want to open.
+#. Create a configuration for the {+realm+} you want to open.
 #. Open the {+realm+} using the config.
 #. :ref:`Close the {+realm+} <java-close-a-realm>` to free up
    resources when you're finished.
@@ -229,7 +229,7 @@ The following example configures a synced {+realm+} with:
   before returning an open {+realm+}
 - automatic compaction when launching the {+realm+} to save file space
 
-.. important:: Production Applications Should Handle Client Resets
+.. warning:: Production Applications Should Handle Client Resets
 
    Applications used in production environments should handle client
    reset errors. To learn more, see :ref:`Reset a Client Realm

--- a/source/sdk/java/examples/react-to-changes.txt
+++ b/source/sdk/java/examples/react-to-changes.txt
@@ -19,9 +19,9 @@ React to Changes - Java SDK
 Register a Realm Change Listener
 --------------------------------
 
-You can register a notification handler on an entire {+realm+}.
+You can register a notification handler on an entire realm.
 {+client-database+} calls the notification handler whenever any write
-transaction involving that {+realm+} is committed. The
+transaction involving that realm is committed. The
 handler receives no information about the change.
 
 This is useful when you want to know that there has been a
@@ -39,7 +39,7 @@ granular notifications.
    activity, you want to have an indicator that lights up when
    any change is made. In that case, a realm notification
    handler would be a great way to drive the code that controls
-   the indicator. The following code shows how to observe a {+realm+}
+   the indicator. The following code shows how to observe a realm
    for changes with with :java-sdk:`addChangeListener() <io/realm/RealmResults.html#addChangeListener-io.realm.OrderedRealmCollectionChangeListener->`:
 
    .. tabs-realm-languages::
@@ -64,7 +64,7 @@ granular notifications.
 
    All threads that contain a ``Looper`` automatically refresh
    ``RealmObject`` and ``RealmResult`` instances when new changes are
-   written to the {+realm+}. As a result, it isn't necessary to fetch
+   written to the realm. As a result, it isn't necessary to fetch
    those objects again when reacting to a ``RealmChangeListener``, since
    those objects are already updated and ready to be redrawn to the
    screen.
@@ -76,7 +76,7 @@ Register a Collection Change Listener
 -------------------------------------
 
 You can register a notification handler on a specific
-collection within a {+realm+}. The handler receives a
+collection within a realm. The handler receives a
 description of changes since the last notification.
 Specifically, this description consists of three lists of
 indices:
@@ -89,7 +89,7 @@ Stop notification delivery by calling the ``removeChangeListener()`` or
 ``removeAllChangeListeners()`` methods. Notifications also stop if:
 
 - the object on which the listener is registered gets garbage collected.
-- the {+realm+} instance closes.
+- the realm instance closes.
 
 Keep a strong reference to the object you're listening to
 for as long as you need the notifications.
@@ -106,34 +106,32 @@ collection. After that, {+client-database+} delivers collection
 notifications asynchronously whenever a write transaction
 adds, changes, or removes objects in the collection.
 
-Unlike {+realm+} notifications, collection notifications contain
+Unlike realm notifications, collection notifications contain
 detailed information about the change. This enables
 sophisticated and selective reactions to changes. Collection
 notifications provide all the information needed to manage a
 list or other view that represents the collection in the UI.
 
-.. example::
-
-   The following code shows how to observe a collection for
-   changes with :java-sdk:`addChangeListener()
-   <io/realm/Realm.html#addChangeListener-io.realm.RealmChangeListener->`:
+The following code shows how to observe a collection for
+changes with :java-sdk:`addChangeListener()
+<io/realm/Realm.html#addChangeListener-io.realm.RealmChangeListener->`:
 
 
-   .. tabs-realm-languages::
-     
-      .. tab::
-         :tabid: kotlin
+.. tabs-realm-languages::
+  
+   .. tab::
+      :tabid: kotlin
 
-         .. literalinclude:: /examples/generated/java/sync/NotificationsTest.snippet.collection-notifications.kt
-            :language: kotlin
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/NotificationsTest.snippet.collection-notifications.kt
+         :language: kotlin
+         :copyable: false
 
-      .. tab::
-         :tabid: java
+   .. tab::
+      :tabid: java
 
-         .. literalinclude:: /examples/generated/java/sync/NotificationsTest.snippet.collection-notifications.java
-            :language: java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/NotificationsTest.snippet.collection-notifications.java
+         :language: java
+         :copyable: false
 
 .. _java-register-an-object-change-listener:
 .. _java-object-notifications:
@@ -142,7 +140,7 @@ Register an Object Change Listener
 ----------------------------------
 
 You can register a notification handler on a specific object
-within a {+realm+}. {+client-database+} notifies your handler:
+within a realm. {+client-database+} notifies your handler:
 
 - When the object is deleted.
 - When any of the object's properties change.
@@ -154,32 +152,30 @@ Stop notification delivery by calling the ``removeChangeListener()`` or
 ``removeAllChangeListeners()`` methods. Notifications also stop if:
 
 - the object on which the listener is registered gets garbage collected.
-- the {+realm+} instance closes.
+- the realm instance closes.
 
 Keep a strong reference of the object you're listening to
 for as long as you need the notifications.
 
-.. example::
+The following code shows how create a new instance of a class
+in a realm and observe that instance for changes with
+:java-sdk:`addChangeListener() <io/realm/RealmObject.html#addChangeListener-E-io.realm.RealmObjectChangeListener->`:
 
-   The following code shows how create a new instance of a class
-   in a {+realm+} and observe that instance for changes with
-   :java-sdk:`addChangeListener() <io/realm/RealmObject.html#addChangeListener-E-io.realm.RealmObjectChangeListener->`:
+.. tabs-realm-languages::
+  
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-     
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/NotificationsTest.snippet.object-notifications.kt
+         :language: kotlin
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/NotificationsTest.snippet.object-notifications.kt
-            :language: kotlin
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/NotificationsTest.snippet.object-notifications.java
-            :language: java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/NotificationsTest.snippet.object-notifications.java
+         :language: java
+         :copyable: false
 
 .. _java-unregister-a-change-listener:
 
@@ -190,7 +186,7 @@ You can unregister a change listener by passing your change listener to
 :java-sdk:`Realm.removeChangeListener()
 <io/realm/Realm.html#removeChangeListener-io.realm.RealmChangeListener->`.
 You can unregister all change listeners currently subscribed to changes
-in a {+realm+} or any of its linked objects or collections with
+in a realm or any of its linked objects or collections with
 :java-sdk:`Realm.removeAllChangeListeners()
 <io/realm/Realm.html#removeAllChangeListeners-->`.
 
@@ -200,7 +196,7 @@ Use Realm in System Apps on Custom ROMs
 ---------------------------------------
 
 {+service-short+} uses named pipes in order to support notifications and
-access to the {+realm+} file from multiple processes. While this is
+access to the realm file from multiple processes. While this is
 allowed by default for normal user apps, it is disallowed for system
 apps.
 

--- a/source/sdk/java/examples/react-to-changes.txt
+++ b/source/sdk/java/examples/react-to-changes.txt
@@ -20,7 +20,7 @@ Register a Realm Change Listener
 --------------------------------
 
 You can register a notification handler on an entire realm.
-{+client-database+} calls the notification handler whenever any write
+Realm Database calls the notification handler whenever any write
 transaction involving that realm is committed. The
 handler receives no information about the change.
 
@@ -101,8 +101,8 @@ for as long as you need the notifications.
    modifications. Handling insertions before deletions may
    result in unexpected behavior.
 
-{+client-database+} emits an initial notification after retrieving the
-collection. After that, {+client-database+} delivers collection
+Realm Database emits an initial notification after retrieving the
+collection. After that, Realm Database delivers collection
 notifications asynchronously whenever a write transaction
 adds, changes, or removes objects in the collection.
 
@@ -140,7 +140,7 @@ Register an Object Change Listener
 ----------------------------------
 
 You can register a notification handler on a specific object
-within a realm. {+client-database+} notifies your handler:
+within a realm. Realm Database notifies your handler:
 
 - When the object is deleted.
 - When any of the object's properties change.
@@ -195,7 +195,7 @@ in a realm or any of its linked objects or collections with
 Use Realm in System Apps on Custom ROMs
 ---------------------------------------
 
-{+service-short+} uses named pipes in order to support notifications and
+Realm uses named pipes in order to support notifications and
 access to the realm file from multiple processes. While this is
 allowed by default for normal user apps, it is disallowed for system
 apps.
@@ -232,7 +232,7 @@ as part of AOSP:
       audit2allow -p policy -i input.txt
 
 #. The tool should output a rule you can add to your existing policy
-   to enable the use of {+service-short+}.
+   to enable the use of Realm.
 
 An example of such a policy is provided below:
 

--- a/source/sdk/java/examples/read-and-write-data.txt
+++ b/source/sdk/java/examples/read-and-write-data.txt
@@ -55,7 +55,7 @@ See the schema for these two classes, ``Project`` and
 Read from Realm Database
 ------------------------
 
-A read from a :term:`realm` generally consists of the following
+A read from a realm generally consists of the following
 steps:
 
 - Get all :ref:`objects <java-realm-objects>` of a certain type from the realm.

--- a/source/sdk/java/examples/read-and-write-data.txt
+++ b/source/sdk/java/examples/read-and-write-data.txt
@@ -15,52 +15,50 @@ Read & Write Data - Java SDK
 About the Examples on this Page
 -------------------------------
 
-.. note::
+The examples on this page use the data model of a project
+management app that has two Realm object types: ``Project``
+and ``Task``. A ``Project`` has zero or more ``Tasks``.
 
-   The examples on this page use the data model of a project
-   management app that has two {+service-short+} object types: ``Project``
-   and ``Task``. A ``Project`` has zero or more ``Tasks``.
+See the schema for these two classes, ``Project`` and
+``Task``, below:
 
-   See the schema for these two classes, ``Project`` and
-   ``Task``, below:
+.. tabs-realm-languages::
+  
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-     
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/ProjectTask.snippet.projecttask.kt
+         :language: kotlin
+         :caption: ProjectTask.kt
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/ProjectTask.snippet.projecttask.kt
-            :language: kotlin
-            :caption: ProjectTask.kt
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/Project.snippet.project.kt
+         :language: kotlin
+         :caption: Project.kt
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/Project.snippet.project.kt
-            :language: kotlin
-            :caption: Project.kt
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
+      .. literalinclude:: /examples/generated/java/sync/ProjectTask.snippet.projecttask.java
+         :language: java
+         :caption: ProjectTask.java
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/ProjectTask.snippet.projecttask.java
-            :language: java
-            :caption: ProjectTask.java
-            :copyable: false
-
-         .. literalinclude:: /examples/generated/java/sync/Project.snippet.project.java
-            :language: java
-            :caption: Project.java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/Project.snippet.project.java
+         :language: java
+         :caption: Project.java
+         :copyable: false
 
 .. _java-read-from-realm:
 
 Read from Realm Database
 ------------------------
 
-A read from a :term:`{+realm+}` generally consists of the following
+A read from a :term:`realm` generally consists of the following
 steps:
 
-- Get all :ref:`objects <java-realm-objects>` of a certain type from the {+realm+}.
+- Get all :ref:`objects <java-realm-objects>` of a certain type from the realm.
 - Optionally, :ref:`filter <java-filter-results>` the results using the :ref:`query engine <java-client-query-engine>`.
 - Optionally, :ref:`sort <java-sort-results>` the results.
 
@@ -80,7 +78,7 @@ results of the associated query.
 Find a Specific Object by Primary Key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To find an object with a specific primary key value, open a {+realm+}
+To find an object with a specific primary key value, open a realm
 and query the primary key field for the desired primary key value
 using the :java-sdk:`RealmQuery.equalTo() <io/realm/RealmQuery.html#equalTo-java.lang.String-Decimal128->` method:
 
@@ -106,31 +104,29 @@ Query All Objects of a Given Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The first step of any read is to **get all objects** of a
-certain type in a {+realm+}. With this results collection, you
+certain type in a realm. With this results collection, you
 can operate on all instances on a type or filter and sort to
 refine the results.
 
-.. example::
+In order to access all instances of ``ProjectTask`` and ``Project``, use
+the :java-sdk:`where() <io/realm/RealmResults.html#where-->` method
+to specify a class:
 
-   In order to access all instances of ``ProjectTask`` and ``Project``, use
-   the :java-sdk:`where() <io/realm/RealmResults.html#where-->` method
-   to specify a class:
+.. tabs-realm-languages::
 
-   .. tabs-realm-languages::
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
+      .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.get-all-objects.java
+         :language: java
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.get-all-objects.java
-            :language: java
-            :copyable: false
+   .. tab::
+      :tabid: kotlin
 
-      .. tab::
-         :tabid: kotlin
-
-         .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.get-all-objects.kt
-            :language: kotlin
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.get-all-objects.kt
+         :language: kotlin
+         :copyable: false
 
 .. _java-filter-queries-based-on-object-properties:
 .. _java-filter-results:
@@ -139,7 +135,7 @@ Filter Queries Based on Object Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A **filter** selects a subset of results based on the
-value(s) of one or more object properties. {+client-database+} provides a
+value(s) of one or more object properties. Realm Database provides a
 full-featured :ref:`query engine <java-client-query-engine>` you
 can use to define filters. The most common use case is to
 find objects where a certain property matches a certain
@@ -147,31 +143,30 @@ value. Additionally, you can compare strings, aggregate over
 collections of numbers, and use logical operators to build
 up complex queries.
 
-.. example::
 
-   In the following example, we use the query
-   engine's comparison operators to:
+In the following example, we use the query
+engine's comparison operators to:
 
-   - Find high priority tasks by comparing the value of the ``priority`` property value with a threshold number, above which priority can be considered high.
-   - Find just-started or short-running tasks by seeing if the ``progressMinutes`` property falls within a certain range.
-   - Find unassigned tasks by finding tasks where the ``assignee`` property is equal to null.
-   - Find tasks assigned to specific teammates Ali or Jamie by seeing if the ``assignee`` property is in a list of names.
+- Find high priority tasks by comparing the value of the ``priority`` property value with a threshold number, above which priority can be considered high.
+- Find just-started or short-running tasks by seeing if the ``progressMinutes`` property falls within a certain range.
+- Find unassigned tasks by finding tasks where the ``assignee`` property is equal to null.
+- Find tasks assigned to specific teammates Ali or Jamie by seeing if the ``assignee`` property is in a list of names.
 
-   .. tabs-realm-languages::
+.. tabs-realm-languages::
 
-      .. tab::
-         :tabid: java
+   .. tab::
+      :tabid: java
 
-         .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.filter-results.java
-            :language: java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.filter-results.java
+         :language: java
+         :copyable: false
 
-      .. tab::
-         :tabid: kotlin
+   .. tab::
+      :tabid: kotlin
 
-         .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.filter-results.kt
-            :language: kotlin
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.filter-results.kt
+         :language: kotlin
+         :copyable: false
 
 .. _java-sort-query-results:
 .. _java-sort-results:
@@ -180,33 +175,31 @@ Sort Query Results
 ~~~~~~~~~~~~~~~~~~
 
 A **sort** operation allows you to configure the order in
-which {+client-database+} returns queried objects. You can sort based on
+which Realm Database returns queried objects. You can sort based on
 one or more properties of the objects in the results
 collection.
 
-{+client-database+} only guarantees a consistent order of results when the
+Realm Database only guarantees a consistent order of results when the
 results are sorted.
 
-.. example::
+The following code sorts the projects by name in reverse
+alphabetical order (i.e. "descending" order).
 
-   The following code sorts the projects by name in reverse
-   alphabetical order (i.e. "descending" order).
+.. tabs-realm-languages::
 
-   .. tabs-realm-languages::
+   .. tab::
+       :tabid: java
 
-      .. tab::
-          :tabid: java
+       .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.sort-results.java
+         :language: java
+         :copyable: false
 
-          .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.sort-results.java
-            :language: java
-            :copyable: false
+   .. tab::
+      :tabid: kotlin
 
-      .. tab::
-         :tabid: kotlin
-
-         .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.sort-results.kt
-            :language: kotlin
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/ReadsTest.snippet.sort-results.kt
+         :language: kotlin
+         :copyable: false
 
 .. _java-query-a-relationship:
 
@@ -343,17 +336,17 @@ Aggregate Data
 Write Operations
 ----------------
 
-All write operations to a {+realm+} must occur within a
+All write operations to a realm must occur within a
 **write transaction**. For more information about how to perform a write
 transaction, see :ref:`Write Transactions <java-write-transactions>`.
 
-.. important:: Realm Object Writes are File Writes
+.. tip:: Realm Object Writes are File Writes
 
-   Whenever you create, update, or delete a {+service-short+} object,
+   Whenever you create, update, or delete a Realm object,
    your changes update the representation of that object in
-   {+client-database+} and emit
+   Realm Database and emit
    :ref:`notifications <java-react-to-changes>` to any subscribed
-   listeners. As a result, you should only write to {+service-short+}
+   listeners. As a result, you should only write to Realm
    objects when necessary to persist data.
 
 .. include:: /includes/java-synchronous-reads-writes-ui-thread.rst
@@ -368,58 +361,54 @@ in a transaction to create a persistent instance of a Realm object in a
 realm. You can then modify the returned object with other field values
 using accessors and mutators.
 
-.. example::
+The following example demonstrates how to create an object with 
+:java-sdk:`createObject() <io/realm/Realm.html#createObject-java.lang.Class-java.lang.Object->`:
 
-   This code demonstrates how to create an object with 
-   :java-sdk:`createObject() <io/realm/Realm.html#createObject-java.lang.Class-java.lang.Object->`:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.create-an-object.kt
+         :language: kotlin
+         :emphasize-lines: 3
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.create-an-object.kt
-            :language: kotlin
-            :emphasize-lines: 3
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.create-an-object.java
+         :language: java
+         :emphasize-lines: 3
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.create-an-object.java
-            :language: java
-            :emphasize-lines: 3
-            :copyable: false
-
-You can also insert objects into a {+realm+} from JSON. {+service-short+}
+You can also insert objects into a realm from JSON. Realm
 supports creating objects from ``String``,
 :android:`JSONObject <reference/org/json/JSONObject.html>`, and
 :android:`InputStream <reference/java/io/InputStream.html>` types.
-{+service-short+} ignores any properties present in the JSON that are
-not defined in the {+service-short+} object schema.
+Realm ignores any properties present in the JSON that are
+not defined in the Realm object schema.
 
-.. example::
+The following example demonstrates how to create a single object from JSON with 
+:java-sdk:`createObjectFromJson() <io/realm/Realm.html#createObjectFromJson-java.lang.Class-java.lang.String->`
+or multiple objects from JSON with
+:java-sdk:`createAllFromJson() <io/realm/Realm.html#createAllFromJson-java.lang.Class-java.lang.String->`:
 
-   This code demonstrates how to create a single object from JSON with 
-   :java-sdk:`createObjectFromJson() <io/realm/Realm.html#createObjectFromJson-java.lang.Class-java.lang.String->`
-   or multiple objects from JSON with
-   :java-sdk:`createAllFromJson() <io/realm/Realm.html#createAllFromJson-java.lang.Class-java.lang.String->`:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/local/WritesTest.snippet.create-an-object-json.kt
+         :language: kotlin
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/local/WritesTest.snippet.create-an-object-json.kt
-            :language: kotlin
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/local/WritesTest.snippet.create-an-object-json.java
-            :language: java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/local/WritesTest.snippet.create-an-object-json.java
+         :language: java
+         :copyable: false
 
 .. _java-modify-an-object:
 .. _java-update:
@@ -427,33 +416,31 @@ not defined in the {+service-short+} object schema.
 Modify an Object
 ~~~~~~~~~~~~~~~~
 
-Within a transaction, you can update a {+service-short+} object the same
+Within a transaction, you can update a Realm object the same
 way you would update any other object in your language of
 choice. Just assign a new value to the property or update
 the property.
 
-.. example::
+The following example changes the turtle's name to "Archibald" and
+sets Archibald's age to 101 by assigning new values to properties:
 
-   This code changes the turtle's name to "Archibald" and
-   sets Archibald's age to 101 by assigning new values to properties:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.update-an-object.kt
+         :language: kotlin
+         :emphasize-lines: 6,7
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.update-an-object.kt
-            :language: kotlin
-            :emphasize-lines: 6,7
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.update-an-object.java
-            :language: java
-            :emphasize-lines: 6,7
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.update-an-object.java
+         :language: java
+         :emphasize-lines: 6,7
+         :copyable: false
 
 .. _java-upsert:
 
@@ -465,33 +452,31 @@ with a given primary key or updates an existing object that already has
 that primary key. We call this an upsert because it is an "**update** or
 **insert**" operation. This is useful when an object may or may not
 already exist, such as when bulk importing a dataset into an existing
-{+realm+}. Upserting is an elegant way to update existing entries while
+realm. Upserting is an elegant way to update existing entries while
 adding any new entries.
 
-.. example::
+The following example demonstrates how to upsert an object with
+realm. We create a new turtle enthusiast named "Drew" and then
+update their name to "Andy" using :java-sdk:`insertOrUpdate()
+<io/realm/Realm.html#insertOrUpdate-io.realm.RealmModel->`:
 
-   This code demonstrates how to upsert an object with
-   {+realm+}. We create a new turtle enthusiast named "Drew" and then
-   update their name to "Andy" using :java-sdk:`insertOrUpdate()
-   <io/realm/Realm.html#insertOrUpdate-io.realm.RealmModel->`:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.upsert-an-object.kt
+         :language: kotlin
+         :emphasize-lines: 14-16
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.upsert-an-object.kt
-            :language: kotlin
-            :emphasize-lines: 14-16
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.upsert-an-object.java
-            :language: java
-            :emphasize-lines: 14-16
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.upsert-an-object.java
+         :language: java
+         :emphasize-lines: 14-16
+         :copyable: false
 
 You can also use :java-sdk:`copyToRealmOrUpdate()
 <io/realm/Realm.html#copyToRealmOrUpdate-E-io.realm.ImportFlag...->` to
@@ -501,28 +486,26 @@ existing object with the same primary key value. Use the
 :java-sdk:`ImportFlag <io/realm/ImportFlag.html>` to only update fields
 that are different in the supplied object:
 
-.. example::
+The following example demonstrates how to insert an object or, if an object already
+exists with the same primary key, update only those fields that differ:
 
-   This code demonstrates how to insert an object or, if an object already
-   exists with the same primary key, update only those fields that differ:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.copy-or-update-same-values-flag.kt
+         :language: kotlin
+         :emphasize-lines: 15-16
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.copy-or-update-same-values-flag.kt
-            :language: kotlin
-            :emphasize-lines: 15-16
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.copy-or-update-same-values-flag.java
-            :language: java
-            :emphasize-lines: 16
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.copy-or-update-same-values-flag.java
+         :language: java
+         :emphasize-lines: 16
+         :copyable: false
 
 
 .. _java-batch-update:
@@ -530,45 +513,43 @@ that are different in the supplied object:
 Update a Collection
 ~~~~~~~~~~~~~~~~~~~
 
-{+client-database+} supports collection-wide updates. A collection update
+Realm Database supports collection-wide updates. A collection update
 applies the same update to specific properties of several
 objects in a collection at once.
 
-.. example::
+The following example demonstrates how to update a
+collection. Thanks to the :ref:`implicit inverse
+relationship <java-inverse-relationship>` between the Turtle's
+``owner`` property and the TurtleEnthusiast's ``turtles`` property,
+Realm Database automatically updates Josephine's list of turtles
+when you use :java-sdk:`setObject()
+<io/realm/RealmResults.html#setObject-java.lang.String-io.realm.RealmModel->`
+to update the "owner" property for all turtles in the collection.
 
-   The following code demonstrates how to update a
-   collection. Thanks to the :ref:`implicit inverse
-   relationship <java-inverse-relationship>` between the Turtle's
-   ``owner`` property and the TurtleEnthusiast's ``turtles`` property,
-   {+client-database+} automatically updates Josephine's list of turtles
-   when you use :java-sdk:`setObject()
-   <io/realm/RealmResults.html#setObject-java.lang.String-io.realm.RealmModel->`
-   to update the "owner" property for all turtles in the collection.
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.update-a-collection.kt
+         :language: kotlin
+         :emphasize-lines: 11,12
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.update-a-collection.kt
-            :language: kotlin
-            :emphasize-lines: 11,12
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.update-a-collection.java
-            :language: java
-            :emphasize-lines: 9,10
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.update-a-collection.java
+         :language: java
+         :emphasize-lines: 9,10
+         :copyable: false
 
 .. _java-iteration:
 
 Iteration
 ~~~~~~~~~
 
-Because {+realm+} collections always reflect the latest state, they
+Because realm collections always reflect the latest state, they
 can appear, disappear, or change while you iterate over a collection.
 To get a stable collection you can iterate over, you can create a
 **snapshot** of a collection's data. A snapshot guarantees the order of
@@ -582,100 +563,94 @@ or
 :java-sdk:`RealmResults.createSnapshot() <io/realm/RealmResults.html#createSnapshot-->`
 to manually generate a snapshot you can iterate over manually:
 
-.. example::
+The following example demonstrates how to iterate over a collection
+safely using either an implicit snapshot created from a ``RealmResults``
+``Iterator`` or a manual snapshot created from a ``RealmList``:
 
-   The following code demonstrates how to iterate over a collection
-   safely using either an implicit snapshot created from a ``RealmResults``
-   ``Iterator`` or a manual snapshot created from a ``RealmList``:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/local/WritesTest.snippet.iterate.kt
+         :language: kotlin
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/local/WritesTest.snippet.iterate.kt
-            :language: kotlin
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/local/WritesTest.snippet.iterate.java
-            :language: java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/local/WritesTest.snippet.iterate.java
+         :language: java
+         :copyable: false
 
 .. _java-delete-an-object:
 
 Delete an Object
 ~~~~~~~~~~~~~~~~
 
-To delete an object from a {+realm+}, use either the dynamic or static
+To delete an object from a realm, use either the dynamic or static
 versions of the ``deleteFromRealm()`` method of a :java-sdk:`RealmObject
 <io/realm/RealmObject.html>` subclass.
 
-.. important:: Do not use objects after delete
+The following example shows how to delete one object from
+its realm with :java-sdk:`deleteFromRealm()
+<io/realm/RealmObject.html#deleteFromRealm-->`:
 
-   {+client-database+} throws an error if you try to use an object after
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
+
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-an-object.kt
+         :language: kotlin
+         :emphasize-lines: 6
+         :copyable: false
+
+   .. tab::
+      :tabid: java
+
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-an-object.java
+         :language: java
+         :emphasize-lines: 4
+         :copyable: false
+
+.. tip:: Do not use objects after delete
+
+   The SDK throws an error if you try to use an object after
    it has been deleted.
-
-.. example::
-
-   The following code shows how to delete one object from
-   its {+realm+} with :java-sdk:`deleteFromRealm()
-   <io/realm/RealmObject.html#deleteFromRealm-->`:
-
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-an-object.kt
-            :language: kotlin
-            :emphasize-lines: 6
-            :copyable: false
-
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-an-object.java
-            :language: java
-            :emphasize-lines: 4
-            :copyable: false
 
 .. _java-delete-multiple-objects:
 
 Delete Multiple Objects
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-To delete an object from a {+realm+}, use the ``deleteAllFromRealm()``
+To delete an object from a realm, use the ``deleteAllFromRealm()``
 method of the :java-sdk:`RealmResults <io/realm/RealmResults.html>`
 instance that contains the objects you would like to delete. You can
 filter the ``RealmResults`` down to a subset of objects using the
 :java-sdk:`where() <io/realm/Realm.html#where-java.lang.Class->` method.
 
-.. example::
+The following example demonstrates how to delete a
+collection from a realm with :java-sdk:`deleteAllFromRealm()
+<io/realm/RealmResults.html#deleteAllFromRealm-->`:
 
-   The following code demonstrates how to delete a
-   collection from a {+realm+} with :java-sdk:`deleteAllFromRealm()
-   <io/realm/RealmResults.html#deleteAllFromRealm-->`:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-a-collection.kt
+         :language: kotlin
+         :emphasize-lines: 6
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-a-collection.kt
-            :language: kotlin
-            :emphasize-lines: 6
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-a-collection.java
-            :language: java
-            :emphasize-lines: 4
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-a-collection.java
+         :language: java
+         :emphasize-lines: 4
+         :copyable: false
 
 .. _java-delete-object-and-dependent-objects:
 
@@ -685,100 +660,94 @@ Delete an Object and its Dependent Objects
 Sometimes, you have :ref:`dependent objects
 <java-client-relationships>` that you want to delete when
 you delete the parent object. We call this a **chaining
-delete**. {+client-database+} does not delete the dependent
+delete**. Realm Database does not delete the dependent
 objects for you. If you do not delete the objects yourself,
-they will remain orphaned in your {+realm+}. Whether or not
+they will remain orphaned in your realm. Whether or not
 this is a problem depends on your application's needs.
 
 Currently, the best way to delete dependent objects is to
 iterate through the dependencies and delete them before
 deleting the parent object.
 
-.. example::
+The following example demonstrates how to perform a
+chaining delete by first deleting all of Ali's turtles,
+then deleting Ali:
 
-   The following code demonstrates how to perform a
-   chaining delete by first deleting all of Ali's turtles,
-   then deleting Ali:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.cascading-deletes.kt
+         :language: kotlin
+         :emphasize-lines: 6
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.cascading-deletes.kt
-            :language: kotlin
-            :emphasize-lines: 6
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.cascading-deletes.java
-            :language: java
-            :emphasize-lines: 5
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.cascading-deletes.java
+         :language: java
+         :emphasize-lines: 5
+         :copyable: false
 
 .. _java-delete-all-object-of-a-specific-type:
 
 Delete All Objects of a Specific Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-{+client-database+} supports deleting all instances of a :ref:`{+service-short+} type
-<java-realm-objects>` from a {+realm+}.
+Realm Database supports deleting all instances of a :ref:`Realm type
+<java-realm-objects>` from a realm.
 
-.. example::
+The following example demonstrates how to delete all
+Turtle instances from a realm with :java-sdk:`delete()
+<io/realm/Realm.html#delete-java.lang.Class->`:
 
-   The following code demonstrates how to delete all
-   Turtle instances from a {+realm+} with :java-sdk:`delete()
-   <io/realm/Realm.html#delete-java.lang.Class->`:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-all-instances-of-a-type.kt
+         :language: kotlin
+         :emphasize-lines: 2
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-all-instances-of-a-type.kt
-            :language: kotlin
-            :emphasize-lines: 2
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-all-instances-of-a-type.java
-            :language: java
-            :emphasize-lines: 2
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-all-instances-of-a-type.java
+         :language: java
+         :emphasize-lines: 2
+         :copyable: false
 
 .. _java-delete-all-objects-in-a-realm:
 
 Delete All Objects in a Realm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is possible to delete all objects from the {+realm+}. This
-does not affect the schema of the {+realm+}. This is useful for
-quickly clearing out your {+realm+} while prototyping.
+It is possible to delete all objects from the realm. This
+does not affect the schema of the realm. This is useful for
+quickly clearing out your realm while prototyping.
 
-.. example::
+The following example demonstrates how to delete everything
+from a realm with :java-sdk:`deleteAll()
+<io/realm/Realm.html#deleteAll-->`:
 
-   The following code demonstrates how to delete everything
-   from a {+realm+} with :java-sdk:`deleteAll()
-   <io/realm/Realm.html#deleteAll-->`:
+.. tabs-realm-languages::
+   
+   .. tab::
+      :tabid: kotlin
 
-   .. tabs-realm-languages::
-      
-      .. tab::
-         :tabid: kotlin
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-all.kt
+         :language: kotlin
+         :emphasize-lines: 2
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-all.kt
-            :language: kotlin
-            :emphasize-lines: 2
-            :copyable: false
+   .. tab::
+      :tabid: java
 
-      .. tab::
-         :tabid: java
-
-         .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-all.java
-            :language: java
-            :emphasize-lines: 2
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/WritesTest.snippet.delete-all.java
+         :language: java
+         :emphasize-lines: 2
+         :copyable: false

--- a/source/sdk/java/examples/reset-a-client-realm.txt
+++ b/source/sdk/java/examples/reset-a-client-realm.txt
@@ -138,11 +138,12 @@ example manually discards unsynced changes to handle the client reset:
 Manually Recover Unsynced Changes
 ---------------------------------
 
-.. note:: Manual Recovery Replaces ``SyncSession.ClientResetHandler``
+.. tip::
 
-   This strategy works like the deprecated
+   Manual recovery replaces the deprecated
    ``SyncSession.ClientResetHandler``.
-   Clients can update to manual recovery with no logic changes.
+   Clients using the deprecated handler can update to manual recovery
+   with no logic changes.
 
 We do not recommend manual client reset recovery. It requires:
 

--- a/source/sdk/java/examples/sync-changes-between-devices.txt
+++ b/source/sdk/java/examples/sync-changes-between-devices.txt
@@ -152,7 +152,7 @@ To check the current network connection, call :java-sdk:`getConnectionState() <i
          :language: java
          :copyable: false
 
-.. warning:: Connection States vs. Session States
+.. important:: Connection States vs. Session States
 
    The SDK manages communication with {+backend+} at two levels:
    **connection state** and **session state**. *Connection state* tracks
@@ -280,7 +280,7 @@ handler:
          :language: java
          :copyable: false
 
-.. tip::
+.. seealso::
 
    To see how to recover unsynced local changes in a client reset, check out
    this :github:`example on GitHub

--- a/source/sdk/java/examples/sync-changes-between-devices.txt
+++ b/source/sdk/java/examples/sync-changes-between-devices.txt
@@ -15,13 +15,13 @@ Sync Changes Between Devices - Java SDK
 Prerequisites
 -------------
 
-Before you can access a synced {+realm+} from the client, you must:
+Before you can access a synced realm from the client, you must:
 
-1. :ref:`Enable sync <enable-sync>` in the {+ui+}.
+1. :ref:`Enable sync <enable-sync>` in the App Services UI.
 
 #. :ref:`Initialize the app <java-quick-start-init-app>`
 
-#. Enable {+sync+} in your application by adding the following to the
+#. Enable Sync in your application by adding the following to the
    top level of your application-level :file:`build.gradle` file:
 
    .. code-block:: groovy
@@ -46,19 +46,19 @@ Sync Data
 The syntax to :ref:`read <java-realm-database-reads>`, :ref:`write
 <java-realm-database-writes>`, and
 :ref:`watch for changes <java-client-notifications>` on a
-synced {+realm+} is identical to the syntax for non-synced {+realms+}. While you work with
+synced realm is identical to the syntax for non-synced realms. While you work with
 local data, a background thread efficiently integrates, uploads, and downloads changesets.
 
 .. important:: When Using Sync, Avoid Writes on the Main Thread
 
-   The fact that {+service-short+} performs sync integrations on a background thread means
-   that if you write to your {+realm+} on the main thread, there's a small chance your UI
+   The fact that Realm performs sync integrations on a background thread means
+   that if you write to your realm on the main thread, there's a small chance your UI
    could appear to hang as it waits for the background sync thread to finish a write
    transaction. Therefore, it's a best practice :ref:`never to write on the main thread
-   when using {+sync+} <java-threading-three-rules>`.
+   when using Sync <java-threading-three-rules>`.
 
 The following code reads a collection of ``Task`` objects, then writes a
-new ``Task`` to the {+realm+}:
+new ``Task`` to the realm:
 
 .. tabs-realm-languages::
    
@@ -154,10 +154,10 @@ To check the current network connection, call :java-sdk:`getConnectionState() <i
 
 .. important:: Connection States vs. Session States
 
-   The SDK manages communication with {+backend+} at two levels:
+   The SDK manages communication with App Services at two levels:
    **connection state** and **session state**. *Connection state* tracks
    the state of the network connection between a client device and your
-   backend {+app+}. *Session state* refers to a single user's
+   backend App. *Session state* refers to a single user's
    synchronization state, which can be :ref:`paused and resumed
    <java-pause-or-resume-a-sync-session>` in the SDK at will. As a
    result, you must check *both* states to determine whether
@@ -233,7 +233,7 @@ Handle Sync Errors
 ------------------
 
 You can configure an error handler to detect and respond to any errors that
-occur in the {+sync+} process. To define an error handler, pass an
+occur in the Sync process. To define an error handler, pass an
 :java-sdk:`ErrorHandler <io/realm/mongodb/sync/SyncSession.ErrorHandler.html>`
 to the :java-sdk:`SyncConfiguration.Builder.errorHandler()
 <io/realm/mongodb/sync/SyncConfiguration.Builder.html#errorHandler-io.realm.mongodb.sync.SyncSession.ErrorHandler->`

--- a/source/sdk/java/fundamentals/application-services.txt
+++ b/source/sdk/java/fundamentals/application-services.txt
@@ -32,7 +32,7 @@ App Services. Initialize the ``App`` object  with the App ID, which you can
 .. seealso::
 
    To learn how to initialize the Realm App client, see
-   :ref:`Connect to an Atlas App Services Backend <java-init-appclient>`.
+   :ref:`Connect to an Atlas App Services backend <java-init-appclient>`.
 
 Authentication & User Management
 --------------------------------

--- a/source/sdk/java/fundamentals/application-services.txt
+++ b/source/sdk/java/fundamentals/application-services.txt
@@ -26,14 +26,13 @@ The Realm App Client
 --------------------
 When using the SDK to access the {+service-short+} backend, you start with a 
 Realm App object. This object provides all other functionality related to 
-{+backend+}. The``App`` object is 
-:ref:`initialized <java-init-appclient>` with the {+app+} ID, which you can 
+{+backend+}. Initialize the ``App`` object  with the App ID, which you can 
 :ref:`find in the Realm UI <find-your-app-id>`.
 
-.. tip::
+.. seealso::
 
    To learn how to initialize the Realm App client, see
-   :ref:`java-init-appclient`.
+   :ref:`Connect to an Atlas App Services Backend <java-init-appclient>`.
 
 Authentication & User Management
 --------------------------------
@@ -50,16 +49,16 @@ implement the following functionality:
 - Linking user accounts from different providers 
 - Providing custom user data 
 
-.. tip::
+.. seealso::
 
    To learn how to set up authentication with different providers, see
-   :ref:`java-authenticate`.
+   :ref:`Authenticate Users <java-authenticate>`.
 
-   To learn how to manage multiple users, see :ref:`java-multi-user-applications`.
+   To learn how to manage multiple users, see :ref:`Multi-User Applications <java-multi-user-applications>`.
 
-   To learn how to link user accounts, see :ref:`java-link-user-identities`.
+   To learn how to link user accounts, see :ref:`Link User Identities <java-link-user-identities>`.
 
-   To learn how to provide custom user data, see :ref:`java-custom-user-data`.
+   To learn how to provide custom user data, see :ref:`Custom User Data <java-custom-user-data>`.
 
 Calling Functions
 -----------------
@@ -73,7 +72,7 @@ By using Realm functions, you provide a secure way for a variety of client
 applications to share complex functionality without having to reproduce that 
 logic client-side. 
 
-.. tip::
+.. seealso::
 
    To learn how to call functions, see :ref:`Call a Function <java-call-a-function>`.
 
@@ -85,6 +84,6 @@ client. For security, you configure server-side :ref:`data access rules <mongodb
 to dynamically determine read & write permissions for every object that 
 is accessed.
 
-.. tip::
+.. seealso::
 
    To learn how to use the MongoDB APIs, see :ref:`Query MongoDB <java-mongodb-data-access>`.

--- a/source/sdk/java/fundamentals/application-services.txt
+++ b/source/sdk/java/fundamentals/application-services.txt
@@ -16,17 +16,17 @@ Application Services - Java SDK
 Overview
 --------
 
-{+service+} provides SDKs that help you connect your client apps to the {+service-short+} 
-backend. The SDK provides the {+service+} functionality needed to 
+Realm provides SDKs that help you connect your client apps to the Realm 
+backend. The SDK provides the Realm functionality needed to 
 authenticate users with any of the built-in :ref:`authentication providers <authentication-providers>`, 
 call backend :ref:`functions <functions>`, and directly access a linked
 :ref:`MongoDB data source <data-sources>`.
 
 The Realm App Client
 --------------------
-When using the SDK to access the {+service-short+} backend, you start with a 
+When using the SDK to access the Realm backend, you start with a 
 Realm App object. This object provides all other functionality related to 
-{+backend+}. Initialize the ``App`` object  with the App ID, which you can 
+App Services. Initialize the ``App`` object  with the App ID, which you can 
 :ref:`find in the Realm UI <find-your-app-id>`.
 
 .. seealso::
@@ -38,8 +38,8 @@ Authentication & User Management
 --------------------------------
 
 One of the most challenging aspects of client development is implementing a 
-robust and secure authentication system. With the {+service-short+} SDKs, however, you 
-can use any of the {+service+} authentication providers with very minimal backend 
+robust and secure authentication system. With the Realm SDKs, however, you 
+can use any of the Realm authentication providers with very minimal backend 
 setup or client-side code required. With the authentication APIs, you can 
 implement the following functionality:
 
@@ -64,7 +64,7 @@ Calling Functions
 -----------------
 :ref:`Realm functions <functions>` enable you to define and execute server-side 
 logic for your application. You can call these functions from your client applications
-via the {+service+} SDKs. These server-side functions can run under the context 
+via the Realm SDKs. These server-side functions can run under the context 
 of the authenticated user, and thus honor the rules, roles, and permissions that 
 you have assigned to your collections.
 

--- a/source/sdk/java/fundamentals/async-api.txt
+++ b/source/sdk/java/fundamentals/async-api.txt
@@ -36,7 +36,7 @@ depending on which part of the SDK you're using.
 Realm.Callback
 ~~~~~~~~~~~~~~
 
-Asynchronous calls to open a {+realm+}, both with and without {+sync+},
+Asynchronous calls to open a realm, both with and without Sync,
 use a final parameter of type :java-sdk:`Realm.Callback
 <io/realm/Realm.Callback.html>`. To retrieve returned values after the
 request completes, implement the ``onSuccess()`` method in the callback
@@ -65,7 +65,7 @@ but it is not required.
 App.Callback
 ~~~~~~~~~~~~
 
-When you query {+service+} App Services like :ref:`Functions
+When you query Realm App Services like :ref:`Functions
 <java-call-a-function>` and :ref:`user authentication
 <java-authenticate-users>`, asynchronous calls accept a final
 parameter of type  :java-sdk:`App.Callback
@@ -105,7 +105,7 @@ RealmAsyncTask
 ~~~~~~~~~~~~~~
 
 Asynchronous calls to :ref:`execute transactions
-<java-write-transactions>` on a {+realm+} return
+<java-write-transactions>` on a realm return
 an instance of :java-sdk:`RealmAsyncTask
 <io/realm/RealmAsyncTask.html>`. You can optionally :java-sdk:`specify an error
 handler <io/realm/Realm.Transaction.OnError.html>` or a
@@ -138,7 +138,7 @@ transaction.
 RealmResults
 ~~~~~~~~~~~~
 
-Asynchronous reads from a {+realm+} using :java-sdk:`findAllAsync()
+Asynchronous reads from a realm using :java-sdk:`findAllAsync()
 <io/realm/RealmQuery.html#findAllAsync-->` immediately return an empty
 :java-sdk:`RealmResults <io/realm/RealmResults.html>` instance. The SDK
 executes the query on a background thread and populates the
@@ -221,13 +221,13 @@ and :kotlin-ext:`write
 .. tip:: Kotlin Flows use Frozen Objects Across Multiple Threads
 
    The ``toFlow()`` extension method passes :ref:`frozen
-   <java-frozen-objects>` {+service-short+} objects to safely
+   <java-frozen-objects>` Realm objects to safely
    communicate between threads.
 
 .. seealso::
    
    The SDK also includes Kotlin extensions that make specifying type
-   parameters for {+client-database+} :kotlin-ext:`reads
+   parameters for Realm Database :kotlin-ext:`reads
    <io.realm.kotlin/io.realm.-realm/where.html>` and
    :kotlin-ext:`writes
    <io.realm.kotlin/io.realm.-realm/create-object.html>` easier.

--- a/source/sdk/java/fundamentals/async-api.txt
+++ b/source/sdk/java/fundamentals/async-api.txt
@@ -218,13 +218,13 @@ and :kotlin-ext:`write
    :language: kotlin
    :copyable: false
 
-.. note:: Kotlin Flows use Frozen Objects Across Multiple Threads
+.. tip:: Kotlin Flows use Frozen Objects Across Multiple Threads
 
    The ``toFlow()`` extension method passes :ref:`frozen
    <java-frozen-objects>` {+service-short+} objects to safely
    communicate between threads.
 
-.. tip::
+.. seealso::
    
    The SDK also includes Kotlin extensions that make specifying type
    parameters for {+client-database+} :kotlin-ext:`reads

--- a/source/sdk/java/fundamentals/device-sync.txt
+++ b/source/sdk/java/fundamentals/device-sync.txt
@@ -17,18 +17,18 @@ Overview
 
 Atlas Device Sync automatically synchronizes data between client applications and 
 an :ref:`Atlas App Services backend <realm-cloud>`. When a client 
-device is online, {+sync-short+} asynchronously synchronizes data in a 
-background thread between the device and your backend {+app+}. 
+device is online, Sync asynchronously synchronizes data in a 
+background thread between the device and your backend App. 
 
 When you use Sync in your client application, your implementation must match 
-the Sync Mode you select in your backend {+app+} configuration. The Sync Mode
+the Sync Mode you select in your backend App configuration. The Sync Mode
 options are:
 
 - Partition-Based Sync
 - Flexible Sync
 
 You can only use one Sync Mode for your application. You cannot mix 
-Partition-Based Sync and Flexible Sync within the same {+app+}.
+Partition-Based Sync and Flexible Sync within the same App.
 
 .. seealso::
 
@@ -40,7 +40,7 @@ Partition-Based Sync
 --------------------
 
 When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
-backend {+app+} configuration, your client implementation must include a 
+backend App configuration, your client implementation must include a 
 partition value. This is the value of the :ref:`partition key 
 <partition-key>` field you select when you configure Partition-Based Sync. 
 
@@ -53,7 +53,7 @@ You pass in the partition value when you open a synced realm.
 Flexible Sync
 -------------
 
-When you select :ref:`Flexible Sync <flexible-sync>` for your backend {+app+} 
+When you select :ref:`Flexible Sync <flexible-sync>` for your backend App 
 configuration, your client implementation must include subscriptions to 
 queries on :ref:`queryable fields <queryable-fields>`. Flexible Sync works 
 by synchronizing data that matches query subscriptions you maintain in the 

--- a/source/sdk/java/fundamentals/live-queries.txt
+++ b/source/sdk/java/fundamentals/live-queries.txt
@@ -152,7 +152,7 @@ Managed Objects
 based on changes to underlying data in Realm Database. Managed
 objects can only come from an open realm, and receive updates
 as long as that realm remains open. Managed objects *cannot be passed
-between threads.*
+between threads*.
 
 .. _java-unmanaged-objects:
 

--- a/source/sdk/java/fundamentals/live-queries.txt
+++ b/source/sdk/java/fundamentals/live-queries.txt
@@ -62,7 +62,7 @@ Read Operations
 ---------------
 
 You can read back the data that you have
-:ref:`stored <java-realm-database-writes>` in :term:`Realm Database`.
+:ref:`stored <java-realm-database-writes>` in Realm Database.
 The standard data access pattern across Realm
 SDKs is to find, filter, and sort objects, in that order. To
 get the best performance from Realm as your app grows and

--- a/source/sdk/java/fundamentals/live-queries.txt
+++ b/source/sdk/java/fundamentals/live-queries.txt
@@ -52,8 +52,8 @@ any other thread, you should configure a ``Looper`` for that thread.
    Realms on a thread without a :android:`Looper <reference/android/os/Looper>`
    do not automatically advance their version. This can increase the size of the
    realm in memory and on disk. Avoid using realm instances on
-   non-Looper threads when possible. When unavoidable, always ensure
-   that you close the realm when you're done using it.
+   non-Looper threads when possible. If you *do* open a realm on a non-Looper
+   thread, close the realm when you're done using it.
 
 .. _java-read-operations:
 .. _java-realm-database-reads:

--- a/source/sdk/java/fundamentals/live-queries.txt
+++ b/source/sdk/java/fundamentals/live-queries.txt
@@ -136,8 +136,8 @@ objects that are never accessed, but if you choose to only
 copy the foreign key, referenced object lookups can cause
 your application to slow down.
 
-Realm Database bypasses all of this using :term:`zero-copy`
-:term:`live objects`. :term:`Realm object` accessors point directly into
+Realm Database bypasses all of this using zero-copy
+live objects. Realm object accessors point directly into
 database storage using memory mapping, so there is no distinction
 between the objects in Realm Database and the results of your query in
 application memory. Because of this, you can traverse direct references
@@ -183,7 +183,7 @@ data, independent of the writes that caused the changes.
 Realm emits three kinds of notifications:
 
 - :ref:`Realm notifications <java-realm-notifications>` whenever a specific realm commits a write transaction.
-- :ref:`Collection notifications <java-collection-notifications>` whenever any :term:`Realm object` in a collection changes, including inserts, updates, and deletes.
+- :ref:`Collection notifications <java-collection-notifications>` whenever any Realm object in a collection changes, including inserts, updates, and deletes.
 - :ref:`Object notifications <java-object-notifications>` whenever a specific Realm object changes, including updates and deletes.
 
 .. seealso::

--- a/source/sdk/java/fundamentals/live-queries.txt
+++ b/source/sdk/java/fundamentals/live-queries.txt
@@ -13,7 +13,7 @@ Live Queries - Java SDK
    :depth: 2
    :class: singlecol
 
-Objects in {+service-short+} clients are **live objects** that
+Objects in Realm clients are **live objects** that
 update automatically to reflect data changes, including
 :ref:`synced <sync>` remote changes, and emit
 :ref:`notification events <java-client-notifications>` that you
@@ -27,38 +27,33 @@ means that a live object doesn't directly contain data. Instead, a live
 object always references the most up-to-date data on disk and
 :wikipedia:`lazy loads <Lazy_loading>` field values when you access
 them from a :ref:`collection <java-client-collections>`. This means that a
-{+realm+} can contain many objects but only pays the performance cost for
+realm can contain many objects but only pays the performance cost for
 data that the application is actually using.
 
 Valid write operations on a live object automatically persist to the
-{+realm+} and propagate to any other synced clients. You do not need to
-call an update method, modify the {+realm+}, or otherwise "push" updates.
+realm and propagate to any other synced clients. You do not need to
+call an update method, modify the realm, or otherwise "push" updates.
 
 .. _java-auto-refresh:
 
 Auto-Refresh
 ------------
 
-{+service-short+} objects accessed on a thread associated with a
+Realm objects accessed on a thread associated with a
 :android:`Looper <reference/android/os/Looper.html>` automatically
 update periodically to reflect changes to underlying data.
 
 The Android UI thread always contains a ``Looper`` instance. If you need
-to keep {+service-short+} objects around for long periods of time on
+to keep Realm objects around for long periods of time on
 any other thread, you should configure a ``Looper`` for that thread.
 
 .. warning:: Always Close Realm Instances on Non-Looper Threads to Avoid Resource Leaks
 
-   Instances of a {+realm+} instantiated on a thread that does not have a
-   :android:`Looper <reference/android/os/Looper>` message loop configured
-   do not :java-sdk:`automatically advance <io/realm/Realm.html#refresh-->` their version of underlying data. This
-   results in the SDK "pinning" that version of the data, which can cause
-   an increased memory footprint for your instance of {+client-database+}.
-   Avoid using {+realm+} instances on non-Looper threads when possible.
-   When unavoidable, always ensure that you close the {+realm+}
-   when you're done using it, or the pinned version will consume
-   application memory indefinitely.
-   
+   Realms on a thread without a :android:`Looper <reference/android/os/Looper>`
+   do not automatically advance their version. This can increase the size of the
+   realm in memory and on disk. Avoid using realm instances on
+   non-Looper threads when possible. When unavoidable, always ensure
+   that you close the realm when you're done using it.
 
 .. _java-read-operations:
 .. _java-realm-database-reads:
@@ -96,7 +91,9 @@ directly. This memory mapping also means that results are
 **live**: that is, they always reflect the current state on
 disk.
 
-See also: :ref:`Collections are Live <java-live-collections>`.
+.. seealso::
+
+   :ref:`Collections are Live <java-live-collections>`.
 
 .. _java-results-are-lazy:
 
@@ -108,8 +105,9 @@ results. You can chain several filter and sort operations
 without requiring extra work to process the intermediate
 state.
 
-See also: :ref:`Results are Lazily Evaluated
-<java-lazy-evaluated-results>`.
+.. seealso::
+
+   :ref:`Results are Lazily Evaluated <java-lazy-evaluated-results>`.
 
 .. _java-references-retained:
 
@@ -139,39 +137,35 @@ copy the foreign key, referenced object lookups can cause
 your application to slow down.
 
 {+client-database+} bypasses all of this using :term:`zero-copy`
-:term:`live objects`. :term:`{+service-short+} object` accessors point directly into
+:term:`live objects`. :term:`Realm object` accessors point directly into
 database storage using memory mapping, so there is no distinction
 between the objects in {+client-database+} and the results of your query in
 application memory. Because of this, you can traverse direct references
-across an entire {+realm+} from any query result.
+across an entire realm from any query result.
 
 .. _java-managed-objects:
 
 Managed Objects
 ---------------
 
-**Managed objects** are live {+service-short+} objects that update
+**Managed objects** are live Realm objects that update
 based on changes to underlying data in {+client-database+}. Managed
-objects can only come from an open {+realm+}, and receive updates
-as long as that {+realm+} remains open.
-
-.. note:: Managed Objects are Not Thread-safe
-
-   Managed objects cannot be passed between threads.
+objects can only come from an open realm, and receive updates
+as long as that realm remains open. Managed objects *cannot be passed
+between threads.*
 
 .. _java-unmanaged-objects:
 
 Unmanaged objects
 -----------------
 
-**Unmanaged objects** are instances of {+service-short+} objects that are
+**Unmanaged objects** are instances of Realm objects that are
 not live. You can get an unmanaged object by manually constructing a
-{+service-short+} object yourself, or by calling
+Realm object yourself, or by calling
 :java-sdk:`Realm.copyFromRealm() <io/realm/Realm.html#copyFromRealm-E->`.
+Unmanaged objects *can be passed between threads*.
 
-.. note:: Unmanaged Objects are Thread-safe
-
-   Unmanaged objects can be passed between threads.
+.. _java-subscribe-to-changes:
 
 Notifications
 -------------
@@ -186,24 +180,12 @@ probably want to remove it from the UI. {+service+}'s notification
 system allows you to watch for and react to changes in your
 data, independent of the writes that caused the changes.
 
-{+service-short+} emits three kinds of notifications:
+Realm emits three kinds of notifications:
 
-- :ref:`Realm notifications <java-realm-notifications>` whenever a specific {+realm+} commits a write transaction.
-- :ref:`Collection notifications <java-collection-notifications>` whenever any :term:`{+service-short+} object` in a collection changes, including inserts, updates, and deletes.
-- :ref:`Object notifications <java-object-notifications>` whenever a specific {+service-short+} object changes, including updates and deletes.
+- :ref:`Realm notifications <java-realm-notifications>` whenever a specific realm commits a write transaction.
+- :ref:`Collection notifications <java-collection-notifications>` whenever any :term:`Realm object` in a collection changes, including inserts, updates, and deletes.
+- :ref:`Object notifications <java-object-notifications>` whenever a specific Realm object changes, including updates and deletes.
 
 .. seealso::
 
    :ref:`Usage Example: React to Changes <java-react-to-changes>`
-
-.. _java-subscribe-to-changes:
-
-Subscribe to Changes
-~~~~~~~~~~~~~~~~~~~~
-
-Generally, this is how you observe a {+realm+}, collection, or object:
-
-1. Create a notification handler for the {+realm+}, collection, or object notification.
-2. Add the notification handler to the {+realm+}, collection, or object that you want to observe.
-3. Receive a notification token from the call to add the handler. Retain this token as long as you want to observe.
-4. When you are done observing, invalidate the token.

--- a/source/sdk/java/fundamentals/live-queries.txt
+++ b/source/sdk/java/fundamentals/live-queries.txt
@@ -62,12 +62,12 @@ Read Operations
 ---------------
 
 You can read back the data that you have
-:ref:`stored <java-realm-database-writes>` in :term:`{+client-database+}`.
-The standard data access pattern across {+service+}
+:ref:`stored <java-realm-database-writes>` in :term:`Realm Database`.
+The standard data access pattern across Realm
 SDKs is to find, filter, and sort objects, in that order. To
-get the best performance from {+service+} as your app grows and
+get the best performance from Realm as your app grows and
 your queries become more complex, design your app's data
-access patterns around a solid understanding of {+client-database+}
+access patterns around a solid understanding of Realm Database
 :ref:`read characteristics <java-realm-read-characteristics>`.
 
 .. _java-realm-read-characteristics:
@@ -76,7 +76,7 @@ Read Characteristics
 ~~~~~~~~~~~~~~~~~~~~
 
 When you design your app's data access patterns around the
-following three key characteristics of reads in {+client-database+},
+following three key characteristics of reads in Realm Database,
 you can be confident you are reading data as
 efficiently as possible.
 
@@ -100,7 +100,7 @@ disk.
 Results Are Lazy
 ~~~~~~~~~~~~~~~~
 
-{+client-database+} defers execution of a query until you access the
+Realm Database defers execution of a query until you access the
 results. You can chain several filter and sort operations
 without requiring extra work to process the intermediate
 state.
@@ -114,8 +114,8 @@ state.
 References Are Retained
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-One benefit of {+client-database+}'s object model is that
-{+client-database+} automatically retains all of an object's
+One benefit of Realm Database's object model is that
+Realm Database automatically retains all of an object's
 :ref:`relationships <java-client-relationships>` as
 direct references, so you can traverse your graph of
 relationships directly through the results of a query.
@@ -136,10 +136,10 @@ objects that are never accessed, but if you choose to only
 copy the foreign key, referenced object lookups can cause
 your application to slow down.
 
-{+client-database+} bypasses all of this using :term:`zero-copy`
+Realm Database bypasses all of this using :term:`zero-copy`
 :term:`live objects`. :term:`Realm object` accessors point directly into
 database storage using memory mapping, so there is no distinction
-between the objects in {+client-database+} and the results of your query in
+between the objects in Realm Database and the results of your query in
 application memory. Because of this, you can traverse direct references
 across an entire realm from any query result.
 
@@ -149,7 +149,7 @@ Managed Objects
 ---------------
 
 **Managed objects** are live Realm objects that update
-based on changes to underlying data in {+client-database+}. Managed
+based on changes to underlying data in Realm Database. Managed
 objects can only come from an open realm, and receive updates
 as long as that realm remains open. Managed objects *cannot be passed
 between threads.*
@@ -176,7 +176,7 @@ a new item to a list, you may want to update the UI, show a
 notification, or log a message. When someone updates that
 item, you may want to change its visual state or fire off a
 network request. Finally, when someone deletes the item, you
-probably want to remove it from the UI. {+service+}'s notification
+probably want to remove it from the UI. Realm's notification
 system allows you to watch for and react to changes in your
 data, independent of the writes that caused the changes.
 

--- a/source/sdk/java/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/java/fundamentals/object-models-and-schemas.txt
@@ -38,7 +38,7 @@ Realm guarantees that all objects in a realm conform to the
 schema for their object type and validates objects whenever they're
 created, modified, or deleted.
 
-Apps that take advantage of Sync can define schemas in two ways:
+Apps that use Atlas Device Sync can define schemas in two ways:
 
 - object schemas :ref:`using Kotlin and Java class declarations
   <create-schema-from-rom>` with :ref:`Development Mode <enable-development-mode>`.

--- a/source/sdk/java/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/java/fundamentals/object-models-and-schemas.txt
@@ -13,15 +13,15 @@ Object Models & Schemas - Java SDK
    :class: singlecol
 
 An **object schema** is a configuration object that defines the fields and
-relationships of a {+service-short+} object type. Android
-{+service-short+} applications define object schemas with Java or Kotlin
+relationships of a Realm object type. Android
+Realm applications define object schemas with Java or Kotlin
 classes using :term:`{+frontend-schema+}s <{+frontend-schema+}>`.
 
 Object schemas specify constraints on object fields such as the data
 :ref:`type <java-supported-data-types>` of each field, whether a
 field is required, and default field values. Schemas can also define
 :ref:`relationships <java-client-relationships>` between object types in
-a {+realm+}.
+a realm.
 
 Modifying your application's {+frontend-schema+} requires you to
 :ref:`migrate <java-schema-versions-and-migrations>` data from older
@@ -30,20 +30,20 @@ versions of your {+frontend-schema+} to the new version.
 Realm Apps
 ----------
 
-Every {+app+} has a :ref:`{+backend-schema+} <java-realm-schema>`
+Every App has a :ref:`{+backend-schema+} <java-realm-schema>`
 composed of a list of object schemas for each type of object that the
 {+realms+} in that application may contain.
 
-{+service+} guarantees that all objects in a {+realm+} conform to the
+{+service+} guarantees that all objects in a realm conform to the
 schema for their object type and validates objects whenever they're
 created, modified, or deleted.
 
-{+app+}s that take advantage of {+sync+} can define schemas in two ways:
+Apps that take advantage of {+sync+} can define schemas in two ways:
 
 - object schemas :ref:`using Kotlin and Java class declarations
   <create-schema-from-rom>` with :ref:`Development Mode <enable-development-mode>`.
 
-- JSON :ref:`object schemas <object-schema>` in your {+app+} backend.
+- JSON :ref:`object schemas <object-schema>` in your App backend.
 
 .. _java-primary-key-fundamentals:
 
@@ -53,9 +53,10 @@ Primary Keys
 .. versionadded:: 10.6.0
 
    {+client-database+} automatically :ref:`indexes <java-indexes-fundamentals>`
-   primary key fields. Previously, only ``String`` fields were automatically indexed.
+   primary key fields. Previously, Realm only indexed ``String`` primary
+   keys automatically.
 
-{+service-short+} treats fields marked with the
+Realm treats fields marked with the
 :java-sdk:`@PrimaryKey <io/realm/annotations/PrimaryKey.html>` annotation
 as primary keys for their corresponding object schema. Primary keys are
 subject to the following limitations:
@@ -63,7 +64,7 @@ subject to the following limitations:
 - You can define only one primary key per object schema.
 
 - Primary key values must be unique across all instances of an object
-  in a {+realm+}. Attempting to insert a duplicate primary key value
+  in a realm. Attempting to insert a duplicate primary key value
   results in a :java-sdk:`RealmPrimaryKeyConstraintException
   <io/realm/exceptions/RealmPrimaryKeyConstraintException.html>`.
 
@@ -87,7 +88,7 @@ You can create a primary key with any of the following types:
 Non-primitive types can contain a value of ``null`` as a primary key
 value, but only for one object of a particular type, since each primary
 key value must be unique. Attempting to insert an object with an existing
-primary key into a {+realm+} will result in a
+primary key into a realm will result in a
 :java-sdk:`RealmPrimaryKeyConstraintException <io/realm/exceptions/RealmPrimaryKeyConstraintException.html>`.
 
 {+client-database+} automatically :ref:`indexes <java-index-field>`
@@ -95,7 +96,7 @@ primary key fields, which allows you to efficiently read and modify
 objects based on their primary key.
 
 You cannot change the primary key field for an object type after adding
-any object of that type to a {+realm+}. If you are using {+sync+},
+any object of that type to a realm. If you are using {+sync+},
 you cannot change the primary key field for an object after defining the
 primary key in your backend :ref:`schema <schemas>`.
 
@@ -141,7 +142,7 @@ Primitive types such as ``int`` and the ``RealmList`` type are
 implicitly required. Fields with the ``RealmObject`` type are always
 nullable, and cannot be made required.
 
-.. warning:: Kotlin Types and Nullability
+.. important:: Kotlin Types and Nullability
 
    In Kotlin, types are non-nullable by default unless you explicitly
    add a ``?`` suffix to the type. You can only annotate
@@ -214,9 +215,9 @@ You can make **inverse** relationships traversable with the
 :java-sdk:`@LinkingObjects <io/realm/annotations/LinkingObjects.html>`
 annotation on a :java-sdk:`RealmResults <io/realm/RealmResults.html>`
 field. In an instance of a ``RealmObject``, inverse relationship fields
-contain the set of {+service-short+} objects that point to that object
+contain the set of Realm objects that point to that object
 instance through the described relationship. You can find the same set
-of {+service-short+} objects with a manual query, but the inverse
+of Realm objects with a manual query, but the inverse
 relationship field reduces boilerplate query code and capacity for error.
 
 .. seealso::
@@ -237,15 +238,15 @@ query, {+client-database+} can use the index to limit the number of
 documents that it must inspect.
 
 Indexes are special data structures that store a small portion of a
-{+realm+}'s data in an easy to traverse form. The index stores the value
+realm's data in an easy to traverse form. The index stores the value
 of a specific field ordered by the value of the field. The ordering of
 the index entries supports efficient equality matches and range-based
 query operations.
 
 Adding an index to a field makes writing slightly slower, but makes
-certain queries faster. Indexes require space in your {+realm+} file, so
+certain queries faster. Indexes require space in your realm file, so
 adding an index to a field will increase disk space consumed by your
-{+realm+} file.
+realm file.
 
 You can index fields with the following types:
 
@@ -260,7 +261,7 @@ You can index fields with the following types:
 - ``Date``
 - ``RealmAny``
 
-{+service-short+} creates indexes for fields annotated with
+Realm creates indexes for fields annotated with
 :java-sdk:`@Index <io/realm/annotations/Index.html>`. Indexes speed up
 some queries, but have a negative impact on insert and update operation
 speed. Indexes also consume additional space on disk.
@@ -274,18 +275,18 @@ speed. Indexes also consume additional space on disk.
 Modules
 -------
 
-{+service-short+} Modules describe the set of {+service-short+} objects
-that can be stored in a {+realm+}. By default, {+service-short+}
-automatically creates a {+service-short+} Module that contains all
-{+service-short+} objects defined in your application.
+Realm Modules describe the set of Realm objects
+that can be stored in a realm. By default, Realm
+automatically creates a Realm Module that contains all
+Realm objects defined in your application.
 You can define a :java-sdk:`RealmModule <io/realm/annotations/RealmModule.html>`
-to restrict a {+realm+} to a subset of classes defined in an application.
-If you produce a library that uses {+service-short+}, you can use a
-{+service-short+} Module to explicitly include only the {+service-short+}
-objects defined in your library in your {+realm+}. This allows
-applications that include your library to also use {+service-short+}
+to restrict a realm to a subset of classes defined in an application.
+If you produce a library that uses Realm, you can use a
+Realm Module to explicitly include only the Realm
+objects defined in your library in your realm. This allows
+applications that include your library to also use Realm
 without managing object name conflicts and migrations with your library's
-defined {+service-short+} objects.
+defined Realm objects.
 
 .. seealso::
 
@@ -297,8 +298,8 @@ Realm Objects
 -------------
 
 Unlike normal Java objects, which contain their own data, a
-{+service-short+} object doesn't contain data. Instead,
-{+service-short+} objects read and write properties directly to
+Realm object doesn't contain data. Instead,
+Realm objects read and write properties directly to
 {+client-database+}.
 
 Instances of Realm objects can be either **managed** or **unmanaged**.
@@ -329,12 +330,12 @@ and :java-sdk:`realm.copyFromRealm()
 RealmProxy
 ~~~~~~~~~~
 
-The ``RealmProxy`` classes are the {+service-short+} SDK's way of
-ensuring that {+service-short+} objects don't contain any data
+The ``RealmProxy`` classes are the Realm SDK's way of
+ensuring that Realm objects don't contain any data
 themselves. Instead, each class's ``RealmProxy`` accesses data directly
 in the database.
 
-For every model class in your project, the {+service-short+} annotation
+For every model class in your project, the Realm annotation
 processor generates a corresponding ``RealmProxy`` class. This class
 extends your model class and is returned when you call
 ``Realm.createObject()``. In your code, this object works just like your
@@ -345,7 +346,7 @@ model class.
 Realm Object Limitations
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-{+service-short+} objects:
+Realm objects:
 
 - cannot contain fields that use the ``final`` or ``volatile`` modifiers
   (except for :ref:`inverse relationship <java-inverse-relationship>`
@@ -370,16 +371,16 @@ Size limitations:
 
 Usage limitations:
 
-- Because {+service-short+} objects are live and can change at any time,
+- Because Realm objects are live and can change at any time,
   their ``hashCode()`` value can change over time. As a result, you
   should not use ``RealmObject`` instances as a key in any map or set.
 
 Incremental Builds
 ------------------
 
-The bytecode transformer used by {+service-short+} supports incremental
+The bytecode transformer used by Realm supports incremental
 builds, but your application requires a full rebuild when adding or
-removing the following from a {+service-short+} object field:
+removing the following from a Realm object field:
 
 - an ``@Ignore`` annotation
 
@@ -389,16 +390,3 @@ removing the following from a {+service-short+} object field:
 
 You can perform a full rebuild with :guilabel:`Build > Clean Project`
 and :guilabel:`Build > Rebuild Project` in these cases.
-
-Summary
--------
-
-- {+service-short+} objects are of a **type** defined as you would any other
-  class.
-
-- The {+service-short+} object's **schema** defines the fields of the object and
-  which fields are optional, which fields have a default value,
-  and which fields are indexed.
-
-- You can define to-one, to-many, and inverse relationships in your schema. Inverse relationships automatically
-  form backlinks.

--- a/source/sdk/java/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/java/fundamentals/object-models-and-schemas.txt
@@ -15,7 +15,7 @@ Object Models & Schemas - Java SDK
 An **object schema** is a configuration object that defines the fields and
 relationships of a Realm object type. Android
 Realm applications define object schemas with Java or Kotlin
-classes using :term:`Realm Schemas <Realm Schema>`.
+classes using Realm Schemas.
 
 Object schemas specify constraints on object fields such as the data
 :ref:`type <java-supported-data-types>` of each field, whether a

--- a/source/sdk/java/fundamentals/object-models-and-schemas.txt
+++ b/source/sdk/java/fundamentals/object-models-and-schemas.txt
@@ -15,7 +15,7 @@ Object Models & Schemas - Java SDK
 An **object schema** is a configuration object that defines the fields and
 relationships of a Realm object type. Android
 Realm applications define object schemas with Java or Kotlin
-classes using :term:`{+frontend-schema+}s <{+frontend-schema+}>`.
+classes using :term:`Realm Schemas <Realm Schema>`.
 
 Object schemas specify constraints on object fields such as the data
 :ref:`type <java-supported-data-types>` of each field, whether a
@@ -23,22 +23,22 @@ field is required, and default field values. Schemas can also define
 :ref:`relationships <java-client-relationships>` between object types in
 a realm.
 
-Modifying your application's {+frontend-schema+} requires you to
+Modifying your application's Realm Schema requires you to
 :ref:`migrate <java-schema-versions-and-migrations>` data from older
-versions of your {+frontend-schema+} to the new version.
+versions of your Realm Schema to the new version.
 
 Realm Apps
 ----------
 
-Every App has a :ref:`{+backend-schema+} <java-realm-schema>`
+Every App has a :ref:`Realm Schema <java-realm-schema>`
 composed of a list of object schemas for each type of object that the
-{+realms+} in that application may contain.
+realms in that application may contain.
 
-{+service+} guarantees that all objects in a realm conform to the
+Realm guarantees that all objects in a realm conform to the
 schema for their object type and validates objects whenever they're
 created, modified, or deleted.
 
-Apps that take advantage of {+sync+} can define schemas in two ways:
+Apps that take advantage of Sync can define schemas in two ways:
 
 - object schemas :ref:`using Kotlin and Java class declarations
   <create-schema-from-rom>` with :ref:`Development Mode <enable-development-mode>`.
@@ -52,7 +52,7 @@ Primary Keys
 
 .. versionadded:: 10.6.0
 
-   {+client-database+} automatically :ref:`indexes <java-indexes-fundamentals>`
+   Realm Database automatically :ref:`indexes <java-indexes-fundamentals>`
    primary key fields. Previously, Realm only indexed ``String`` primary
    keys automatically.
 
@@ -91,12 +91,12 @@ key value must be unique. Attempting to insert an object with an existing
 primary key into a realm will result in a
 :java-sdk:`RealmPrimaryKeyConstraintException <io/realm/exceptions/RealmPrimaryKeyConstraintException.html>`.
 
-{+client-database+} automatically :ref:`indexes <java-index-field>`
+Realm Database automatically :ref:`indexes <java-index-field>`
 primary key fields, which allows you to efficiently read and modify
 objects based on their primary key.
 
 You cannot change the primary key field for an object type after adding
-any object of that type to a realm. If you are using {+sync+},
+any object of that type to a realm. If you are using Sync,
 you cannot change the primary key field for an object after defining the
 primary key in your backend :ref:`schema <schemas>`.
 
@@ -175,7 +175,7 @@ nullable, and cannot be made required.
    .. tab::
       :tabid: java
 
-      Nullable fields are optional by default in {+client-database+}, unless
+      Nullable fields are optional by default in Realm Database, unless
       otherwise specified with the :ref:`@Required <java-required-field>`
       annotation. The following types are nullable:
 
@@ -231,10 +231,10 @@ Indexes
 -------
 
 **Indexes** support the efficient execution of queries in
-{+client-database+}. Without indexes, {+client-database+} must perform a
+Realm Database. Without indexes, Realm Database must perform a
 *collection scan*, i.e. scan every document in a collection, to select
 those documents that match a query. If an appropriate index exists for a
-query, {+client-database+} can use the index to limit the number of
+query, Realm Database can use the index to limit the number of
 documents that it must inspect.
 
 Indexes are special data structures that store a small portion of a
@@ -300,13 +300,13 @@ Realm Objects
 Unlike normal Java objects, which contain their own data, a
 Realm object doesn't contain data. Instead,
 Realm objects read and write properties directly to
-{+client-database+}.
+Realm Database.
 
 Instances of Realm objects can be either **managed** or **unmanaged**.
 
 - **Managed** objects are:
 
-  - persisted in {+client-database+}
+  - persisted in Realm Database
 
   - always up to date
 

--- a/source/sdk/java/fundamentals/query-engine.txt
+++ b/source/sdk/java/fundamentals/query-engine.txt
@@ -34,7 +34,7 @@ for a complete list of available methods.
 There are several types of operators available to filter a
 :ref:`Realm collection <java-client-collections>`.
 Filters work by **evaluating** an operator expression for
-every :term:`object <Realm object>` in the collection being
+every object in the collection being
 filtered. If the expression resolves to ``true``, Realm
 Database includes the object in the results collection.
 

--- a/source/sdk/java/fundamentals/query-engine.txt
+++ b/source/sdk/java/fundamentals/query-engine.txt
@@ -19,9 +19,6 @@ There are two ways to access the query engine with the Java SDK:
 - :ref:`Fluent interface <java-query-fluent-interface>`
 - :ref:`Realm Query Language <java-realm-query-language>`
 
-You should use the Fluent interface for
-querying when possible, as it aligns with Java conventions.  
-
 .. _java-query-fluent-interface:
 
 Fluent Interface
@@ -47,46 +44,47 @@ An **expression** consists of one of the following:
 - An operator and up to two argument expression(s).
 - A literal string, number, or date.
 
-.. note:: About the examples on this page
+About the examples on this page
+-------------------------------
 
-   The examples in this page use a simple data set for a
-   task list app. The two Realm object types are ``Project``
-   and ``Task``. A ``Task`` has a name, assignee's name, and
-   completed flag. There is also an arbitrary number for
-   priority -- higher is more important -- and a count of
-   minutes spent working on it. A ``Project`` has zero or more
-   ``Tasks``.
+The examples in this page use a simple data set for a
+task list app. The two Realm object types are ``Project``
+and ``Task``. A ``Task`` has a name, assignee's name, and
+completed flag. There is also an arbitrary number for
+priority -- higher is more important -- and a count of
+minutes spent working on it. A ``Project`` has zero or more
+``Tasks``.
 
-   See the schema for these two classes, ``Project`` and
-   ``Task``, below:
+See the schema for these two classes, ``Project`` and
+``Task``, below:
 
-   .. tabs-realm-languages::
-     
-      .. tab::
-         :tabid: kotlin
+.. tabs-realm-languages::
+  
+   .. tab::
+      :tabid: kotlin
 
-         .. literalinclude:: /examples/generated/java/sync/ProjectTask.snippet.projecttask.kt
-            :language: kotlin
-            :caption: ProjectTask.kt
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/ProjectTask.snippet.projecttask.kt
+         :language: kotlin
+         :caption: ProjectTask.kt
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/Project.snippet.project.kt
-            :language: kotlin
-            :caption: Project.kt
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/Project.snippet.project.kt
+         :language: kotlin
+         :caption: Project.kt
+         :copyable: false
 
-      .. tab::
-         :tabid: java
+   .. tab::
+      :tabid: java
 
-         .. literalinclude:: /examples/generated/java/sync/ProjectTask.snippet.projecttask.java
-            :language: java
-            :caption: ProjectTask.java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/ProjectTask.snippet.projecttask.java
+         :language: java
+         :caption: ProjectTask.java
+         :copyable: false
 
-         .. literalinclude:: /examples/generated/java/sync/Project.snippet.project.java
-            :language: java
-            :caption: Project.java
-            :copyable: false
+      .. literalinclude:: /examples/generated/java/sync/Project.snippet.project.java
+         :language: java
+         :caption: Project.java
+         :copyable: false
 
 Comparison Operators
 ~~~~~~~~~~~~~~~~~~~~
@@ -335,9 +333,3 @@ a string-based query language inspired by `NSPredicate
    :ref:`Usage Examples - Realm Query Language <java-filter-with-realm-query-language>`
 
 .. include:: /includes/tip-realm-query-language-reference-examples.rst
-
-Summary
--------
-
-- There are several categories of operators available to filter results:
-  comparison, logical, string and aggregate operators.

--- a/source/sdk/java/fundamentals/query-engine.txt
+++ b/source/sdk/java/fundamentals/query-engine.txt
@@ -12,7 +12,7 @@ Query Engine - Java SDK
    :depth: 2
    :class: singlecol
 
-To filter data in your {+realm+}, use the {+client-database+} query engine. 
+To filter data in your realm, use the Realm Database query engine. 
 
 There are two ways to access the query engine with the Java SDK:
 
@@ -324,7 +324,7 @@ to a single value.
 Realm Query Language
 --------------------
 
-You can also query {+realm+}s using :ref:`Realm Query Language <realm-query-language>`,
+You can also query realms using :ref:`Realm Query Language <realm-query-language>`,
 a string-based query language inspired by `NSPredicate
 <https://academy.realm.io/posts/nspredicate-cheatsheet/>`_.
 

--- a/source/sdk/java/fundamentals/query-engine.txt
+++ b/source/sdk/java/fundamentals/query-engine.txt
@@ -51,7 +51,7 @@ The examples in this page use a simple data set for a
 task list app. The two Realm object types are ``Project``
 and ``Task``. A ``Task`` has a name, assignee's name, and
 completed flag. There is also an arbitrary number for
-priority -- higher is more important -- and a count of
+priority (higher is more important) and a count of
 minutes spent working on it. A ``Project`` has zero or more
 ``Tasks``.
 

--- a/source/sdk/java/fundamentals/realms.txt
+++ b/source/sdk/java/fundamentals/realms.txt
@@ -349,7 +349,7 @@ You can remove unused space by **compacting** the realm file:
   builder option when opening the first connection to a realm in your
   Android application
 
-.. important:: All Production Applications Should Compact
+.. important:: Compact All Production Applications
 
    Every production application should implement compacting to 
    periodically reduce realm file size.

--- a/source/sdk/java/fundamentals/realms.txt
+++ b/source/sdk/java/fundamentals/realms.txt
@@ -119,7 +119,7 @@ opening an additional instance requires fewer resources:
 - If the realm is already open on the same thread within the same
   process, opening the realm requires minimal additional resources.
 
-When you open a realm for the first time, {+client-database+}
+When you open a realm for the first time, Realm Database
 performs the memory-mapping and schema validation required to read and
 write data to the realm. Additional instances of that
 realm on the same thread use the same underlying resources.
@@ -127,9 +127,9 @@ Instances of that realm on separate threads use some of the same
 underlying resources.
 
 When all connections to a realm are closed in
-a thread, {+client-database+} frees the thread resources used to
+a thread, Realm Database frees the thread resources used to
 connect to that realm. When all connections to a realm are
-closed in a process, {+client-database+} frees all resources used to
+closed in a process, Realm Database frees all resources used to
 connect to that realm.
 
 As a best practice, we recommend tying the realm instance
@@ -168,13 +168,13 @@ receive notifications from multiple APKs.
 Comparison with Other Databases
 -------------------------------
 
-The {+service+} data model is similar to both relational and document
+The Realm data model is similar to both relational and document
 databases but has distinct differences from both. To underscore these
 differences, it's helpful to highlight what a realm **is not**:
 
 A realm is not a single, application-wide database.
     Unlike other applications, which store all of their data in a single
-    database, {+app+}s often split data across multiple {+realms+} to
+    database, Apps often split data across multiple realms to
     organize data more efficiently and to enforce access controls.
 
 A realm is not a table.
@@ -192,16 +192,16 @@ A realm is not a collection of schemaless documents.
 Realm Schema
 ------------
 
-A **{+backend-schema+}** is a list of valid :ref:`object schemas
-<java-realm-objects>` that each define an object type that an {+app+}
-may persist. All objects in a realm must conform to the {+backend-schema+}.
+A **Realm Schema** is a list of valid :ref:`object schemas
+<java-realm-objects>` that each define an object type that an App
+may persist. All objects in a realm must conform to the Realm Schema.
 
 By default, the SDK automatically adds all classes in your project
 that derive from :java-sdk:`RealmObject <io/realm/RealmObject.html>` to the
 realm schema.
 
-Client applications provide a {+frontend-schema+} when they open a
-realm. If a realm already contains data, then {+client-database+}
+Client applications provide a Realm Schema when they open a
+realm. If a realm already contains data, then Realm Database
 validates each existing object to ensure that an object schema was
 provided for its type and that it meets all of the constraints specified
 in the schema.
@@ -241,31 +241,31 @@ Synced Realms
 
 When you use :ref:`Partition-Based Sync <partition-based-sync>`, synced 
 realms represent partitions of Atlas data. Each realm corresponds to 
-a subset of the data in your :term:`{+app+}'s <{+app+}>`
+a subset of the data in your :term:`App's <App>`
 :term:`synced {+atlas+} cluster <synced cluster>`. You can customize the
 :ref:`partitioning <sync-partitions>` of data using your application's
 :ref:`partition key <partition-key>`. Unique values of the partition
 key, known as :ref:`partition values <partition-value>`, correspond to
-individual {+realms+}.
+individual realms.
 
 When you use :ref:`Flexible Sync <flexible-sync>`, you can customize the 
 data your client application syncs by :ref:`subscribing to queries 
 <java-sync-subscribe-to-queryable-fields>`. These queries search for 
-data in your {+app+} backend, and the Flexible Sync realm syncs data that 
+data in your App backend, and the Flexible Sync realm syncs data that 
 matches the queries. The client application can only sync data where the
 user has the appropriate :ref:`read or read and write permissions 
 <flexible-sync-rules-and-permissions>` to access the data.
 
 You can customize permissions for the data that synced realms can read
-and write from your {+app+} when you configure 
-:ref:`{+service-short+} Rules <sync-rules>`.
+and write from your App when you configure 
+:ref:`Realm Rules <sync-rules>`.
 
 .. _java-realm-file:
 
 Find Your Realm File
 --------------------
 
-{+client-database+} stores a binary encoded version of every object
+Realm Database stores a binary encoded version of every object
 and type in a realm in a single ``.realm`` file.
 
 .. include:: /includes/find-realm-file-java.rst
@@ -281,9 +281,9 @@ and type in a realm in a single ``.realm`` file.
 Realm File Size
 ---------------
 
-{+client-database+} usually takes up less space on disk than an
+Realm Database usually takes up less space on disk than an
 equivalent SQLite database. However, in order to give you a consistent
-view of your data, {+service-short+} operates on multiple versions of a
+view of your data, Realm operates on multiple versions of a
 realm. If many versions of a realm are opened simultaneously,
 the realm file can require additional space on disk.
 
@@ -294,9 +294,9 @@ overhead as a small number of large transactions.
 Unexpected file size growth usually happens for one of three reasons:
 
 1) *You open a realm on a background thread and forget to close it
-   again.* As a result, {+client-database+} retains a reference to the
+   again.* As a result, Realm Database retains a reference to the
    older version of data on the background thread. Because
-   {+client-database+} automatically updates realms to the most
+   Realm Database automatically updates realms to the most
    recent version on threads with loopers, the UI thread and other
    Looper threads do not have this problem.
 
@@ -309,7 +309,7 @@ Unexpected file size growth usually happens for one of three reasons:
 
 3) *You read some data from a realm. Then, you block the thread with
    a long-running operation. Meanwhile, you write many times to the
-   realm on other threads.* This causes {+client-database+} to
+   realm on other threads.* This causes Realm Database to
    create many intermediate versions. You can avoid this by:
 
    - batching the writes
@@ -329,9 +329,9 @@ when building your ``RealmConfiguration`` to throw an
 a realm than the permitted number. Versions are created when
 executing a write transaction.
 
-{+client-database+} automatically removes older versions of data once
+Realm Database automatically removes older versions of data once
 they are no longer used by your application. However,
-{+client-database+} does not free the space used by older versions of
+Realm Database does not free the space used by older versions of
 data; instead, that space is used for new writes to the realm.
 
 .. _java-compact-a-realm:
@@ -359,7 +359,7 @@ You can remove unused space by **compacting** the realm file:
 Backup and Restore Realms
 -------------------------
 
-{+client-database+} persists {+realms+} to disk using files on your
+Realm Database persists realms to disk using files on your
 Android device. To back up a realm, :ref:`find your realm file
 <java-realm-file>` and copy it to a safe location. You should close
 all instances of the realm before copying it.
@@ -383,10 +383,10 @@ Summary
   schema. It is not a single, application-wide database. There can and
   usually will be more than one realm per application.
 
-- A :term:`{+backend-schema+}` is a versioned specification of the
-  object types used in an {+app+}.
+- A :term:`Realm Schema` is a versioned specification of the
+  object types used in an App.
 
-- {+service-short+} Rules define who can read or write
+- Realm Rules define who can read or write
   the realm and apply to the realm as a whole.
 
 - When using :ref:`Partition-Based Sync <partition-based-sync>`, a 

--- a/source/sdk/java/fundamentals/realms.txt
+++ b/source/sdk/java/fundamentals/realms.txt
@@ -45,8 +45,8 @@ throw an ``IllegalStateException`` if a write occurs.
 
 .. warning:: Read-Only Realm Files are Writeable
 
-   Read-only realms are only enforced as read-only in process; the
-   realm file itself is still writeable.
+   Read-only realms are only enforced as read-only in process.
+   The realm file itself is still writeable.
 
 .. seealso::
 

--- a/source/sdk/java/fundamentals/realms.txt
+++ b/source/sdk/java/fundamentals/realms.txt
@@ -16,7 +16,7 @@ A **realm** is a set of related objects that conform to a pre-defined
 schema. Realms may contain more than one type of data as long as a 
 schema exists for each type.
 
-Every realm stores data in a separate :term:`realm file` that 
+Every realm stores data in a separate realm file that 
 contains a binary encoding of each object in the realm. You can
 automatically :ref:`synchronize realm across multiple
 devices <sync>` and set up :ref:`reactive
@@ -241,8 +241,7 @@ Synced Realms
 
 When you use :ref:`Partition-Based Sync <partition-based-sync>`, synced 
 realms represent partitions of Atlas data. Each realm corresponds to 
-a subset of the data in your :term:`App's <App>`
-:term:`synced {+atlas+} cluster <synced cluster>`. You can customize the
+a subset of the data in your App's data source. You can customize the
 :ref:`partitioning <sync-partitions>` of data using your application's
 :ref:`partition key <partition-key>`. Unique values of the partition
 key, known as :ref:`partition values <partition-value>`, correspond to
@@ -375,22 +374,3 @@ version of a realm to a destination file.
    <https://medium.com/glucosio-project/example-class-to-export-import-a-realm-database-on-java-c429ade2b4ed#.80ibsc7wm>`__,
    `Part 2 <https://medium.com/glucosio-project/backup-restore-a-realm-database-on-google-drive-with-drive-api-c238515a5975#.qbuugb322>`__,
    `Part 3 <https://medium.com/glucosio-project/build-a-nice-ux-to-backup-and-sync-your-app-data-on-google-drive-3-3-a3b598cab68b#.5mjk4w4se>`__).
-
-Summary
--------
-
-- A :term:`realm` is a collection of objects that conform to a
-  schema. It is not a single, application-wide database. There can and
-  usually will be more than one realm per application.
-
-- A :term:`Realm Schema` is a versioned specification of the
-  object types used in an App.
-
-- Realm Rules define who can read or write
-  the realm and apply to the realm as a whole.
-
-- When using :ref:`Partition-Based Sync <partition-based-sync>`, a 
-  :term:`partition value` is a realm's unique identifier.
-
-- Modules let you selectively include subsets of the Realm objects defined
-  in your application schema when opening a realm.

--- a/source/sdk/java/fundamentals/realms.txt
+++ b/source/sdk/java/fundamentals/realms.txt
@@ -12,16 +12,16 @@ Realms - Java SDK
    :depth: 2
    :class: singlecol
 
-A **{+realm+}** is a set of related objects that conform to a pre-defined
+A **realm** is a set of related objects that conform to a pre-defined
 schema. Realms may contain more than one type of data as long as a 
 schema exists for each type.
 
-Every {+realm+} stores data in a separate :term:`{+realm+} file` that 
-contains a binary encoding of each object in the {+realm+}. You can
-automatically :ref:`synchronize {+realm+} across multiple
+Every realm stores data in a separate :term:`realm file` that 
+contains a binary encoding of each object in the realm. You can
+automatically :ref:`synchronize realm across multiple
 devices <sync>` and set up :ref:`reactive
 event handlers <java-realm-notifications>` that call a
-function any time an object in a {+realm+} is created,
+function any time an object in a realm is created,
 modified, or deleted.
 
 .. _java-realm-types:
@@ -29,25 +29,24 @@ modified, or deleted.
 Types of Realm
 --------------
 
-When opening a {+realm+}, you can configure many properties of the {+realm+}.
+When opening a realm, you can configure many properties of the realm.
 
 .. _java-read-only-realms-fundamentals:
 
 Read-Only Realms
 ~~~~~~~~~~~~~~~~
 
-It's sometimes useful to ship a prepared {+realm+} file with your app
+It's sometimes useful to ship a prepared realm file with your app
 that contains shared data that does not frequently change. You can use
 the :java-sdk:`readOnly() <io/realm/RealmConfiguration.Builder.html#readOnly-->`
-method when configuring your {+realm+} to make it read-only. This can
-prevent accidental writes to the {+realm+} and causes the {+realm+} to
+method when configuring your realm to make it read-only. This can
+prevent accidental writes to the realm and causes the realm to
 throw an ``IllegalStateException`` if a write occurs.
 
 .. warning:: Read-Only Realm Files are Writeable
 
-   Read-only {+realm+}s are only enforced as read-only in process; the
-   {+realm+} file itself is still writeable. As a result, it is still
-   possible for other process to write to a read-only {+realm+}.
+   Read-only realms are only enforced as read-only in process; the
+   realm file itself is still writeable.
 
 .. seealso::
 
@@ -58,17 +57,16 @@ throw an ``IllegalStateException`` if a write occurs.
 In-Memory Realms
 ~~~~~~~~~~~~~~~~
 
-To create a {+realm+} that runs entirely in memory without being written
-to a file, use the :java-sdk:`inMemory() <io/realm/RealmConfiguration.Builder.html#inMemory-->` method when configuring your
-{+realm+}.
+To create a realm that runs entirely in memory without being written
+to a file, use the :java-sdk:`inMemory() <io/realm/RealmConfiguration.Builder.html#inMemory-->` method.
 
-.. important:: In-Memory Realms May Persist to Disk Under High Memory Pressure
+When memory runs low on an Android device, in-memory realms
+may :wikipedia:`swap <Memory_paging#Terminology>` temporarily from main
+memory to disk space. The SDK deletes all files created by an in-memory
+realm when:
 
-   When memory runs low on an Android device, in-memory {+realm+}s
-   may :wikipedia:`swap <Memory_paging#Terminology>` temporarily from main
-   memory to disk space. However, all files created by an in-memory
-   {+realm+} are deleted when that {+realm+} closes or all references
-   to that {+realm+} fall out of scope.
+- the realm closes
+- all references to that realm fall out of scope
 
 .. seealso::
 
@@ -79,19 +77,17 @@ to a file, use the :java-sdk:`inMemory() <io/realm/RealmConfiguration.Builder.ht
 Dynamic Realms
 ~~~~~~~~~~~~~~
 
-Conventional {+realm+}s define a schema using ``RealmObject`` subclasses
+Conventional realms define a schema using ``RealmObject`` subclasses
 or the ``RealmModel`` interface. A
 :java-sdk:`DynamicRealm <io/realm/DynamicRealm.html>` uses strings to
-define a schema at runtime. Opening a dynamic {+realm+} uses the same
-configuration as a conventional {+realm+}, but dynamic {+realm+}s ignore
+define a schema at runtime. Opening a dynamic realm uses the same
+configuration as a conventional realm, but dynamic realms ignore
 all configured schema, migration, and schema versions.
 
-.. important:: Dynamic Realms Lack Type-Safety
-
-   Dynamic {+realm+}s offer flexibility at the expense of type safety and
-   performance. As a result, only use dynamic {+realm+}s when that
-   flexibility is required, such as during migrations, manual client
-   resets, and when working with string-based data like CSV files or JSON.
+Dynamic realms offer flexibility at the expense of type safety and
+performance. As a result, only use dynamic realms when that
+flexibility is required, such as during migrations, manual client
+resets, and when working with string-based data like CSV files or JSON.
 
 .. seealso::
 
@@ -102,70 +98,70 @@ all configured schema, migration, and schema versions.
 The Realm Lifecycle
 -------------------
 
-Every {+realm+} instance consumes a significant amount of resources.
-Opening and closing a {+realm+} are both expensive operations, but
-keeping a {+realm+} open also incurs significant resource overhead. To
+Every realm instance consumes a significant amount of resources.
+Opening and closing a realm are both expensive operations, but
+keeping a realm open also incurs significant resource overhead. To
 maximize the performance of your application, you should minimize the
-number of open {+realm+}s at any given time and limit the number of
+number of open realms at any given time and limit the number of
 open and close operations used.
 
-However, opening a {+realm+} is not always consistently expensive.
-If the {+realm+} is already open within the same process or thread,
+However, opening a realm is not always consistently expensive.
+If the realm is already open within the same process or thread,
 opening an additional instance requires fewer resources:
 
-- If the {+realm+} is not open within the same process, opening the
-  {+realm+} is expensive.
+- If the realm is not open within the same process, opening the
+  realm is expensive.
 
-- If the {+realm+} is already open on a different thread within the
-  same process, opening the {+realm+} is less expensive, but still
+- If the realm is already open on a different thread within the
+  same process, opening the realm is less expensive, but still
   nontrivial.
 
-- If the {+realm+} is already open on the same thread within the same
-  process, opening the {+realm+} requires minimal additional resources.
+- If the realm is already open on the same thread within the same
+  process, opening the realm requires minimal additional resources.
 
-When you open a {+realm+} for the first time, {+client-database+}
+When you open a realm for the first time, {+client-database+}
 performs the memory-mapping and schema validation required to read and
-write data to the {+realm+}. Additional instances of that
-{+realm+} on the same thread use the same underlying resources.
-Instances of that {+realm+} on separate threads use some of the same
+write data to the realm. Additional instances of that
+realm on the same thread use the same underlying resources.
+Instances of that realm on separate threads use some of the same
 underlying resources.
 
-When all connections to a {+realm+} are closed in
+When all connections to a realm are closed in
 a thread, {+client-database+} frees the thread resources used to
-connect to that {+realm+}. When all connections to a {+realm+} are
+connect to that realm. When all connections to a realm are
 closed in a process, {+client-database+} frees all resources used to
-connect to that {+realm+}.
+connect to that realm.
 
-As a best practice, we recommend tying the {+realm+} instance
-lifecycle to the lifecycles of the views that observe the {+realm+}. For
+As a best practice, we recommend tying the realm instance
+lifecycle to the lifecycles of the views that observe the realm. For
 instance, consider a ``RecyclerView`` that displays ``RealmResults``
 data via a ``Fragment``. You could:
 
-- Open a single {+realm+} that contains the data for that view
+- Open a single realm that contains the data for that view
   in the ``Fragment.onCreateView()`` lifecycle method.
-- Close that same {+realm+} in the ``Fragment.onDestroyView()``
+- Close that same realm in the ``Fragment.onDestroyView()``
   lifecycle method.
 
 .. note::
 
-   If your {+realm+} is especially large, fetching a {+realm+} instance
+   If your realm is especially large, fetching a realm instance
    in ``Fragment.onCreateView()`` may briefly block rendering. If
-   opening your {+realm+} in ``onCreateView()`` causes performance
-   issues, consider managing the {+realm+} from ``Fragment.onStart()``
+   opening your realm in ``onCreateView()`` causes performance
+   issues, consider managing the realm from ``Fragment.onStart()``
    and ``Fragment.onStop()`` instead.
 
 If multiple ``Fragment`` instances require access to the same dataset,
-you could manage a single {+realm+} in the enclosing ``Activity``:
+you could manage a single realm in the enclosing ``Activity``:
 
-- Open the {+realm+} in the ``Activity.onCreate()`` lifecycle method.
-- Close the {+realm+} in the ``Activity.onDestroy()`` lifecycle method.
+- Open the realm in the ``Activity.onCreate()`` lifecycle method.
+- Close the realm in the ``Activity.onDestroy()`` lifecycle method.
 
 Multi-process
 -------------
 
 You cannot access :ref:`encrypted <java-encrypt-a-realm>` or
-:ref:`synced <java-sync-changes-between-devices>` {+realm+}s
-simultaneously from different processes. However, local {+realm+}s
+:ref:`synced <java-sync-changes-between-devices>` realms
+simultaneously from different processes. However, local realms
 function normally across processes, so you can read, write, and
 receive notifications from multiple APKs.
 
@@ -174,21 +170,21 @@ Comparison with Other Databases
 
 The {+service+} data model is similar to both relational and document
 databases but has distinct differences from both. To underscore these
-differences, it's helpful to highlight what a {+realm+} **is not**:
+differences, it's helpful to highlight what a realm **is not**:
 
-A {+realm+} is not a single, application-wide database.
+A realm is not a single, application-wide database.
     Unlike other applications, which store all of their data in a single
     database, {+app+}s often split data across multiple {+realms+} to
     organize data more efficiently and to enforce access controls.
 
-A {+realm+} is not a table.
+A realm is not a table.
     Tables typically only store one kind of information, such as street
-    addresses or items in a store inventory, whereas a {+realm+} can contain
+    addresses or items in a store inventory, whereas a realm can contain
     any number of object types.
 
-A {+realm+} is not a collection of schemaless documents.
+A realm is not a collection of schemaless documents.
     Application objects are similar to documents, but every object in a
-    {+realm+} conforms to a defined schema for its object type. An object
+    realm conforms to a defined schema for its object type. An object
     cannot contain a field that is not described by its schema.
 
 .. _java-realm-schema:
@@ -198,21 +194,21 @@ Realm Schema
 
 A **{+backend-schema+}** is a list of valid :ref:`object schemas
 <java-realm-objects>` that each define an object type that an {+app+}
-may persist. All objects in a {+realm+} must conform to the {+backend-schema+}.
+may persist. All objects in a realm must conform to the {+backend-schema+}.
 
 By default, the SDK automatically adds all classes in your project
 that derive from :java-sdk:`RealmObject <io/realm/RealmObject.html>` to the
-{+realm+} schema.
+realm schema.
 
 Client applications provide a {+frontend-schema+} when they open a
-{+realm+}. If a {+realm+} already contains data, then {+client-database+}
+realm. If a realm already contains data, then {+client-database+}
 validates each existing object to ensure that an object schema was
 provided for its type and that it meets all of the constraints specified
 in the schema.
 
 .. example::
    
-   A {+realm+} that contains basic data about books in libraries might use a
+   A realm that contains basic data about books in libraries might use a
    schema like the following:
    
    .. code-block:: json
@@ -244,7 +240,7 @@ Synced Realms
 -------------
 
 When you use :ref:`Partition-Based Sync <partition-based-sync>`, synced 
-realms represent partitions of Atlas data. Each {+realm+} corresponds to 
+realms represent partitions of Atlas data. Each realm corresponds to 
 a subset of the data in your :term:`{+app+}'s <{+app+}>`
 :term:`synced {+atlas+} cluster <synced cluster>`. You can customize the
 :ref:`partitioning <sync-partitions>` of data using your application's
@@ -274,9 +270,9 @@ and type in a realm in a single ``.realm`` file.
 
 .. include:: /includes/find-realm-file-java.rst
 
-.. note:: Auxiliary Realm Files
+.. seealso:: Auxiliary Realm Files
    
-   Realm Database creates additional files for each {+realm+}.
+   Realm Database creates additional files for each realm.
    To learn more about these files, see :ref:`Realm Database Internals
    <java-realm-database>`.
 
@@ -288,8 +284,8 @@ Realm File Size
 {+client-database+} usually takes up less space on disk than an
 equivalent SQLite database. However, in order to give you a consistent
 view of your data, {+service-short+} operates on multiple versions of a
-{+realm+}. If many versions of a {+realm+} are opened simultaneously,
-the {+realm+} file can require additional space on disk.
+realm. If many versions of a realm are opened simultaneously,
+the realm file can require additional space on disk.
 
 These versions take up an amount of space dependent on the amount of
 changes in each transaction. Many small transactions have the same
@@ -297,28 +293,28 @@ overhead as a small number of large transactions.
 
 Unexpected file size growth usually happens for one of three reasons:
 
-1) *You open a {+realm+} on a background thread and forget to close it
+1) *You open a realm on a background thread and forget to close it
    again.* As a result, {+client-database+} retains a reference to the
    older version of data on the background thread. Because
-   {+client-database+} automatically updates {+realm+}s to the most
+   {+client-database+} automatically updates realms to the most
    recent version on threads with loopers, the UI thread and other
    Looper threads do not have this problem.
 
 2) *You hold references to too many versions of frozen objects.*
-   Frozen objects preserve the version of a {+realm+} that existed when
+   Frozen objects preserve the version of a realm that existed when
    the object was first frozen. If you need to freeze a large number of
    objects, consider using :java-sdk:`Realm.copyFromRealm()
    <io/realm/Realm.html#copyFromRealm-E->` instead to only preserve the
    data you need.
 
-3) *You read some data from a {+realm+}. Then, you block the thread with
+3) *You read some data from a realm. Then, you block the thread with
    a long-running operation. Meanwhile, you write many times to the
-   {+realm+} on other threads.* This causes {+client-database+} to
+   realm on other threads.* This causes {+client-database+} to
    create many intermediate versions. You can avoid this by:
 
    - batching the writes
 
-   - avoiding leaving the {+realm+} open while otherwise blocking the
+   - avoiding leaving the realm open while otherwise blocking the
      background thread.
 
 .. _java-limit-max-number-of-active-versions:
@@ -330,33 +326,33 @@ You can set :java-sdk:`maxNumberOfActiveVersions()
 <io/realm/RealmConfiguration.Builder.html#maxNumberOfActiveVersions-long->`
 when building your ``RealmConfiguration`` to throw an
 ``IllegalStateException`` if your application opens more versions of
-a {+realm+} than the permitted number. Versions are created when
+a realm than the permitted number. Versions are created when
 executing a write transaction.
 
 {+client-database+} automatically removes older versions of data once
 they are no longer used by your application. However,
 {+client-database+} does not free the space used by older versions of
-data; instead, that space is used for new writes to the {+realm+}.
+data; instead, that space is used for new writes to the realm.
 
 .. _java-compact-a-realm:
 
 Compact a Realm
 ~~~~~~~~~~~~~~~
 
-You can remove unused space by **compacting** the {+realm+} file:
+You can remove unused space by **compacting** the realm file:
 
 - Manually: call :java-sdk:`compactRealm()
   <io/realm/Realm.html#compactRealm-io.realm.RealmConfiguration->`
 
 - Automatically: specify the :java-sdk:`compactOnLaunch()
   <io/realm/RealmConfiguration.Builder.html#compactOnLaunch-io.realm.CompactOnLaunchCallback->`
-  builder option when opening the first connection to a {+realm+} in your
+  builder option when opening the first connection to a realm in your
   Android application
 
-.. tip:: Implement Compacting in Your Production Application
+.. important:: All Production Applications Should Compact
 
    Every production application should implement compacting to 
-   periodically reduce the realm file size.
+   periodically reduce realm file size.
 
 .. _java-backup-and-restore-realms:
 
@@ -364,17 +360,17 @@ Backup and Restore Realms
 -------------------------
 
 {+client-database+} persists {+realms+} to disk using files on your
-Android device. To back up a {+realm+}, :ref:`find your {+realm+} file
+Android device. To back up a realm, :ref:`find your realm file
 <java-realm-file>` and copy it to a safe location. You should close
-all instances of the {+realm+} before copying it.
+all instances of the realm before copying it.
 
 Alternatively, you can also use :java-sdk:`realm.writeCopyTo()
 <io/realm/Realm.html#writeCopyTo-java.io.File->` to write a compacted
-version of a {+realm+} to a destination file.
+version of a realm to a destination file.
 
 .. seealso::
 
-   If you want to back up a {+realm+} to an external location like
+   If you want to back up a realm to an external location like
    Google Drive, see the following article series: (`Part 1
    <https://medium.com/glucosio-project/example-class-to-export-import-a-realm-database-on-java-c429ade2b4ed#.80ibsc7wm>`__,
    `Part 2 <https://medium.com/glucosio-project/backup-restore-a-realm-database-on-google-drive-with-drive-api-c238515a5975#.qbuugb322>`__,
@@ -383,18 +379,18 @@ version of a {+realm+} to a destination file.
 Summary
 -------
 
-- A :term:`{+realm+}` is a collection of objects that conform to a
+- A :term:`realm` is a collection of objects that conform to a
   schema. It is not a single, application-wide database. There can and
-  usually will be more than one {+realm+} per application.
+  usually will be more than one realm per application.
 
 - A :term:`{+backend-schema+}` is a versioned specification of the
   object types used in an {+app+}.
 
 - {+service-short+} Rules define who can read or write
-  the {+realm+} and apply to the {+realm+} as a whole.
+  the realm and apply to the realm as a whole.
 
 - When using :ref:`Partition-Based Sync <partition-based-sync>`, a 
-  :term:`partition value` is a {+realm+}'s unique identifier.
+  :term:`partition value` is a realm's unique identifier.
 
 - Modules let you selectively include subsets of the Realm objects defined
-  in your application schema when opening a {+realm+}.
+  in your application schema when opening a realm.

--- a/source/sdk/java/fundamentals/relationships.txt
+++ b/source/sdk/java/fundamentals/relationships.txt
@@ -12,17 +12,17 @@ Relationships - Java SDK
    :depth: 2
    :class: singlecol
 
-{+service+} allows you to define explicit relationships between the types of
-objects in an {+app+}. A relationship is an object property that references
-another {+service-short+} object rather than one of the primitive data types. You
+Realm allows you to define explicit relationships between the types of
+objects in an App. A relationship is an object property that references
+another Realm object rather than one of the primitive data types. You
 define relationships by setting the type of an object property to
 another object type in the :ref:`property schema <property-schema>`.
 
-Relationships are direct references to other objects in a {+realm+}, which
+Relationships are direct references to other objects in a realm, which
 means that you don't need bridge tables or explicit joins to define a
 relationship like you would in a relational database. Instead you can
 access related objects by reading and writing to the property that
-defines the relationship. {+client-database+} executes read operations
+defines the relationship. Realm Database executes read operations
 lazily as they come in, so querying a relationship is just as performant
 as reading a regular property.
 
@@ -53,10 +53,10 @@ To-One Relationship
 A **to-one** relationship means that an object is related in a specific
 way to no more than one other object. You define a to-one relationship
 for an object type in its :ref:`object schema <java-object-schema>` by
-specifying a property where the type is the related {+service-short+} object type.
+specifying a property where the type is the related Realm object type.
 
 Setting a relationship field to null removes the connection between
-objects, but {+client-database+} does not delete the referenced object
+objects, but Realm Database does not delete the referenced object
 unless that object is :ref:`embedded <java-field-relationships-embedded>`.
 
 .. seealso::
@@ -71,7 +71,7 @@ To-Many Relationship
 A **to-many** relationship means that an object is related in a specific
 way to multiple objects. You can create a relationship between one object
 and any number of objects using a field of type ``RealmList<?>``
-where ``T`` is a {+service-short+} object in your application:
+where ``T`` is a Realm object in your application:
 
 .. seealso::
 
@@ -96,7 +96,7 @@ To define an inverse relationship, define a ``LinkingObjects`` property in your
 object model. The ``LinkingObjects`` definition specifies the object type and
 property name of the relationship that it inverts.
 
-{+client-database+} automatically updates implicit relationships whenever an
+Realm Database automatically updates implicit relationships whenever an
 object is added or removed in the specified relationship. You cannot manually
 set the value of an inverse relationship property.
 

--- a/source/sdk/java/fundamentals/relationships.txt
+++ b/source/sdk/java/fundamentals/relationships.txt
@@ -115,14 +115,3 @@ Like any other ``RealmResults`` set, you can
 .. seealso::
 
    :ref:`Usage Example: Inverse Relationships <java-field-relationships-inverse>`
-
-Summary
--------
-
-- A **relationship** is an object property that allows an object to
-  reference other objects of the same or another object type.
-
-- Relationships are direct references. You can access related objects
-  directly through a relationship property without writing any type of join.
-
-- {+client-database+} supports to-one, to-many, and inverse relationships.

--- a/source/sdk/java/fundamentals/schema-versions-and-migrations.txt
+++ b/source/sdk/java/fundamentals/schema-versions-and-migrations.txt
@@ -17,7 +17,7 @@ Schema Versions & Migrations - Java SDK
 Schema Version
 --------------
 
-A **schema version** identifies the state of a :ref:`{+backend-schema+}
+A **schema version** identifies the state of a :ref:`Realm Schema
 <java-realm-schema>` at some point in time. Realm Database tracks the schema
 version of each realm and uses it to map the objects in each realm
 to the correct schema.
@@ -42,9 +42,9 @@ Migrations
 ----------
 
 A **local migration** is a migration for a realm that does
-not automatically :ref:`{+sync-short+} <sync>` with
+not automatically :ref:`Sync <sync>` with
 another realm. Local migrations have access to the existing
-{+backend-schema+}, version, and objects and define logic that
+Realm Schema, version, and objects and define logic that
 incrementally updates the realm to its new schema version.
 To perform a local migration you must specify a new schema
 version that is higher than the current version and provide

--- a/source/sdk/java/fundamentals/schema-versions-and-migrations.txt
+++ b/source/sdk/java/fundamentals/schema-versions-and-migrations.txt
@@ -18,22 +18,22 @@ Schema Version
 --------------
 
 A **schema version** identifies the state of a :ref:`{+backend-schema+}
-<java-realm-schema>` at some point in time. {+client-database+} tracks the schema
-version of each {+realm+} and uses it to map the objects in each {+realm+}
+<java-realm-schema>` at some point in time. Realm Database tracks the schema
+version of each realm and uses it to map the objects in each realm
 to the correct schema.
 
 Schema versions are integers that you may include
-in the {+realm+} configuration when you open a {+realm+}. If a client
-application does not specify a version number when it opens a {+realm+} then
-the {+realm+} defaults to version ``0``.
+in the realm configuration when you open a realm. If a client
+application does not specify a version number when it opens a realm then
+the realm defaults to version ``0``.
 
 .. important:: Increment Versions Monotonically
 
-   :ref:`Migrations <java-client-migrations>` must update a {+realm+} to a
-   higher schema version. {+client-database+} will throw an error if a client
-   application opens a {+realm+} with a schema version that is lower than
-   the {+realm+}'s current version or if the specified schema version is the
-   same as the {+realm+}'s current version but includes different
+   :ref:`Migrations <java-client-migrations>` must update a realm to a
+   higher schema version. Realm Database throws an error if a client
+   application opens a realm with a schema version that is lower than
+   the realm's current version or if the specified schema version is the
+   same as the realm's current version but includes different
    :ref:`object schemas <java-object-schema>`.
 
 .. _java-migrations:
@@ -41,14 +41,14 @@ the {+realm+} defaults to version ``0``.
 Migrations
 ----------
 
-A **local migration** is a migration for a {+realm+} that does
+A **local migration** is a migration for a realm that does
 not automatically :ref:`{+sync-short+} <sync>` with
-another {+realm+}. Local migrations have access to the existing
+another realm. Local migrations have access to the existing
 {+backend-schema+}, version, and objects and define logic that
-incrementally updates the {+realm+} to its new schema version.
+incrementally updates the realm to its new schema version.
 To perform a local migration you must specify a new schema
 version that is higher than the current version and provide
-a migration function when you open the out-of-date {+realm+}.
+a migration function when you open the out-of-date realm.
 
 With the SDK, you can update underlying data to reflect schema changes
 using manual migrations. During such a manual migration, you can
@@ -58,7 +58,7 @@ your schema. The editable schema exposed via a
 convenience functions for renaming fields. This gives you full control
 over the behavior of your data during complex schema migrations.
 
-.. important:: Migrations During Application Development
+.. tip:: Migrations During Application Development
 
    During development of an application, ``RealmObject`` classes can
    change frequently. You can use :java-sdk:`Realm.deleteRealm()

--- a/source/sdk/java/fundamentals/write-transactions.txt
+++ b/source/sdk/java/fundamentals/write-transactions.txt
@@ -12,7 +12,7 @@ Write Transactions - Java SDK
    :depth: 2
    :class: singlecol
 
-You can **create** objects in a :term:`realm`,
+You can **create** objects in a realm,
 **update** objects in a realm, and eventually **delete**
 objects from a realm. Because these operations modify the
 state of the realm, we call them writes.

--- a/source/sdk/java/fundamentals/write-transactions.txt
+++ b/source/sdk/java/fundamentals/write-transactions.txt
@@ -38,8 +38,8 @@ When you are done with your transaction, Realm either
 **commits** it or **cancels** it:
 
 - When Realm **commits** a transaction, Realm writes
-  all changes to disk. For :term:`synced realms <Sync>`, Realm queues the change
-  for synchronization with :term:`Realm`.
+  all changes to disk. For synced realms, Realm queues the change
+  for synchronization with App Services.
 - When Realm **cancels** a write transaction or an operation in
   the transaction causes an error, all changes are discarded
   (or "rolled back").

--- a/source/sdk/java/fundamentals/write-transactions.txt
+++ b/source/sdk/java/fundamentals/write-transactions.txt
@@ -38,8 +38,8 @@ When you are done with your transaction, Realm either
 **commits** it or **cancels** it:
 
 - When Realm **commits** a transaction, Realm writes
-  all changes to disk. For :term:`synced {+realms+} <{+sync+}>`, Realm queues the change
-  for synchronization with :term:`{+service+}`.
+  all changes to disk. For :term:`synced realms <Sync>`, Realm queues the change
+  for synchronization with :term:`Realm`.
 - When Realm **cancels** a write transaction or an operation in
   the transaction causes an error, all changes are discarded
   (or "rolled back").

--- a/source/sdk/java/fundamentals/write-transactions.txt
+++ b/source/sdk/java/fundamentals/write-transactions.txt
@@ -12,15 +12,14 @@ Write Transactions - Java SDK
    :depth: 2
    :class: singlecol
 
-:term:`{+client-database+}` uses a highly efficient storage engine
-to persist objects. You can **create** objects in a :term:`{+realm+}`,
-**update** objects in a {+realm+}, and eventually **delete**
-objects from a {+realm+}. Because these operations modify the
-state of the {+realm+}, we call them writes.
+You can **create** objects in a :term:`realm`,
+**update** objects in a realm, and eventually **delete**
+objects from a realm. Because these operations modify the
+state of the realm, we call them writes.
 
-{+service-short+} handles writes in terms of **transactions**. A
+Realm Database handles writes in terms of **transactions**. A
 transaction is a list of read and write operations that
-{+service-short+} treats as a single indivisible operation. In other
+Realm treats as a single indivisible operation. In other
 words, a transaction is *all or nothing*: either all of the
 operations in the transaction succeed or none of the
 operations in the transaction take effect.
@@ -29,19 +28,19 @@ operations in the transaction take effect.
    
    All writes must happen in a transaction.
 
-A {+realm+} allows only one open write transaction at a time. {+service-short+}
+A realm allows only one open write transaction at a time. Realm
 blocks other writes on other threads until the open
 transaction is complete. Consequently, there is no race
-condition when reading values from the {+realm+} within a
+condition when reading values from the realm within a
 transaction.
 
-When you are done with your transaction, {+service-short+} either
+When you are done with your transaction, Realm either
 **commits** it or **cancels** it:
 
-- When {+service-short+} **commits** a transaction, {+service-short+} writes
-  all changes to disk. For :term:`synced {+realms+} <{+sync+}>`, {+service-short+} queues the change
+- When Realm **commits** a transaction, Realm writes
+  all changes to disk. For :term:`synced {+realms+} <{+sync+}>`, Realm queues the change
   for synchronization with :term:`{+service+}`.
-- When {+service-short+} **cancels** a write transaction or an operation in
+- When Realm **cancels** a write transaction or an operation in
   the transaction causes an error, all changes are discarded
   (or "rolled back").
 
@@ -50,13 +49,13 @@ When you are done with your transaction, {+service-short+} either
 Run a Transaction
 -----------------
 
-{+service-short+} represents each transaction as a callback function
+Realm represents each transaction as a callback function
 that contains zero or more read and write operations. To run
 a transaction, define a transaction callback and pass it to
-the {+realm+}'s ``write`` method. Within this callback, you are
-free to create, read, update, and delete on the {+realm+}. If
-the code in the callback throws an exception when {+service-short+} runs
-it, {+service-short+} cancels the transaction. Otherwise, {+service-short+} commits
+the realm's ``write`` method. Within this callback, you are
+free to create, read, update, and delete on the realm. If
+the code in the callback throws an exception when Realm runs
+it, Realm cancels the transaction. Otherwise, Realm commits
 the transaction immediately after the callback.
 
 .. example::
@@ -64,8 +63,8 @@ the transaction immediately after the callback.
    The following code shows how to run a transaction with
    :java-sdk:`executeTransaction() <io/realm/Realm.html#executeTransaction-io.realm.Realm.Transaction->`
    or :java-sdk:`executeTransactionAsync() <io/realm/Realm.html#executeTransactionAsync-io.realm.Realm.Transaction->`.
-   If the code in the callback throws an exception, {+service-short+}
-   cancels the transaction. Otherwise, {+service-short+} commits the
+   If the code in the callback throws an exception, Realm
+   cancels the transaction. Otherwise, Realm commits the
    transaction.
 
    .. tabs-realm-languages::

--- a/source/sdk/java/install.txt
+++ b/source/sdk/java/install.txt
@@ -15,7 +15,7 @@ Install Realm - Java SDK
 Overview
 --------
 
-This page details how to install {+service-short+} in your project
+This page details how to install Realm in your project
 and get started.
 
 Prerequisites
@@ -29,14 +29,14 @@ Prerequisites
 Installation
 ------------
 
-{+service+} only supports the Gradle build system. Follow these steps
-to add the {+service+} Java SDK to your project.
+Realm only supports the Gradle build system. Follow these steps
+to add the Realm Java SDK to your project.
 
 .. note:: ProGuard
 
-   Because {+service+} provides a ProGuard configuration as part
-   of the {+service+} library, you do not need to add any
-   {+service+}-specific rules to your ProGuard configuration.
+   Because Realm provides a ProGuard configuration as part
+   of the Realm library, you do not need to add any
+   Realm-specific rules to your ProGuard configuration.
 
 Project Gradle Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/sdk/java/livedata.txt
+++ b/source/sdk/java/livedata.txt
@@ -61,17 +61,15 @@ repository directly from GitHub:
 
    git clone https://github.com/mongodb-university/realm-android-livedata.git
 
-.. important::
+The repository contains two branches:
+``final`` and ``start``. The ``final`` branch is a finished version
+of the app as it should look *after* you complete this tutorial.
+To walk through this tutorial, please check out the ``start``
+branch:
 
-   The realm-quickstart-android-livedata repository contains two branches:
-   ``final`` and ``start``. The ``final`` branch is a finished version
-   of the app as it should look *after* you complete this tutorial.
-   To walk through this tutorial, please check out the ``start``
-   branch:
+.. code-block:: console
 
-   .. code-block:: console
-
-      git checkout start
+   git checkout start
 
 Import Dependencies
 -------------------
@@ -144,13 +142,11 @@ have to handle a few events:
      :language: kotlin
      :copyable: false
 
-.. note:: Using LiveData with Collections of RealmResults
+.. seealso:: Using LiveData with ``RealmResults``
 
-   Even though this example project doesn't use LiveData to display
-   RealmResults, we've also provided an example implementation that follows
-   these same principles to encapsulate a collection of data contained in a
-   ``RealmResults`` object, called `LiveRealmResults
-   <https://github.com/mongodb-university/realm-android-livedata/blob/final/app/src/main/java/com/mongodb/realm/livedataquickstart/model/LiveRealmResults.kt>`__.
+   This example only uses LiveData to display ``RealmObjects`` in the UI.
+   For a sample implementation displaying ``RealmResults``,
+   see `LiveRealmResults <https://github.com/mongodb-university/realm-android-livedata/blob/final/app/src/main/java/com/mongodb/realm/livedataquickstart/model/LiveRealmResults.kt>`__.
 
 Instantiating LiveData in the ViewModel
 ---------------------------------------
@@ -163,7 +159,7 @@ To create an instance of LiveData, we need to access a ``Counter`` object
 stored in a {+realm+} and pass it to the ``LiveRealmObject`` constructor.
 To accomplish this:
 
-1. Connect to your {+app+}.
+1. Connect to your {+app+} *with your* **App ID**.
 
 2. Authenticate a user.
 
@@ -180,20 +176,15 @@ The following code snippet implements this behavior:
 .. literalinclude:: /examples/generated/java/sync/CounterModel.snippet.constructor.kt
    :language: kotlin
 
-.. important:: Fill in Your App ID to connect to your Realm App with the Java SDK
+.. important:: Don't Read or Write on the UI Thread
 
-   To connect to your backend instance of {+sync+}, replace the
-   App ID placeholder with your {+app+}'s App ID.
-
-.. note:: Reads and Writes on the UI Thread
-
-   Reads and writes are expensive, frequently involving context switches
-   and disk I/O operations. As a result, reads and writes are disabled
-   by default on the UI thread. While you can use the
-   ``allowWritesOnUiThread()`` and ``allowQueriesOnUiThread()`` config
-   builder methods to enable writes and reads, respectively, on the UI
-   thread, you should almost always defer reads and writes to a
-   background thread using asynchronous patterns.
+   Database reads and writes are computationally expensive, so
+   the SDK disables reads and writes by default on the UI thread.
+   For simplicity, this example enables UI thread reads and writes with
+   the ``allowWritesOnUiThread()`` and ``allowQueriesOnUiThread()``
+   config builder methods. In production applications, you should almost
+   always defer reads and writes to a background thread using
+   asynchronous methods.
 
 Connecting the ViewModel to the UI
 ----------------------------------
@@ -228,8 +219,8 @@ in the ``onCreateView()`` method of ``CounterFragment``:
    :language: kotlin
    :copyable: false
 
-Running the Application
------------------------
+Run the Application
+-------------------
 
 Now you should be able to run the sample application. You should see an
 interface that looks something like this:

--- a/source/sdk/java/livedata.txt
+++ b/source/sdk/java/livedata.txt
@@ -12,7 +12,7 @@ Quick Start with LiveData - Java SDK
    :depth: 2
    :class: singlecol
 
-This page contains instructions to quickly get {+client-database+} integrated
+This page contains instructions to quickly get Realm Database integrated
 into an example Android application that uses :android:`LiveData
 <reference/androidx/lifecycle/LiveData>`. This example application
 allows a user to increment a counter using a button.
@@ -20,17 +20,17 @@ allows a user to increment a counter using a button.
 Prerequisites
 -------------
 
-This quick start guide uses :ref:`{+sync+} <sync>` to synchronize data
+This quick start guide uses :ref:`Sync <sync>` to synchronize data
 changes between clients. Before you begin, ensure you have:
 
 - :ref:`Installed the Java SDK <java-install>`.
-- :ref:`Created an {+app+} <create-a-realm-app>`.
+- :ref:`Created an App <create-a-realm-app>`.
 - :ref:`Enabled anonymous authentication <anonymous-authentication-configuration>`.
-- :ref:`Enabled {+sync+} <enable-sync>`.
+- :ref:`Enabled Sync <enable-sync>`.
 
-.. note:: Using LiveData without {+sync+}
+.. note:: Using LiveData without Sync
 
-   To use this quick start without {+sync+}, disable the sync features
+   To use this quick start without Sync, disable the sync features
    in the SDK. You can do this by removing the following lines from your
    app-level :file:`build.gradle` file:
 
@@ -44,7 +44,7 @@ changes between clients. Before you begin, ensure you have:
    reload the Java SDK in an offline-only state. Remove the lines
    related to importing and using Sync Configuration, user login, and
    partition values from the ``CounterModel`` file to use the Java SDK
-   without {+sync+}.
+   without Sync.
 
 Clone the LiveData Quick Start Repository
 -----------------------------------------
@@ -92,7 +92,7 @@ You'll also have to add the Android LiveData Dependency to the
    :emphasize-lines: 10
    :copyable: false
 
-Next, enable {+sync+} in the SDK by creating the
+Next, enable Sync in the SDK by creating the
 following top-level block in your app level :file:`build.gradle` file:
 
 .. literalinclude:: /examples/generated/java/sync/build.snippet.sync-enable.gradle
@@ -156,17 +156,17 @@ called ``CounterModel``. When the application runs, it creates an instance
 of ``CounterModel`` that is used until the application closes. That
 instance contains the LiveData that displays on the UI of the application.
 To create an instance of LiveData, we need to access a ``Counter`` object
-stored in a {+realm+} and pass it to the ``LiveRealmObject`` constructor.
+stored in a realm and pass it to the ``LiveRealmObject`` constructor.
 To accomplish this:
 
-1. Connect to your {+app+} *with your* **App ID**.
+1. Connect to your App *with your* **App ID**.
 
 2. Authenticate a user.
 
-3. Connect to a specific {+realm+} using {+sync+}.
+3. Connect to a specific realm using Sync.
 
-4. Query the {+realm+} for a ``Counter``, inserting a new ``Counter`` if
-   one hasn't already been created in this {+realm+}.
+4. Query the realm for a ``Counter``, inserting a new ``Counter`` if
+   one hasn't already been created in this realm.
 
 5. Instantiate a ``LiveRealmObject`` using the ``Counter`` instance and
    store it in the ``counter`` member of ``CounterModel``.
@@ -229,7 +229,7 @@ interface that looks something like this:
    :alt: The LiveData QuickStart Counter app.
 
 Clicking the "ADD" button should add one to the value of your counter.
-With {+sync+}, you can view your {+app+} logs to see individual increment
+With Sync, you can view your App logs to see individual increment
 events. Android LiveData is lifecycle-aware, so rotating the screen or
 freeing the application's state by clearing your device's RAM should
 have no effect on the application state, which should seamlessly resume

--- a/source/sdk/java/migrate.txt
+++ b/source/sdk/java/migrate.txt
@@ -13,17 +13,17 @@ Upgrade from Stitch to Realm - Java SDK
    :class: singlecol
 
 If you have an existing app built with the Stitch SDK, you should migrate your 
-app to use the new {+service-short+} SDK. While much of the logic and flow of information 
+app to use the new Realm SDK. While much of the logic and flow of information 
 hasn't changed, there are a few important changes in the way your app connects to 
-the {+realm+} backend.
+the realm backend.
 
 New Features
 ------------
 
-- The {+service-short+} Java SDK supports Android applications written in Kotlin.
+- The Realm Java SDK supports Android applications written in Kotlin.
 
-- The {+service-short+} Java SDK now includes {+client-database+}, which includes
-  local object storage and :ref:`{+sync+} <java-sync-data>`.
+- The Realm Java SDK now includes Realm Database, which includes
+  local object storage and :ref:`Sync <java-sync-data>`.
 
 Changes
 -------
@@ -41,8 +41,8 @@ Changes
    * - Application users previously accessed via `StitchUser <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/java/4/com/mongodb/stitch/android/core/auth/StitchUser.html>`__ are now accessed through :java-sdk:`User <io/realm/mongodb/User.html>`.
      - Migrate all occurrences of ``StitchUser`` to ``User``.
 
-   * - In the Stitch SDK, network requests like `callFunction() <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/java/4/com/mongodb/stitch/android/core/StitchAppClient.html#callFunction(java.lang.String,java.util.List)>`__ were asynchronous by default. In the {+service-short+} Java SDK, you can choose synchronous or asynchronous requests with the "Async" suffix, e.g. :java-sdk:`callFunction() <io/realm/mongodb/functions/Functions.html#callFunction-java.lang.String-java.util.List-->` and :java-sdk:`callFunctionAsync() <io/realm/mongodb/functions/Functions.html#callFunctionAsync-java.lang.String-java.util.List--io.realm.mongodb.App.Callback->`.
-     - Migrate all asynchronous Stitch SDK requests to their :ref:`asynchronous {+service-short+} SDK equivalents <java-async-api>`.
+   * - In the Stitch SDK, network requests like `callFunction() <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/java/4/com/mongodb/stitch/android/core/StitchAppClient.html#callFunction(java.lang.String,java.util.List)>`__ were asynchronous by default. In the Realm Java SDK, you can choose synchronous or asynchronous requests with the "Async" suffix, e.g. :java-sdk:`callFunction() <io/realm/mongodb/functions/Functions.html#callFunction-java.lang.String-java.util.List-->` and :java-sdk:`callFunctionAsync() <io/realm/mongodb/functions/Functions.html#callFunctionAsync-java.lang.String-java.util.List--io.realm.mongodb.App.Callback->`.
+     - Migrate all asynchronous Stitch SDK requests to their :ref:`asynchronous Realm SDK equivalents <java-async-api>`.
 
    * - Async SDK requests no longer use the built-in Android `Task <https://developers.google.com/android/reference/com/google/android/gms/tasks/Task.html?is-external=true>`__ class to return success status and values via ``onComplete()``; instead, Async requests now use a :java-sdk:`App.Callback <io/realm/mongodb/App.Callback.html>` to return success status and values via ``onResult()``.
      - Rewrite all asynchronous Stitch SDK requests to use ``App.Callback`` and ``onResult()``.
@@ -50,7 +50,7 @@ Changes
    * - The login API has changed from `stitchAppClient.getAuth().loginWithCredential() <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/java/4/com/mongodb/stitch/android/core/auth/StitchAuth.html#loginWithCredential(com.mongodb.stitch.core.auth.StitchCredential)>`__ to :java-sdk:`app.loginAsync() <io/realm/mongodb/App.html#login-io.realm.mongodb.Credentials->` or the synchronous equivalent :java-sdk:`app.login() <io/realm/mongodb/App.html#login-io.realm.mongodb.Credentials->`.
      - Rewrite all authentication logic to use the :ref:`new login API <java-authenticate>`.
 
-   * - The Stitch SDK used `stitchAppClient.getAuth().logout() <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/java/4/com/mongodb/stitch/android/core/auth/StitchAuth.html#logout()>`__ to handle user logout. To logout a user in the {+service-short+} SDK, call the :java-sdk:`logOut() <io/realm/mongodb/User.html#logOut-->` method of that user's ``User`` object.
+   * - The Stitch SDK used `stitchAppClient.getAuth().logout() <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/java/4/com/mongodb/stitch/android/core/auth/StitchAuth.html#logout()>`__ to handle user logout. To logout a user in the Realm SDK, call the :java-sdk:`logOut() <io/realm/mongodb/User.html#logOut-->` method of that user's ``User`` object.
      - Rewrite all logout logic to use the user's ``User`` object instead of the ``StitchAppClient``.
 
    * - Instead of calling functions using the app client directly, like `stitchAppClient.callFunction() <http://stitch-sdks.s3-website-us-east-1.amazonaws.com/stitch-sdks/java/4/com/mongodb/stitch/android/core/StitchAppClient.html#callFunction(java.lang.String,java.util.List)>`__, you can only call functions through a :java-sdk:`Functions Manager <io/realm/mongodb/functions/Functions.html>`, which you can access through your backend realm app connection: :java-sdk:`app.getFunctions(user).callFunctionAsync() <io/realm/mongodb/functions/Functions.html#callFunctionAsync-java.lang.String-java.util.List--io.realm.mongodb.App.Callback->`.
@@ -62,5 +62,5 @@ Changes
    * - The BSON package, which contains BSON data types and the ``Document`` data type for reading/writing to MongoDB Atlas, has moved from ``com.mongodb.stitch.core.internal.common`` to ``org.bson``.
      - Refactor all imports of the BSON package to use ``io.realm.mongodb.mongo``.
      
-   * - The {+service-short+} SDK does not provide an interface for calling services such as :ref:`Twilio <twilio-service>` and :ref:`AWS <aws-service>`.
+   * - The Realm SDK does not provide an interface for calling services such as :ref:`Twilio <twilio-service>` and :ref:`AWS <aws-service>`.
      - Convert SDK service API usage in your application to Realm functions using the corresponding npm packages. For more information, see :ref:`Add External Dependencies <add-external-dependencies>`.

--- a/source/sdk/java/quick-start-local.txt
+++ b/source/sdk/java/quick-start-local.txt
@@ -17,12 +17,12 @@ Quick Start - Java SDK
 
    This guide can help you get started with device-local Realm Database.
    If your application needs to communicate with a backend
-   {+app+} over the network using features like :ref:`Sync <sync>`, Realm
+   App over the network using features like :ref:`Sync <sync>`, Realm
    Functions, or user management, you should follow the
    :ref:`Quick Start with Sync <java-client-quick-start-sync>` guide.
 
 
-This page contains information to quickly get {+client-database+}
+This page contains information to quickly get Realm Database
 integrated into your app. Before you begin, ensure you have:
 
 - :ref:`Installed the Java SDK <java-install>`
@@ -33,7 +33,7 @@ Define Your Object Model
 ------------------------
 
 Your application's **data model** defines the structure of data
-stored within {+client-database+}.
+stored within Realm Database.
 You can define your application's data model via Kotlin or
 Java classes in your application code with
 :ref:`Realm Object Models <create-schema-from-rom>`.
@@ -67,9 +67,9 @@ definitions to your application code:
 Open a Realm
 ------------
 
-Use ``RealmConfiguration`` to control the specifics of the {+realm+} you
-would like to open, including the name or location of the {+realm+},
-whether to allow synchronous reads or writes to a {+realm+} on the UI
+Use ``RealmConfiguration`` to control the specifics of the realm you
+would like to open, including the name or location of the realm,
+whether to allow synchronous reads or writes to a realm on the UI
 thread, and more.
 
 .. tabs-realm-languages::
@@ -89,14 +89,14 @@ thread, and more.
 Create, Read, Update, and Delete Objects
 ----------------------------------------
 
-Once you have opened a {+realm+}, you can modify the
-:ref:`objects <java-realm-objects>` within that {+realm+} in a
+Once you have opened a realm, you can modify the
+:ref:`objects <java-realm-objects>` within that realm in a
 :ref:`write transaction <java-open-a-transaction>` block.
 
 .. include:: /includes/java-synchronous-reads-writes-ui-thread.rst
 
 To create a new ``Task``, instantiate an instance of the
-``Task`` class and add it to the {+realm+} in a write block:
+``Task`` class and add it to the realm in a write block:
 
 .. tabs-realm-languages::
 
@@ -115,7 +115,7 @@ To create a new ``Task``, instantiate an instance of the
          :copyable: false
 
 You can retrieve a live :ref:`collection <java-client-collections>`
-of all items in the {+realm+}:
+of all items in the realm:
 
 .. tabs-realm-languages::
 

--- a/source/sdk/java/quick-start-local.txt
+++ b/source/sdk/java/quick-start-local.txt
@@ -17,7 +17,7 @@ Quick Start - Java SDK
 
    This guide can help you get started with device-local Realm Database.
    If your application needs to communicate with a backend
-   App over the network using features like :ref:`Sync <sync>`, Realm
+   App over the network using features like :ref:`Atlas Device Sync <sync>`, Realm
    Functions, or user management, you should follow the
    :ref:`Quick Start with Sync <java-client-quick-start-sync>` guide.
 

--- a/source/sdk/java/quick-start-local.txt
+++ b/source/sdk/java/quick-start-local.txt
@@ -13,7 +13,7 @@ Quick Start - Java SDK
    :depth: 2
    :class: singlecol
 
-.. tip:: This Guide Does Not Use Sync
+.. tip:: This Guide Does Not Use Device Sync
 
    This guide can help you get started with device-local Realm Database.
    If your application needs to communicate with a backend

--- a/source/sdk/java/quick-start-local.txt
+++ b/source/sdk/java/quick-start-local.txt
@@ -13,7 +13,7 @@ Quick Start - Java SDK
    :depth: 2
    :class: singlecol
 
-.. important:: This Guide Does Not Use Atlas Device Sync
+.. tip:: This Guide Does Not Use Sync
 
    This guide can help you get started with device-local Realm Database.
    If your application needs to communicate with a backend

--- a/source/sdk/java/quick-start-sync.txt
+++ b/source/sdk/java/quick-start-sync.txt
@@ -12,7 +12,7 @@ Quick Start with Sync - Java SDK
    :depth: 2
    :class: singlecol
 
-.. important:: This Guide uses Device Sync
+.. tip:: This Guide uses Device Sync
 
    This guide helps you get started with an Android application that
    communicates with an App backend. The App provides features

--- a/source/sdk/java/quick-start-sync.txt
+++ b/source/sdk/java/quick-start-sync.txt
@@ -12,26 +12,26 @@ Quick Start with Sync - Java SDK
    :depth: 2
    :class: singlecol
 
-.. important:: This Guide uses Atlas Device Sync
+.. important:: This Guide uses Device Sync
 
-   This guide can help you get started with an Android application that
-   communicates with a backend {+app+} over the network using features
+   This guide helps you get started with an Android application that
+   communicates with an App backend. The App provides features
    like :ref:`Sync <sync>`, Realm Functions, and user management. If
-   your application only requires local Realm Database functionality,
-   you should follow the :ref:`Quick Start (Local-only)
+   your application requires only local database functionality,
+   check out the :ref:`Quick Start (Local-only)
    <java-client-quick-start-local>` guide.
 
-This page contains information to quickly get {+client-database+}
+This page contains information to quickly get App Services
 integrated into your app. Before you begin, ensure you have:
 
 - :ref:`Created an {+app+} <create-a-realm-app>`
 - :ref:`Enabled {+sync+} <enable-sync>`
 - :ref:`Installed the Java SDK <java-install>`
 
-.. note:: Check Out the Tutorial
+.. tip:: Check Out the Tutorial
 
-   This page contains only the essential information that you need to set up an
-   Atlas App Services backend. If you prefer to follow a guided tutorial that
+   This page contains the essential information to interact with an App.
+   If you prefer to follow a guided tutorial that
    shows you step-by-step how to set up a working app, check out the
    :ref:`Java Tutorial <java-sdk-tutorial>` where you'll build a mobile
    app that connects to the :ref:`Task Tracker backend
@@ -44,9 +44,9 @@ integrated into your app. Before you begin, ensure you have:
 Initialize the App
 ------------------
 
-To use {+backend+} features such as authentication and sync, you must
-access your {+app+} using your {+app+} ID. You can find your {+app+} ID in the
-{+ui+}.
+To use App Services features such as authentication and sync, you must
+access your App using your App ID. You can find your App ID in the
+App Services UI.
 
 .. tabs-realm-languages::
 
@@ -159,12 +159,10 @@ Open a Realm
 ------------
 
 Once you have :ref:`enabled {+sync+} <enable-sync>` and authenticated a
-user, you can open a synced :ref:`{+realm+} <java-realms>`. Use the
+user, you can open a synced :ref:`{+realm+} <java-realms>`. Use
 ``SyncConfiguration`` to control the specifics of how your application
-synchronizes data with {+backend+}, including the :ref:`partition
-<sync-partitions>`, how long to wait before a request times out, whether
-to allow synchronous reads or writes to a {+realm+} on the UI thread,
-and more.
+synchronizes data with {+backend+}, including timeouts, synchronous
+reads and writes on the UI thread, and more.
 
 .. tabs-realm-languages::
 
@@ -348,7 +346,7 @@ remember to:
 - replace the App ID placeholder with your {+app+}'s App ID
 
 - update the ``import`` statements for ``Task`` and ``TaskStatus`` if
-  you're using java
+  you're using Java
 
 .. tabs-realm-languages::
 

--- a/source/sdk/java/quick-start-sync.txt
+++ b/source/sdk/java/quick-start-sync.txt
@@ -24,8 +24,8 @@ Quick Start with Sync - Java SDK
 This page contains information to quickly get App Services
 integrated into your app. Before you begin, ensure you have:
 
-- :ref:`Created an {+app+} <create-a-realm-app>`
-- :ref:`Enabled {+sync+} <enable-sync>`
+- :ref:`Created an App <create-a-realm-app>`
+- :ref:`Enabled Sync <enable-sync>`
 - :ref:`Installed the Java SDK <java-install>`
 
 .. tip:: Check Out the Tutorial
@@ -82,16 +82,16 @@ Define Your Object Model
 ------------------------
 
 Your application's **data model** defines the structure of data
-stored within {+client-database+} and synchronized to and from
-{+backend+}. You can define your application's data model in two ways:
+stored within Realm Database and synchronized to and from
+App Services. You can define your application's data model in two ways:
 
-- Via :ref:`schemas <schemas>` in {+backend+}.
+- Via :ref:`schemas <schemas>` in App Services.
 
 - Via Kotlin or Java classes in your application code with
   :ref:`Realm Object Models <create-schema-from-rom>`.
 
 This quick start uses the latter approach, which defines your schema
-using classes in your mobile application code. To define your {+app+}'s
+using classes in your mobile application code. To define your App's
 object model in this way, you need to :ref:`enable Development Mode
 <enable-development-mode>`.
 
@@ -130,7 +130,7 @@ Authenticate a User
 -------------------
 
 When you have enabled :ref:`anonymous authentication <anonymous-authentication>` in the
-{+ui+}, users can immediately log into your app without providing any identifying
+App Services UI, users can immediately log into your app without providing any identifying
 information:
 
 .. tabs-realm-languages::
@@ -149,7 +149,7 @@ information:
          :language: kotlin
          :copyable: false
 
-{+service-short+} provides many additional ways to authenticate, register, and link users.
+Realm provides many additional ways to authenticate, register, and link users.
 
 .. seealso::
 
@@ -158,10 +158,10 @@ information:
 Open a Realm
 ------------
 
-Once you have :ref:`enabled {+sync+} <enable-sync>` and authenticated a
-user, you can open a synced :ref:`{+realm+} <java-realms>`. Use
+Once you have :ref:`enabled Sync <enable-sync>` and authenticated a
+user, you can open a synced :ref:`realm <java-realms>`. Use
 ``SyncConfiguration`` to control the specifics of how your application
-synchronizes data with {+backend+}, including timeouts, synchronous
+synchronizes data with App Services, including timeouts, synchronous
 reads and writes on the UI thread, and more.
 
 .. tabs-realm-languages::
@@ -187,14 +187,14 @@ reads and writes on the UI thread, and more.
 Create, Read, Update, and Delete Objects
 ----------------------------------------
 
-Once you have opened a {+realm+}, you can modify the
-:ref:`objects <java-realm-objects>` within that {+realm+} in a
+Once you have opened a realm, you can modify the
+:ref:`objects <java-realm-objects>` within that realm in a
 :ref:`write transaction <java-open-a-transaction>` block.
 
 .. include:: /includes/java-synchronous-reads-writes-ui-thread.rst
 
 To create a new ``Task``, instantiate an instance of the
-``Task`` class and add it to the {+realm+} in a write block:
+``Task`` class and add it to the realm in a write block:
 
 .. tabs-realm-languages::
 
@@ -213,7 +213,7 @@ To create a new ``Task``, instantiate an instance of the
          :copyable: false
 
 You can retrieve a live :ref:`collection <java-client-collections>`
-of all items in the {+realm+}:
+of all items in the realm:
 
 .. tabs-realm-languages::
 
@@ -336,14 +336,14 @@ Once logged in, you can log out:
 Complete Example
 ----------------
 
-Run the complete example by replacing the appId with your {+realm+} app ID.
+Run the complete example by replacing the appId with your realm app ID.
 If you're running this project in a fresh Android Studio project, you can
 copy and paste this file into your application's ``MainActivity`` -- just
 remember to:
 
 - change the package declaration so it matches your project
 
-- replace the App ID placeholder with your {+app+}'s App ID
+- replace the App ID placeholder with your App's App ID
 
 - update the ``import`` statements for ``Task`` and ``TaskStatus`` if
   you're using Java

--- a/source/sdk/java/troubleshooting.txt
+++ b/source/sdk/java/troubleshooting.txt
@@ -45,14 +45,14 @@ the APK file by adding the following code to the application's
 Network Calls to Mixpanel
 -------------------------
 
-{+service-short+} collects anonymous analytics when you run the
-{+service-short+} bytecode transformer on your source code. This is
+Realm collects anonymous analytics when you run the
+Realm bytecode transformer on your source code. This is
 completely anonymous and helps us improve the product by flagging:
 
 - which version of the SDK you use
 - which operating system you use
 - if your application uses Kotlin
-- if your application uses local-only {+client-database+} or {+sync+}
+- if your application uses local-only Realm Database or Sync
 
 Analytics do not run when your application runs on user devices - only
 when you compile your source code. To opt out of analytics, you can set
@@ -64,7 +64,7 @@ Change Listeners in Android 12 with SDK Versions Below 10.5.1
 -------------------------------------------------------------
 
 Due to a change in the Linux kernel,
-:ref:`object, collection, and {+realm+} notifications
+:ref:`object, collection, and realm notifications
 <java-client-notifications>` do not work in SDK versions below
 10.5.1 on devices running certain early versions of
 Android 12.
@@ -85,11 +85,11 @@ with the following fixes:
 Configurations Cannot be Different if Used to Open the Same File
 ----------------------------------------------------------------
 
-{+client-database+} runs checks whenever you open a {+realm+} file to
-avoid corruption. In order to avoid accidentally opening a {+realm+}
+Realm Database runs checks whenever you open a realm file to
+avoid corruption. In order to avoid accidentally opening a realm
 file with incompatible settings, the SDK uses Java's ``equals()`` method
 to compare ``RealmConfiguration`` objects. This prevents the SDK from
-opening a single {+realm+} file with different schemas, durability levels,
+opening a single realm file with different schemas, durability levels,
 or writability settings. However, configurations that include lambda
 functions, such as those passed to
 :java-sdk:`initialData() <io/realm/RealmConfiguration.Builder.html#initialData-io.realm.Realm.Transaction->`
@@ -100,7 +100,7 @@ never considered equal using Java's built-in comparison.
 To avoid this error when using lambdas, you can either:
 
 1. Store a single configuration statically in your application, so that
-   separate {+realm+} instances use the exact same
+   separate realm instances use the exact same
    ``RealmConfiguration`` object and it passes the check.
 
 #. Override the default equals check of the ``RealmConfiguration``:
@@ -203,11 +203,11 @@ of architectures supported in a single APK. This is done by adding
 Customize Dependecies Defined by the Realm Gradle Plugin
 --------------------------------------------------------
 
-{+service-short+} uses a Gradle plugin because it makes it easier to set
+Realm uses a Gradle plugin because it makes it easier to set
 up a large number of dependencies. Unfortunately this also makes it a
 bit harder to ignore specific transitive dependencies.
 
-If you want to customize {+service-short+} beyond what is exposed by the
+If you want to customize Realm beyond what is exposed by the
 plugin, you can manually set up all the dependencies and ignore the
 Gradle plugin. The following example demonstrates how to set up the SDK
 for an Android application using Kotlin manually:

--- a/source/sdk/kotlin/app-services/authenticate-users.txt
+++ b/source/sdk/kotlin/app-services/authenticate-users.txt
@@ -13,7 +13,7 @@ Authenticate Users - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-{+service+} provides an API for authenticating users using any enabled
+Realm provides an API for authenticating users using any enabled
 authentication provider. Instantiate a :file:`Credentials` object and pass
 it to `app.login()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app/login.html>`__
@@ -122,7 +122,7 @@ To set up your application for Google User authentication:
    <https://console.cloud.google.com/apis/credentials>`__, create an
    OAuth 2.0 client ID of type "Web application".
 
-#. Configure your backend {+app+} to use that client ID and the associated
+#. Configure your backend App to use that client ID and the associated
    client secret.
 
 #. Enable OpenID Connect on the backend.
@@ -216,7 +216,7 @@ to log in, using `user.logOut()
 
 - deletes locally stored user credentials from the device
 
-- immediately halts any synchronization to and from the user's {+realm+}s
+- immediately halts any synchronization to and from the user's realms
 
 Because logging out halts synchronization, you should only log out after
 all local Realm updates have uploaded to the server.

--- a/source/sdk/kotlin/app-services/connect-to-app-services-backend.txt
+++ b/source/sdk/kotlin/app-services/connect-to-app-services-backend.txt
@@ -13,14 +13,14 @@ Connect to an Atlas App Services backend - Kotlin SDK
    :class: singlecol
 
 The ``App`` class is the interface to App Services. This class provides
-access to :ref:`authentication <kotlin-authenticate>` and {+sync+}.
+access to :ref:`authentication <kotlin-authenticate>` and Device Sync.
 
 .. _kotlin-access-the-app-client:
 
 Access the App
 --------------
 
-Pass the App ID for your {+app+}, which you can :ref:`find in the Realm UI
+Pass the App ID for your App, which you can :ref:`find in the Realm UI
 <find-your-app-id>`.
 
 .. literalinclude:: /examples/generated/kotlin/AppClientTest.snippet.initialize-app-client.kt
@@ -30,7 +30,7 @@ Pass the App ID for your {+app+}, which you can :ref:`find in the Realm UI
 .. note::
 
    You can create multiple :file:`App` instances to connect to multiple
-   {+app+}s or to the same {+app+} with different configurations. All
+   Apps or to the same App with different configurations. All
    :file:`App` instances that share the same App ID use the same underlying
    connection.
 
@@ -51,4 +51,4 @@ use the `AppConfiguration.Builder
 .. note:: 
 
    For most use cases, you only need your application's App ID to connect
-   to {+service+}. The other settings demonstrated here are optional.
+   to App Services. The other settings demonstrated here are optional.

--- a/source/sdk/kotlin/app-services/overview.txt
+++ b/source/sdk/kotlin/app-services/overview.txt
@@ -32,7 +32,7 @@ This object provides all other functionality related to
 the backend. Initialize an App with the {+app+} ID, which you can 
 :ref:`find in the Realm UI <find-your-app-id>`.
 
-.. tip::
+.. seealso::
 
    To learn how to initialize the Realm App client, see
    :ref:`kotlin-connect-to-backend`.
@@ -52,7 +52,7 @@ you can implement the following functionality:
 - Link user accounts from different providers
 - Store custom data for a particular user
 
-.. tip::
+.. seealso::
 
    To learn how to set up authentication in your app, see
    :ref:`kotlin-authenticate`.

--- a/source/sdk/kotlin/app-services/overview.txt
+++ b/source/sdk/kotlin/app-services/overview.txt
@@ -26,10 +26,10 @@ backend using the SDK. Backend functionality includes:
 The Realm App Client
 --------------------
 
-To connect to your {+service-short+} backend, start with an
+To connect to your Realm backend, start with an
 `App <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app/index.html>`__ object.
 This object provides all other functionality related to 
-the backend. Initialize an App with the {+app+} ID, which you can 
+the backend. Initialize an App with the App ID, which you can 
 :ref:`find in the Realm UI <find-your-app-id>`.
 
 .. seealso::
@@ -41,8 +41,8 @@ Authentication & User Management
 --------------------------------
 
 One of the most challenging aspects of client development is implementing a 
-robust and secure authentication system. With the {+service-short+} SDKs,
-however, you can use any of the {+service+} authentication providers with
+robust and secure authentication system. With the Realm SDKs,
+however, you can use any of the Realm authentication providers with
 minimal backend setup and client-side code. With the authentication APIs,
 you can implement the following functionality:
 

--- a/source/sdk/kotlin/app-services/overview.txt
+++ b/source/sdk/kotlin/app-services/overview.txt
@@ -26,7 +26,7 @@ backend using the SDK. Backend functionality includes:
 The Realm App Client
 --------------------
 
-To connect to your Realm backend, start with an
+To connect to your Atlas App Services backend, start with an
 `App <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app/index.html>`__ object.
 This object provides all other functionality related to 
 the backend. Initialize an App with the App ID, which you can 

--- a/source/sdk/kotlin/app-services/register-users.txt
+++ b/source/sdk/kotlin/app-services/register-users.txt
@@ -13,7 +13,7 @@ Register Users - Kotlin SDK
    :class: singlecol
 
 When you have enabled the :ref:`email/password provider
-<email-password-authentication>` in your {+app+}, you can register a new
+<email-password-authentication>` in your App, you can register a new
 account, confirm an email address, and reset a user's password from
 client code.
 

--- a/source/sdk/kotlin/install/android.txt
+++ b/source/sdk/kotlin/install/android.txt
@@ -8,7 +8,7 @@ Install (Android) - Kotlin SDK
 
 .. include:: /includes/kotlin-install-prerequisites.rst
 
-.. warning:: Kotlin Plugin Version
+.. tip:: Kotlin Plugin Version
 
    The Kotlin Multiplatform ecosystem frequently changes. If you experience
    any issues installing the SDK, check your Kotlin Plugin version, since

--- a/source/sdk/kotlin/migrate-from-java-sdk-to-kotlin-sdk.txt
+++ b/source/sdk/kotlin/migrate-from-java-sdk-to-kotlin-sdk.txt
@@ -53,7 +53,7 @@ architecture and the Kotlin SDK architecture:
 
 .. seealso::
 
-   :ref:`Kotlin SDK Frozen Architecture <kotlin-frozen-architecture>`
+   :ref:`Frozen Architecture in the Kotlin SDK <kotlin-frozen-architecture>`
 
 Opening Realms
 --------------
@@ -117,7 +117,7 @@ to customize your configuration even more:
 
 .. seealso::
 
-   :ref:`Open & Close a Realm (Kotlin SDK) <kotlin-open-and-close-a-realm>`
+   :ref:`Open & Close a Realm <kotlin-open-and-close-a-realm>`
 
 Realm Object Models
 -------------------
@@ -164,7 +164,7 @@ primary keys, and indexes.
 
 .. seealso::
 
-   :ref:`Supported Schemas Types (Kotlin SDK) <kotlin-supported-types>`
+   :ref:`Supported Schemas Types <kotlin-supported-types>`
 
 Relationships
 -------------
@@ -355,9 +355,9 @@ With the Java SDK, you could write synchronously to a realm with
 
 .. seealso::
 
-   - :ref:`Create a New Object (Kotlin SDK) <kotlin-create-a-new-object>`
-   - :ref:`Modify an Object (Kotlin SDK) <kotlin-modify-an-object>`
-   - :ref:`Delete an Object (Kotlin SDK) <kotlin-delete-an-object>`
+   - :ref:`Create a New Object <kotlin-create-a-new-object>`
+   - :ref:`Modify an Object <kotlin-modify-an-object>`
+   - :ref:`Delete an Object <kotlin-delete-an-object>`
 
 Queries
 -------
@@ -451,7 +451,7 @@ Sort, Distinct, Limit
 
 .. seealso::
 
-   :ref:`Realm Query Language (Kotlin SDK) <kotlin-query-language>`
+   :ref:`Realm Query Language <kotlin-query-language>`
 
 Deletes
 -------
@@ -493,9 +493,9 @@ you can directly query for live objects and delete them without using
 
 .. seealso::
 
-   - :ref:`Delete all Objects of a Type (Kotlin SDK) <kotlin-delete-all-objects-of-a-type>`
-   - :ref:`Delete Multiple Objects (Kotlin SDK) <kotlin-delete-multiple-objects>`
-   - :ref:`Delete an Object (Kotlin SDK) <kotlin-delete-an-object>`
+   - :ref:`Delete all Objects of a Type <kotlin-delete-all-objects-of-a-type>`
+   - :ref:`Delete Multiple Objects <kotlin-delete-multiple-objects>`
+   - :ref:`Delete an Object <kotlin-delete-an-object>`
 
 Notifications
 -------------
@@ -585,7 +585,7 @@ updates instead.
 
 .. seealso::
 
-   :ref:`Frozen Architecture (Kotlin SDK) <kotlin-frozen-architecture>`
+   :ref:`Frozen Architecture <kotlin-frozen-architecture>`
 
 Migrations
 ----------

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -81,7 +81,7 @@ of objects:
 
 .. seealso::
 
-   You can find more information about string Realm Database queries in
+   Find more information about string Realm Database queries in
    :ref:`Realm Query Language <kotlin-query-language>`.
 
 To modify a task, update its properties in a write transaction block:

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -13,7 +13,7 @@ Quick Start - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-This page contains information to quickly get {+client-database+}
+This page contains information to quickly get Realm Database
 integrated into your app. Before you begin, ensure you have installed
 the Kotlin SDK for your platform:
 
@@ -24,7 +24,7 @@ Define Your Object Model
 ------------------------
 
 Your application's **data model** defines the structure of data
-stored within {+client-database+}.
+stored within Realm Database.
 You can define your application's data model via Kotlin
 classes in your application code with
 :ref:`Realm Object Models <create-schema-from-rom>`.
@@ -41,11 +41,11 @@ Open a Realm
 
 Use `RealmConfiguration
 <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__
-to control the specifics of the {+realm+} you
+to control the specifics of the realm you
 would like to open, including the name, location, and schema.
 Pass your configuration to the `Realm factory constructor
 <{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__
-to generate an instance of that {+realm+}:
+to generate an instance of that realm:
 
 .. literalinclude:: /examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-realm.kt
    :language: kotlin
@@ -54,18 +54,18 @@ to generate an instance of that {+realm+}:
 Create, Read, Update, and Delete Objects
 ----------------------------------------
 
-Once opened, you can create objects within a {+realm+} in a
+Once opened, you can create objects within a realm in a
 `write transaction block
 <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write.html>`__.
 
 To create a new :file:`Task`, instantiate an instance of the
-:file:`Task` class and add it to the {+realm+} in a write transaction block:
+:file:`Task` class and add it to the realm in a write transaction block:
 
 .. literalinclude:: /examples/generated/kotlin/QuickStartTest.snippet.quick-start-create.kt
    :language: kotlin
    :copyable: false
 
-You can retrieve a collection of all tasks in the {+realm+} with
+You can retrieve a collection of all tasks in the realm with
 `query.find() <{+kotlin-local-prefix+}io.realm.kotlin.query/find.html>`__:
 
 .. literalinclude:: /examples/generated/kotlin/QuickStartTest.snippet.quick-start-read.kt
@@ -81,7 +81,7 @@ of objects:
 
 .. seealso::
 
-   You can find more information about string {+client-database+} queries in
+   You can find more information about string Realm Database queries in
    :ref:`Realm Query Language <kotlin-query-language>`.
 
 To modify a task, update its properties in a write transaction block:

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -79,7 +79,7 @@ of objects:
    :language: kotlin
    :copyable: false
 
-.. note:: Realm Query Language
+.. seealso::
 
    You can find more information about string {+client-database+} queries in
    :ref:`Realm Query Language <kotlin-query-language>`.

--- a/source/sdk/kotlin/realm-database/create/create-a-new-object.txt
+++ b/source/sdk/kotlin/realm-database/create/create-a-new-object.txt
@@ -13,10 +13,10 @@ Create a New Object - Kotlin SDK
    :class: singlecol
 
 Instantiate Realm objects as you would any other object. In a
-transaction, you can add the object to the {+realm+} if the
-{+realm+}'s schema includes the object
-type. When you add an instance to the {+realm+}, it becomes
-*managed* by that {+realm+}.
+transaction, you can add the object to the realm if the
+realm's schema includes the object
+type. When you add an instance to the realm, it becomes
+*managed* by that realm.
 
 To persist a new object to a realm:
 

--- a/source/sdk/kotlin/realm-database/frozen-arch.txt
+++ b/source/sdk/kotlin/realm-database/frozen-arch.txt
@@ -60,7 +60,7 @@ support change listeners.
    :language: kotlin
    :copyable: false
 
-.. note:: Flows API Requires Kotlinx Coroutines
+.. important:: Flows API Requires Kotlinx Coroutines
 
    To use the Flows API in your KMM project, install the
    :github:`kotlinx.coroutines <Kotlin/kotlinx.coroutines#multiplatform>`

--- a/source/sdk/kotlin/realm-database/frozen-arch.txt
+++ b/source/sdk/kotlin/realm-database/frozen-arch.txt
@@ -6,7 +6,7 @@ Frozen Architecture - Kotlin SDK
 
 .. default-domain:: mongodb
 
-Unlike the other {+service+} SDKs, the Kotlin SDK
+Unlike the other Realm SDKs, the Kotlin SDK
 does not provide live objects and collections that
 update simultaneously with underlying data. Instead,
 the Kotlin SDK works exclusively with **frozen objects**
@@ -16,8 +16,8 @@ Work with Frozen Objects
 ------------------------
 
 Because frozen objects don't automatically update when data changes
-in your {+realm+}, they work a little differently from the live objects
-you may have used in other {+service-short+} SDKs.
+in your realm, they work a little differently from the live objects
+you may have used in other Realm SDKs.
 
 Access a Live Version of Frozen Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -41,8 +41,8 @@ Thread-safe Realms
 ------------------
 
 The `Realm <{+kotlin-local-prefix+}io.realm.kotlin/-realm/index.html>`__
-class is no longer thread-confined, so you can share a single {+realm+}
-across multiple threads. You no longer need to handle the {+realm+}
+class is no longer thread-confined, so you can share a single realm
+across multiple threads. You no longer need to handle the realm
 lifecycle explicitly with calls to
 `Realm.close() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/close.html>`__.
 
@@ -66,13 +66,13 @@ support change listeners.
    :github:`kotlinx.coroutines <Kotlin/kotlinx.coroutines#multiplatform>`
    library.
 
-Just like in other {+service-short+} SDKs, write transactions implicitly
-advance your {+realm+} to the most recent version of data stored on disk.
+Just like in other Realm SDKs, write transactions implicitly
+advance your realm to the most recent version of data stored on disk.
 
 Lazy Loading
 ~~~~~~~~~~~~
 
-{+service-short+} objects are still lazy-loaded by default. This allows
+Realm objects are still lazy-loaded by default. This allows
 you to query large collections of objects without reading large amounts
 of data from disk. This also means that the first access to
 a field of an object will always return the most recent data.

--- a/source/sdk/kotlin/realm-database/open-and-close-a-realm.txt
+++ b/source/sdk/kotlin/realm-database/open-and-close-a-realm.txt
@@ -17,7 +17,7 @@ Open a Realm - Kotlin SDK
 Open a Realm
 ------------
 
-To open a {+realm+}, create a
+To open a realm, create a
 `RealmConfiguration <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__ with
 `RealmConfiguration.Builder <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-builder/index.html>`__
 and pass the resulting :file:`RealmConfiguration` to

--- a/source/sdk/kotlin/realm-database/overview.txt
+++ b/source/sdk/kotlin/realm-database/overview.txt
@@ -16,7 +16,7 @@ Realm Database Overview - Kotlin SDK
 .. switch back to the include and remove duplicated content.
 .. .. include:: /includes/realm-database.rst
 
-{+client-database+} is a reactive, object-oriented, cross-platform,
+Realm Database is a reactive, object-oriented, cross-platform,
 mobile database:
 
 - **Reactive**: query the current state of data
@@ -32,73 +32,73 @@ mobile database:
 - **Mobile**: designed for the low-power, battery-sensitive, real-time
   environment of a mobile device.
 
-{+client-database+} is an alternative to
+Realm Database is an alternative to
 `SQLite <https://www.sqlite.org/index.html>`__ and
 :apple:`Core Data <documentation/coredata>`.
 
 This page explains some of the implementation details and inner workings
-of {+client-database+} and {+sync+}. This page is for you if you are:
+of Realm Database and Device Sync. This page is for you if you are:
 
-- a developer interested in learning more about {+client-database+}
+- a developer interested in learning more about Realm Database
 
-- comparing {+client-database+} with competing databases
+- comparing Realm Database with competing databases
 
-- trying to understand the difference between {+client-database+} and
-  {+sync+}
+- trying to understand the difference between Realm Database and
+  Device Sync
 
 This explanation begins with a deep dive into database internals,
 continues with a high-level introduction to some of the features of
-{+client-database+}, and wraps up with some of the differences between
-{+sync+} and the local version of {+client-database+}.
+Realm Database, and wraps up with some of the differences between
+Device Sync and the local version of Realm Database.
 
 Database Internals
 ------------------
 
-{+client-database+} uses a completely unique database engine,
+Realm Database uses a completely unique database engine,
 file format, and design. This section describes some of the high-level
 details of those choices. This section applies to both the device-local
-version of {+client-database+} as well as the networked {+sync+} version.
+version of Realm Database as well as the networked Device Sync version.
 Differences between the local database and the synchronized database are
 explained in the Atlas Device Sync section.
 
 Native Database Engine
 ~~~~~~~~~~~~~~~~~~~~~~
 
-{+client-database+} is an entire database written from
+Realm Database is an entire database written from
 scratch in C++, instead of building on top of an underlying database
-engine like SQLite. {+client-database+}'s underlying storage layer uses
+engine like SQLite. Realm Database's underlying storage layer uses
 :wikipedia:`B+ trees <B%2B_tree>` to organize objects. As a result,
-{+client-database+} controls optimizations from the storage level all
+Realm Database controls optimizations from the storage level all
 the way up to the access level.
 
-{+client-database+} stores data in **{+realm+}s**: collections of
-heterogeneous {+realm+} objects. You can think of each {+realm+} as a
-database. Each object in a {+realm+} is equivalent to a row
-in a SQL database table or a MongoDB document. Unlike SQL, {+realm+}s do
+Realm Database stores data in **realms**: collections of
+heterogeneous realm objects. You can think of each realm as a
+database. Each object in a realm is equivalent to a row
+in a SQL database table or a MongoDB document. Unlike SQL, realms do
 not separate different object types into individual tables.
 
-{+client-database+} stores objects as groups of property values. We call
+Realm Database stores objects as groups of property values. We call
 this column-based storage. This means that queries or writes for
 individual objects can be slower than row-based storage equivalents when
 unindexed, but querying a single field across multiple objects or
 fetching multiple objects can be much faster due to spatial locality and
 in-CPU vector operations.
 
-{+client-database+} uses a :wikipedia:`zero-copy <Zero-copy>` design to
+Realm Database uses a :wikipedia:`zero-copy <Zero-copy>` design to
 make queries faster than an ORM, and often faster than raw SQLite.
 
 
 Realm Files
 ~~~~~~~~~~~
 
-{+client-database+} persists data in files saved on device
+Realm Database persists data in files saved on device
 storage. The database uses several kinds of file:
 
 - **realm files**, suffixed with "realm", e.g. :file:`default.realm`:
   contain object data.
 - **lock files**, suffixed with "lock", e.g. :file:`default.realm.lock`:
-  keep track of which versions of data in a {+realm+} are
-  actively in use. This prevents {+realm+} from reclaiming storage space
+  keep track of which versions of data in a realm are
+  actively in use. This prevents realm from reclaiming storage space
   that is still used by a client application. 
 - **note files**, suffixed with "note", e.g. :file`default.realm.note`:
   enable inter-thread and inter-process notifications.
@@ -106,14 +106,14 @@ storage. The database uses several kinds of file:
   internal state management.
 
 Realm files contain object data with the following data structures:
-Groups, Tables, Cluster Trees, and Clusters. {+client-database+}
+Groups, Tables, Cluster Trees, and Clusters. Realm Database
 organizes these data structures into a tree structure with the following
 form:
 
 - The top level, known as a Group, stores object metadata, a transaction
   log, and a collection of Tables.
 
-- Each class in the {+realm+} schema corresponds to a Table within the
+- Each class in the realm schema corresponds to a Table within the
   top-level Group.
 
 - Each Table contains a Cluster Tree, an implementation of a B+ tree.
@@ -132,16 +132,16 @@ form:
   value.
 
 Since pointers refer to memory addresses, objects written to persistent
-files cannot store references as pointers. Instead, {+realm+} files
+files cannot store references as pointers. Instead, realm files
 refer to data using the offset from the beginning of the file. We call
-this a ref. As {+client-database+} uses memory mapping to read and
+this a ref. As Realm Database uses memory mapping to read and
 write data, database operations translate these refs from offsets to
 memory pointers when navigating database structures.
 
 Copy-on-Write: The Secret Sauce of Data Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-{+client-database+} uses a technique called **copy-on-write**, which
+Realm Database uses a technique called **copy-on-write**, which
 copies data to a new location on disk for every write operation instead
 of overwriting older data on disk. Once the new copy of data is fully
 written, the database updates existing references to that data. Older
@@ -150,7 +150,7 @@ actively in use by a client application.
 
 Because of copy-on-write, older copies of data remain valid, since all
 of the references in those copies still point to other valid data.
-{+client-database+} leverages this fact to offer multiple versions of
+Realm Database leverages this fact to offer multiple versions of
 data simultaneously to different threads in client applications. Most
 applications tie data refreshes to the repaint cycle of the looper
 thread that controls the UI, since data only needs to refresh as often
@@ -167,32 +167,32 @@ mutators read and write to disk via memory mapping. As a result, object
 data is never stored on the stack or heap of your app. By default, data
 is memory-mapped as read-only to prevent accidental writes.
 
-{+client-database+} uses operating system level paging, trusting each
+Realm Database uses operating system level paging, trusting each
 operating system to implement memory mapping and persistence better than
 a single library could on its own.
 
 Compaction
 ~~~~~~~~~~
 
-{+client-database+} automatically reuses free space that is no longer
-needed after database writes. However, {+realm+} files never shrink
-automatically, even if the amount of data stored in your {+realm+}
-decreases significantly. Compact your {+realm+} to optimize storage
+Realm Database automatically reuses free space that is no longer
+needed after database writes. However, realm files never shrink
+automatically, even if the amount of data stored in your realm
+decreases significantly. Compact your realm to optimize storage
 space and decrease file size if possible.
 
-You should compact your {+realm+}s occasionally to keep them at an
+You should compact your realms occasionally to keep them at an
 optimal size. You can do this manually, or by configuring your
-{+realm+}s to compact on launch. However, {+client-database+}
+realms to compact on launch. However, Realm Database
 reclaims unused space for future writes, so compaction is only an
 optimization to conserve space on-device.
 
 ACID Compliance
 ~~~~~~~~~~~~~~~
 
-{+client-database+} guarantees that transactions are :wikipedia:`ACID
+Realm Database guarantees that transactions are :wikipedia:`ACID
 <ACID>` compliant. This means that all committed write
 operations are guaranteed to be valid and that clients don't
-see transient states in the event of a system crash. {+client-database+}
+see transient states in the event of a system crash. Realm Database
 complies with ACID with the following design choices:
 
 - :wikipedia:`Atomicity <Atomicity_(database_systems)>`: groups
@@ -201,7 +201,7 @@ complies with ACID with the following design choices:
 
 - :wikipedia:`Consistency <Consistency_(database_systems)>`: avoids
   data corruption by validating changes against the schema. If the
-  result of any write operation is not valid, {+service-short+} cancels
+  result of any write operation is not valid, Realm cancels
   and rolls back the entire transaction.
 
 - :wikipedia:`Isolation <Isolation_(database_systems)>`: allows only
@@ -214,12 +214,12 @@ complies with ACID with the following design choices:
 Features
 --------
 
-{+client-database+} supports many popular database features.
+Realm Database supports many popular database features.
 
 Queries
 ~~~~~~~
 
-You can query {+client-database+} using platform-native queries or a
+You can query Realm Database using platform-native queries or a
 raw query language that works across platforms.
 
 Indexes
@@ -232,11 +232,11 @@ support one column, and thus only one property, at a time.
 Schemas
 ~~~~~~~
 
-Every {+realm+} object has a schema. That schema is defined via a native
+Every realm object has a schema. That schema is defined via a native
 object in your SDK's language. Object schemas can include embedded lists
 and relations between object instances.
 
-Each {+realm+} uses a versioned schema. When that schema changes, you
+Each realm uses a versioned schema. When that schema changes, you
 must define a migration to move object data between schema versions.
 Non-breaking schema changes, also referred to as additive schema changes, 
 happen automatically. However, your SDK may require you to increase the 
@@ -250,21 +250,21 @@ See your SDK's documentation for more information on migrations.
 Atlas Device Sync
 -----------------
 
-{+sync+} adds network synchronization between an {+backend+} backend and
-client devices on top of all of the functionality of {+client-database+}.
-When you use {+client-database+} with Sync, {+realm+}s exist on device
-just like when you only use {+client-database+}. However, changes to
-the data stored in those {+realm+}s synchronize between all client
-devices through a backend {+backend+} instance. That backend also stores
-{+realm+} data in a cloud-based {+atlas+} cluster running MongoDB.
+Device Sync adds network synchronization between an App Services backend and
+client devices on top of all of the functionality of Realm Database.
+When you use Realm Database with Sync, realms exist on device
+just like when you only use Realm Database. However, changes to
+the data stored in those realms synchronize between all client
+devices through a backend App Services instance. That backend also stores
+realm data in a cloud-based {+atlas+} cluster running MongoDB.
 
-{+sync+} relies on a worker client that communicates with your
+Device Sync relies on a worker client that communicates with your
 application backend in a dedicated thread in your application.
-Additionally, synced {+realm+}s keep a history of changes to contained
+Additionally, synced realms keep a history of changes to contained
 objects. Sync uses this history to resolve conflicts between client
 changes and backend changes.
 
-Applications that use {+sync+} define their schema on the backend using
+Applications that use Device Sync define their schema on the backend using
 `JSON Schema <https://json-schema.org/learn/getting-started-step-by-step.html>`__.
 Client applications must match that backend schema to synchronize data.
 However, if you prefer to define your initial schema in your application's

--- a/source/sdk/kotlin/realm-database/read/find-object-by-primary-key.txt
+++ b/source/sdk/kotlin/realm-database/read/find-object-by-primary-key.txt
@@ -22,7 +22,7 @@ Specify the object type as a type parameter passed to :file:`query()`:
    :language: kotlin
    :copyable: false
 
-.. note:: :file:`find()` is Synchronous
+.. tip:: :file:`find()` is Synchronous
 
    `find() <{+kotlin-local-prefix+}io.realm.query/find.html>`__
    runs a synchronous query on the thread it is called from.

--- a/source/sdk/kotlin/realm-database/read/find-object-by-primary-key.txt
+++ b/source/sdk/kotlin/realm-database/read/find-object-by-primary-key.txt
@@ -12,7 +12,7 @@ Find Object by Primary Key - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-To find an object with a specific primary key value, open a {+realm+}
+To find an object with a specific primary key value, open a realm
 and query the primary key field for the desired primary key value
 using `realm.query()
 <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-query/query.html>`__.

--- a/source/sdk/kotlin/realm-database/read/find-objects-of-a-type.txt
+++ b/source/sdk/kotlin/realm-database/read/find-objects-of-a-type.txt
@@ -20,7 +20,7 @@ and pass the type as a type parameter to `realm.query()
    :language: kotlin
    :copyable: false
 
-.. note:: :file:`find()` is Synchronous
+.. tip:: :file:`find()` is Synchronous
 
    `find() <{+kotlin-local-prefix+}io.realm.query/find.html>`__
    runs a synchronous query on the thread it is called from.

--- a/source/sdk/kotlin/realm-database/read/iteration.txt
+++ b/source/sdk/kotlin/realm-database/read/iteration.txt
@@ -14,7 +14,7 @@ Iteration - Kotlin SDK
 
 You can iterate through results using :file:`Flows`.
 
-.. tip::
+.. seealso::
 
    To learn more about Kotlin Flows, check out `the kotlinx.coroutines documentation on Flows
    <https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-flow/>`__.
@@ -28,7 +28,7 @@ Then iterate through the results with `flow.collect()
    :language: kotlin
    :copyable: false
 
-.. note:: :file:`find()` is Synchronous
+.. tip:: :file:`find()` is Synchronous
 
    You can also iterate through results returned via `find() <{+kotlin-local-prefix+}io.realm.query/find.html>`__.
    :file:`find()` runs a synchronous query on the thread it is called from.

--- a/source/sdk/kotlin/realm-database/read/sort-queries.txt
+++ b/source/sdk/kotlin/realm-database/read/sort-queries.txt
@@ -33,7 +33,7 @@ to the query. This can impact the results returned from your query.
    :language: kotlin
    :copyable: false
 
-.. note:: :file:`find()` is Synchronous
+.. tip:: :file:`find()` is Synchronous
 
    `find() <{+kotlin-local-prefix+}io.realm.query/find.html>`__
    runs a synchronous query on the thread it is called from.

--- a/source/sdk/kotlin/realm-database/schemas/index.txt
+++ b/source/sdk/kotlin/realm-database/schemas/index.txt
@@ -44,3 +44,4 @@ You can index fields with the following types:
 - ``Long``
 - ``Boolean``
 - ``RealmInstant``
+- ``ObjectId``

--- a/source/sdk/kotlin/realm-database/schemas/primary-key.txt
+++ b/source/sdk/kotlin/realm-database/schemas/primary-key.txt
@@ -43,6 +43,7 @@ You can create a primary key with any of the following types:
 - ``Short``
 - ``Int``
 - ``Long``
+- ``ObjectId``
 
 Optional fields can contain a value of null as a primary key value,
 but only for one object of a particular type, since each primary key

--- a/source/sdk/kotlin/realm-database/schemas/relationships.txt
+++ b/source/sdk/kotlin/realm-database/schemas/relationships.txt
@@ -27,7 +27,7 @@ There are two primary types of relationships between objects:
 - To-One Relationship
 - To-Many Relationship
 
-.. note:: One-to vs. Many-to Relationships
+.. tip:: One-to vs. Many-to Relationships
 
    In Realm Database, there is no way to limit object references from
    other objects within the same realm. As a result, there is no way to

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -23,6 +23,7 @@ Realm Database supports the following field data types:
 - ``Boolean``
 - ``Double``
 - ``Float``
+- ``ObjectId``
 - ``RealmInstant``
 - Any ``RealmObject`` subclass
 - ``RealmList``

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -40,7 +40,7 @@ constructors, you must declare a public constructor with no arguments.
 Updating Strings and Byte Arrays
 --------------------------------
 
-Since {+client-database+} operates on fields as a whole, it's not possible
+Since Realm Database operates on fields as a whole, it's not possible
 to directly update individual elements of strings or byte arrays. Instead,
 you'll need to read the whole field, make your modification to individual
 elements, and then write the entire field back again in a transaction block.

--- a/source/sdk/kotlin/realm-database/write-transactions.txt
+++ b/source/sdk/kotlin/realm-database/write-transactions.txt
@@ -12,15 +12,15 @@ Write Transactions - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-:term:`{+client-database+}` uses a highly efficient storage engine
-to persist objects. You can **create** objects in a :term:`{+realm+}`,
-**update** objects in a {+realm+}, and eventually **delete**
-objects from a {+realm+}. Because these operations modify the
-state of the {+realm+}, we call them writes.
+:term:`Realm Database` uses a highly efficient storage engine
+to persist objects. You can **create** objects in a :term:`realm`,
+**update** objects in a realm, and eventually **delete**
+objects from a realm. Because these operations modify the
+state of the realm, we call them writes.
 
-{+service-short+} handles writes in terms of **transactions**. A
+Realm handles writes in terms of **transactions**. A
 transaction is a list of read and write operations that
-{+service-short+} treats as a single indivisible operation. In other
+Realm treats as a single indivisible operation. In other
 words, a transaction is *all or nothing*: either all of the
 operations in the transaction succeed or none of the
 operations in the transaction take effect.
@@ -29,19 +29,19 @@ operations in the transaction take effect.
 
    All writes must happen in a transaction.
 
-A {+realm+} allows only one open write transaction at a time. {+service-short+}
+A realm allows only one open write transaction at a time. Realm
 blocks other writes on other threads until the open
 transaction is complete. Consequently, there is no race
-condition when reading values from the {+realm+} within a
+condition when reading values from the realm within a
 transaction.
 
-When you are done with your transaction, {+service-short+} either
+When you are done with your transaction, Realm either
 **commits** it or **cancels** it:
 
-- When {+service-short+} **commits** a transaction, {+service-short+} writes
+- When Realm **commits** a transaction, Realm writes
   all changes to disk. For synced realms, the SDK queues the change
   for synchronization with the backend.
-- When {+service-short+} **cancels** a write transaction or an operation in
+- When Realm **cancels** a write transaction or an operation in
   the transaction causes an error, all changes are discarded
   (or "rolled back").
 
@@ -50,13 +50,13 @@ When you are done with your transaction, {+service-short+} either
 Run a Transaction
 -----------------
 
-{+service-short+} represents each transaction as a callback function
+Realm represents each transaction as a callback function
 that contains zero or more read and write operations. To run
 a transaction, define a transaction callback and pass it to
-the {+realm+}'s ``write`` method. Within this callback, you are
-free to create, read, update, and delete on the {+realm+}. If
-the code in the callback throws an exception when {+service-short+} runs
-it, {+service-short+} cancels the transaction. Otherwise, {+service-short+} commits
+the realm's ``write`` method. Within this callback, you are
+free to create, read, update, and delete on the realm. If
+the code in the callback throws an exception when Realm runs
+it, Realm cancels the transaction. Otherwise, Realm commits
 the transaction immediately after the callback.
 
 .. example::
@@ -64,8 +64,8 @@ the transaction immediately after the callback.
    The following code shows how to run a transaction with
    `write() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write.html>`__
    or `writeBlocking() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write-blocking.html>`__.
-   If the code in the callback throws an exception, {+service-short+}
-   cancels the transaction. Otherwise, {+service-short+} commits the
+   If the code in the callback throws an exception, Realm
+   cancels the transaction. Otherwise, Realm commits the
    transaction.
 
    .. literalinclude:: /examples/generated/kotlin/CRUDTest.snippet.run-a-transaction.kt

--- a/source/sdk/kotlin/realm-database/write-transactions.txt
+++ b/source/sdk/kotlin/realm-database/write-transactions.txt
@@ -12,8 +12,8 @@ Write Transactions - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-:term:`Realm Database` uses a highly efficient storage engine
-to persist objects. You can **create** objects in a :term:`realm`,
+Realm Database uses a highly efficient storage engine
+to persist objects. You can **create** objects in a realm,
 **update** objects in a realm, and eventually **delete**
 objects from a realm. Because these operations modify the
 state of the realm, we call them writes.

--- a/source/sdk/kotlin/sync/open-a-synced-realm.txt
+++ b/source/sdk/kotlin/sync/open-a-synced-realm.txt
@@ -15,7 +15,7 @@ Open a Synced Realm - Kotlin SDK
 Prerequisites
 -------------
 
-Before you can access a synced {+realm+} from the client, you must:
+Before you can access a synced realm from the client, you must:
 
 1. :ref:`Enable sync <enable-sync>` in the {+ui+}.
 
@@ -34,7 +34,7 @@ Open a Synced Realm
    .. tab:: Partition Based Sync
       :tabid: pbs
 
-      To open a :ref:`synced {+realm+} <sync-modes-partition-based-sync>`,
+      To open a :ref:`synced realm <sync-modes-partition-based-sync>`,
       pass a user, a partition, and a set of Realm object schemas to
       `SyncConfiguration.Builder()
       <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__.
@@ -49,7 +49,7 @@ Open a Synced Realm
    .. tab:: Flexible Sync
       :tabid: flex
 
-      To open a :ref:`flexible sync {+realm+} <sync-modes-flexible-sync>`,
+      To open a :ref:`flexible sync realm <sync-modes-flexible-sync>`,
       pass a user and a set of Realm object schemas to
       `SyncConfiguration.Builder()
       <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__. Next, create a set of initial subscriptions with the ``initialSubscriptions()``

--- a/source/sdk/kotlin/sync/overview.txt
+++ b/source/sdk/kotlin/sync/overview.txt
@@ -20,10 +20,10 @@ Overview
 Atlas Device Sync automatically synchronizes data between client applications and
 an :ref:`Atlas App Services backend <realm-cloud>`. When a client
 device is online, {+sync-short+} asynchronously synchronizes data in a
-background thread between the device and your backend {+app+}.
+background thread between the device and your backend App.
 
 When you use Sync in your client application, your implementation must match
-the :ref:`Sync <sync-modes>` you select in your backend {+app+} configuration.
+the :ref:`Sync <sync-modes>` you select in your backend App configuration.
 The Sync Mode options are:
 
 - Partition-Based Sync
@@ -41,7 +41,7 @@ Partition-Based Sync
 --------------------
 
 When you select :ref:`Partition-Based Sync <partition-based-sync>` for your
-backend {+app+} configuration, your client implementation must include a
+backend App configuration, your client implementation must include a
 partition value. This is the value of the :ref:`partition key
 <partition-key>` field you select when you configure Partition-Based Sync.
 
@@ -54,7 +54,7 @@ You must provide a partition value when you open a synced realm.
 Flexible Sync
 -------------
 
-When you select :ref:`Flexible Sync <flexible-sync>` for your backend {+app+}
+When you select :ref:`Flexible Sync <flexible-sync>` for your backend App
 configuration, your client implementation must include subscriptions to
 queries on :ref:`queryable fields <queryable-fields>`. Flexible Sync works
 by synchronizing data that matches query subscriptions you maintain in the

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -51,7 +51,7 @@ permissions, syncs between clients and the backend application.
 
 You can specify an optional string name for your subscription.
 
-.. note:: Always Specify a Subscription Name
+.. tip:: Always Specify a Subscription Name
 
    Always specify a subscription name if your application uses multiple
    subscriptions. This makes your subscriptions easier to look up,
@@ -82,9 +82,9 @@ new subscription to the client's Realm subscriptions.
    set to see a linked object.
    
    If your subscription results contain an object with a property that links 
-   to an object not contained in the results, the link appears to be nil.
+   to an object not contained in the results, the link appears to be null.
    There is no way to distinguish whether that property's value is 
-   legitimately nil, or whether the object it links to exists but is out of
+   legitimately null, or whether the object it links to exists but is out of
    view of the query subscription.
 
 .. _kotlin-sync-check-subscription-state:
@@ -110,8 +110,8 @@ You can also use `SubscriptionSet.waitForSynchronization()
 to delay execution until subscription sync completes after instantiating
 a sync connection.
 
-SubscriptionSet.State`` Enum
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``SubscriptionSet.State`` Enum
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Additionally, you can watch the state of the subscription set with the 
 `SubscriptionSetState
@@ -206,7 +206,7 @@ To remove all subscriptions from the subscription set, use
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-mutable-subscription-set/remove-all.html>`__.
 with no arguments:
 
-.. important::
+.. warning::
 
    If you remove all subscriptions and do not add a new one, you'll 
    get an error. A realm opened with a flexible sync configuration needs

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -13,7 +13,7 @@ Subscribe to Queryable Fields - Kotlin SDK
    :class: singlecol
 
 Flexible Sync uses subscriptions and permissions to determine which
-data to sync with your {+app+}.
+data to sync with your App.
 
 Prerequisites
 -------------
@@ -96,10 +96,10 @@ Writing an update to the subscription set locally is only one component
 of changing a subscription. After the local subscription change, the client
 synchronizes with the server to resolve any updates to the data due to 
 the subscription change. This could mean adding or removing data from the 
-synced {+realm+}. Use the `SynConfiguration.waitForInitialRemoteData()
+synced realm. Use the `SynConfiguration.waitForInitialRemoteData()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/wait-for-initial-remote-data.html>`__
 builder method to force your application to block until client subscription
-data synchronizes to the backend before opening the {+realm+}:
+data synchronizes to the backend before opening the realm:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.wait-for-subscription-changes.kt
    :language: kotlin


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-19614
- This ticket is actually for a global Realm/App Services docs admonitions review... considering how long the Java SDK took alone, and how much SDK knowledge comes in handy, I suspect we should create tickets for each SDK.
- Also took the liberty of removing a lot of unneeded source constants, some of which were applied inconsistently or incorrectly.
- Lots of small cleanup work to boot.

### Staged Changes (Requires MongoDB Corp SSO)

- [Java SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19614/sdk/java/)
- [Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-19614/sdk/kotlin/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
