### PR TITLE
Remove Flutter `seealso` directives

### DIFF
--- a/source/sdk/flutter/app-services.txt
+++ b/source/sdk/flutter/app-services.txt
@@ -34,10 +34,8 @@ This object provides all other functionality related to
 the backend. Initialize an App with the Realm app ID, which you can
 :ref:`find in the Realm UI <find-your-app-id>`.
 
-.. seealso::
-
-   To learn how to initialize the Realm App client, see
-   :ref:`flutter-connect-to-backend`.
+To learn how to initialize the Realm App client, refer to
+:ref:`Connect to App Services <flutter-connect-to-backend>`.
 
 
 .. button:: Create an App Services Account
@@ -59,10 +57,8 @@ you can implement the following functionality:
 - Link user accounts from different providers
 - Store custom data for a particular user
 
-.. seealso::
-
-   To learn how to set up authentication in your app, see
-   :ref:`Authenticate Users <flutter-authenticate>`.
+To learn how to set up authentication in your app, refer to
+:ref:`Authenticate Users <flutter-authenticate>`.
 
 Device Sync
 -----------
@@ -75,6 +71,4 @@ the data stored in those realms synchronize between all client
 devices through a backend App Services instance. That backend also stores
 realm data in a cloud-based Atlas cluster running MongoDB.
 
-.. seealso::
-
-   To get started with Sync, see :ref:`Device Sync <flutter-sync>`.
+To get started with Sync, refer to :ref:`Device Sync <flutter-sync>`.

--- a/source/sdk/flutter/quick-start.txt
+++ b/source/sdk/flutter/quick-start.txt
@@ -31,9 +31,7 @@ a Realm object schema.
 You then have to generate the :flutter-sdk:`RealmObject <realm/RealmObject-mixin.html>`
 class that's used within your application.
 
-.. seealso:: Further Reading
-
-   :ref:`Define a Realm Object Schema - Flutter SDK <flutter-define-realm-object-schema>`
+For more information, refer to :ref:`Define a Realm Object Schema - Flutter SDK <flutter-define-realm-object-schema>`.
 
 Create Data Model
 ~~~~~~~~~~~~~~~~~
@@ -70,8 +68,6 @@ Some considerations when defining your Realm model class:
       .. literalinclude:: /examples/generated/flutter/define_realm_model_test.snippet.define-model-dart.dart
          :language: dart
          :caption: car.dart
-
-
 
 .. _flutter-generate-realmobject-class:
 
@@ -136,9 +132,7 @@ to generate an instance of that realm:
 
 You can now use that realm instance to work with objects in the database.
 
-.. seealso:: Further Reading
-
-   :ref:`Open and Close a Realm - Flutter SDK <flutter-open-close-realm>`
+For more information, refer to :ref:`Open and Close a Realm - Flutter SDK <flutter-open-close-realm>`.
 
 Work with Realm Objects
 -----------------------
@@ -146,9 +140,7 @@ Work with Realm Objects
 Once you've opened a realm, you can create objects within it using a
 :flutter-sdk:`write transaction block <realm/Realm/write.html>`.
 
-.. seealso:: Further Reading
-
-   :ref:`Read and Write Data - Flutter SDK <flutter-read-write-data>`
+For more information, refer to :ref:`Read and Write Data - Flutter SDK <flutter-read-write-data>`.
 
 Create Objects
 ~~~~~~~~~~~~~~
@@ -241,9 +233,7 @@ Once you've finished listening to changes, close the change listener to prevent 
 .. literalinclude:: /examples/generated/flutter/react_to_changes_test.snippet.cancel-subscription.dart
    :language: dart
 
-.. seealso:: Further Reading
-
-   :ref:`React to Changes - Flutter SDK <flutter-react-to-changes>`
+For more information, refer to :ref:`React to Changes - Flutter SDK <flutter-react-to-changes>`.
 
 Close a Realm
 -------------

--- a/source/sdk/flutter/realm-database/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/define-realm-object-schema.txt
@@ -84,11 +84,6 @@ Create Model
          :language: dart
          :caption: schemas.dart
 
