### PR TITLE
(DOCSP-25095): document 'reuseExisting' support for Realm Kotlin

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/AuthenticationTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/AuthenticationTest.kt
@@ -15,6 +15,13 @@ class AuthenticationTest: RealmTest() {
             val user = app.login(Credentials.anonymous())
         }
         // :snippet-end:
+
+        // :snippet-start: anonymous-authentication-reuse-existing
+        runBlocking { // use runBlocking sparingly -- it can delay UI interactions
+            // logs in with an existing anonymous user, as long as the user hasn't logged out
+            val user = app.login(Credentials.anonymous(reuseExisting = true))
+        }
+        // :snippet-end:
     }
 
     @Test

--- a/source/examples/generated/kotlin/AuthenticationTest.snippet.anonymous-authentication-reuse-existing.kt
+++ b/source/examples/generated/kotlin/AuthenticationTest.snippet.anonymous-authentication-reuse-existing.kt
@@ -1,0 +1,4 @@
+runBlocking { // use runBlocking sparingly -- it can delay UI interactions
+    // logs in with an existing anonymous user, as long as the user hasn't logged out
+    val user = app.login(Credentials.anonymous(reuseExisting = true))
+}

--- a/source/sdk/kotlin/app-services/authenticate-users.txt
+++ b/source/sdk/kotlin/app-services/authenticate-users.txt
@@ -58,7 +58,7 @@ and then pass the generated credential to
    :copyable: false
 
 You can optionally specify whether the anonymous user should be reused by 
-passing ``reuseExisting = true` to ``Credentials.anonymous()`` as long as the anonymous user being reused hasn't logged out.
+passing ``reuseExisting = true`` to ``Credentials.anonymous()`` as long as the anonymous user being reused hasn't logged out.
 The ``reuseExisting`` parameter defaults to false, which creates a new anonymous user credential rather than reusing an existing one.
 
 .. literalinclude:: /examples/generated/kotlin/AuthenticationTest.snippet.anonymous-authentication-reuse-existing.kt

--- a/source/sdk/kotlin/app-services/authenticate-users.txt
+++ b/source/sdk/kotlin/app-services/authenticate-users.txt
@@ -57,6 +57,14 @@ and then pass the generated credential to
    :language: kotlin
    :copyable: false
 
+You can optionally specify whether the anonymous user should be reused by 
+passing ``reuseExisting = true` to ``Credentials.anonymous()`` as long as the anonymous user being reused hasn't logged out.
+The ``reuseExisting`` parameter defaults to false, which creates a new anonymous user credential rather than reusing an existing one.
+
+.. literalinclude:: /examples/generated/kotlin/AuthenticationTest.snippet.anonymous-authentication-reuse-existing.kt
+   :language: kotlin
+   :copyable: false
+
 .. _kotlin-email-password-login:
 
 Email/Password


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-25095

### Staged Changes (Requires MongoDB Corp SSO)

- [Authenticate Users - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/reuse-existing-anon-credential/sdk/kotlin/app-services/authenticate-users/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
