### PR TITLE
Fix .NET landing page spacing

### DIFF
--- a/source/sdk/dotnet.txt
+++ b/source/sdk/dotnet.txt
@@ -26,13 +26,11 @@ Realm .NET SDK
    API Reference <https://www.mongodb.com/docs/realm-sdks/dotnet/latest>
    Release Notes <https://github.com/realm/realm-dotnet/releases>
 
-.. introduction::
+Use the Realm .NET SDK to develop client applications written in C# for .NET,
+`UWP <https://docs.microsoft.com/en-us/windows/uwp/get-started/>`__, `Xamarin
+<https://dotnet.microsoft.com/apps/xamarin>`__, and `Unity
+<https://unity.com/>`_.
 
-   Use the Realm .NET SDK to develop client applications written in C# for .NET,
-   `UWP <https://docs.microsoft.com/en-us/windows/uwp/get-started/>`__, `Xamarin
-   <https://dotnet.microsoft.com/apps/xamarin>`__, and `Unity
-   <https://unity.com/>`_.
-   
 .. kicker:: Learning Paths
 
 Get Started with Realm .NET


### PR DESCRIPTION
## Pull Request Info

remove the `.. introduction::` directive so that the first line of the landing page stretches across the entire screen width.

### Jira

n/a

### Staged Changes (Requires MongoDB Corp SSO)

- [.NET SDK (landing page)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/dotnet_landing_page_fix/sdk/dotnet)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
