### PR TITLE
(DOCSP-24661): note Realm Dart/Flutter incompatible with Dart 2.17.3

### DIFF
--- a/source/sdk/flutter/install.txt
+++ b/source/sdk/flutter/install.txt
@@ -22,7 +22,7 @@ Prerequisites
 .. warning:: Incompatible with Dart 2.17.3
 
    The Realm Flutter SDK and Realm Dart Standalone SDK are not compatible with
-   Dart version 2.17.3 due to an issue with the Dart virtual machine in this version.
+   Dart 2.17.3 due to an issue with the Dart virtual machine in this version.
    You may use any other Dart 2.17.x version with Realm.
 
 .. _flutter-install-steps:

--- a/source/sdk/flutter/install.txt
+++ b/source/sdk/flutter/install.txt
@@ -19,6 +19,12 @@ Prerequisites
 - `Install Flutter in your development environment <https://docs.flutter.dev/get-started/install>`__.
   You must use Flutter version 3.0 or later and Dart version 2.17.0 or later.
 
+.. warning:: Incompatible with Dart 2.17.3
+
+   The Realm Flutter SDK and Realm Dart Standalone SDK are not compatible with
+   Dart version 2.17.3 due to an issue with the Dart virtual machine in that version.
+   You may use any other Dart 2.17.x version with Realm.
+
 .. _flutter-install-steps:
 
 Installation

--- a/source/sdk/flutter/install.txt
+++ b/source/sdk/flutter/install.txt
@@ -22,7 +22,7 @@ Prerequisites
 .. warning:: Incompatible with Dart 2.17.3
 
    The Realm Flutter SDK and Realm Dart Standalone SDK are not compatible with
-   Dart version 2.17.3 due to an issue with the Dart virtual machine in that version.
+   Dart version 2.17.3 due to an issue with the Dart virtual machine in this version.
    You may use any other Dart 2.17.x version with Realm.
 
 .. _flutter-install-steps:


### PR DESCRIPTION
## Pull Request Info

note Realm Dart/Flutter incompatible with Dart 2.17.3

### Jira

- https://jira.mongodb.org/browse/DOCSP-24661

### Staged Changes (Requires MongoDB Corp SSO)

- [Install (flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24661/sdk/flutter/install)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
