### PR TITLE
(DOCSP-23333): Asymmetric Sync docs for Swift SDK

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "14.0"
+          xcode-version: "14.0.1"
       - name: Build
         env:
           scheme: ${{ 'default' }}

--- a/examples/ios/Examples/AsymmetricSync.swift
+++ b/examples/ios/Examples/AsymmetricSync.swift
@@ -15,14 +15,6 @@ class AsymmetricSync_WeatherSensor: AsymmetricObject {
     @Persisted var temperatureInFahrenheit: Float
     @Persisted var barometricPressureInHg: Float
     @Persisted var windSpeedInMph: Int
-    
-    convenience init(deviceId: String, temperatureInFahrenheit: Float, barometricPressureInHg: Float, windSpeedInMph: Int) {
-        self.init()
-        self.deviceId = deviceId
-        self.temperatureInFahrenheit = temperatureInFahrenheit
-        self.barometricPressureInHg = barometricPressureInHg
-        self.windSpeedInMph = windSpeedInMph
-    }
     // :remove-start:
     override class func shouldIncludeInDefaultSchema() -> Bool {
         return false
@@ -44,7 +36,7 @@ class AsymmetricSync: XCTestCase {
         }
 
         func login() async throws -> User {
-            let user = try await app.login(credentials: Credentials.anonymous)
+            let user = try await app.login(credentials: .anonymous)
             return user
         }
         // :snippet-end:

--- a/examples/ios/Examples/AsymmetricSync.swift
+++ b/examples/ios/Examples/AsymmetricSync.swift
@@ -1,6 +1,7 @@
 // :replace-start: {
 //   "terms": {
-//     "AsymmetricSync_": ""
+//     "AsymmetricSync_": "",
+//     "FLEX_SYNC_APP_ID": "INSERT_APP_ID_HERE"
 //   }
 // }
 
@@ -33,6 +34,7 @@ class AsymmetricSync_WeatherSensor: AsymmetricObject {
 class AsymmetricSync: XCTestCase {    
     @MainActor
     func testAsymmetricSync() async {
+        // :snippet-start: connect-and-authenticate
         let app = App(id: FLEX_SYNC_APP_ID)
         do {
             let user = try await login()
@@ -45,17 +47,21 @@ class AsymmetricSync: XCTestCase {
             let user = try await app.login(credentials: Credentials.anonymous)
             return user
         }
+        // :snippet-end:
 
+        // :snippet-start: open-asymmetric-sync-realm
         func openSyncedRealm(user: User) async {
             do {
                 var asymmetricConfig = user.flexibleSyncConfiguration()
                 asymmetricConfig.objectTypes = [AsymmetricSync_WeatherSensor.self]
-                let asymmetricRealm = try await Realm(configuration: asymmetricConfig, downloadBeforeOpen: .always)
+                let asymmetricRealm = try await Realm(configuration: asymmetricConfig)
                 await useRealm(asymmetricRealm, user)
             } catch {
                 print("Error opening realm: \(error.localizedDescription)")
             }
         }
+        // :snippet-end:
+        
         func useRealm(_ asymmetricRealm: Realm, _ user: User) async {
             // :snippet-start: create-asymmetric-object
             try! asymmetricRealm.write {

--- a/examples/ios/Examples/AsymmetricSync.swift
+++ b/examples/ios/Examples/AsymmetricSync.swift
@@ -1,0 +1,84 @@
+// :replace-start: {
+//   "terms": {
+//     "AsymmetricSync_": ""
+//   }
+// }
+
+import XCTest
+import RealmSwift
+
+// :snippet-start: asymmetric-model
+class AsymmetricSync_WeatherSensor: AsymmetricObject {
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var deviceId: String
+    @Persisted var temperatureInFahrenheit: Float
+    @Persisted var barometricPressureInHg: Float
+    @Persisted var windSpeedInMph: Int
+
+    convenience init(deviceId: String, temperatureInFahrenheit: Float, barometricPressureInHg: Float, windSpeedInMph: Int) {
+        self.init()
+        self.deviceId = deviceId
+        self.temperatureInFahrenheit = temperatureInFahrenheit
+        self.barometricPressureInHg = barometricPressureInHg
+        self.windSpeedInMph = windSpeedInMph
+    }
+}
+// :snippet-end:
+
+class AsymmetricSync: XCTestCase {    
+    @MainActor
+    func testAsymmetricSync() async {
+        let app = App(id: FLEX_SYNC_APP_ID)
+        do {
+            let user = try await login()
+            await openSyncedRealm(user: user)
+        } catch {
+            print("Error logging in: \(error.localizedDescription)")
+        }
+
+        func login() async throws -> User {
+            let user = try await app.login(credentials: Credentials.anonymous)
+            return user
+        }
+
+        func openSyncedRealm(user: User) async {
+            do {
+                var config = user.flexibleSyncConfiguration()
+                config.objectTypes = [AsymmetricSync_WeatherSensor.self]
+                let realm = try await Realm(configuration: config, downloadBeforeOpen: .always)
+                await useRealm(realm, user)
+            } catch {
+                print("Error opening realm: \(error.localizedDescription)")
+            }
+        }
+        func useRealm(_ realm: Realm, _ user: User) async {
+            // :snippet-start: create-asymmetric-object
+            try! realm.write {
+                realm.create(AsymmetricSync_WeatherSensor.self, value: ["_id": ObjectId.generate(),
+                                                                        "deviceId": "WX1278UIT",
+                                                                        "temperatureInFahrenheit": 66.7,
+                                                                        "barometricPressureInHg": 29.65,
+                                                                        "windSpeedInMph": 2
+                                                                       ])
+            }
+            // :snippet-end:
+            // Add a delay to give the document time to sync
+            sleep(10)
+            // Verify the document was added, and then delete it for cleanup.
+            let client = app.currentUser!.mongoClient("mongodb-atlas")
+            let database = client.database(named: "ios-flexible")
+            let collection = database.collection(withName: "AsymmetricSync_WeatherSensor")
+            let weatherSensorDocument: Document = ["deviceId": "WX1278UIT"]
+            do {
+                let foundWeatherSensorDocuments = try await collection.find(filter: weatherSensorDocument)
+                print("Found these matching documents: \(foundWeatherSensorDocuments)")
+                XCTAssertNotNil(foundWeatherSensorDocuments)
+                let deletedResult = try await collection.deleteManyDocuments(filter: weatherSensorDocument)
+                print("Deleted documents: \(deletedResult)")
+            } catch {
+                print("Error finding or deleting documents: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+// :replace-end:

--- a/examples/ios/Examples/AsymmetricSync.swift
+++ b/examples/ios/Examples/AsymmetricSync.swift
@@ -14,7 +14,7 @@ class AsymmetricSync_WeatherSensor: AsymmetricObject {
     @Persisted var temperatureInFahrenheit: Float
     @Persisted var barometricPressureInHg: Float
     @Persisted var windSpeedInMph: Int
-
+    
     convenience init(deviceId: String, temperatureInFahrenheit: Float, barometricPressureInHg: Float, windSpeedInMph: Int) {
         self.init()
         self.deviceId = deviceId
@@ -22,6 +22,11 @@ class AsymmetricSync_WeatherSensor: AsymmetricObject {
         self.barometricPressureInHg = barometricPressureInHg
         self.windSpeedInMph = windSpeedInMph
     }
+    // :remove-start:
+    override class func shouldIncludeInDefaultSchema() -> Bool {
+        return false
+    }
+    // :remove-end:
 }
 // :snippet-end:
 
@@ -43,23 +48,24 @@ class AsymmetricSync: XCTestCase {
 
         func openSyncedRealm(user: User) async {
             do {
-                var config = user.flexibleSyncConfiguration()
-                config.objectTypes = [AsymmetricSync_WeatherSensor.self]
-                let realm = try await Realm(configuration: config, downloadBeforeOpen: .always)
-                await useRealm(realm, user)
+                var asymmetricConfig = user.flexibleSyncConfiguration()
+                asymmetricConfig.objectTypes = [AsymmetricSync_WeatherSensor.self]
+                let asymmetricRealm = try await Realm(configuration: asymmetricConfig, downloadBeforeOpen: .always)
+                await useRealm(asymmetricRealm, user)
             } catch {
                 print("Error opening realm: \(error.localizedDescription)")
             }
         }
-        func useRealm(_ realm: Realm, _ user: User) async {
+        func useRealm(_ asymmetricRealm: Realm, _ user: User) async {
             // :snippet-start: create-asymmetric-object
-            try! realm.write {
-                realm.create(AsymmetricSync_WeatherSensor.self, value: ["_id": ObjectId.generate(),
-                                                                        "deviceId": "WX1278UIT",
-                                                                        "temperatureInFahrenheit": 66.7,
-                                                                        "barometricPressureInHg": 29.65,
-                                                                        "windSpeedInMph": 2
-                                                                       ])
+            try! asymmetricRealm.write {
+                asymmetricRealm.create(AsymmetricSync_WeatherSensor.self,
+                                       value: [ "_id": ObjectId.generate(),
+                                                "deviceId": "WX1278UIT",
+                                                "temperatureInFahrenheit": 66.7,
+                                                "barometricPressureInHg": 29.65,
+                                                "windSpeedInMph": 2
+                                                ])
             }
             // :snippet-end:
             // Add a delay to give the document time to sync

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		48F38B58252793F600DDEB65 /* ManageApiKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B57252793F600DDEB65 /* ManageApiKeys.swift */; };
 		48F38B5A252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */; };
 		48F38B5C2527A3FE00DDEB65 /* ManageApiKeys.m in Sources */ = {isa = PBXBuildFile; fileRef = 48F38B5B2527A3FE00DDEB65 /* ManageApiKeys.m */; };
+		9107C21328D35EA600E9EAF7 /* AsymmetricSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9107C21228D35EA600E9EAF7 /* AsymmetricSync.swift */; };
 		911366EB27BC0C6100DF865D /* ConvertSyncLocalRealms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911366EA27BC0C6100DF865D /* ConvertSyncLocalRealms.swift */; };
 		912ACA7B28415292006CDDD8 /* SwiftUIFlexSyncExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912ACA7A28415292006CDDD8 /* SwiftUIFlexSyncExampleApp.swift */; };
 		912ACA7F28415294006CDDD8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 912ACA7E28415294006CDDD8 /* Assets.xcassets */; };
@@ -206,6 +207,7 @@
 		48F38B57252793F600DDEB65 /* ManageApiKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageApiKeys.swift; sourceTree = "<group>"; };
 		48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymouslyLoggedInTestCase.swift; sourceTree = "<group>"; };
 		48F38B5B2527A3FE00DDEB65 /* ManageApiKeys.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ManageApiKeys.m; sourceTree = "<group>"; };
+		9107C21228D35EA600E9EAF7 /* AsymmetricSync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsymmetricSync.swift; sourceTree = "<group>"; };
 		911366EA27BC0C6100DF865D /* ConvertSyncLocalRealms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvertSyncLocalRealms.swift; sourceTree = "<group>"; };
 		9126A02E27ED00A1002006D2 /* RealmPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = RealmPlayground.playground; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		912ACA7828415292006CDDD8 /* SwiftUIFlexSyncExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIFlexSyncExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -373,6 +375,7 @@
 				48BD8FF025800B4D009DE2E6 /* AnonymouslyLoggedInTestCase.h */,
 				48BD8FEB25800AA3009DE2E6 /* AnonymouslyLoggedInTestCase.m */,
 				48F38B59252794B300DDEB65 /* AnonymouslyLoggedInTestCase.swift */,
+				9107C21228D35EA600E9EAF7 /* AsymmetricSync.swift */,
 				48E63FB7252646A700F883B1 /* Authenticate.swift */,
 				915C666927B41B0900E7BDB4 /* BundleRealms.swift */,
 				916AC597273036C100270C64 /* ClassProjection.swift */,
@@ -913,6 +916,7 @@
 				48F38B58252793F600DDEB65 /* ManageApiKeys.swift in Sources */,
 				48637F4F25C8B8EC002209AF /* Migrations.m in Sources */,
 				917E73E826B8A9F80068242A /* MongoDBRemoteAccessAggregate.swift in Sources */,
+				9107C21328D35EA600E9EAF7 /* AsymmetricSync.swift in Sources */,
 				9185DB1925E82C0300AF1389 /* LocalOnlyCompleteQuickStart.swift in Sources */,
 				485C5D0B258A71200069AAE8 /* Encrypt.swift in Sources */,
 				482A859C2576E34300BA8700 /* QueryEngine.m in Sources */,

--- a/source/examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
+++ b/source/examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
@@ -1,0 +1,15 @@
+class WeatherSensor: AsymmetricObject {
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var deviceId: String
+    @Persisted var temperatureInFahrenheit: Float
+    @Persisted var barometricPressureInHg: Float
+    @Persisted var windSpeedInMph: Int
+
+    convenience init(deviceId: String, temperatureInFahrenheit: Float, barometricPressureInHg: Float, windSpeedInMph: Int) {
+        self.init()
+        self.deviceId = deviceId
+        self.temperatureInFahrenheit = temperatureInFahrenheit
+        self.barometricPressureInHg = barometricPressureInHg
+        self.windSpeedInMph = windSpeedInMph
+    }
+}

--- a/source/examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
+++ b/source/examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
@@ -4,12 +4,4 @@ class WeatherSensor: AsymmetricObject {
     @Persisted var temperatureInFahrenheit: Float
     @Persisted var barometricPressureInHg: Float
     @Persisted var windSpeedInMph: Int
-    
-    convenience init(deviceId: String, temperatureInFahrenheit: Float, barometricPressureInHg: Float, windSpeedInMph: Int) {
-        self.init()
-        self.deviceId = deviceId
-        self.temperatureInFahrenheit = temperatureInFahrenheit
-        self.barometricPressureInHg = barometricPressureInHg
-        self.windSpeedInMph = windSpeedInMph
-    }
 }

--- a/source/examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
+++ b/source/examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
@@ -4,7 +4,7 @@ class WeatherSensor: AsymmetricObject {
     @Persisted var temperatureInFahrenheit: Float
     @Persisted var barometricPressureInHg: Float
     @Persisted var windSpeedInMph: Int
-
+    
     convenience init(deviceId: String, temperatureInFahrenheit: Float, barometricPressureInHg: Float, windSpeedInMph: Int) {
         self.init()
         self.deviceId = deviceId

--- a/source/examples/generated/code/start/AsymmetricSync.snippet.connect-and-authenticate.swift
+++ b/source/examples/generated/code/start/AsymmetricSync.snippet.connect-and-authenticate.swift
@@ -1,0 +1,12 @@
+let app = App(id: INSERT_APP_ID_HERE)
+do {
+    let user = try await login()
+    await openSyncedRealm(user: user)
+} catch {
+    print("Error logging in: \(error.localizedDescription)")
+}
+
+func login() async throws -> User {
+    let user = try await app.login(credentials: Credentials.anonymous)
+    return user
+}

--- a/source/examples/generated/code/start/AsymmetricSync.snippet.connect-and-authenticate.swift
+++ b/source/examples/generated/code/start/AsymmetricSync.snippet.connect-and-authenticate.swift
@@ -7,6 +7,6 @@ do {
 }
 
 func login() async throws -> User {
-    let user = try await app.login(credentials: Credentials.anonymous)
+    let user = try await app.login(credentials: .anonymous)
     return user
 }

--- a/source/examples/generated/code/start/AsymmetricSync.snippet.create-asymmetric-object.swift
+++ b/source/examples/generated/code/start/AsymmetricSync.snippet.create-asymmetric-object.swift
@@ -1,0 +1,8 @@
+try! realm.write {
+    realm.create(WeatherSensor.self, value: ["_id": ObjectId.generate(),
+                                                            "deviceId": "WX1278UIT",
+                                                            "temperatureInFahrenheit": 66.7,
+                                                            "barometricPressureInHg": 29.65,
+                                                            "windSpeedInMph": 2
+                                                           ])
+}

--- a/source/examples/generated/code/start/AsymmetricSync.snippet.create-asymmetric-object.swift
+++ b/source/examples/generated/code/start/AsymmetricSync.snippet.create-asymmetric-object.swift
@@ -1,8 +1,9 @@
-try! realm.write {
-    realm.create(WeatherSensor.self, value: ["_id": ObjectId.generate(),
-                                                            "deviceId": "WX1278UIT",
-                                                            "temperatureInFahrenheit": 66.7,
-                                                            "barometricPressureInHg": 29.65,
-                                                            "windSpeedInMph": 2
-                                                           ])
+try! asymmetricRealm.write {
+    asymmetricRealm.create(WeatherSensor.self,
+                           value: [ "_id": ObjectId.generate(),
+                                    "deviceId": "WX1278UIT",
+                                    "temperatureInFahrenheit": 66.7,
+                                    "barometricPressureInHg": 29.65,
+                                    "windSpeedInMph": 2
+                                    ])
 }

--- a/source/examples/generated/code/start/AsymmetricSync.snippet.open-asymmetric-sync-realm.swift
+++ b/source/examples/generated/code/start/AsymmetricSync.snippet.open-asymmetric-sync-realm.swift
@@ -1,0 +1,10 @@
+func openSyncedRealm(user: User) async {
+    do {
+        var asymmetricConfig = user.flexibleSyncConfiguration()
+        asymmetricConfig.objectTypes = [WeatherSensor.self]
+        let asymmetricRealm = try await Realm(configuration: asymmetricConfig)
+        await useRealm(asymmetricRealm, user)
+    } catch {
+        print("Error opening realm: \(error.localizedDescription)")
+    }
+}

--- a/source/sdk/swift/crud/create.txt
+++ b/source/sdk/swift/crud/create.txt
@@ -357,7 +357,7 @@ Create an Asymmetric Object
 
 .. versionadded:: 10.29.0
 
-You can only create an AsymmetricObject using :swift-sdk:`create(_ type:, value:)
+You can create an AsymmetricObject using :swift-sdk:`create(_ type:, value:)
 <Structs/Realm.html#/s:10RealmSwift0A0V6create_5valueyxm_yptSo0aB16AsymmetricObjectCRbzlF>`.
 When you create an AsymmetricObject, it syncs unidirectionally to the Atlas 
 database linked to your Atlas App Services App. You cannot access an

--- a/source/sdk/swift/crud/create.txt
+++ b/source/sdk/swift/crud/create.txt
@@ -359,7 +359,8 @@ Create an Asymmetric Object
 
 You can create an AsymmetricObject using :swift-sdk:`create(_ type:, value:)
 <Structs/Realm.html#/s:10RealmSwift0A0V6create_5valueyxm_yptSo0aB16AsymmetricObjectCRbzlF>`.
-When you create an AsymmetricObject, it syncs unidirectionally to the Atlas 
+When you create an AsymmetricObject, it syncs unidirectionally via 
+:ref:`Asymmetric Sync <optimize-asymmetric-sync>` to the Atlas 
 database linked to your Atlas App Services App. You cannot access an
 AsymmetricObject locally, add it to or remove it from a realm, or query for it.
 

--- a/source/sdk/swift/crud/create.txt
+++ b/source/sdk/swift/crud/create.txt
@@ -355,6 +355,8 @@ you must check the type before you do anything with the value.
 Create an Asymmetric Object
 ---------------------------
 
+.. versionadded:: 10.29.0
+
 You can only create an AsymmetricObject using :swift-sdk:`create(_ type:, value:)
 <Structs/Realm.html#/s:10RealmSwift0A0V6create_5valueyxm_yptSo0aB16AsymmetricObjectCRbzlF>`.
 When you create an AsymmetricObject, it syncs unidirectionally to the Atlas 
@@ -366,6 +368,8 @@ AsymmetricObject locally, add it to or remove it from a realm, or query for it.
 
 You can create AsymmetricObjects for a realm initialized with a :swift-sdk:`Flexible Sync configuration 
 <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE25flexibleSyncConfigurationAC0B0V0F0VyF>`.
+For more information, see: :ref:`Open a Synced Realm for Flexible Sync 
+<ios-flexible-sync-open-realm>`.
 
 .. _ios-copy-an-object-to-another-realm:
 

--- a/source/sdk/swift/crud/create.txt
+++ b/source/sdk/swift/crud/create.txt
@@ -357,7 +357,7 @@ Create an Asymmetric Object
 
 .. versionadded:: 10.29.0
 
-You can create an AsymmetricObject using :swift-sdk:`create(_ type:, value:)
+You can only create an AsymmetricObject using :swift-sdk:`create(_ type:, value:)
 <Structs/Realm.html#/s:10RealmSwift0A0V6create_5valueyxm_yptSo0aB16AsymmetricObjectCRbzlF>`.
 When you create an AsymmetricObject, it syncs unidirectionally via 
 :ref:`Asymmetric Sync <optimize-asymmetric-sync>` to the Atlas 

--- a/source/sdk/swift/crud/create.txt
+++ b/source/sdk/swift/crud/create.txt
@@ -350,6 +350,23 @@ you must check the type before you do anything with the value.
 .. literalinclude:: /examples/generated/code/start/CreateRealmObjects.snippet.mixed-data-type.swift
    :language: swift
 
+.. _swift-create-asymmetric-object:
+
+Create an Asymmetric Object
+---------------------------
+
+You can only create an AsymmetricObject using :swift-sdk:`create(_ type:, value:)
+<Structs/Realm.html#/s:10RealmSwift0A0V6create_5valueyxm_yptSo0aB16AsymmetricObjectCRbzlF>`.
+When you create an AsymmetricObject, it syncs unidirectionally to the Atlas 
+database linked to your Atlas App Services App. You cannot access an
+AsymmetricObject locally, add it to or remove it from a realm, or query for it.
+
+.. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.create-asymmetric-object.swift
+   :language: swift
+
+You can create AsymmetricObjects for a realm initialized with a :swift-sdk:`Flexible Sync configuration 
+<Extensions/User.html#/s:So7RLMUserC10RealmSwiftE25flexibleSyncConfigurationAC0B0V0F0VyF>`.
+
 .. _ios-copy-an-object-to-another-realm:
 
 Copy an Object to Another Realm

--- a/source/sdk/swift/model-data/define-model/object-models.txt
+++ b/source/sdk/swift/model-data/define-model/object-models.txt
@@ -674,7 +674,6 @@ Define an asymmetric object by deriving from :swift-sdk:`AsymmetricObject
 with a few exceptions:
 
 - Asymmetric objects can only link to embedded objects
-
    - ``Object`` and ``List<Object>`` properties are not supported 
    - ``EmbeddedObject`` and ``List<EmbeddedObject>`` are supported
 

--- a/source/sdk/swift/model-data/define-model/object-models.txt
+++ b/source/sdk/swift/model-data/define-model/object-models.txt
@@ -677,12 +677,18 @@ with a few exceptions:
    - ``Object`` and ``List<Object>`` properties are not supported 
    - ``EmbeddedObject`` and ``List<EmbeddedObject>`` are supported
 
-You cannot link an ``AsymmetricObject`` from within an ``Object``. Doing so 
+You cannot link to an ``AsymmetricObject`` from within an ``Object``. Doing so 
 throws an error.
 
-Asymmetric objects cannot be added to or removed from a realm, or queried.
-They can only be created, and are then synced unidirectionally to the 
-Atlas database linked to your App with Device Sync.
+Asymmetric objects do not function in the same way as other Realm Objects. 
+You cannot:
+
+- Add an asymmetric object to a realm
+- Remove an asymmetric object from a realm
+- Query an asymmetric object
+
+You can only create an Asymmetric object, which then syncs unidirectionally 
+to the Atlas database linked to your App with Device Sync.
 
 For more information, see: :ref:`Create an Asymmetric Object 
 <swift-create-asymmetric-object>`.

--- a/source/sdk/swift/model-data/define-model/object-models.txt
+++ b/source/sdk/swift/model-data/define-model/object-models.txt
@@ -674,8 +674,9 @@ Define an asymmetric object by deriving from :swift-sdk:`AsymmetricObject
 with a few exceptions:
 
 - Asymmetric objects can only link to embedded objects
-- Object and List<Object> properties are not supported 
-- EmbeddedObject and List<EmbeddedObject> are supported
+
+   - ``Object`` and ``List<Object>`` properties are not supported 
+   - ``EmbeddedObject`` and ``List<EmbeddedObject>`` are supported
 
 You cannot link an ``AsymmetricObject`` from within an ``Object``. Doing so 
 throws an error.
@@ -684,4 +685,5 @@ Asymmetric objects cannot be added to or removed from a realm, or queried.
 They can only be created, and are then synced unidirectionally to the 
 Atlas database linked to your App with Device Sync.
 
-For more information, see: Create an Asymmetric Object.
+For more information, see: :ref:`Create an Asymmetric Object 
+<swift-create-asymmetric-object>`.

--- a/source/sdk/swift/model-data/define-model/object-models.txt
+++ b/source/sdk/swift/model-data/define-model/object-models.txt
@@ -654,3 +654,34 @@ property in several ways:
   excluded. This enables you to watch for changes to a class projection 
   and not see changes for properties that are not part of the class 
   projection. 
+
+.. _swift-define-asymmetric-object:
+
+Define an Asymmetric Object
+--------------------------
+
+.. versionadded:: 10.29.0
+
+You can use Flexible Sync to sync an object unidirectionally
+from your device to the database linked to your Atlas App Services App. 
+Define an asymmetric object by deriving from :swift-sdk:`AsymmetricObject 
+<Extensions/AsymmetricObject.html>`.
+
+.. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
+   :language: swift
+
+``AsymmetricObjects`` broadly support the same property types as ``Object``, 
+with a few exceptions:
+
+- Asymmetric objects can only link to embedded objects
+- Object and List<Object> properties are not supported 
+- EmbeddedObject and List<EmbeddedObject> are supported
+
+You cannot link an ``AsymmetricObject`` from within an ``Object``. Doing so 
+throws an error.
+
+Asymmetric objects cannot be added to or removed from a realm, or queried.
+They can only be created, and are then synced unidirectionally to the 
+Atlas database linked to your App with Device Sync.
+
+For more information, see: Create an Asymmetric Object.

--- a/source/sdk/swift/model-data/define-model/object-models.txt
+++ b/source/sdk/swift/model-data/define-model/object-models.txt
@@ -665,7 +665,7 @@ Define an Asymmetric Object
 If your app uses Flexible Sync, you can use :ref:`Asymmetric Sync 
 <optimize-asymmetric-sync>` to sync an object unidirectionally
 from your device to the database linked to your Atlas App Services App. 
-Define an asymmetric object by deriving from :swift-sdk:`AsymmetricObject 
+Define an asymmetric object by inheriting from :swift-sdk:`AsymmetricObject 
 <Extensions/AsymmetricObject.html>`.
 
 .. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift

--- a/source/sdk/swift/model-data/define-model/object-models.txt
+++ b/source/sdk/swift/model-data/define-model/object-models.txt
@@ -662,7 +662,8 @@ Define an Asymmetric Object
 
 .. versionadded:: 10.29.0
 
-You can use Flexible Sync to sync an object unidirectionally
+If your app uses Flexible Sync, you can use :ref:`Asymmetric Sync 
+<optimize-asymmetric-sync>` to sync an object unidirectionally
 from your device to the database linked to your Atlas App Services App. 
 Define an asymmetric object by deriving from :swift-sdk:`AsymmetricObject 
 <Extensions/AsymmetricObject.html>`.

--- a/source/sdk/swift/sync.txt
+++ b/source/sdk/swift/sync.txt
@@ -15,6 +15,7 @@ Sync Data Between Devices - Swift SDK
    Check the Network Connection </sdk/swift/sync/network-connection>
    Set the Client Log Level </sdk/swift/sync/log-level>
    Record Realm Events </sdk/swift/sync/event-library>
+   Stream Data to Atlas </sdk/swift/sync/_swift-stream-data-to-atlas>
 
 - :doc:`Add Sync to an App </sdk/swift/sync/add-sync-to-app>`
 - :doc:`Configure & Open a Synced Realm </sdk/swift/sync/configure-and-open-a-synced-realm>`
@@ -26,3 +27,4 @@ Sync Data Between Devices - Swift SDK
 - :doc:`Check the Network Connection </sdk/swift/sync/network-connection>`
 - :doc:`Set the Client Log Level </sdk/swift/sync/log-level>`
 - :doc:`Record Realm Events </sdk/swift/sync/event-library>`
+- :doc:`Stream Data to Atlas </sdk/swift/sync/_swift-stream-data-to-atlas>`

--- a/source/sdk/swift/sync.txt
+++ b/source/sdk/swift/sync.txt
@@ -15,7 +15,7 @@ Sync Data Between Devices - Swift SDK
    Check the Network Connection </sdk/swift/sync/network-connection>
    Set the Client Log Level </sdk/swift/sync/log-level>
    Record Realm Events </sdk/swift/sync/event-library>
-   Stream Data to Atlas </sdk/swift/sync/_swift-stream-data-to-atlas>
+   Stream Data to Atlas </sdk/swift/sync/swift-stream-data-to-atlas>
 
 - :doc:`Add Sync to an App </sdk/swift/sync/add-sync-to-app>`
 - :doc:`Configure & Open a Synced Realm </sdk/swift/sync/configure-and-open-a-synced-realm>`
@@ -27,4 +27,4 @@ Sync Data Between Devices - Swift SDK
 - :doc:`Check the Network Connection </sdk/swift/sync/network-connection>`
 - :doc:`Set the Client Log Level </sdk/swift/sync/log-level>`
 - :doc:`Record Realm Events </sdk/swift/sync/event-library>`
-- :doc:`Stream Data to Atlas </sdk/swift/sync/_swift-stream-data-to-atlas>`
+- :doc:`Stream Data to Atlas </sdk/swift/sync/swift-stream-data-to-atlas>`

--- a/source/sdk/swift/sync.txt
+++ b/source/sdk/swift/sync.txt
@@ -15,7 +15,7 @@ Sync Data Between Devices - Swift SDK
    Check the Network Connection </sdk/swift/sync/network-connection>
    Set the Client Log Level </sdk/swift/sync/log-level>
    Record Realm Events </sdk/swift/sync/event-library>
-   Stream Data to Atlas </sdk/swift/sync/swift-stream-data-to-atlas>
+   Stream Data to Atlas </sdk/swift/sync/stream-data-to-atlas>
 
 - :doc:`Add Sync to an App </sdk/swift/sync/add-sync-to-app>`
 - :doc:`Configure & Open a Synced Realm </sdk/swift/sync/configure-and-open-a-synced-realm>`
@@ -27,4 +27,4 @@ Sync Data Between Devices - Swift SDK
 - :doc:`Check the Network Connection </sdk/swift/sync/network-connection>`
 - :doc:`Set the Client Log Level </sdk/swift/sync/log-level>`
 - :doc:`Record Realm Events </sdk/swift/sync/event-library>`
-- :doc:`Stream Data to Atlas </sdk/swift/sync/swift-stream-data-to-atlas>`
+- :doc:`Stream Data to Atlas </sdk/swift/sync/stream-data-to-atlas>`

--- a/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
@@ -174,9 +174,13 @@ to open a synced realm.
 
 .. important:: Flexible Sync Requires a Subscription
 
-   You can't use a Flexible Sync realm until you add at least one subscription.
-   To learn how to add subscriptions, see: :ref:`<ios-sync-add-subscription>`.
-   
+   If your app uses regular Device Sync, you can't use a Flexible Sync 
+   realm until you add at least one subscription. To learn how to add 
+   subscriptions, see: :ref:`<ios-sync-add-subscription>`.
+
+   This does not apply to :ref:`Asymmetric Sync <app-services-concept-asymmetric-sync>`.
+   You cannot create a subscription for an ``AsymmetricObject``.
+
 .. _ios-open-synced-realm-as-different-sync-user:
 
 Open a Synced Realm as a Different Sync User

--- a/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
@@ -178,7 +178,7 @@ to open a synced realm.
    realm until you add at least one subscription. To learn how to add 
    subscriptions, see: :ref:`<ios-sync-add-subscription>`.
 
-   This does not apply to :ref:`Asymmetric Sync <app-services-concept-asymmetric-sync>`.
+   This does not apply to :ref:`Asymmetric Sync <optimize-asymmetric-sync>`.
    You cannot create a subscription for an ``AsymmetricObject``.
 
 .. _ios-open-synced-realm-as-different-sync-user:

--- a/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
@@ -174,9 +174,9 @@ to open a synced realm.
 
 .. important:: Flexible Sync Requires a Subscription
 
-   If your app uses regular Device Sync, you can't use a Flexible Sync 
-   realm until you add at least one subscription. To learn how to add 
-   subscriptions, see: :ref:`<ios-sync-add-subscription>`.
+   If your app uses bidirectional, standard Device Sync, you can't use a 
+   Flexible Sync realm until you add at least one subscription. To learn 
+   how to add subscriptions, see: :ref:`<ios-sync-add-subscription>`.
 
    This does not apply to :ref:`Asymmetric Sync <optimize-asymmetric-sync>`.
    You cannot create a subscription for an ``AsymmetricObject``.

--- a/source/sdk/swift/sync/flexible-sync.txt
+++ b/source/sdk/swift/sync/flexible-sync.txt
@@ -33,11 +33,16 @@ To use Flexible Sync in an iOS client:
 You can add, update, and remove query subscriptions to determine which data 
 syncs to the client device.
 
+**Note**: Flexible Sync subscriptions only apply to using Atlas Device Sync 
+with regular Realm Objects. If your app uses Asymmetric Sync to unidirectionally
+sync :swift-sdk:`AsymmetricObjects <Extensions/AsymmetricObject.html>` via an 
+Atlas App Services App, you do not create subscriptions for those objects.
+
 .. seealso::
 
    This page details how to manage subscriptions for Flexible Sync. 
    
-   For general information about using Atlas Device Sync with the Swift SDK, 
+   For general information about using Device Sync with the Swift SDK, 
    such as how to sync changes in the background or pause a sync session,
    see: :ref:`Sync Changes Between Devices <ios-sync-changes-between-devices>`.
 

--- a/source/sdk/swift/sync/flexible-sync.txt
+++ b/source/sdk/swift/sync/flexible-sync.txt
@@ -33,10 +33,10 @@ To use Flexible Sync in an iOS client:
 You can add, update, and remove query subscriptions to determine which data 
 syncs to the client device.
 
-**Note**: Flexible Sync subscriptions only apply to using Atlas Device Sync 
-with regular Realm Objects. If your app uses Asymmetric Sync to unidirectionally
-sync :swift-sdk:`AsymmetricObjects <Extensions/AsymmetricObject.html>` via an 
-Atlas App Services App, you do not create subscriptions for those objects.
+If your app uses :ref:`Asymmetric Sync <optimize-asymmetric-sync>` to 
+unidirectionally sync :swift-sdk:`AsymmetricObjects 
+<Extensions/AsymmetricObject.html>` via an Atlas App Services App, you 
+cannot create subscriptions for those objects.
 
 .. seealso::
 

--- a/source/sdk/swift/sync/stream-data-to-atlas.txt
+++ b/source/sdk/swift/sync/stream-data-to-atlas.txt
@@ -85,10 +85,10 @@ Sync Data Unidirectionally from a Client Application
          
          You cannot query an AsymmetricObject or write it to a local
          realm, so AsymmetricObjects are incompatible with bi-directional
-         Flexible Sync or local Realm use. Automatic schema discovery means
-         that unless you explicitly pass a subset of classes to a realm 
-         in a mixed project, opening a realm can throw an error related to 
-         trying to use an incompatible object type.
+         Flexible Sync, Partition-Based Sync, or local Realm use. Automatic 
+         schema discovery means that unless you explicitly pass a subset 
+         of classes to a realm in a mixed project, opening a realm can 
+         throw an error related to trying to use an incompatible object type.
 
    .. step:: Create Asymmetric Objects
 

--- a/source/sdk/swift/sync/stream-data-to-atlas.txt
+++ b/source/sdk/swift/sync/stream-data-to-atlas.txt
@@ -1,0 +1,103 @@
+.. _swift-stream-data-to-atlas:
+
+================================
+Stream Data to Atlas - Swift SDK
+================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+.. versionadded:: 10.29.0
+
+You can use :ref:`Asymmetric Sync <optimize-asymmetric-sync>` to stream 
+data from the client application to a Flexible Sync-enabled Atlas App Services
+App.
+
+You might want to sync data unidirectionally in IoT applications, such as
+a weather sensor sending data to the cloud. Asymmetric sync is also useful 
+for writing other types of immutable data where you do not require conflict 
+resolution, such as creating invoices from a retail app or logging application 
+events.
+
+Asymmetric Sync is optimized to provide performance improvements for heavy
+client-side *insert-only* workloads.
+
+Sync Data Unidirectionally from a Client Application
+----------------------------------------------------
+
+.. procedure::
+
+   .. step:: Define an AsymmetricObject
+
+      You can data unidirectionally when that object is an 
+      ``AsymmetricObject``.
+      Define an AsymmetricObject by deriving from :swift-sdk:`AsymmetricObject 
+      <Extensions/AsymmetricObject.html>`:
+
+      .. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
+         :language: swift
+
+      For more information on how to define an AsymmetricObject, including
+      limitations when linking to other object types, see: 
+      :ref:`Define an AsymmetricObject <swift-define-asymmetric-object>`.
+
+   .. step:: Connect and Authenticate with an App Services App
+
+      To stream data from the client to your backend App, you must 
+      :ref:`connect to an App Services backend <ios-init-appclient>` and
+      :ref:`authenticate a user <ios-authenticate-users>`.
+
+      .. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.connect-and-authenticate.swift
+         :language: swift
+
+      Asymmetric Sync is a feature of Flexible Sync, so the App you connect 
+      to must use :ref:`Flexible Sync <sync-modes-flexible-sync>`.
+
+   .. step:: Open a Realm
+
+      After you have an authenticated user, you can open a synced realm
+      using a :swift-sdk:`flexibleSyncConfiguration() 
+      <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE25flexibleSyncConfigurationAC0B0V0F0VyF>`.
+      Specify the ``AsymmetricObject`` types you want to sync.
+
+      .. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.open-asymmetric-sync-realm.swift
+         :language: swift
+
+      Unlike bidirectional Sync, Asymmetric Sync does not use a 
+      :ref:`Flexible Sync subscription <swift-manage-flexible-sync-subscriptions>`.
+
+      .. tip:: Mixed Object and AsymmetricObject Types in Projects
+
+         Generally, Realm expects that you do not mix ``Object`` and 
+         ``AsymmetricObject`` types within a project. If your project does
+         contain both types, you must explicitly :ref:`pass a subset of 
+         classes in your Realm configuration 
+         <ios-provide-a-subset-of-classes-to-a-realm>` each time you open 
+         a Realm. 
+         
+         You cannot query an AsymmetricObject or write it to a local
+         realm, so AsymmetricObjects are incompatible with bi-directional
+         Flexible Sync or local Realm use. Automatic schema discovery means
+         that unless you explicitly pass a subset of classes to a realm 
+         in a mixed project, opening a realm can throw an error related to 
+         trying to use an incompatible object type.
+
+   .. step:: Create Asymmetric Objects
+
+      Once you have an open Realm, you can create an ``AsymmetricObject`` inside
+      a write transaction using :swift-sdk:`create(_ type:, value:)
+      <Structs/Realm.html#/s:10RealmSwift0A0V6create_5valueyxm_yptSo0aB16AsymmetricObjectCRbzlF>`.
+
+      .. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.create-asymmetric-object.swift
+         :language: swift
+      
+      You cannot read these objects. Once created, they sync to the App 
+      Services backend and the linked Atlas database.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-23333

### Staged Changes (Requires MongoDB Corp SSO)

- [Model Data/Define an Object Model](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23333/sdk/swift/model-data/define-model/object-models/#define-an-asymmetric-object): New "Define an Asymmetric Object" section
- [CRUD/Create](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23333/sdk/swift/crud/create/#create-an-asymmetric-object): New "Create an Asymmetric Object" section
- [Sync Data/Configure & Open a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23333/sdk/swift/sync/configure-and-open-a-synced-realm/#open-a-synced-realm-for-flexible-sync): Update note to specify Asymmetric Sync does not require a subscription
- [Sync Data/Manage Flexible Sync Subscriptions](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23333/sdk/swift/sync/flexible-sync/#overview): Add note that Asymmetric Sync does not require a subscription
- [Sync Data/Stream Data to Atlas](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23333/sdk/swift/sync/stream-data-to-atlas/): New task-oriented rollup page with some overview content for context, and a procedure putting all the pieces together and calling out some of the specific differences between Asymmetric and bidirectional Sync

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
