### PR TITLE
(DOCSP-23489): Swift client reset with recovery docs

### DIFF
--- a/examples/ios/Examples/ClientReset.swift
+++ b/examples/ios/Examples/ClientReset.swift
@@ -3,6 +3,7 @@
 //     "ClientReset_": ""
 //   }
 // }
+// swiftlint:disable identifier_name
 import XCTest
 import RealmSwift
 

--- a/examples/ios/Examples/ClientReset.swift
+++ b/examples/ios/Examples/ClientReset.swift
@@ -30,6 +30,10 @@ class ClientReset: XCTestCase {
     func testSpecifyClientResetModeWithBeforeAfterBlock() async {
         let myRecoveryPath = URL(string: "some-file-url")
         // :snippet-start: client-reset-with-blocks
+        // A block called after a client reset error is detected, but before the
+        // client recovery process is executed.
+        // This block could be used for any custom logic, reporting, debugging etc.
+        // This is one example, but your usage may vary.
         let beforeClientResetBlock: (Realm) -> Void = { before in
             var recoveryConfig = Realm.Configuration()
             recoveryConfig.fileURL = myRecoveryPath
@@ -41,16 +45,17 @@ class ClientReset: XCTestCase {
              }
         }
 
+        // A block called after the client recovery process has executed.
+        // This block could be used for custom recovery, reporting, debugging etc.
+        // This is one example, but your usage may vary.
         let afterClientResetBlock: (Realm, Realm) -> Void = { before, after in
-            /// // This block could be used to add custom recovery logic, back-up a realm file, send reporting, etc. For illustration:
-            /// for object in before.objects(myClass.self) {
-            ///     let res = after.objects(myClass.self)
-            ///     if (res.filter("primaryKey == %@", object.primaryKey).first != nil) {
-            ///         // ...custom recovery logic...
-            ///     } else {
-            ///         // ...custom recovery logic...
-            ///     }
-            /// }
+            //     let res = after.objects(myClass.self)
+            //     if (res.filter("primaryKey == %@", object.primaryKey).first != nil) {
+            //         // ...custom recovery logic...
+            //     } else {
+            //         // ...custom recovery logic...
+            //     }
+            // }
         }
 
         do {

--- a/examples/ios/Examples/ClientReset.swift
+++ b/examples/ios/Examples/ClientReset.swift
@@ -56,7 +56,10 @@ class ClientReset: XCTestCase {
         do {
             let app = App(id: YOUR_APP_SERVICES_APP_ID)
             let user = try await app.login(credentials: Credentials.anonymous)
-            var configuration = user.flexibleSyncConfiguration(clientResetMode: .recoverOrDiscardUnsyncedChanges(beforeReset: beforeClientResetBlock, afterReset: afterClientResetBlock))
+            var configuration = user.flexibleSyncConfiguration(clientResetMode:
+                                                                .recoverOrDiscardUnsyncedChanges(
+                                                                    beforeReset: beforeClientResetBlock,
+                                                                    afterReset: afterClientResetBlock))
         } catch {
             print("Error logging in user: \(error.localizedDescription)")
         }

--- a/examples/ios/Examples/ClientReset.swift
+++ b/examples/ios/Examples/ClientReset.swift
@@ -6,6 +6,8 @@
 import XCTest
 import RealmSwift
 
+let APP_ID = "swift-flexible-vkljj"
+
 class ClientReset_Dog: Object {
     @Persisted(primaryKey: true) var _id: ObjectId
     @Persisted var name = ""
@@ -24,8 +26,8 @@ class ClientReset: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testSpecifyClientResetMode() async {
-        // :snippet-start: client-reset-discard-changes-with-blocks
+    func testSpecifyClientResetModeWithBeforeAfterBlock() async {
+        // :snippet-start: client-reset-with-blocks
         let beforeClientResetBlock: (Realm) -> Void = { before in
             // This block could be used to back-up a realm file, send reporting, etc.
         }
@@ -37,13 +39,79 @@ class ClientReset: XCTestCase {
         do {
             let app = App(id: YOUR_APP_SERVICES_APP_ID)
             let user = try await app.login(credentials: Credentials.anonymous)
+            var configuration = user.flexibleSyncConfiguration(clientResetMode: .recoverOrDiscardUnsyncedChanges(beforeReset: beforeClientResetBlock, afterReset: afterClientResetBlock))
+        } catch {
+            print("Error logging in user: \(error.localizedDescription)")
+        }
+        // :snippet-end:
+    }
+    
+    func testSpecifyRecoverUnsyncedChanges() async {
+        do {
+            let app = App(id: YOUR_APP_SERVICES_APP_ID)
+            let user = try await app.login(credentials: Credentials.anonymous)
             // :snippet-start: specify-client-reset-mode
             // Specify the clientResetMode when you create the SyncConfiguration.
-            // If you do not specify, this defaults to `.manual` mode.
-            var configuration = user.configuration(partitionValue: "myPartition", clientResetMode: .discardLocal(beforeClientResetBlock, afterClientResetBlock))
+            // If you do not specify, this defaults to `.recoverUnsyncedChanges` mode.
+            var configuration = user.flexibleSyncConfiguration(clientResetMode: .recoverUnsyncedChanges())
             // :snippet-end:
         } catch {
             print("Error logging in user: \(error.localizedDescription)")
+        }
+    }
+    
+    func testSpecifyDiscardUnsyncedChanges() async {
+        // :snippet-start: specify-discard
+        do {
+            let app = App(id: APP_ID)
+            let user = try await app.login(credentials: Credentials.anonymous)
+            var config = user.flexibleSyncConfiguration(clientResetMode: .discardUnsyncedChanges())
+        } catch {
+            print("Error logging in user: \(error.localizedDescription)")
+        }
+        // :snippet-end:
+    }
+    
+    func testSpecifyManual() async {
+        // :snippet-start: specify-manual
+        do {
+            let app = App(id: APP_ID)
+            let user = try await app.login(credentials: Credentials.anonymous)
+            var config = user.flexibleSyncConfiguration(clientResetMode: .manual())
+        } catch {
+            print("Error logging in user: \(error.localizedDescription)")
+        }
+        // :snippet-end:
+    }
+    
+    func testManualFallbackErrorHandler() async {
+        // :snippet-start: manual-fallback-error-handler
+        func handleClientReset() {
+            // Report the client reset error to the user, or do some custom logic.
+        }
+        
+        do {
+            let app = App(id: APP_ID)
+            let user = try await app.login(credentials: Credentials.anonymous)
+            var config = user.flexibleSyncConfiguration(clientResetMode: .recoverOrDiscardUnsyncedChanges())
+            // If client recovery fails,
+            app.syncManager.errorHandler = { error, session in
+                guard let syncError = error as? SyncError else {
+                    fatalError("Unexpected error type passed to sync error handler! \(error)")
+                }
+                switch syncError.code {
+                case .clientResetError:
+                    if let (path, clientResetToken) = syncError.clientResetInfo() {
+                        handleClientReset()
+                        SyncSession.immediatelyHandleError(clientResetToken, syncManager: app.syncManager)
+                    }
+                default:
+                    // Handle other errors...
+                    ()
+                }
+            }
+        } catch {
+            print("Error: \(error.localizedDescription)")
         }
         // :snippet-end:
     }

--- a/examples/ios/Examples/ClientReset.swift
+++ b/examples/ios/Examples/ClientReset.swift
@@ -28,13 +28,29 @@ class ClientReset: XCTestCase {
     }
 
     func testSpecifyClientResetModeWithBeforeAfterBlock() async {
+        let myRecoveryPath = URL(string: "some-file-url")
         // :snippet-start: client-reset-with-blocks
         let beforeClientResetBlock: (Realm) -> Void = { before in
-            // This block could be used to back-up a realm file, send reporting, etc.
+            var recoveryConfig = Realm.Configuration()
+            recoveryConfig.fileURL = myRecoveryPath
+            do {
+               try before.writeCopy(configuration: recoveryConfig)
+                // The copied realm could be used later for recovery, debugging, reporting, etc.
+             } catch {
+                    // handle error
+             }
         }
 
         let afterClientResetBlock: (Realm, Realm) -> Void = { before, after in
-            // This block could be used to add custom recovery logic, send reporting, etc.
+            /// // This block could be used to add custom recovery logic, back-up a realm file, send reporting, etc. For illustration:
+            /// for object in before.objects(myClass.self) {
+            ///     let res = after.objects(myClass.self)
+            ///     if (res.filter("primaryKey == %@", object.primaryKey).first != nil) {
+            ///         // ...custom recovery logic...
+            ///     } else {
+            ///         // ...custom recovery logic...
+            ///     }
+            /// }
         }
 
         do {

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1575,8 +1575,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 10.28.1;
+				branch = master;
+				kind = branch;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -827,6 +827,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		48FA32DE25B7979C00715468 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1575,8 +1575,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = exactVersion;
+				version = 10.32.0;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/source/examples/generated/code/start/ClientReset.snippet.client-reset-with-blocks.swift
+++ b/source/examples/generated/code/start/ClientReset.snippet.client-reset-with-blocks.swift
@@ -24,7 +24,10 @@ let afterClientResetBlock: (Realm, Realm) -> Void = { before, after in
 do {
     let app = App(id: YOUR_APP_SERVICES_APP_ID)
     let user = try await app.login(credentials: Credentials.anonymous)
-    var configuration = user.flexibleSyncConfiguration(clientResetMode: .recoverOrDiscardUnsyncedChanges(beforeReset: beforeClientResetBlock, afterReset: afterClientResetBlock))
+    var configuration = user.flexibleSyncConfiguration(clientResetMode:
+                                                        .recoverOrDiscardUnsyncedChanges(
+                                                            beforeReset: beforeClientResetBlock,
+                                                            afterReset: afterClientResetBlock))
 } catch {
     print("Error logging in user: \(error.localizedDescription)")
 }

--- a/source/examples/generated/code/start/ClientReset.snippet.client-reset-with-blocks.swift
+++ b/source/examples/generated/code/start/ClientReset.snippet.client-reset-with-blocks.swift
@@ -1,3 +1,7 @@
+// A block called after a client reset error is detected, but before the
+// client recovery process is executed.
+// This block could be used for any custom logic, reporting, debugging etc.
+// This is one example, but your usage may vary.
 let beforeClientResetBlock: (Realm) -> Void = { before in
     var recoveryConfig = Realm.Configuration()
     recoveryConfig.fileURL = myRecoveryPath
@@ -9,16 +13,17 @@ let beforeClientResetBlock: (Realm) -> Void = { before in
      }
 }
 
+// A block called after the client recovery process has executed.
+// This block could be used for custom recovery, reporting, debugging etc.
+// This is one example, but your usage may vary.
 let afterClientResetBlock: (Realm, Realm) -> Void = { before, after in
-    /// // This block could be used to add custom recovery logic, back-up a realm file, send reporting, etc. For illustration:
-    /// for object in before.objects(myClass.self) {
-    ///     let res = after.objects(myClass.self)
-    ///     if (res.filter("primaryKey == %@", object.primaryKey).first != nil) {
-    ///         // ...custom recovery logic...
-    ///     } else {
-    ///         // ...custom recovery logic...
-    ///     }
-    /// }
+    //     let res = after.objects(myClass.self)
+    //     if (res.filter("primaryKey == %@", object.primaryKey).first != nil) {
+    //         // ...custom recovery logic...
+    //     } else {
+    //         // ...custom recovery logic...
+    //     }
+    // }
 }
 
 do {

--- a/source/examples/generated/code/start/ClientReset.snippet.client-reset-with-blocks.swift
+++ b/source/examples/generated/code/start/ClientReset.snippet.client-reset-with-blocks.swift
@@ -9,9 +9,7 @@ let afterClientResetBlock: (Realm, Realm) -> Void = { before, after in
 do {
     let app = App(id: YOUR_APP_SERVICES_APP_ID)
     let user = try await app.login(credentials: Credentials.anonymous)
-    // Specify the clientResetMode when you create the SyncConfiguration.
-    // If you do not specify, this defaults to `.manual` mode.
-    var configuration = user.configuration(partitionValue: "myPartition", clientResetMode: .discardLocal(beforeClientResetBlock, afterClientResetBlock))
+    var configuration = user.flexibleSyncConfiguration(clientResetMode: .recoverOrDiscardUnsyncedChanges(beforeReset: beforeClientResetBlock, afterReset: afterClientResetBlock))
 } catch {
     print("Error logging in user: \(error.localizedDescription)")
 }

--- a/source/examples/generated/code/start/ClientReset.snippet.client-reset-with-blocks.swift
+++ b/source/examples/generated/code/start/ClientReset.snippet.client-reset-with-blocks.swift
@@ -1,9 +1,24 @@
 let beforeClientResetBlock: (Realm) -> Void = { before in
-    // This block could be used to back-up a realm file, send reporting, etc.
+    var recoveryConfig = Realm.Configuration()
+    recoveryConfig.fileURL = myRecoveryPath
+    do {
+       try before.writeCopy(configuration: recoveryConfig)
+        // The copied realm could be used later for recovery, debugging, reporting, etc.
+     } catch {
+            // handle error
+     }
 }
 
 let afterClientResetBlock: (Realm, Realm) -> Void = { before, after in
-    // This block could be used to add custom recovery logic, send reporting, etc.
+    /// // This block could be used to add custom recovery logic, back-up a realm file, send reporting, etc. For illustration:
+    /// for object in before.objects(myClass.self) {
+    ///     let res = after.objects(myClass.self)
+    ///     if (res.filter("primaryKey == %@", object.primaryKey).first != nil) {
+    ///         // ...custom recovery logic...
+    ///     } else {
+    ///         // ...custom recovery logic...
+    ///     }
+    /// }
 }
 
 do {

--- a/source/examples/generated/code/start/ClientReset.snippet.manual-fallback-error-handler.swift
+++ b/source/examples/generated/code/start/ClientReset.snippet.manual-fallback-error-handler.swift
@@ -1,0 +1,27 @@
+func handleClientReset() {
+    // Report the client reset error to the user, or do some custom logic.
+}
+
+do {
+    let app = App(id: APP_ID)
+    let user = try await app.login(credentials: Credentials.anonymous)
+    var config = user.flexibleSyncConfiguration(clientResetMode: .recoverOrDiscardUnsyncedChanges())
+    // If client recovery fails,
+    app.syncManager.errorHandler = { error, session in
+        guard let syncError = error as? SyncError else {
+            fatalError("Unexpected error type passed to sync error handler! \(error)")
+        }
+        switch syncError.code {
+        case .clientResetError:
+            if let (path, clientResetToken) = syncError.clientResetInfo() {
+                handleClientReset()
+                SyncSession.immediatelyHandleError(clientResetToken, syncManager: app.syncManager)
+            }
+        default:
+            // Handle other errors...
+            ()
+        }
+    }
+} catch {
+    print("Error: \(error.localizedDescription)")
+}

--- a/source/examples/generated/code/start/ClientReset.snippet.specify-client-reset-mode.swift
+++ b/source/examples/generated/code/start/ClientReset.snippet.specify-client-reset-mode.swift
@@ -1,3 +1,3 @@
 // Specify the clientResetMode when you create the SyncConfiguration.
-// If you do not specify, this defaults to `.manual` mode.
-var configuration = user.configuration(partitionValue: "myPartition", clientResetMode: .discardLocal(beforeClientResetBlock, afterClientResetBlock))
+// If you do not specify, this defaults to `.recoverUnsyncedChanges` mode.
+var configuration = user.flexibleSyncConfiguration(clientResetMode: .recoverUnsyncedChanges())

--- a/source/examples/generated/code/start/ClientReset.snippet.specify-discard.swift
+++ b/source/examples/generated/code/start/ClientReset.snippet.specify-discard.swift
@@ -1,0 +1,7 @@
+do {
+    let app = App(id: APP_ID)
+    let user = try await app.login(credentials: Credentials.anonymous)
+    var config = user.flexibleSyncConfiguration(clientResetMode: .discardUnsyncedChanges())
+} catch {
+    print("Error logging in user: \(error.localizedDescription)")
+}

--- a/source/examples/generated/code/start/ClientReset.snippet.specify-manual.swift
+++ b/source/examples/generated/code/start/ClientReset.snippet.specify-manual.swift
@@ -1,0 +1,7 @@
+do {
+    let app = App(id: APP_ID)
+    let user = try await app.login(credentials: Credentials.anonymous)
+    var config = user.flexibleSyncConfiguration(clientResetMode: .manual())
+} catch {
+    print("Error logging in user: \(error.localizedDescription)")
+}

--- a/source/includes/client-recovery-rules.rst
+++ b/source/includes/client-recovery-rules.rst
@@ -1,0 +1,11 @@
+When Client Recovery is enabled, these rules determine how objects are 
+integrated, including how conflicts are resolved when both 
+the backend and the client make changes to the same object:
+
+- Objects created locally that were not synced before client reset are synced.
+- If an object is deleted on the server, but is modified on the recovering 
+  client, the delete takes precedence and the client discards the update.
+- If an object is deleted on the recovering client, but not the server, 
+  then the client applies the delete instruction.
+- In the case of conflicting updates to the same field, the client update 
+  is applied.

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -107,7 +107,7 @@ requires specific client reset logic that can't be handled automatically.
 Specify a Client Reset Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 10.32.0. Client recovery added, discardLocal name changed
+.. versionchanged:: 10.32.0 Client recovery added, discardLocal name changed
 
 The Swift SDK provides the option to specify a client 
 reset mode in your :swift-sdk:`SyncConfiguration 
@@ -224,7 +224,7 @@ Client Recovery Rules
 Discard Unsynced Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 10.32.0. .discardLocal changed to .discardUnsyncedChanges
+.. versionchanged:: 10.32.0 .discardLocal changed to .discardUnsyncedChanges
 
 The **discard unsynced changes** client reset mode permanently deletes all 
 local unsynced changes made since the last successful sync. You might 

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -68,7 +68,6 @@ error recovery task that your client app must perform in the following
 situation:
 
 - The given synced realm on the server was restored from a backup.
-  For example, due to a Realm server crash.
 
 - The client app made changes to that realm since the backup was made,
   but did not sync those changes back to the server before the server
@@ -77,6 +76,9 @@ situation:
 In other words, the client app must carry out a client reset on a given
 synced realm if the server is restored to a version older than the
 version on the client.
+
+For more information about what might cause a client reset to occur, see:
+:ref:`client-resets`.
 
 .. _ios-automatic-vs-manual-client-reset:
 
@@ -105,7 +107,7 @@ requires specific client reset logic that can't be handled automatically.
 Specify a Client Reset Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 10.32.0: Client recovery added, discardLocal name changed
+.. versionchanged:: 10.32.0. Client recovery added, discardLocal name changed
 
 The Swift SDK provides the option to specify a client 
 reset mode in your :swift-sdk:`SyncConfiguration 
@@ -141,13 +143,20 @@ you have specific custom logic your app must perform during a client reset,
 or if the :ref:`client recovery rules <ios-client-recovery-rules>` do not 
 work for your app.
 
+.. note:: 
+   
+   If your app uses Swift SDK version 10.24.2 or earlier, ``.clientResetMode`` 
+   is not an available property on the ``SyncConfiguration``.
+
 .. _ios-handle-schema-changes:
 
 Handle Schema Changes
 ~~~~~~~~~~~~~~~~~~~~~
 
-Client Recovery can automatically manage the client reset process in most 
-cases. When you make schema changes, Client Recovery has these limitations:
+:ref:`Client Recovery <enable-or-disable-recovery-mode>` is a feature that is
+enabled by default when you :ref:`configure Device Sync <enable-sync>`. When 
+Client Recovery is enabled, Realm Database can automatically manage the 
+client reset process in most cases. When you make schema changes:
 
 - The client can :ref:`recover unsynced changes <ios-recover-unsynced-changes>` 
   when there are no schema changes, or non-breaking schema changes.
@@ -186,8 +195,10 @@ one of:
   changes that have not yet synced. If the client cannot recover unsynced 
   data, it falls through to :ref:`discard unsynced changes 
   <ios-discard-local-changes>` but continues to automatically perform the 
-  client reset. Choose this mode when you want to enable automatic client 
-  recovery to fall back to discard unsynced changes. 
+  client reset. If there are breaking schema changes, the client cannot 
+  execute an automatic recovery and instead falls through to ``.manual``. 
+  Choose this mode when you want to enable automatic client recovery to 
+  fall back to discard unsynced changes. 
 
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-client-reset-mode.swift
    :language: swift
@@ -196,7 +207,7 @@ If the client reset operation cannot complete in recover unsynced changes mode,
 as in when there are breaking schema changes, the client reset process falls 
 through to ``.manual`` mode. You can set an error handler for this fall
 through case via the :swift-sdk:`SyncManager 
-<https://www.mongodb.com/docs/realm-sdks/swift/latest/Typealiases.html#/s:10RealmSwift11SyncManagera>`:
+<Typealiases.html#/s:10RealmSwift11SyncManagera>`:
 
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.manual-fallback-error-handler.swift
    :language: swift
@@ -206,24 +217,14 @@ through case via the :swift-sdk:`SyncManager
 Client Recovery Rules
 `````````````````````
 
-When Client Recovery is enabled, these rules determine how objects are 
-integrated, including how conflicts are resolved when both 
-the backend and the client make changes to the same object:
-
-- Objects created locally that were not synced before client reset are synced.
-- If an object is deleted on the server, but is modified on the recovering 
-  client, the delete takes precedence and the client discards the update.
-- If an object is deleted on the recovering client, but not the server, 
-  then the client applies the delete instruction.
-- In the case of conflicting updates to the same field, the client update 
-  is applied.
+.. include:: /includes/client-recovery-rules.rst
 
 .. _ios-discard-local-changes:
 
 Discard Unsynced Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 10.32.0: .discardLocal changed to .discardUnsyncedChanges
+.. versionchanged:: 10.32.0. .discardLocal changed to .discardUnsyncedChanges
 
 The **discard unsynced changes** client reset mode permanently deletes all 
 local unsynced changes made since the last successful sync. You might 
@@ -256,10 +257,10 @@ one of:
    :language: swift
 
 If the client reset operation cannot complete in discard unsynced changes mode, 
-as in when there are breaking schema changes, the client reset process falls 
-through to ``.manual`` mode. You can set an error handler for this fall
-through case via the :swift-sdk:`SyncManager 
-<https://www.mongodb.com/docs/realm-sdks/swift/latest/Typealiases.html#/s:10RealmSwift11SyncManagera>`:
+like when there are breaking schema changes, the client reset process falls
+back to ``.manual`` mode. You can set an error handler for this fallback 
+case via the :swift-sdk:`SyncManager 
+<Typealiases.html#/s:10RealmSwift11SyncManagera>`:
 
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.manual-fallback-error-handler.swift
    :language: swift
@@ -272,14 +273,13 @@ Manual Client Reset
 
 When you specify ``.manual`` for ``.clientResetMode``, or if your app makes
 breaking schema changes, you should implement a manual client reset handler.
-If your app uses Swift SDK version 10.24.2 or earlier, ``.clientResetMode`` 
-is not an available property on the SyncConfiguration.
 
 In ``.manual`` mode, you define your own client reset handler. The handler 
 can take an ``ErrorReportingBlock``. We recommend using the
-automatic client recovery modes when possible, and treating the manual
-handler as a fatal error recovery situation where you advise client app 
-users to update the app or perform some other action. 
+:ref:`automatic client recovery modes <ios-automatic-vs-manual-client-reset>` 
+when possible, and treating the manual handler as a tool for fatal error 
+recovery situations where you advise users to update the app or perform 
+some other action. 
 
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-manual.swift
    :language: swift

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -64,8 +64,7 @@ Client Reset
 ------------
 
 When using :ref:`Device Sync <sync>`, a **client reset** is an
-error recovery task that your client app must perform in the following
-situation:
+error recovery task that your client app must perform when:
 
 - The given synced realm on the server was restored from a backup.
 
@@ -77,7 +76,7 @@ In other words, the client app must carry out a client reset on a given
 synced realm if the server is restored to a version older than the
 version on the client.
 
-For more information about what might cause a client reset to occur, see:
+For more information about what might cause a client reset to occur, see
 :ref:`client-resets`.
 
 .. _ios-automatic-vs-manual-client-reset:
@@ -160,11 +159,13 @@ client reset process in most cases. When you make schema changes:
 
 - The client can :ref:`recover unsynced changes <ios-recover-unsynced-changes>` 
   when there are no schema changes, or non-breaking schema changes.
-- When you make breaking schema changes, you must set a :ref:`manual client 
-  reset handler <ios-manual-client-reset-handler>`. Automatic client recovery
-  cannot occur when your app makes breaking schema changes.
+- When you make breaking schema changes, the automatic client reset modes fall
+  back to a manual error handler. You can set a :ref:`manual client 
+  reset error handler <ios-client-reset-manual-fallback>` for this case. 
+  Automatic client recovery cannot occur when your app makes breaking 
+  schema changes.
 
-For information on breaking vs. non-breaking schema changes, see: 
+For information on breaking vs. non-breaking schema changes, see 
 :ref:`breaking-change-quick-reference`.
 
 .. _ios-recover-unsynced-changes:
@@ -203,14 +204,11 @@ one of:
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-client-reset-mode.swift
    :language: swift
 
-If the client reset operation cannot complete in recover unsynced changes mode, 
-as in when there are breaking schema changes, the client reset process falls 
-through to ``.manual`` mode. You can set an error handler for this fall
-through case via the :swift-sdk:`SyncManager 
-<Typealiases.html#/s:10RealmSwift11SyncManagera>`:
-
-.. literalinclude:: /examples/generated/code/start/ClientReset.snippet.manual-fallback-error-handler.swift
-   :language: swift
+There may be times when the client reset operation cannot complete in 
+recover unsynced changes mode, like when there are breaking schema changes or
+:ref:`Client Recovery <recover-unsynced-changes>` is disabled in the 
+Device Sync configuration. To handle this case, your app can implement a
+:ref:`manual client reset fallback <ios-client-reset-manual-fallback>`.
 
 .. _ios-client-recovery-rules:
 
@@ -256,30 +254,26 @@ one of:
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-discard.swift
    :language: swift
 
-If the client reset operation cannot complete in discard unsynced changes mode, 
-like when there are breaking schema changes, the client reset process falls
-back to ``.manual`` mode. You can set an error handler for this fallback 
-case via the :swift-sdk:`SyncManager 
-<Typealiases.html#/s:10RealmSwift11SyncManagera>`:
-
-.. literalinclude:: /examples/generated/code/start/ClientReset.snippet.manual-fallback-error-handler.swift
-   :language: swift
+There may be times when the client reset operation cannot complete in 
+discard unsynced changes mode, like when there are breaking schema changes or
+:ref:`Client Recovery <recover-unsynced-changes>` is disabled in the 
+Device Sync configuration. To handle this case, your app can implement a
+:ref:`manual client reset fallback <ios-client-reset-manual-fallback>`.
 
 .. _ios-manual-client-reset-handler:
 .. _ios-manual-mode:
 
-Manual Client Reset
-~~~~~~~~~~~~~~~~~~~
+Manual Client Reset Mode
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you specify ``.manual`` for ``.clientResetMode``, or if your app makes
-breaking schema changes, you should implement a manual client reset handler.
+When you specify ``.manual`` for ``.clientResetMode``, you should implement 
+a manual client reset handler.
 
 In ``.manual`` mode, you define your own client reset handler. The handler 
 can take an ``ErrorReportingBlock``. We recommend using the
 :ref:`automatic client recovery modes <ios-automatic-vs-manual-client-reset>` 
-when possible, and treating the manual handler as a tool for fatal error 
-recovery situations where you advise users to update the app or perform 
-some other action. 
+when possible, and only choosing ``.manual`` mode if the automatic recovery 
+logic is not suitable for your app.
 
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-manual.swift
    :language: swift
@@ -290,3 +284,20 @@ some other action.
    how you might manually recover changes in a manual client reset, check out
    this :github:`example on GitHub
    <mongodb/realm-practice/blob/main/swift/RealmPractice/Classes/ViewController.swift#L286>`.
+
+.. _ios-client-reset-manual-fallback:
+
+Manual Client Reset Fallback
+----------------------------
+
+If the client reset operation cannot complete automatically, like when there 
+are breaking schema changes, the client reset process falls through to a 
+manual error handler.
+
+You can set an error handler for this fallback case via the :swift-sdk:`SyncManager 
+<Typealiases.html#/s:10RealmSwift11SyncManagera>`. We recommend treating 
+the manual handler as a tool for fatal error recovery situations where 
+you advise users to update the app or perform some other action. 
+
+.. literalinclude:: /examples/generated/code/start/ClientReset.snippet.manual-fallback-error-handler.swift
+   :language: swift

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -64,17 +64,14 @@ Client Reset
 ------------
 
 When using :ref:`Device Sync <sync>`, a **client reset** is an
-error recovery task that your client app must perform when:
+error recovery task that your client app must perform when a given
+synced realm on the server can no longer sync with the client realm. 
+In this case, the client must reset its realm to a state that matches the
+server in order to restore the ability to sync.
 
-- The given synced realm on the server was restored from a backup.
-
-- The client app made changes to that realm since the backup was made,
-  but did not sync those changes back to the server before the server
-  was restored.
-
-In other words, the client app must carry out a client reset on a given
-synced realm if the server is restored to a version older than the
-version on the client.
+When this occurs, the unsyncable realm on the client may contain data that 
+has not yet synced to the server. Realm SDKs can attempt to recover or 
+discard that data during the client reset process.
 
 For more information about what might cause a client reset to occur, see
 :ref:`client-resets`.
@@ -188,18 +185,14 @@ in the :swift-sdk:`SyncConfiguration <Structs/SyncConfiguration.html>` to
 one of:
 
 - ``.recoverUnsyncedChanges``: When you choose this mode, the client attempts 
-  to recover unsynced changes. If there are breaking schema changes, the 
-  client cannot execute an automatic recovery and instead falls 
-  through to ``.manual``. Choose this mode when you do not want to fall
+  to recover unsynced changes. Choose this mode when you do not want to fall
   through to discard unsynced changes. 
 - ``.recoverOrDiscardUnsyncedChanges``: The client first attempts to recover 
   changes that have not yet synced. If the client cannot recover unsynced 
   data, it falls through to :ref:`discard unsynced changes 
   <ios-discard-local-changes>` but continues to automatically perform the 
-  client reset. If there are breaking schema changes, the client cannot 
-  execute an automatic recovery and instead falls through to ``.manual``. 
-  Choose this mode when you want to enable automatic client recovery to 
-  fall back to discard unsynced changes. 
+  client reset. Choose this mode when you want to enable automatic client 
+  recovery to fall back to discard unsynced changes. 
 
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-client-reset-mode.swift
    :language: swift
@@ -288,11 +281,15 @@ logic is not suitable for your app.
 .. _ios-client-reset-manual-fallback:
 
 Manual Client Reset Fallback
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the client reset operation cannot complete automatically, like when there 
 are breaking schema changes, the client reset process falls through to a 
-manual error handler.
+manual error handler. This may occur in any of these automatic client reset modes:
+
+- ``.recoverUnsyncedChanges``
+- ``.recoverOrDiscardUnsyncedChanges``
+- ``.discardUnsyncedChanges`` 
 
 You can set an error handler for this fallback case via the :swift-sdk:`SyncManager 
 <Typealiases.html#/s:10RealmSwift11SyncManagera>`. We recommend treating 

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -73,8 +73,8 @@ When this occurs, the unsyncable realm on the client may contain data that
 has not yet synced to the server. Realm SDKs can attempt to recover or 
 discard that data during the client reset process.
 
-For more information about what might cause a client reset to occur, see
-:ref:`client-resets`.
+For more information about what might cause a client reset to occur, go to
+:ref:`Client Resets in the App Services documentation <client-resets>`.
 
 .. _ios-automatic-vs-manual-client-reset:
 
@@ -230,28 +230,23 @@ To perform an automatic client reset that discards unsynced changes, set
 the :swift-sdk:`.clientResetMode 
 <Structs/SyncConfiguration.html#/s:10RealmSwift17SyncConfigurationV15clientResetModeAA06ClientfG0Ovp>`
 in the :swift-sdk:`SyncConfiguration <Structs/SyncConfiguration.html>` to 
-one of:
-
-- ``.recoverOrDiscardUnsyncedChanges``: When you choose this mode, the 
-  client attempts to recover unsynced changes. If the client cannot recover 
-  unsynced data, it instead falls through to discard it. This enables your 
-  app to complete the automatic client reset without any manual handling 
-  except in the event of breaking schema changes. Choose this mode when 
-  you want to first attempt to recover unsynced changes. 
-- ``.discardUnsyncedChanges``: You might prefer to discard changes by default
-  if the :ref:`Client Recovery Rules <ios-client-recovery-rules>` do not 
-  work for your app's logic. Choose this mode when you do not want to 
-  attempt to recover unsynced changes, but do want to automatically recover
-  from a client reset error.
+``.discardUnsyncedChanges``.
 
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-discard.swift
    :language: swift
 
+.. note:: Discard with Recovery
+
+   If you'd like to attempt to recover unsynced changes, but but discard 
+   any changes that cannot be recovered, refer to the 
+   ``.recoverOrDiscardUnsyncedChanges`` documentation in :ref:`Recover 
+   Unsynced Changes <ios-recover-unsynced-changes>`.
+
 There may be times when the client reset operation cannot complete in 
 discard unsynced changes mode, like when there are breaking schema changes or
 :ref:`Client Recovery <recover-unsynced-changes>` is disabled in the 
-Device Sync configuration. To handle this case, your app can implement a
-:ref:`manual client reset fallback <ios-client-reset-manual-fallback>`.
+server-side Device Sync configuration. To handle this case, your app can 
+implement a :ref:`manual client reset fallback <ios-client-reset-manual-fallback>`.
 
 .. _ios-manual-client-reset-handler:
 .. _ios-manual-mode:

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -106,7 +106,7 @@ requires specific client reset logic that can't be handled automatically.
 Specify a Client Reset Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 10.3x.0: Client recovery added, discardLocal name changed
+.. versionchanged:: 10.32.0: Client recovery added, discardLocal name changed
 
 The Swift SDK provides the option to specify a client 
 reset mode in your :swift-sdk:`SyncConfiguration 
@@ -164,7 +164,7 @@ For information on breaking vs. non-breaking schema changes, see:
 Recover Unsynced Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 10.3x.0
+.. versionadded:: 10.32.0
 
 During a client reset, client applications can attempt to recover data 
 in the local realm that has not yet synced to the backend. To recover 
@@ -224,7 +224,7 @@ the backend and the client make changes to the same object:
 Discard Unsynced Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 10.3x.0: .discardLocal changed to .discardUnsyncedChanges
+.. versionchanged:: 10.32.0: .discardLocal changed to .discardUnsyncedChanges
 
 The **discard unsynced changes** client reset mode permanently deletes all 
 local unsynced changes made since the last successful sync. You might 

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -92,10 +92,9 @@ All the client reset modes except ``.manual`` perform an automatic client
 reset. The differences between the modes are based on how they handle 
 changes on the device that have not yet synced to the backend.
 
-Choose ``.recoverOrDiscardUnsyncedChanges`` to handle most client reset 
+Choose ``.recoverUnsyncedChanges`` to handle most client reset 
 scenarios automatically. This attempts to recover unsynced changes when a 
-client reset occurs, and falls through to discard unsynced changes when 
-the client cannot recover unsynced data.
+client reset occurs.
 
 In some cases, you may want or need to :ref:`set a manual client reset handler 
 <ios-manual-client-reset-handler>`. You may want to do this if your app 
@@ -128,7 +127,7 @@ reset modes <Enums/ClientResetMode.html>`:
 If you do not specify ``.clientResetMode`` in your configuration, the client 
 reset mode defaults to ``.recoverUnsyncedChanges``.
 
-You can specify a before and after block to execute during the automatic client 
+You can specify a ``before`` and ``after`` block to execute during the automatic client 
 reset process. You might use this to perform recovery logic that is important 
 to your application.
 
@@ -178,17 +177,17 @@ the :swift-sdk:`.clientResetMode
 in the :swift-sdk:`SyncConfiguration <Structs/SyncConfiguration.html>` to 
 one of:
 
-- ``.recoverUnsyncedChanges``: choose this mode when you do not want to fall
-  through to discard unsynced changes. When you choose this mode, the 
-  client attempts to recover unsynced changes. If there are breaking schema 
-  changes, the client cannot execute an automatic recovery and instead falls 
-  through to ``.manual``.
-- ``.recoverOrDiscardUnsyncedChanges``: choose this mode when you want to 
-  enable automatic client recovery to fall back to discard unsynced changes. 
-  The client first attempts to recover changes that have not yet synced. 
-  If the client cannot recover unsynced data, it falls through to 
-  :ref:`discard unsynced changes <ios-discard-local-changes>` but continues 
-  to automatically perform the client reset.
+- ``.recoverUnsyncedChanges``: When you choose this mode, the client attempts 
+  to recover unsynced changes. If there are breaking schema changes, the 
+  client cannot execute an automatic recovery and instead falls 
+  through to ``.manual``. Choose this mode when you do not want to fall
+  through to discard unsynced changes. 
+- ``.recoverOrDiscardUnsyncedChanges``: The client first attempts to recover 
+  changes that have not yet synced. If the client cannot recover unsynced 
+  data, it falls through to :ref:`discard unsynced changes 
+  <ios-discard-local-changes>` but continues to automatically perform the 
+  client reset. Choose this mode when you want to enable automatic client 
+  recovery to fall back to discard unsynced changes. 
 
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-client-reset-mode.swift
    :language: swift
@@ -241,17 +240,17 @@ the :swift-sdk:`.clientResetMode
 in the :swift-sdk:`SyncConfiguration <Structs/SyncConfiguration.html>` to 
 one of:
 
-- ``.recoverOrDiscardUnsyncedChanges``: choose this mode when you want to 
-  first attempt to recover unsynced changes. When you choose this mode, the 
+- ``.recoverOrDiscardUnsyncedChanges``: When you choose this mode, the 
   client attempts to recover unsynced changes. If the client cannot recover 
   unsynced data, it instead falls through to discard it. This enables your 
   app to complete the automatic client reset without any manual handling 
-  except in the event of breaking schema changes.
-- ``.discardUnsyncedChanges``: choose this mode when you do not want to 
-  attempt to recover unsynced changes, but do want to automatically recover
-  from a client reset error. You might prefer to discard changes by default
+  except in the event of breaking schema changes. Choose this mode when 
+  you want to first attempt to recover unsynced changes. 
+- ``.discardUnsyncedChanges``: You might prefer to discard changes by default
   if the :ref:`Client Recovery Rules <ios-client-recovery-rules>` do not 
-  work for your app's logic.
+  work for your app's logic. Choose this mode when you do not want to 
+  attempt to recover unsynced changes, but do want to automatically recover
+  from a client reset error.
 
 .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-discard.swift
    :language: swift

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -63,7 +63,7 @@ API calls.
 Client Reset
 ------------
 
-When using :ref:`Device Sync <sync>`, a **client reset** is a serious
+When using :ref:`Device Sync <sync>`, a **client reset** is an
 error recovery task that your client app must perform in the following
 situation:
 
@@ -78,15 +78,38 @@ In other words, the client app must carry out a client reset on a given
 synced realm if the server is restored to a version older than the
 version on the client.
 
-A client reset discards local data and reverts to the data stored in 
-MongoDB Atlas. Performing a client reset loses all local changes made 
-since the client last successfully synced, unless manually recovered
-by the developer.
+.. _ios-automatic-vs-manual-client-reset:
 
-.. versionadded:: 10.25.0
+Automatic vs. Manual Client Reset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting in 10.25.0, the Swift SDK provides the option to specify a client 
-reset strategy in your :swift-sdk:`SyncConfiguration 
+The Realm SDKs provide :ref:`client reset modes <ios-specify-client-reset-mode>` 
+that automatically handle most client reset errors. Automatic client 
+reset modes restore your local realm file to a syncable state without 
+closing the realm or missing notifications. 
+
+All the client reset modes except ``.manual`` perform an automatic client 
+reset. The differences between the modes are based on how they handle 
+changes on the device that have not yet synced to the backend.
+
+Choose ``.recoverOrDiscardUnsyncedChanges`` to handle most client reset 
+scenarios automatically. This attempts to recover unsynced changes when a 
+client reset occurs, and falls through to discard unsynced changes when 
+the client cannot recover unsynced data.
+
+In some cases, you may want or need to :ref:`set a manual client reset handler 
+<ios-manual-client-reset-handler>`. You may want to do this if your app 
+requires specific client reset logic that can't be handled automatically.
+
+.. _ios-specify-client-reset-mode:
+
+Specify a Client Reset Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionchanged:: 10.3x.0: Client recovery added, discardLocal name changed
+
+The Swift SDK provides the option to specify a client 
+reset mode in your :swift-sdk:`SyncConfiguration 
 <Structs/SyncConfiguration.html>`. This is the :swift-sdk:`.clientResetMode 
 <Structs/SyncConfiguration.html#/s:10RealmSwift17SyncConfigurationV15clientResetModeAA06ClientfG0Ovp>`
 property. 
@@ -95,111 +118,176 @@ property.
    :language: swift
 
 This property takes :swift-sdk:`an enum representing the different client 
-reset strategies <Enums/ClientResetMode.html>`: 
+reset modes <Enums/ClientResetMode.html>`: 
 
-- ``.discardLocal`` 
+- ``.recoverUnsyncedChanges``
+- ``.recoverOrDiscardUnsyncedChanges``
+- ``.discardUnsyncedChanges`` 
 - ``.manual``
 
-If you do not specify ``.clientResetMode`` in your configuration, it 
-defaults to ``.manual``.
+If you do not specify ``.clientResetMode`` in your configuration, the client 
+reset mode defaults to ``.recoverUnsyncedChanges``.
+
+You can specify a before and after block to execute during the automatic client 
+reset process. You might use this to perform recovery logic that is important 
+to your application.
+
+.. literalinclude:: /examples/generated/code/start/ClientReset.snippet.client-reset-with-blocks.swift
+   :language: swift
+
+If your app has specific client recovery needs, you 
+can specify the ``.manual`` client reset mode and set a :ref:`manual client
+reset handler <ios-manual-client-reset-handler>`. You might do this if 
+you have specific custom logic your app must perform during a client reset,
+or if the :ref:`client recovery rules <ios-client-recovery-rules>` do not 
+work for your app.
+
+.. _ios-handle-schema-changes:
+
+Handle Schema Changes
+~~~~~~~~~~~~~~~~~~~~~
+
+Client Recovery can automatically manage the client reset process in most 
+cases. When you make schema changes, Client Recovery has these limitations:
+
+- The client can :ref:`recover unsynced changes <ios-recover-unsynced-changes>` 
+  when there are no schema changes, or non-breaking schema changes.
+- When you make breaking schema changes, you must set a :ref:`manual client 
+  reset handler <ios-manual-client-reset-handler>`. Automatic client recovery
+  cannot occur when your app makes breaking schema changes.
+
+For information on breaking vs. non-breaking schema changes, see: 
+:ref:`breaking-change-quick-reference`.
+
+.. _ios-recover-unsynced-changes:
+
+Recover Unsynced Changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 10.3x.0
+
+During a client reset, client applications can attempt to recover data 
+in the local realm that has not yet synced to the backend. To recover 
+unsynced changes, :ref:`Client Recovery <recover-unsynced-changes>` must 
+be :ref:`enabled in your App Services App <enable-or-disable-recovery-mode>`, 
+as it is by default.
+
+If you want your app to recover changes that have not yet synced, set 
+the :swift-sdk:`.clientResetMode 
+<Structs/SyncConfiguration.html#/s:10RealmSwift17SyncConfigurationV15clientResetModeAA06ClientfG0Ovp>`
+in the :swift-sdk:`SyncConfiguration <Structs/SyncConfiguration.html>` to 
+one of:
+
+- ``.recoverUnsyncedChanges``: choose this mode when you do not want to fall
+  through to discard unsynced changes. When you choose this mode, the 
+  client attempts to recover unsynced changes. If there are breaking schema 
+  changes, the client cannot execute an automatic recovery and instead falls 
+  through to ``.manual``.
+- ``.recoverOrDiscardUnsyncedChanges``: choose this mode when you want to 
+  enable automatic client recovery to fall back to discard unsynced changes. 
+  The client first attempts to recover changes that have not yet synced. 
+  If the client cannot recover unsynced data, it falls through to 
+  :ref:`discard unsynced changes <ios-discard-local-changes>` but continues 
+  to automatically perform the client reset.
+
+.. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-client-reset-mode.swift
+   :language: swift
+
+If the client reset operation cannot complete in recover unsynced changes mode, 
+as in when there are breaking schema changes, the client reset process falls 
+through to ``.manual`` mode. You can set an error handler for this fall
+through case via the :swift-sdk:`SyncManager 
+<https://www.mongodb.com/docs/realm-sdks/swift/latest/Typealiases.html#/s:10RealmSwift11SyncManagera>`:
+
+.. literalinclude:: /examples/generated/code/start/ClientReset.snippet.manual-fallback-error-handler.swift
+   :language: swift
+
+.. _ios-client-recovery-rules:
+
+Client Recovery Rules
+`````````````````````
+
+When Client Recovery is enabled, these rules determine how objects are 
+integrated, including how conflicts are resolved when both 
+the backend and the client make changes to the same object:
+
+- Objects created locally that were not synced before client reset are synced.
+- If an object is deleted on the server, but is modified on the recovering 
+  client, the delete takes precedence and the client discards the update.
+- If an object is deleted on the recovering client, but not the server, 
+  then the client applies the delete instruction.
+- In the case of conflicting updates to the same field, the client update 
+  is applied.
 
 .. _ios-discard-local-changes:
 
-Discard Local Changes
----------------------
+Discard Unsynced Changes
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you specify ``.discardLocal`` for ``.clientResetMode``, Realm 
-automatically performs a client reset with minimal code and minimal disruption 
-to your application workflow. This client reset mode restores your local 
-realm file to a syncable state without closing the realm or missing 
-notifications.
+.. versionchanged:: 10.3x.0: .discardLocal changed to .discardUnsyncedChanges
 
-Be aware: this strategy permanently deletes all local unsynced changes 
-made since the last successful sync. To incorporate changes, you must 
-recover them manually with a :ref:`client reset handler 
-<ios-manual-client-reset-handler>`. Do not use ``.discardLocal`` mode if 
-your application cannot lose local data that has not yet synced to the backend.
+The **discard unsynced changes** client reset mode permanently deletes all 
+local unsynced changes made since the last successful sync. You might 
+use this mode when your app requires client recovery logic that is not 
+consistent with the Device Sync :ref:`Client Recovery Rules 
+<ios-client-recovery-rules>`, or when you don't want to recover unsynced data.
 
-If the client reset operation cannot complete in discard local changes mode, 
-the client reset process reverts to manual mode.
+Do not use discard unsynced changes mode if your application cannot lose local 
+data that has not yet synced to the backend.
 
-The :swift-sdk:`.discardLocal 
-<Enums/ClientResetMode.html#/s:10RealmSwift15ClientResetModeO12discardLocalyACyAA0A0VcSg_yAF_AFtcSgtcACmF>` 
-version of client reset mode can take a before and after block. This gives 
-you the option to specify additional logic to execute before or after a 
-client reset occurs. You might use these blocks to send reporting or perform
-custom recovery logic, such as copying the realm to a local directory and 
-using your own logic to apply local changes.
+To perform an automatic client reset that discards unsynced changes, set 
+the :swift-sdk:`.clientResetMode 
+<Structs/SyncConfiguration.html#/s:10RealmSwift17SyncConfigurationV15clientResetModeAA06ClientfG0Ovp>`
+in the :swift-sdk:`SyncConfiguration <Structs/SyncConfiguration.html>` to 
+one of:
 
-.. important:: You Still Need a Manual Client Reset Handler
+- ``.recoverOrDiscardUnsyncedChanges``: choose this mode when you want to 
+  first attempt to recover unsynced changes. When you choose this mode, the 
+  client attempts to recover unsynced changes. If the client cannot recover 
+  unsynced data, it instead falls through to discard it. This enables your 
+  app to complete the automatic client reset without any manual handling 
+  except in the event of breaking schema changes.
+- ``.discardUnsyncedChanges``: choose this mode when you do not want to 
+  attempt to recover unsynced changes, but do want to automatically recover
+  from a client reset error. You might prefer to discard changes by default
+  if the :ref:`Client Recovery Rules <ios-client-recovery-rules>` do not 
+  work for your app's logic.
 
-   Some conditions, such as :ref:`breaking or destructive schema changes, 
-   <destructive-changes-synced-schema>` may cause ``.discardLocal`` 
-   client reset mode to fail. When Realm cannot perform the discard local 
-   client reset operation, the process reverts to manual mode. For this
-   reason, you should continue to provide :ref:`a manual client reset 
-   handler <ios-manual-client-reset-handler>` even if you prefer to use 
-   ``.discardLocal`` mode.
+.. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-discard.swift
+   :language: swift
 
-.. example::
+If the client reset operation cannot complete in discard unsynced changes mode, 
+as in when there are breaking schema changes, the client reset process falls 
+through to ``.manual`` mode. You can set an error handler for this fall
+through case via the :swift-sdk:`SyncManager 
+<https://www.mongodb.com/docs/realm-sdks/swift/latest/Typealiases.html#/s:10RealmSwift11SyncManagera>`:
 
-   You can specify a before and after block to execute during the client 
-   reset process. You might use this to perform recovery logic that is 
-   important to your application.
-
-   .. literalinclude:: /examples/generated/code/start/ClientReset.snippet.client-reset-discard-changes-with-blocks.swift
-      :language: swift
+.. literalinclude:: /examples/generated/code/start/ClientReset.snippet.manual-fallback-error-handler.swift
+   :language: swift
 
 .. _ios-manual-client-reset-handler:
 .. _ios-manual-mode:
 
 Manual Client Reset
--------------------
+~~~~~~~~~~~~~~~~~~~
 
-When you specify ``.manual`` for ``.clientResetMode``, or if you do not 
-specify a client reset mode, you should implement your own client reset handler.
-If your app uses 10.24.2 or earlier, ``.clientResetMode`` is not an 
-available property on the SyncConfiguration. Older SDK versions use the manual 
-client reset handler.
+When you specify ``.manual`` for ``.clientResetMode``, or if your app makes
+breaking schema changes, you should implement a manual client reset handler.
+If your app uses Swift SDK version 10.24.2 or earlier, ``.clientResetMode`` 
+is not an available property on the SyncConfiguration.
 
-In ``.manual`` mode, the SDK copies the local realm file into a recovery 
-directory, and deletes the original. The next time your app opens the realm 
-for that partition, the SDK downloads a new copy of the realm. This new realm
-contains all of the data from the backend, and synchronizes as normal.
-You can choose to write a handler to incorporate any local changes that exist
-in the old copied realm file into the newly downloaded realm.
+In ``.manual`` mode, you define your own client reset handler. The handler 
+can take an ``ErrorReportingBlock``. We recommend using the
+automatic client recovery modes when possible, and treating the manual
+handler as a fatal error recovery situation where you advise client app 
+users to update the app or perform some other action. 
 
-The SDK performs client resets automatically on startup when instructed 
-to do so by the App Services App. When a client reset occurs, the SDK creates a 
-backup of local data. By default, the SDK makes no effort to
-recover lost local changes from this backup. However, you can manually
-override the client reset handler to transfer data from the backup 
-copy to the new realm.
-
-If you override the client reset handler, you can access this backup
-copy through the path stored in the :objc-sdk:`SyncError
-<Enums/RLMSyncError.html#/c:@E@RLMSyncError@RLMSyncErrorClientResetError>`
-to manually transfer data from the backup copy to the newly created
-realm.
-
-.. tabs-realm-languages::
-   
-   .. tab::
-       :tabid: swift
-
-       .. literalinclude:: /examples/generated/code/start/Errors.snippet.client-reset.swift
-         :language: swift
-
-   .. tab::
-       :tabid: objective-c
-
-       .. literalinclude:: /examples/generated/code/start/Errors.snippet.client-reset.m
-         :language: objectivec
-
+.. literalinclude:: /examples/generated/code/start/ClientReset.snippet.specify-manual.swift
+   :language: swift
 
 .. tip::
 
-   To see how to recover unsynced local changes in a client reset, check out
+   If you are using an older version of the SDK, and want to see an example of 
+   how you might manually recover changes in a manual client reset, check out
    this :github:`example on GitHub
-   <mongodb/realm-practice/blob/main/swift/RealmPractice/Classes/ViewController.swift#L260>`.
-
+   <mongodb/realm-practice/blob/main/swift/RealmPractice/Classes/ViewController.swift#L286>`.


### PR DESCRIPTION
## Pull Request Info

Note for reviewer: there are a couple of :ref:s that won't work until the App Services Client Reset PR is merged ([#165](https://github.com/mongodb/docs-app-services/pull/165)).

Todo before merging:

- [x] Wait for a Swift SDK version release that includes Recovery Client Reset ([#7938](https://github.com/realm/realm-swift/pull/7938))
- [x] Update "versionadded" and "versionchanged" directives to refer to the Swift SDK version in which these changes are released
- [x] Point SPM in the iOS Examples Xcode project at the Swift SDK version instead of `realm-swift/master`

### Jira

- https://jira.mongodb.org/browse/DOCSP-23489

### Staged Changes (Requires MongoDB Corp SSO)

- [Handle Sync Errors](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23489/sdk/swift/sync/handle-sync-errors/#client-reset): Revised Client Reset section

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
