### PR TITLE
(DOCSP-24797): Update deprecated RLM_ARRAY_TYPE to RLM_COLLECTION_TYPE macro

### DIFF
--- a/examples/ios/Examples/EmbeddedObjects.m
+++ b/examples/ios/Examples/EmbeddedObjects.m
@@ -16,7 +16,7 @@
 @end
 
 // Enable EmbeddedObjectObjcExamples_Address for use in RLMArray
-RLM_ARRAY_TYPE(EmbeddedObjectObjcExamples_Address)
+RLM_COLLECTION_TYPE(EmbeddedObjectObjcExamples_Address)
 
 
 @implementation EmbeddedObjectObjcExamples_Address

--- a/examples/ios/Examples/ObjectModels.m
+++ b/examples/ios/Examples/ObjectModels.m
@@ -14,7 +14,7 @@
 @end
 
 // Define an RLMArray<ObjectModelsExamplesObjc_Task> type
-RLM_ARRAY_TYPE(ObjectModelsExamplesObjc_Task)
+RLM_COLLECTION_TYPE(ObjectModelsExamplesObjc_Task)
 
 
 // ObjectModelsExamplesObjc_User.h

--- a/examples/ios/Examples/QueryEngine.m
+++ b/examples/ios/Examples/QueryEngine.m
@@ -15,7 +15,7 @@
 @property int priority;
 @property int progressMinutes;
 @end
-RLM_ARRAY_TYPE(QueryEngineExamplesObjc_Task)
+RLM_COLLECTION_TYPE(QueryEngineExamplesObjc_Task)
 // Task.m
 @implementation QueryEngineExamplesObjc_Task
 @end

--- a/examples/ios/Examples/ReadWriteData.m
+++ b/examples/ios/Examples/ReadWriteData.m
@@ -24,7 +24,7 @@
 @end
 
 // Enable ReadWriteDataObjcExample_Dog for use in RLMArray
-RLM_ARRAY_TYPE(ReadWriteDataObjcExample_Dog)
+RLM_COLLECTION_TYPE(ReadWriteDataObjcExample_Dog)
 
 
 // Person.h
@@ -40,7 +40,7 @@ RLM_ARRAY_TYPE(ReadWriteDataObjcExample_Dog)
 @property (readonly) RLMLinkingObjects *clubs;
 @end
 
-RLM_ARRAY_TYPE(ReadWriteDataObjcExample_Person)
+RLM_COLLECTION_TYPE(ReadWriteDataObjcExample_Person)
 
 
 // DogClub.h

--- a/examples/ios/Examples/Relationships.m
+++ b/examples/ios/Examples/Relationships.m
@@ -16,7 +16,7 @@
 @end
 
 // Define an RLMArray<InverseRelationshipObjcExample_Task> type
-RLM_ARRAY_TYPE(InverseRelationshipObjcExample_Task)
+RLM_COLLECTION_TYPE(InverseRelationshipObjcExample_Task)
 
 
 // InverseRelationshipObjcExample_User.h
@@ -50,7 +50,7 @@ RLM_ARRAY_TYPE(InverseRelationshipObjcExample_Task)
 @end
 
 // Define an RLMArray<ToManyObjcExample_Dog> type
-RLM_ARRAY_TYPE(ToManyObjcExample_Dog)
+RLM_COLLECTION_TYPE(ToManyObjcExample_Dog)
 
 // ToManyObjcExample_Person.h
 @interface ToManyObjcExample_Person : RLMObject
@@ -77,7 +77,7 @@ RLM_ARRAY_TYPE(ToManyObjcExample_Dog)
 @end
 
 // Define an RLMArray<ToManyObjcExample_Dog> type
-RLM_ARRAY_TYPE(ToOneRelationshipObjc_Dog)
+RLM_COLLECTION_TYPE(ToOneRelationshipObjc_Dog)
 
 // ToOneRelationshipObjc_Person.h
 @interface ToOneRelationshipObjc_Person : RLMObject

--- a/examples/ios/RealmExamples.xcodeproj/xcshareddata/xcschemes/RealmExamplesHostApp.xcscheme
+++ b/examples/ios/RealmExamples.xcodeproj/xcshareddata/xcschemes/RealmExamplesHostApp.xcscheme
@@ -41,6 +41,9 @@
                <Test
                   Identifier = "BundleRealms">
                </Test>
+               <Test
+                  Identifier = "FlexibleSync/testCheckForSubscriptionBeforeAddingOne()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/source/examples/generated/code/start/EmbeddedObjects.snippet.models.m
+++ b/source/examples/generated/code/start/EmbeddedObjects.snippet.models.m
@@ -7,7 +7,7 @@
 @end
 
 // Enable Address for use in RLMArray