-      .. seealso::
-
-         - :ref:`Supported Data Types - Flutter SDK <flutter-data-types>`
-         - :ref:`Property Annotations - Flutter SDK <flutter-property-annotations>`
-
    .. step:: Generate RealmObject
 
       Generate the ``RealmObject``, which you'll use in your application:
@@ -168,6 +163,12 @@ For further information on defining your schema and which of these approaches yo
 should consider for your application, refer to the :ref:`Create a Realm Schema documentation
 <create-schema-for-backend-realm-app>`.
 
+Supported Data Types
+--------------------
+
+You can define schemas with supports many Dart-language data types, in addition
+to some Realm-specific types. For a comprehensive reference of all supported data types,
+refer to :ref:`Data Types <flutter-data-types>`.
 
 .. _flutter-client-relationships:
 
@@ -216,10 +217,6 @@ Property Annotations
 --------------------
 
 Use annotations to add functionality to properties in your Realm object models.
-
-.. seealso::
-
-   :ref:`Supported Data Types - Flutter SDK <flutter-data-types>`
 
 .. _flutter-required-optional-properties:
 

--- a/source/sdk/flutter/realm-database/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/define-realm-object-schema.txt
@@ -166,9 +166,8 @@ should consider for your application, refer to the :ref:`Create a Realm Schema d
 Supported Data Types
 --------------------
 
-You can define schemas with supports many Dart-language data types, in addition
-to some Realm-specific types. For a comprehensive reference of all supported data types,
-refer to :ref:`Data Types <flutter-data-types>`.
+Realm schemas support many Dart-language data types, in addition to some Realm-specific types.
+For a comprehensive reference of all supported data types, refer to :ref:`Data Types <flutter-data-types>`.
 
 .. _flutter-client-relationships:
 

--- a/source/sdk/flutter/users/authenticate.txt
+++ b/source/sdk/flutter/users/authenticate.txt
@@ -83,11 +83,9 @@ Then pass the credential to ``app.logIn``.
 .. literalinclude:: /examples/generated/flutter/authenticate_users_test.snippet.email-password-credentials.dart
    :language: dart
 
-.. seealso::
-
-   To learn more about the complete flow of using App Services Email/Password
-   authentication, refer to the :ref:`Email/Password Users documentation
-   <flutter-manage-email-password-users>`.
+To learn more about the complete flow of using App Services Email/Password
+authentication, refer to :ref:`Email/Password Users
+<flutter-manage-email-password-users>`.
 
 .. _flutter-login-custom-jwt:
 

--- a/source/sdk/flutter/users/multiple-users.txt
+++ b/source/sdk/flutter/users/multiple-users.txt
@@ -70,9 +70,8 @@ the application's :ref:`active user <active-user>`.
 .. literalinclude:: /examples/generated/flutter/authenticate_users_test.snippet.email-password-credentials.dart
    :language: dart
 
-.. seealso::
-
-   :ref:`Log In Users - Flutter SDK <flutter-login>`
+For more information on logging users in for the first time, refer to
+:ref:`Register a New User Account <flutter-register>`.
 
 .. _flutter-list-all-users-on-the-device:
 

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -13,7 +13,7 @@ Reset a Client Realm - Node SDK
 .. seealso:: Learn More About Client Resets
 
    To learn about the causes of and strategies for handling client
-   resets, check out the Sync :ref:`Client Resets <client-resets>` page.
+   resets, check out the Device Sync :ref:`Client Resets <client-resets>` page.
 
 A **client reset error** is a scenario where a client realm cannot sync
 data with the application backend. Clients in this state may continue to


### PR DESCRIPTION
## Pull Request Info

Remove all `.. seealso::` directives in the Realm Flutter SDK.

replaced all these with "For more information [about a topic (sometimes)], refer to :ref:`Page Title <top-of-page-ref>`."

**Note:** i've prefixed all of the page title links with "refer to". not committed to using this longer-term. did this b/c there were already some "refer to"s spread throughout the flutter docs. there's been some docs team discussion abt what the verb should be here ("see", "go to", maybe something else?). if we want to change "refer to" to something else, it would be a simple find-replace operation.

### Jira

n/a

### Staged Changes (Requires MongoDB Corp SSO)

- [Flutter SDK (changes throughout section)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/remove_flutter_see_also/sdk/flutter)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
