### PR TITLE
(DOCSP-24604): Add information about notification delivery

### DIFF
--- a/source/sdk/swift/react-to-changes.txt
+++ b/source/sdk/swift/react-to-changes.txt
@@ -359,6 +359,7 @@ logic does need strict guarantees, use care in how you write things in your
 notification handlers. Otherwise, you may trigger this error:
 
 .. code-block:: console
+   :copyable: false
 
    Cannot register notification blocks from within write transactions.
 

--- a/source/sdk/swift/react-to-changes.txt
+++ b/source/sdk/swift/react-to-changes.txt
@@ -349,3 +349,27 @@ This notification block fires for changes in:
 
 .. literalinclude:: /examples/generated/code/start/ClassProjection.snippet.register-a-class-projection-change-listener.swift
    :language: swift
+
+Notification Delivery
+---------------------
+
+If you don't need strict guarantees around when notifications are delivered,
+subscribe to a dispatch queue instead of the main thread. If your notification
+logic does need strict guarantees, use care in how you write things in your
+notification handlers. Otherwise, you may trigger this error:
+
+.. code-block:: console
+
+   Cannot register notification blocks from within write transactions.
+
+This issue occurs when you try to perform updates as a result of a 
+notification, but the notification occurs while a write transaction is in
+progress.
+
+The observe function takes a dispatch queue. If that's set, Realm delivers 
+notifications there instead of to the current thread. Realm's notification 
+system promises that notifications for writes on different threads are always 
+delivered synchronously as part of the refresh process. As long as you aren't 
+performing writes on the current thread, you can rely on the guarantee that 
+your app cannot see the value you read from an object change without 
+receiving a notification about the change in between the reads. 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-24604

### Staged Changes (Requires MongoDB Corp SSO)

- [React to Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24604/sdk/swift/react-to-changes/#notification-delivery): New "Notification Delivery" section describing notification delivery guarantees relative to an issue that can be triggered when you try to notify while within a write transaction.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
