### PR TITLE
Quickfixes quickstart

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/QuickStartTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/QuickStartTest.kt
@@ -97,21 +97,21 @@ class QuickStartTest: RealmTest() {
             // :snippet-start: quick-start-open-a-synced-realm
             // create a SyncConfiguration
             // :uncomment-start:
-//            val config = SyncConfiguration.Builder(
-//                user,
-//                setOf(Item::class)
-//            ) // the SyncConfiguration defaults to Flexible Sync, if a Partition is not specified
-//                .initialSubscriptions { realm ->
-//                    add(
-//                        realm.query<Item>(
-//                            "owner_id == $0", // owner_id == the logged in user
-//                            user.identity
-//                        ),
-//                        "User's Items"
-//                    )
-//                }
-//                .build()
-//            val realm = Realm.open(config)
+            // val config = SyncConfiguration.Builder(
+            //     user,
+            //     setOf(Item::class)
+            // ) // the SyncConfiguration defaults to Flexible Sync, if a Partition is not specified
+            //     .initialSubscriptions { realm ->
+            //         add(
+            //             realm.query<Item>(
+            //                 "owner_id == $0", // owner_id == the logged in user
+            //                 user.identity
+            //             ),
+            //             "User's Items"
+            //         )
+            //     }
+            //     .build()
+            // val realm = Realm.open(config)
             // :uncomment-end:
             // :snippet-end:
         }

--- a/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-synced-realm.kt
+++ b/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-synced-realm.kt
@@ -1,16 +1,16 @@
-            // create a SyncConfiguration
-           val config = SyncConfiguration.Builder(
-               user,
-               setOf(Item::class)
-           ) // the SyncConfiguration defaults to Flexible Sync, if a Partition is not specified
-               .initialSubscriptions { realm ->
-                   add(
-                       realm.query<Item>(
-                           "owner_id == $0", // owner_id == the logged in user
-                           user.identity
-                       ),
-                       "User's Items"
-                   )
-               }
-               .build()
-           val realm = Realm.open(config)
+// create a SyncConfiguration
+val config = SyncConfiguration.Builder(
+    user,
+    setOf(Item::class)
+) // the SyncConfiguration defaults to Flexible Sync, if a Partition is not specified
+    .initialSubscriptions { realm ->
+        add(
+            realm.query<Item>(
+                "owner_id == $0", // owner_id == the logged in user
+                user.identity
+            ),
+            "User's Items"
+        )
+    }
+    .build()
+val realm = Realm.open(config)

--- a/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start.kt
+++ b/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start.kt
@@ -1,82 +1,82 @@
 
-        val app = App.create(YOUR_APP_ID)
+val app = App.create(YOUR_APP_ID)
 
