### PR TITLE
landing page fix

### DIFF
--- a/source/sdk/swift.txt
+++ b/source/sdk/swift.txt
@@ -27,11 +27,9 @@ Realm Swift SDK
    Sync Data </sdk/swift/sync>
    Realm in Xcode Playgrounds </sdk/swift/xcode-playgrounds>
 
-.. introduction::
+Use the Realm Swift SDK to develop iOS, macOS, watchOS and tvOS apps in
+Swift and Objective-C.
 
-   Use the Realm Swift SDK to develop iOS, macOS, watchOS and tvOS apps in 
-   Swift and Objective-C. 
-   
 .. kicker:: Learning Paths
 
 Get Started with Realm Swift

--- a/source/web.txt
+++ b/source/web.txt
@@ -23,17 +23,16 @@ Realm Web SDK
    Release Notes <https://github.com/realm/realm-js/releases>
    Next.js Integration Guide </web/nextjs>
 
-.. introduction::
 
-   The Realm Web SDK lets browser-based applications access
-   data stored in Atlas and interact with App Services services like
-   Functions and authentication. The Web SDK supports both JavaScript and
-   TypeScript.
+The Realm Web SDK lets browser-based applications access
+data stored in Atlas and interact with App Services services like
+Functions and authentication. The Web SDK supports both JavaScript and
+TypeScript.
 
-   Web apps built with Realm use the :ref:`Atlas GraphQL API <graphql-api>`
-   or query data stored in Atlas directly from the browser.
-   Unlike the other Realm SDKs, the Web SDK does not support creating
-   a local database or using :ref:`Atlas Device Sync <sync>`.
+Web apps built with Realm use the :ref:`Atlas GraphQL API <graphql-api>`
+or query data stored in Atlas directly from the browser.
+Unlike the other Realm SDKs, the Web SDK does not support creating
+a local database or using :ref:`Atlas Device Sync <sync>`.
 
 .. kicker:: Learning Paths
 


### PR DESCRIPTION
## Pull Request Info

remove `.. introduction:: ` directive at top of new SDK landing pages, which was making the content just be in 1 column.

### Jira

n/a

### Staged Changes (Requires MongoDB Corp SSO)

- [Swift SDK (landing page)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/landing_page_fix/sdk/swift)
- [Web SDK (landing page)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/landing_page_fix//web)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