-RLM_ARRAY_TYPE(Address)
+RLM_COLLECTION_TYPE(Address)
 
 
 @implementation Address

--- a/source/examples/generated/code/start/ObjectModels.snippet.array-declaration.m
+++ b/source/examples/generated/code/start/ObjectModels.snippet.array-declaration.m
@@ -4,7 +4,7 @@
 @end
 
 // Define an RLMArray<Task> type
-RLM_ARRAY_TYPE(Task)
+RLM_COLLECTION_TYPE(Task)
 
 
 // User.h

--- a/source/examples/generated/code/start/QueryEngine.snippet.models.m
+++ b/source/examples/generated/code/start/QueryEngine.snippet.models.m
@@ -6,7 +6,7 @@
 @property int priority;
 @property int progressMinutes;
 @end
-RLM_ARRAY_TYPE(Task)
+RLM_COLLECTION_TYPE(Task)
 // Task.m
 @implementation Task
 @end

--- a/source/examples/generated/code/start/ReadWriteData.snippet.models.m
+++ b/source/examples/generated/code/start/ReadWriteData.snippet.models.m
@@ -15,7 +15,7 @@
 @end
 
 // Enable Dog for use in RLMArray
-RLM_ARRAY_TYPE(Dog)
+RLM_COLLECTION_TYPE(Dog)
 
 
 // Person.h
@@ -31,7 +31,7 @@ RLM_ARRAY_TYPE(Dog)
 @property (readonly) RLMLinkingObjects *clubs;
 @end
 
-RLM_ARRAY_TYPE(Person)
+RLM_COLLECTION_TYPE(Person)
 
 
 // DogClub.h

--- a/source/examples/generated/code/start/Relationships.snippet.inverse-relationship.m
+++ b/source/examples/generated/code/start/Relationships.snippet.inverse-relationship.m
@@ -5,7 +5,7 @@
 @end
 
 // Define an RLMArray<Task> type
-RLM_ARRAY_TYPE(Task)
+RLM_COLLECTION_TYPE(Task)
 
 
 // User.h

--- a/source/examples/generated/code/start/Relationships.snippet.to-many-relationship.m
+++ b/source/examples/generated/code/start/Relationships.snippet.to-many-relationship.m
@@ -5,7 +5,7 @@
 @end
 
 // Define an RLMArray<Dog> type
-RLM_ARRAY_TYPE(Dog)
+RLM_COLLECTION_TYPE(Dog)
 
 // Person.h
 @interface Person : RLMObject

--- a/source/examples/generated/code/start/Relationships.snippet.to-one-relationship.m
+++ b/source/examples/generated/code/start/Relationships.snippet.to-one-relationship.m
@@ -5,7 +5,7 @@
 @end
 
 // Define an RLMArray<Dog> type
-RLM_ARRAY_TYPE(Dog)
+RLM_COLLECTION_TYPE(Dog)
 
 // Person.h
 @interface Person : RLMObject

--- a/source/sdk/swift/model-data/define-model/object-models.txt
+++ b/source/sdk/swift/model-data/define-model/object-models.txt
@@ -320,9 +320,9 @@ generic properties.
       Objective-C interface.
       
       In order to use your interface in a Realm array, pass your
-      interface name to the ``RLM_ARRAY_TYPE()`` macro. You can put this
+      interface name to the ``RLM_COLLECTION_TYPE()`` macro. You can put this
       at the bottom of your interface's header file. The
-      ``RLM_ARRAY_TYPE()`` macro creates a protocol that allows you to
+      ``RLM_COLLECTION_TYPE()`` macro creates a protocol that allows you to
       tag :objc-sdk:`RLMArray <Classes/RLMArray.html>` with your type:
 
       .. literalinclude:: /examples/generated/code/start/ObjectModels.snippet.array-declaration.m

--- a/source/sdk/swift/model-data/define-model/relationships.txt
+++ b/source/sdk/swift/model-data/define-model/relationships.txt
@@ -182,7 +182,7 @@ number of companion dogs as a to-many relationship.
 
       .. tip::
 
-         Remember to use the ``RLM_ARRAY_TYPE()`` macro with your type
+         Remember to use the ``RLM_COLLECTION_TYPE()`` macro with your type
          to :ref:`declare the RLMArray protocol for your type
          <ios-declare-a-property>`.
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-24797

### Staged Changes (Requires MongoDB Corp SSO)

Small updates to Objective-C code examples & accompanying text where it mentions the deprecated `RLM_ARRAY_TYPE` on these pages:

- [Model Data -> Object Models](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24797/sdk/swift/model-data/define-model/object-models/)
- [Model Data -> Relationships](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24797/sdk/swift/model-data/define-model/relationships/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
