### PR TITLE
Fix broken link button

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -33,7 +33,7 @@ Welcome to the Realm Docs
    .. button:: Get started with a tutorial
       :uri: /tutorial
 
-   :doc:`Read the 5 Minute Introduction </introduction>`
+   :doc:`Read the 5 Minute Introduction <introduction>`
 
 .. image:: /images/hero.png
    :alt: Realm landing page hero image


### PR DESCRIPTION
## Pull Request Info

fix broken landing page button link. previously was directing to mongodb.com/tutorial. 

now redirects to correct page by making link relative. 

note that if this button ever moves to another page, the link won't work b/c it's path dependent. (for more info, see [absolute v. relative link](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks#absolute_versus_relative_urls) docs)

### Jira

n/a. issue reported on slack. 

### Staged Changes (Requires MongoDB Corp SSO)

- [index page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fix_broken_link/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
