### PR TITLE
(DOCSP-25668): Flutter email/password auth breaking change note

### DIFF
--- a/source/sdk/flutter/users/email-password-users.txt
+++ b/source/sdk/flutter/users/email-password-users.txt
@@ -13,9 +13,18 @@ Email/Password Users - Flutter SDK
 With Atlas App Services's email/password authentication provider, you can register a new
 account, confirm an email address, and reset a user's password from client code.
 
+.. warning:: Version 0.5.0 Breaking Change
+
+   The Realm Flutter SDK version 0.5.0 includes a breaking change to email/password
+   authentication. The change fixes a bug where the unicode null character ``\u0000``
+   was appended to the end of passwords in previous versions of the SDK.
+
+   As a result, once you upgrade your application to use version >0.5.0,
+   users must either reset their password or create a new account.
+   Previous password will no longer work after updating to >0.5.0.
+
 Before You Begin
 ----------------
-
 
 #. :ref:`Create an App Services app <create-a-realm-app>`.
 #. Before you begin writing client code, you should understand the different email/password

--- a/source/sdk/flutter/users/email-password-users.txt
+++ b/source/sdk/flutter/users/email-password-users.txt
@@ -21,7 +21,7 @@ account, confirm an email address, and reset a user's password from client code.
 
    As a result, once you upgrade your application to use version >0.5.0,
    users must either reset their password or create a new account.
-   Previous password will no longer work after updating to >0.5.0.
+   Previous passwords will no longer work after updating to >0.5.0.
 
 Before You Begin
 ----------------


### PR DESCRIPTION
## Pull Request Info

Add warning admonition about breaking change to email/password authentication in SDK v0.5.0

### Jira

- https://jira.mongodb.org/browse/DOCSP-25668

### Staged Changes (Requires MongoDB Corp SSO)

- [Authenticate Users (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-25668/sdk/flutter/users/authenticate)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
