### PR TITLE
Fix section header monospacing typo

### DIFF
--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -114,8 +114,8 @@ You can also use `SubscriptionSet.waitForSynchronization()
 to delay execution until subscription sync completes after instantiating
 a sync connection.
 
-SubscriptionSet.State`` Enum
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``SubscriptionSet.State`` Enum
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Additionally, you can watch the state of the subscription set with the 
 `SubscriptionSetState


### PR DESCRIPTION
## Pull Request Info
Fixes a typo. The header currently has a floating backtick.

### Staged Changes (Requires MongoDB Corp SSO)
Current header: https://www.mongodb.com/docs/realm/sdk/kotlin/sync/subscribe/#subscriptionset.state---enum
Interestingly, only one backtick appears and the space between the backticks and the word "Enum" does not render. I'm not sure what happens with monospace titles in the new site styling but it might be worth previewing to be sure this is OK.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
