### PR TITLE
(DOCSP-24223): Flutter public realm models with `$`

### DIFF
--- a/source/sdk/flutter/realm-database/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/define-realm-object-schema.txt
@@ -62,11 +62,19 @@ Create Model
 
       Create the model for your Realm schema.
       You must include the annotation `RealmModel <https://pub.dev/documentation/realm_common/latest/realm_common/RealmModel-class.html>`__
-      at the top of the class definition. Prepend the class name with
-      an underscore (``_``) to make it private.
+      at the top of the class definition.
 
-      You'll generate the public ``RealmObject`` used throughout the application
-      in step 4.
+      You'll use the ``RealmModel`` to generate the public ``RealmObject``
+      used throughout the application in step 4.
+
+      You can make the model private or public. We recommend making
+      the all models private and defining them in a single file.
+      Prepend the class name with an underscore (``_``) to make it private.
+
+      If you need to define your schema across multiple files,
+      you can make the RealmModel public. Prepend the name with a dollar sign (``$``)
+      to make the model public. You must do this to generate the ``RealmObject``
+      from the ``RealmModel``, as described in step 4.
 
       Add fields to the ``RealmModel``.
       You can add all :ref:`supported data types <flutter-data-types>`.
@@ -75,11 +83,6 @@ Create Model
       .. literalinclude:: /examples/generated/flutter/schemas.snippet.create-realm-model.dart
          :language: dart
          :caption: schemas.dart
-
-      You can also make the ``RealmModel`` public by prepending the name with a
-      dollar sign (``$``). You must do  this to generate the ``RealmObject``
-      from the ``RealmModel``, as described in step 4.
-      Prepending model names with ``$`` lets you define your schema across multiple files.
 
       .. seealso::
 

--- a/source/sdk/flutter/realm-database/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/define-realm-object-schema.txt
@@ -60,10 +60,13 @@ Create Model
 
    .. step:: Create RealmModel
 
-      Create the model for your Realm schema in a private class.
+      Create the model for your Realm schema.
       You must include the annotation `RealmModel <https://pub.dev/documentation/realm_common/latest/realm_common/RealmModel-class.html>`__
-      at the top of the class definition. Prepend the class name with an underscore
-      to make it private. You'll generate the public ``RealmObject`` in step 4.
+      at the top of the class definition. Prepend the class name with
+      an underscore (``_``) to make it private.
+
+      You'll generate the public ``RealmObject`` used throughout the application
+      in step 4.
 
       Add fields to the ``RealmModel``.
       You can add all :ref:`supported data types <flutter-data-types>`.
@@ -72,6 +75,11 @@ Create Model
       .. literalinclude:: /examples/generated/flutter/schemas.snippet.create-realm-model.dart
          :language: dart
          :caption: schemas.dart
+
+      You can also make the ``RealmModel`` public by prepending the name with a
+      dollar sign (``$``). You must do  this to generate the ``RealmObject``
+      from the ``RealmModel``, as described in step 4.
+      Prepending model names with ``$`` lets you define your schema across multiple files.
 
       .. seealso::
 


### PR DESCRIPTION
## Pull Request Info

Public realm models with `$` prefix on class names. 

note that not heavily documenting this functionality b/c the SDK team advocates defining all models in a single file. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-24223

### Staged Changes (Requires MongoDB Corp SSO)

- [Define Realm Object Schema (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24223/sdk/flutter/realm-database/define-realm-object-schema)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
