### PR TITLE
(DOCSP-24293): Add note about writeCopy only supporting PBS

### DIFF
--- a/source/includes/note-writecopy-pbs-only.rst
+++ b/source/includes/note-writecopy-pbs-only.rst
@@ -1,0 +1,5 @@
+.. note:: Partition-Based Sync Only
+
+   This method only supports Partition-Based Sync. If your app uses 
+   Flexible Sync, you must manually iterate through the objects in one 
+   realm and copy them into the other realm.

--- a/source/sdk/node/examples/open-and-close-a-realm.txt
+++ b/source/sdk/node/examples/open-and-close-a-realm.txt
@@ -131,6 +131,8 @@ To copy data from an existing realm to a new realm with different
 configuration options, pass the new configuration the
 :js-sdk:`Realm.writeCopyTo() <Realm.html#writeCopyTo>` method.
 
+.. include:: /includes/note-writecopy-pbs-only.rst
+
 In the new realm's configuration, you *must* specify the ``path``. 
 
 If you write the copied realm to a realm file that already exists, the data is written object by object.

--- a/source/sdk/react-native/examples/open-and-close-a-realm.txt
+++ b/source/sdk/react-native/examples/open-and-close-a-realm.txt
@@ -131,6 +131,8 @@ To copy data from an existing realm to a new realm with different
 configuration options, pass the new configuration the
 :js-sdk:`Realm.writeCopyTo() <Realm.html#writeCopyTo>` method.
 
+.. include:: /includes/note-writecopy-pbs-only.rst
+
 In the new realm's configuration, you *must* specify the ``path``. 
 
 If you write the copied realm to a realm file that already exists, the data is written object by object.

--- a/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
@@ -193,6 +193,8 @@ configuration.
 After you copy the realm for the new Sync user's configuration, you can 
 open the copy as a synced realm for that user. 
 
+.. include:: /includes/note-writecopy-pbs-only.rst
+
 .. literalinclude:: /examples/generated/code/start/ConvertSyncLocalRealms.snippet.convert-sync-to-sync.swift
    :language: swift
 
@@ -214,6 +216,8 @@ After you copy the realm for use with Sync, you can open the copy as a
 synced realm. Any changes you make to the synced realm will reflect 
 in the synced realm file, and they will also propogate to other devices and
 the Atlas App Services backend.
+
+.. include:: /includes/note-writecopy-pbs-only.rst
 
 .. literalinclude:: /examples/generated/code/start/ConvertSyncLocalRealms.snippet.convert-local-to-sync.swift
    :language: swift


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-24293

### Staged Changes (Requires MongoDB Corp SSO)

- [Open & Close a Realm - Node.js SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24293/sdk/node/examples/open-and-close-a-realm/#copy-data-and-open-a-new-realm)
- [Open & Close a Realm - RN SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24293/sdk/react-native/examples/open-and-close-a-realm/#copy-data-and-open-a-new-realm)
- [Configure & Open a Synced Realm - Swift SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24293/sdk/swift/sync/configure-and-open-a-synced-realm/#open-non-synced-realm-as-a-synced-realm)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
