### PR TITLE
(DOCSP-24587): Add writeAsync example to Flutter docs

### DIFF
--- a/examples/dart/test/read_write_data_test.dart
+++ b/examples/dart/test/read_write_data_test.dart
@@ -83,4 +83,19 @@ void main() {
     expect(prius!.miles, 500);
     cleanUpRealm(realm);
   });
+
+  test('Write async', () async {
+    final config = Configuration.local([Car.schema]);
+    final realm = Realm(config);
+    // :snippet-start: write-async
+    // Add Subaru Outback to the realm using `writeAsync`
+    Car newOutback = Car("Subaru", model: "Outback Touring XT", miles: 2);
+    await realm.writeAsync(() {
+      realm.add<Car>(newOutback);
+    });
+    // :snippet-end:
+    final outback = realm.find<Car>("Subaru");
+    expect(outback!.miles, 2);
+    cleanUpRealm(realm);
+  });
 }

--- a/examples/dart/test/read_write_data_test.dart
+++ b/examples/dart/test/read_write_data_test.dart
@@ -90,12 +90,17 @@ void main() {
     // :snippet-start: write-async
     // Add Subaru Outback to the realm using `writeAsync`
     Car newOutback = Car("Subaru", model: "Outback Touring XT", miles: 2);
-    await realm.writeAsync(() {
+   realm.writeAsync(() {
       realm.add<Car>(newOutback);
     });
     // :snippet-end:
     final outback = realm.find<Car>("Subaru");
-    expect(outback!.miles, 2);
+    expect(outback, isNull);
+    expect(realm.isInTransaction, true);
+    // let transaction resolve
+    await Future.delayed(Duration(milliseconds: 500));
+    expect(realm.isInTransaction, false);
+    expect(realm.find<Car>("Subaru")!.miles, 2);
     cleanUpRealm(realm);
   });
 }

--- a/examples/dart/test/read_write_data_test.dart
+++ b/examples/dart/test/read_write_data_test.dart
@@ -4,6 +4,7 @@ import 'package:test/test.dart';
 import 'package:realm_dart/realm.dart';
 import '../bin/models/car.dart';
 import 'utils.dart';
+import 'dart:io';
 
 part 'read_write_data_test.g.dart';
 
