### PR TITLE
(DOCSP-24897): Small SwiftUI discoverability improvements

### DIFF
--- a/source/sdk/swift.txt
+++ b/source/sdk/swift.txt
@@ -134,6 +134,17 @@ app development:
 - :ref:`Triggers <triggers>`: react to events or define a schedule to execute 
   automated processes
 
+SwiftUI
+-------
+
+The Realm Swift SDK offers property wrappers and convenience features 
+designed to make it easier to work with Realm in SwiftUI. Check out the 
+:ref:`SwiftUI documentation <ios-swiftui-examples>` for example View code 
+that demonstrates common Realm SwiftUI patterns.
+
+.. literalinclude:: /examples/generated/swiftui/PassObjectsToView.snippet.implicitly-open-realm-and-pass-objects.swift
+   :language: swift
+
 OS Support (Xcode 13)
 ---------------------
 

--- a/source/sdk/swift.txt
+++ b/source/sdk/swift.txt
@@ -142,7 +142,7 @@ designed to make it easier to work with Realm in SwiftUI. Check out the
 :ref:`SwiftUI documentation <ios-swiftui-examples>` for example View code 
 that demonstrates common Realm SwiftUI patterns.
 
-.. literalinclude:: /examples/generated/swiftui/PassObjectsToView.snippet.implicitly-open-realm-and-pass-objects.swift
+.. literalinclude:: /examples/generated/swiftui/FilterData.snippet.searchable.swift
    :language: swift
 
 OS Support (Xcode 13)

--- a/source/sdk/swift/quick-start-index.txt
+++ b/source/sdk/swift/quick-start-index.txt
@@ -9,7 +9,6 @@ Realm Swift SDK Quick Starts
 
    Quick Start </sdk/swift/quick-start>
    Quick Start with Sync </sdk/swift/quick-start-with-sync>
-   Quick Start with SwiftUI </sdk/swift/swiftui-tutorial>
    Quick Start with Xcode Playgrounds </sdk/swift/xcode-playgrounds>
 
 Quick Starts
@@ -17,5 +16,4 @@ Quick Starts
 
 - :doc:`Quick Start </sdk/swift/quick-start>`
 - :doc:`Quick Start with Sync </sdk/swift/quick-start-with-sync>`
-- :doc:`Quick Start with SwiftUI </sdk/swift/swiftui-tutorial>`
 - :doc:`Quick Start with Xcode Playgrounds </sdk/swift/xcode-playgrounds>`

--- a/source/sdk/swift/swiftui.txt
+++ b/source/sdk/swift/swiftui.txt
@@ -15,6 +15,7 @@ SwiftUI - Swift SDK
 .. toctree::
    :titlesonly:
 
+   Quick Start </sdk/swift/swiftui-tutorial>
    Model Data </sdk/swift/swiftui/model-data>
    Configure and Open a Realm </sdk/swift/swiftui/configure-and-open-realm>
    React to Changes </sdk/swift/swiftui/react-to-changes>
@@ -29,6 +30,7 @@ Overview
 The Realm Swift SDK offers features that integrate into SwiftUI.
 This documentation provides an overview of those features.
 
+- :doc:`Quick Start </sdk/swift/swiftui-tutorial>`
 - :doc:`Model Data </sdk/swift/swiftui/model-data>`
 - :doc:`Configure and Open a Realm </sdk/swift/swiftui/configure-and-open-realm>`
 - :doc:`React to Changes </sdk/swift/swiftui/react-to-changes>`
@@ -39,7 +41,8 @@ This documentation provides an overview of those features.
 
 .. seealso::
 
-   - :ref:`SwiftUI Quick Start Example App <ios-swiftui-quick-start>`
+   - If you want to explore and modify a working SwiftUI app that uses Device Sync, 
+     check out the :ref:`SwiftUI Template App <template-apps>`.
    - `Realm Swift SDK API Reference <https://www.mongodb.com/docs/realm-sdks/swift/latest>`__
 
 Requirements


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-24897

### Staged Changes (Requires MongoDB Corp SSO)

- [Swift SDK landing page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24897/sdk/swift/#swiftui): Added a SwiftUI header w/example and link to docs
- [SwiftUI landing page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24897/sdk/swift/swiftui/): Added a link to the template apps

I also moved the "SwiftUI Quick Start" from the "Quick Starts" ToC to the SwiftUI ToC. Once we unify the non-Sync/Sync quick start, I think I'll move the Xcode Playground page to the top level of the ToC and get rid of the quick starts directory.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
