### PR TITLE
Quickfix - typo - set query to "owner_id == user.identity", **not** "owner_id == user"

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/QuickStartTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/QuickStartTest.kt
@@ -105,7 +105,7 @@ class QuickStartTest: RealmTest() {
 //                    add(
 //                        realm.query<Item>(
 //                            "owner_id == $0", // owner_id == the logged in user
-//                            user
+//                            user.identity
 //                        ),
 //                        "User's Items"
 //                    )

--- a/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-synced-realm.kt
+++ b/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-synced-realm.kt
@@ -7,7 +7,7 @@
                    add(
                        realm.query<Item>(
                            "owner_id == $0", // owner_id == the logged in user
-                           user
+                           user.identity
                        ),
                        "User's Items"
                    )


### PR DESCRIPTION
## Pull Request Info

### Jira

N/A

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/kotlin-revamped-quickstart-quick-bug-fix/sdk/kotlin/quick-start/#open-a-synced-realm

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
