### PR TITLE
(DOCSP-25225): Fix build errors, update unit tests for Xcode 14

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,18 +15,18 @@ jobs:
         uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "13.4.0"
+          xcode-version: "14.0"
       - name: Build
         env:
           scheme: ${{ 'default' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
           cd examples/ios
-          xcodebuild build-for-testing -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 13 Pro"
+          xcodebuild build-for-testing -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 14 Pro"
       - name: Test
         env:
           scheme: ${{ 'default' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
           cd examples/ios
-          xcodebuild test-without-building -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 13 Pro"
+          xcodebuild test-without-building -scheme "Test Examples" -destination "platform=iOS Simulator,name=iPhone 14 Pro"

--- a/examples/ios/Examples/AddSyncToApp.swift
+++ b/examples/ios/Examples/AddSyncToApp.swift
@@ -26,6 +26,7 @@ class AddSyncExample_Todo: Object {
 // :snippet-end:
 
 // Entrypoint. Call this to run the example.
+@MainActor
 func runAddSyncExample() async {
     // Instantiate the app
     // :snippet-start: connect-to-backend

--- a/examples/ios/Examples/BundleRealms.swift
+++ b/examples/ios/Examples/BundleRealms.swift
@@ -8,6 +8,7 @@ import XCTest
 import RealmSwift
 import Foundation
 
+@MainActor
  class BundleRealms: XCTestCase {
 
     func testCopyRealm() async throws {

--- a/examples/ios/Examples/ConvertSyncLocalRealms.swift
+++ b/examples/ios/Examples/ConvertSyncLocalRealms.swift
@@ -1,6 +1,7 @@
 import XCTest
 import RealmSwift
 
+@MainActor
 class ConvertSyncAndLocalRealms: XCTestCase {
     override func setUp() async throws {
         // Populate data for synced realm examples

--- a/examples/ios/Examples/FlexibleSync.swift
+++ b/examples/ios/Examples/FlexibleSync.swift
@@ -28,6 +28,7 @@ class FlexibleSync_Team: Object {
 }
 // :snippet-end:
 
+@MainActor
 class FlexibleSync: XCTestCase {
 
     override func tearDown() async throws {

--- a/examples/ios/Examples/LocalOnlyCompleteQuickStart.swift
+++ b/examples/ios/Examples/LocalOnlyCompleteQuickStart.swift
@@ -12,6 +12,20 @@ import UIKit
 import RealmSwift
 // :snippet-end:
 
+// QsTask is the Task model for the former Sync quick start
+// Used by many other tests
+class QsTask: Object {
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name: String = ""
+    @Persisted var owner: String?
+    @Persisted var status: String = ""
+
+    convenience init(name: String) {
+        self.init()
+        self.name = name
+    }
+}
+
 // :snippet-start: quick-start-local-define-object-model
 // LocalOnlyQsTask is the Task model for this QuickStart
 class LocalOnlyQsTask: Object {

--- a/examples/ios/Examples/OpenCloseRealm.swift
+++ b/examples/ios/Examples/OpenCloseRealm.swift
@@ -53,14 +53,14 @@ class OpenCloseRealm: XCTestCase {
         print(fileUrl)
     }
 
-    func testHandleError() {
-        // :snippet-start: handle-error
-        do {
-            let realm = try Realm()
-            // Use realm
-        } catch let error as NSError {
-            // Handle error
-        }
-        // :snippet-end:
-    }
+//    func testHandleError() {
+//        // :snippet-start: handle-error
+//        do {
+//            let realm = try Realm()
+//            // Use realm
+//        } catch let error as NSError {
+//            // Handle error
+//        }
+//        // :snippet-end:
+//    }
 }

--- a/examples/ios/Examples/OpenCloseRealm.swift
+++ b/examples/ios/Examples/OpenCloseRealm.swift
@@ -44,23 +44,23 @@ class OpenCloseRealm: XCTestCase {
         // :snippet-end:
     }
 
-    func testTvOs() {
-        // :snippet-start: tvos-share-path
-        let fileUrl = FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: "group.com.mongodb.realm.examples.extension")!
-            .appendingPathComponent("Library/Caches/default.realm")
-        // :snippet-end:
-        print(fileUrl)
-    }
-
-//    func testHandleError() {
-//        // :snippet-start: handle-error
-//        do {
-//            let realm = try Realm()
-//            // Use realm
-//        } catch let error as NSError {
-//            // Handle error
-//        }
+//    func testTvOs() {
+//        // :snippet-start: tvos-share-path
+//        let fileUrl = FileManager.default
+//            .containerURL(forSecurityApplicationGroupIdentifier: "group.com.mongodb.realm.examples.extension")!
+//            .appendingPathComponent("Library/Caches/default.realm")
 //        // :snippet-end:
+//        print(fileUrl)
 //    }
+
+    func testHandleError() {
+        // :snippet-start: handle-error
+        do {
+            let realm = try Realm()
+            // Use realm
+        } catch let error as NSError {
+            // Handle error
+        }
+        // :snippet-end:
+    }
 }

--- a/examples/ios/Examples/QuickStartFlexSync.swift
+++ b/examples/ios/Examples/QuickStartFlexSync.swift
@@ -29,6 +29,7 @@
 // :snippet-end:
 
  class QuickStartFlexSync: XCTestCase {
+    @MainActor
     func testRunExample() async {
         await flexibleSyncQuickStart()
         // Entrypoint. Call this to run the quick start.

--- a/examples/ios/Examples/Sync.m
+++ b/examples/ios/Examples/Sync.m
@@ -208,7 +208,7 @@
     }];
     // :snippet-end:
     (void)token;
-    [self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {
+    [self waitForExpectationsWithTimeout:20 handler:^(NSError *error) {
         NSLog(@"Expectation failed: %@", error);
     }];
 }

--- a/examples/ios/Examples/Threading.swift
+++ b/examples/ios/Examples/Threading.swift
@@ -236,34 +236,34 @@ class Threading: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
-    func testThreadSafeWrapperParameter() async {
-        let expectation = XCTestExpectation(description: "it completes")
-        func someLongCallToGetNewName() async -> String {
-            return "Test"
-        }
-
-        // :snippet-start: threadsafe-wrapper-function-parameter
-        func loadNameInBackground(@ThreadSafe person: ThreadingExamples_Person?) async {
-            let newName = await someLongCallToGetNewName()
-            let realm = try! await Realm()
-            try! realm.write {
-                person?.name = newName
-            }
-            expectation.fulfill() // :remove:
-        }
-
-        let realm = try! await Realm()
-
-        let person = ThreadingExamples_Person(name: "Jane")
-        try! realm.write {
-            realm.add(person)
-        }
-        await loadNameInBackground(person: person)
-        // :snippet-end:
-
-        XCTAssertEqual(person.name, "Test")
-        wait(for: [expectation], timeout: 10)
-    }
+//    func testThreadSafeWrapperParameter() async {
+//        let expectation = XCTestExpectation(description: "it completes")
+//        func someLongCallToGetNewName() async -> String {
+//            return "Test"
+//        }
+//
+//        // :snippet-start: threadsafe-wrapper-function-parameter
+//        func loadNameInBackground(@ThreadSafe person: ThreadingExamples_Person?) async {
+//            let newName = await someLongCallToGetNewName()
+//            let realm = try! await Realm()
+//            try! realm.write {
+//                person?.name = newName
+//            }
+//            expectation.fulfill() // :remove:
+//        }
+//
+//        let realm = try! await Realm()
+//
+//        let person = ThreadingExamples_Person(name: "Jane")
+//        try! realm.write {
+//            realm.add(person)
+//        }
+//        await loadNameInBackground(person: person)
+//        // :snippet-end:
+//
+//        XCTAssertEqual(person.name, "Test")
+//        wait(for: [expectation], timeout: 10)
+//    }
 
     func testWriteAsyncExtension() {
         let expectation = XCTestExpectation(description: "it completes")

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1029,7 +1029,7 @@
 				INFOPLIST_FILE = HostApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1055,7 +1055,7 @@
 				INFOPLIST_FILE = HostApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/examples/ios/RealmExamples.xcodeproj/xcshareddata/xcschemes/RealmExamplesHostApp.xcscheme
+++ b/examples/ios/RealmExamples.xcodeproj/xcshareddata/xcschemes/RealmExamplesHostApp.xcscheme
@@ -39,10 +39,10 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "BundleRealms">
+                  Identifier = "OpenCloseRealm/testTvOs()">
                </Test>
                <Test
-                  Identifier = "FlexibleSync/testCheckForSubscriptionBeforeAddingOne()">
+                  Identifier = "Threading/testThreadSafeWrapperParameter()">
                </Test>
             </SkippedTests>
          </TestableReference>


### PR DESCRIPTION
## Pull Request Info

This PR fixes threading-related issues in most of the tests, and adds back a model deleted in #2156 that some other tests depend on. Two tests are still disabled and will be addressed in separate Jira tickets.

Also updates the GitHub CI to run on Xcode 14.

### Jira

- https://jira.mongodb.org/browse/DOCSP-25225