-        runBlocking {
-            val credentials = Credentials.anonymous()
-            val user = app.login(credentials)
+runBlocking {
+    val credentials = Credentials.anonymous()
+    val user = app.login(credentials)
 
 
-            // create a SyncConfiguration
-           val config = SyncConfiguration.Builder(
-               user,
-               setOf(Item::class)
-           ) // the SyncConfiguration defaults to Flexible Sync, if a Partition is not specified
-               .initialSubscriptions { realm ->
-                   add(
-                       realm.query<Item>(
-                           "owner_id == $0", // owner_id == the logged in user
-                           user
-                       ),
-                       "User's Items"
-                   )
-               }
-               .build()
-           val realm = Realm.open(config)
+    // create a SyncConfiguration
+    val config = SyncConfiguration.Builder(
+        user,
+        setOf(Item::class)
+    ) // the SyncConfiguration defaults to Flexible Sync, if a Partition is not specified
+        .initialSubscriptions { realm ->
+            add(
+                realm.query<Item>(
+                    "owner_id == $0", // owner_id == the logged in user
+                    user.identity
+                ),
+                "User's Items"
+            )
         }
+        .build()
+    val realm = Realm.open(config)
+}
 
 
-        val config = RealmConfiguration.Builder(schema = setOf(Item::class))
-            .build()
-        val realm: Realm = Realm.open(config)
+val config = RealmConfiguration.Builder(schema = setOf(Item::class))
+    .build()
+val realm: Realm = Realm.open(config)
 
-        // all items in the realm
-        val items: RealmResults<Item> = realm.query<Item>().find()
+// all items in the realm
+val items: RealmResults<Item> = realm.query<Item>().find()
 
 
-        // flow.collect() is blocking -- run it in a background context
-        val job = CoroutineScope(Dispatchers.Default).launch {
-            // create a Flow from the Item collection, then add a listener to the Flow
-            val itemsFlow = items.asFlow()
-            itemsFlow.collect { changes: ResultsChange<Item> ->
-                when (changes) {
-                    // UpdatedResults means this change represents an update/insert/delete operation
-                    is UpdatedResults -> {
-                        changes.insertions // indexes of inserted objects
-                        changes.insertionRanges // ranges of inserted objects
-                        changes.changes // indexes of modified objects
-                        changes.changeRanges // ranges of modified objects
-                        changes.deletions // indexes of deleted objects
-                        changes.deletionRanges // ranges of deleted objects
-                        changes.list // the full collection of objects
-                    }
-                    else -> {
-                        // types other than UpdatedResults are not changes -- ignore them
-                    }
-                }
+// flow.collect() is blocking -- run it in a background context
+val job = CoroutineScope(Dispatchers.Default).launch {
+    // create a Flow from the Item collection, then add a listener to the Flow
+    val itemsFlow = items.asFlow()
+    itemsFlow.collect { changes: ResultsChange<Item> ->
+        when (changes) {
+            // UpdatedResults means this change represents an update/insert/delete operation
+            is UpdatedResults -> {
+                changes.insertions // indexes of inserted objects
+                changes.insertionRanges // ranges of inserted objects
+                changes.changes // indexes of modified objects
+                changes.changeRanges // ranges of modified objects
+                changes.deletions // indexes of deleted objects
+                changes.deletionRanges // ranges of deleted objects
+                changes.list // the full collection of objects
+            }
+            else -> {
+                // types other than UpdatedResults are not changes -- ignore them
             }
         }
+    }
+}
 
-        realm.writeBlocking {
-            copyToRealm(Item().apply {
-                summary = "Do the laundry"
-                isComplete = false
-            })
-        }
+realm.writeBlocking {
+    copyToRealm(Item().apply {
+        summary = "Do the laundry"
+        isComplete = false
+    })
+}
 
-        // items in the realm whose name begins with the letter 'D'
-        val itemsThatBeginWIthD: RealmResults<Item> =
-            realm.query<Item>("summary BEGINSWITH $0", "D")
-                .find()
-        //  todo items that have not been completed yet
-        val incompleteItems: RealmResults<Item> =
-            realm.query<Item>("isComplete == false")
-                .find()
-        // change the first item with open status to complete to show that the todo item has been done
-        realm.writeBlocking {
-            findLatest(incompleteItems[0])?.isComplete = true
-        }
-        // delete the first item in the realm
-        realm.writeBlocking {
-            val writeTransactionItems = query<Item>().find()
-            delete(writeTransactionItems.first())
-        }
+// items in the realm whose name begins with the letter 'D'
+val itemsThatBeginWIthD: RealmResults<Item> =
+    realm.query<Item>("summary BEGINSWITH $0", "D")
+        .find()
+//  todo items that have not been completed yet
+val incompleteItems: RealmResults<Item> =
+    realm.query<Item>("isComplete == false")
+        .find()
+// change the first item with open status to complete to show that the todo item has been done
+realm.writeBlocking {
+    findLatest(incompleteItems[0])?.isComplete = true
+}
+// delete the first item in the realm
+realm.writeBlocking {
+    val writeTransactionItems = query<Item>().find()
+    delete(writeTransactionItems.first())
+}

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -153,7 +153,7 @@ The code snippets in this section require the following:
 
 - :ref:`A created App Services App <create-a-realm-app>`
 - :ref:`Enabled anonymous authentication <anonymous-authentication>` in the App Services UI
-- :ref:`Enable Flexible Sync <enable-flexible-sync>` with  :ref:`Development Mode <enable-development-mode>` toggled on and an ``ownerId`` field in the :guilabel:`Queryable Fields` section   
+- :ref:`Enable Flexible Sync <enable-flexible-sync>` with  :ref:`Development Mode <enable-development-mode>` toggled on and an ``owner_id`` field in the :guilabel:`Queryable Fields` section
 
 Initialize the App
 ~~~~~~~~~~~~~~~~~~

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -149,7 +149,7 @@ Flexible Sync realm to begin syncing data between devices.
 Prerequisites
 ~~~~~~~~~~~~~
 
-The code snippets in this section require the following: 
+The code snippets in this section require the following:
 
 - :ref:`A created App Services App <create-a-realm-app>`
 - :ref:`Enabled anonymous authentication <anonymous-authentication>` in the App Services UI


### PR DESCRIPTION
## Pull Request Info

### Jira

N/A

### Staged Changes (Requires MongoDB Corp SSO)

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/quickfixes-quickstart/sdk/kotlin/quick-start/

### This PR fixes:
- Swaps "ownerId" as a queryable field with "owner_id" (which is the correct field)
- Fixes spacing in opening the synced realm with flex sync

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