@@ -90,7 +91,7 @@ void main() {
     // :snippet-start: write-async
     // Add Subaru Outback to the realm using `writeAsync`
     Car newOutback = Car("Subaru", model: "Outback Touring XT", miles: 2);
-   realm.writeAsync(() {
+    realm.writeAsync(() {
       realm.add<Car>(newOutback);
     });
     // :snippet-end:

--- a/source/examples/generated/flutter/read_write_data_test.snippet.write-async.dart
+++ b/source/examples/generated/flutter/read_write_data_test.snippet.write-async.dart
@@ -1,5 +1,5 @@
 // Add Subaru Outback to the realm using `writeAsync`
 Car newOutback = Car("Subaru", model: "Outback Touring XT", miles: 2);
-await realm.writeAsync(() {
+realm.writeAsync(() {
   realm.add<Car>(newOutback);
 });

--- a/source/examples/generated/flutter/read_write_data_test.snippet.write-async.dart
+++ b/source/examples/generated/flutter/read_write_data_test.snippet.write-async.dart
@@ -1,0 +1,5 @@
+// Add Subaru Outback to the realm using `writeAsync`
+Car newOutback = Car("Subaru", model: "Outback Touring XT", miles: 2);
+await realm.writeAsync(() {
+  realm.add<Car>(newOutback);
+});

--- a/source/sdk/flutter/realm-database/read-and-write-data.txt
+++ b/source/sdk/flutter/realm-database/read-and-write-data.txt
@@ -181,24 +181,3 @@ for how long the Sync client will be writing.
 
 .. literalinclude:: /examples/generated/flutter/read_write_data_test.snippet.write-async.dart
    :language: dart
-
-The ``Realm.writeAsync()`` method automatically handles the entire async write
-transaction for you. Optionally, you can use :flutter-sdk:`Realm.beginWriteAsync() 
-<realm/Realm/beginWriteAsync.html>` to manually initiate an async write, and 
-:flutter-sdk:`Transaction.commitAsync() <realm/Transaction/commitAsync.html>`
-to complete it.
-
-You can pass an optional cancellation token to the ``writeAsync`` methods.
-Using ``token.cancel()`` to cancel a writeAsync operation has different 
-behaviors depending on the operation:
-
-- ``Realm.writeAsync()``: depending on which stage of the write process the operation 
-  is in, the cancellation token may do one of:
-
-  - Cancel the entire transaction.
-  - Cancel waiting for fsync, but still commit the transaction.
-
-- ``Realm.beginWriteAsync()``: cancels the wait to obtain the write lock. This cancels
-  the entire transaction.
-- ``Transaction.commitAsync()``: cancels waiting for fsync. The commit still goes through, 
-  but you aren't notified when the data has been written to the disk.

--- a/source/sdk/flutter/realm-database/read-and-write-data.txt
+++ b/source/sdk/flutter/realm-database/read-and-write-data.txt
@@ -169,8 +169,10 @@ Background Writes
 -----------------
 
 You can add, modify, or delete objects in the background using 
-:flutter-sdk:`Realm.writeAsync() <realm/Realm/writeAsync.html>`. With 
-``writeAsync``, you don't need to pass frozen objects across threads. 
+:flutter-sdk:`Realm.writeAsync() <realm/Realm/writeAsync.html>`. Use 
+``Realm.writeAsync()`` to perform write operations without blocking execution
+of the main process. For example, you might use this to perform a large write 
+operation while you keeping the UI responsive. 
 
 .. literalinclude:: /examples/generated/flutter/read_write_data_test.snippet.write-async.dart
    :language: dart

--- a/source/sdk/flutter/realm-database/read-and-write-data.txt
+++ b/source/sdk/flutter/realm-database/read-and-write-data.txt
@@ -162,3 +162,15 @@ Delete multiple objects with the :flutter-sdk:`Realm.deleteMany()
 
 .. literalinclude:: /examples/generated/flutter/quick_start_test.snippet.delete-many-realm-objects.dart
    :language: dart
+
+.. _flutter-write-async:
+
+Background Writes
+-----------------
+
+You can add, modify, or delete objects in the background using 
+:flutter-sdk:`Realm.writeAsync() <realm/Realm/writeAsync.html>`. With 
+``writeAsync``, you don't need to pass frozen objects across threads. 
+
+.. literalinclude:: /examples/generated/flutter/read_write_data_test.snippet.write-async.dart
+   :language: dart

--- a/source/sdk/flutter/realm-database/read-and-write-data.txt
+++ b/source/sdk/flutter/realm-database/read-and-write-data.txt
@@ -168,7 +168,7 @@ Delete multiple objects with the :flutter-sdk:`Realm.deleteMany()
 Background Writes
 -----------------
 
-You can add, modify, or delete objects in the asynchronously using 
+You can add, modify, or delete objects asynchronously using 
 :flutter-sdk:`Realm.writeAsync() <realm/Realm/writeAsync.html>`. 
 
 When you use ``Realm.writeAsync()`` to perform write operations, waiting 
@@ -182,17 +182,23 @@ for how long the Sync client will be writing.
 .. literalinclude:: /examples/generated/flutter/read_write_data_test.snippet.write-async.dart
    :language: dart
 
+The ``Realm.writeAsync()`` method automatically handles the entire async write
+transaction for you. Optionally, you can use :flutter-sdk:`Realm.beginWriteAsync() 
+<realm/Realm/beginWriteAsync.html>` to manually initiate an async write, and 
+:flutter-sdk:`Transaction.commitAsync() <realm/Transaction/commitAsync.html>`
+to complete it.
+
 You can pass an optional cancellation token to the ``writeAsync`` methods.
 Using ``token.cancel()`` to cancel a writeAsync operation has different 
 behaviors depending on the operation:
 
-- ``writeAsync``: depending on which stage of the write process the operation 
+- ``Realm.writeAsync()``: depending on which stage of the write process the operation 
   is in, the cancellation token may do one of:
 
   - Cancel the entire transaction.
   - Cancel waiting for fsync, but still commit the transaction.
 
-- ``beginWriteAsync``: cancels the wait to obtain the write lock. This cancels
+- ``Realm.beginWriteAsync()``: cancels the wait to obtain the write lock. This cancels
   the entire transaction.
-- ``commitAsync``: cancels waiting for fsync. The commit still goes through, 
+- ``Transaction.commitAsync()``: cancels waiting for fsync. The commit still goes through, 
   but you aren't notified when the data has been written to the disk.

--- a/source/sdk/flutter/realm-database/read-and-write-data.txt
+++ b/source/sdk/flutter/realm-database/read-and-write-data.txt
@@ -168,11 +168,31 @@ Delete multiple objects with the :flutter-sdk:`Realm.deleteMany()
 Background Writes
 -----------------
 
-You can add, modify, or delete objects in the background using 
-:flutter-sdk:`Realm.writeAsync() <realm/Realm/writeAsync.html>`. Use 
-``Realm.writeAsync()`` to perform write operations without blocking execution
-of the main process. For example, you might use this to perform a large write 
-operation while you keeping the UI responsive. 
+You can add, modify, or delete objects in the asynchronously using 
+:flutter-sdk:`Realm.writeAsync() <realm/Realm/writeAsync.html>`. 
+
+When you use ``Realm.writeAsync()`` to perform write operations, waiting 
+to obtain the write lock and committing a transaction occur in the background. 
+Only the write itself occurs on the main process. 
+
+This can reduce time spent blocking the execution of the main process. This 
+is particularly useful when using Device Sync, where you don't know when and
+for how long the Sync client will be writing.
 
 .. literalinclude:: /examples/generated/flutter/read_write_data_test.snippet.write-async.dart
    :language: dart
+
+You can pass an optional cancellation token to the ``writeAsync`` methods.
+Using ``token.cancel()`` to cancel a writeAsync operation has different 
+behaviors depending on the operation:
+
+- ``writeAsync``: depending on which stage of the write process the operation 
+  is in, the cancellation token may do one of:
+
+  - Cancel the entire transaction.
+  - Cancel waiting for fsync, but still commit the transaction.
+
+- ``beginWriteAsync``: cancels the wait to obtain the write lock. This cancels
+  the entire transaction.
+- ``commitAsync``: cancels waiting for fsync. The commit still goes through, 
+  but you aren't notified when the data has been written to the disk.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-24587

### Staged Changes (Requires MongoDB Corp SSO)

- [Read & Write Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24587/sdk/flutter/realm-database/read-and-write-data/#background-writes): New "Background Writes" section w/writeAsync example

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
