### PR TITLE
(DOCSP-23425): JS automatic client reset with recovery

### DIFF
--- a/examples/node/Examples/client-reset.js
+++ b/examples/node/Examples/client-reset.js
@@ -213,7 +213,7 @@ describe.skip("Client Reset with Seamless Loss", () => {
           console.log(syncError);
           try {
             console.log("error type is ClientReset....");
-            const path = realm.path; // realm.path will no be accessible after realm.close()
+            const path = realm.path; // realm.path will not be accessible after realm.close()
             realm.close();
             Realm.App.Sync.initiateClientReset(app, path);
 

--- a/examples/node/Examples/client-reset.js
+++ b/examples/node/Examples/client-reset.js
@@ -38,9 +38,9 @@ describe.skip("Client Reset with Seamless Loss", () => {
         schema: [DogSchema],
         sync: {
           user: app.currentUser,
-          partitionValue: "MyPartitionValue",
+          flexible: true,
           clientReset: {
-            mode: "discardLocal",
+            mode: "discardUnsyncedChanges",
             clientResetBefore: (realm) => {
               console.log("Beginning client reset for ", realm.path);
               // :remove-start:
@@ -84,6 +84,59 @@ describe.skip("Client Reset with Seamless Loss", () => {
       });
     });
     expect(clientResetSuccess).toBe(true);
+  });
+
+  // TODO(DOCSP-23425): investigate real example once sdk changes merged
+  test.skip("Recover Unsynced Changes Mode", async () => {
+    const app = new Realm.App({ id: REALM_APP_ID });
+    await app.logIn(new Realm.Credentials.anonymous());
+    // :snippet-start: recover-unsynced-changes
+    const config = {
+      schema: [DogSchema],
+      sync: {
+        user: app.currentUser,
+        flexible: true,
+        clientReset: {
+          mode: "recoverUnsyncedChanges",
+          clientResetBefore: (realm) => {
+            console.log("Beginning client reset for ", realm.path);
+          },
+          clientResetAfter: (beforeRealm, afterRealm) => {
+            console.log("Finished client reset for", beforeRealm.path);
+            console.log("New realm path", afterRealm.path);
+          },
+        },
+      },
+    };
+
+    const realm = await Realm.open(config);
+    // :snippet-end:
+  });
+  // TODO(DOCSP-23425): investigate real example once sdk changes merged
+  test.skip("Recover or Discard Unsynced Changes Mode", async () => {
+    const app = new Realm.App({ id: REALM_APP_ID });
+    await app.logIn(new Realm.Credentials.anonymous());
+    // :snippet-start: recover-or-discard-unsynced-changes
+    const config = {
+      schema: [DogSchema],
+      sync: {
+        user: app.currentUser,
+        flexible: true,
+        clientReset: {
+          mode: "recoverOrDiscardUnsyncedChanges",
+          clientResetBefore: (realm) => {
+            console.log("Beginning client reset for ", realm.path);
+          },
+          clientResetAfter: (beforeRealm, afterRealm) => {
+            console.log("Finished client reset for", beforeRealm.path);
+            console.log("New realm path", afterRealm.path);
+          },
+        },
+      },
+    };
+
+    const realm = await Realm.open(config);
+    // :snippet-end:
   });
 
   // skipping because there's no way to manually trigger breaking schema changes
@@ -146,7 +199,7 @@ describe.skip("Client Reset with Seamless Loss", () => {
           user: app.currentUser,
           partitionValue: "MyPartitionValue",
           clientReset: {
-            mode: "discardLocal",
+            mode: "discardUnsyncedChanges",
             clientResetBefore: (realm) => {
               // NOT used with destructive schema changes
               console.log("Beginning client reset for ", realm.path);

--- a/examples/node/Examples/client-reset.js
+++ b/examples/node/Examples/client-reset.js
@@ -99,11 +99,10 @@ describe.skip("Client Reset with Seamless Loss", () => {
         clientReset: {
           mode: "recoverUnsyncedChanges",
           onBefore: (realm) => {
-            console.log("Beginning client reset for ", realm.path);
+            // This block could be used for custom recovery, reporting, debugging etc.
           },
           onAfter: (beforeRealm, afterRealm) => {
-            console.log("Finished client reset for", beforeRealm.path);
-            console.log("New realm path", afterRealm.path);
+            // This block could be used for custom recovery, reporting, debugging etc.
           },
           onFallback: (session, path) => {
             // See below "Manual Client Reset Fallback" section for example
@@ -125,11 +124,10 @@ describe.skip("Client Reset with Seamless Loss", () => {
         clientReset: {
           mode: "recoverOrDiscardUnsyncedChanges",
           onBefore: (realm) => {
-            console.log("Beginning client reset for ", realm.path);
+            // This block could be used for custom recovery, reporting, debugging etc.
           },
           onAfter: (beforeRealm, afterRealm) => {
-            console.log("Finished client reset for", beforeRealm.path);
-            console.log("New realm path", afterRealm.path);
+            // This block could be used for custom recovery, reporting, debugging etc.
           },
           onFallback: (session, path) => {
             // See below "Manual Client Reset Fallback" section for example
@@ -258,7 +256,8 @@ describe.skip("Client Reset with Seamless Loss", () => {
               // :remove-end:
             },
             onAfter: (beforeRealm, afterRealm) => {
-              // NOT used with destructive schema changes
+              // Destructive schema changes do not hit this function.
+              // Instead, they go through the error handler.
               console.log("Finished client reset for", beforeRealm.path);
               console.log("New realm path", afterRealm.path);
               // :remove-start:

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -21,7 +21,7 @@
         "jest": "^29.1.2",
         "prettier": "^2.7.1",
         "random-email": "^1.0.3",
-        "realm": "^10.21.0",
+        "realm": "^10.23.0",
         "ts-jest": "^29.0.3",
         "typescript": "^4.8.4"
       },
@@ -7248,9 +7248,10 @@
       }
     },
     "node_modules/realm": {
-      "version": "10.21.1",
+      "version": "10.23.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-10.23.0.tgz",
+      "integrity": "sha512-+a8bj50rg0Q5asOe/zjA7gNns9X0E/HlvXpRN0NVFK939EX8moY7bdVHZf+Dvt6HqC4UIzZxF8Aeqemat4HObA==",
       "hasInstallScript": true,
-      "license": "See the actual license in the file LICENSE",
       "dependencies": {
         "@realm.io/common": "^0.1.4",
         "bindings": "^1.5.0",
@@ -13198,7 +13199,9 @@
       }
     },
     "realm": {
-      "version": "10.21.1",
+      "version": "10.23.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-10.23.0.tgz",
+      "integrity": "sha512-+a8bj50rg0Q5asOe/zjA7gNns9X0E/HlvXpRN0NVFK939EX8moY7bdVHZf+Dvt6HqC4UIzZxF8Aeqemat4HObA==",
       "requires": {
         "@realm.io/common": "^0.1.4",
         "bindings": "^1.5.0",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -25,7 +25,7 @@
     "jest": "^29.1.2",
     "prettier": "^2.7.1",
     "random-email": "^1.0.3",
-    "realm": "^10.21.0",
+    "realm": "^10.23.0",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4"
   },

--- a/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
@@ -26,7 +26,7 @@ const config = {
   schema: [DogSchema],
   sync: {
     user: app.currentUser,
-    partitionValue: "MyPartitionValue",
+    flexible: true,
     clientReset: {
       mode: "discardUnsyncedChanges",
       onBefore: (realm) => {

--- a/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
@@ -34,7 +34,8 @@ const config = {
         console.log("Beginning client reset for ", realm.path);
       },
       onAfter: (beforeRealm, afterRealm) => {
-        // NOT used with destructive schema changes
+        // Destructive schema changes do not hit this function.
+        // Instead, they go through the error handler.
         console.log("Finished client reset for", beforeRealm.path);
         console.log("New realm path", afterRealm.path);
       },

--- a/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
@@ -28,7 +28,7 @@ const config = {
     user: app.currentUser,
     partitionValue: "MyPartitionValue",
     clientReset: {
-      mode: "discardLocal",
+      mode: "discardUnsyncedChanges",
       clientResetBefore: (realm) => {
         // NOT used with destructive schema changes
         console.log("Beginning client reset for ", realm.path);

--- a/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
@@ -29,11 +29,11 @@ const config = {
     partitionValue: "MyPartitionValue",
     clientReset: {
       mode: "discardUnsyncedChanges",
-      clientResetBefore: (realm) => {
+      onBefore: (realm) => {
         // NOT used with destructive schema changes
         console.log("Beginning client reset for ", realm.path);
       },
-      clientResetAfter: (beforeRealm, afterRealm) => {
+      onAfter: (beforeRealm, afterRealm) => {
         // NOT used with destructive schema changes
         console.log("Finished client reset for", beforeRealm.path);
         console.log("New realm path", afterRealm.path);

--- a/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
@@ -5,7 +5,7 @@ async function handleSyncError(session, syncError) {
     console.log(syncError);
     try {
       console.log("error type is ClientReset....");
-      const path = realm.path; // realm.path will no be accessible after realm.close()
+      const path = realm.path; // realm.path will not be accessible after realm.close()
       realm.close();
       Realm.App.Sync.initiateClientReset(app, path);
 

--- a/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.discard-unsynced-changes.js
@@ -5,10 +5,10 @@ const config = {
     flexible: true,
     clientReset: {
       mode: "discardUnsyncedChanges",
-      clientResetBefore: (realm) => {
+      onBefore: (realm) => {
         console.log("Beginning client reset for ", realm.path);
       },
-      clientResetAfter: (beforeRealm, afterRealm) => {
+      onAfter: (beforeRealm, afterRealm) => {
         console.log("Finished client reset for", beforeRealm.path);
         console.log("New realm path", afterRealm.path);
       },

--- a/source/examples/generated/node/client-reset.snippet.manual-client-reset-onmanual.js
+++ b/source/examples/generated/node/client-reset.snippet.manual-client-reset-onmanual.js
@@ -1,0 +1,13 @@
+const config = {
+  schema: [DogSchema],
+  sync: {
+    user: app.currentUser,
+    flexible: true,
+    clientReset: {
+      mode: "manual",
+      onManual: (session, path) => {
+        // handle manual client reset here
+      },
+    },
+  },
+};

--- a/source/examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
@@ -6,11 +6,10 @@ const config = {
     clientReset: {
       mode: "recoverOrDiscardUnsyncedChanges",
       onBefore: (realm) => {
-        console.log("Beginning client reset for ", realm.path);
+        // This block could be used for custom recovery, reporting, debugging etc.
       },
       onAfter: (beforeRealm, afterRealm) => {
-        console.log("Finished client reset for", beforeRealm.path);
-        console.log("New realm path", afterRealm.path);
+        // This block could be used for custom recovery, reporting, debugging etc.
       },
       onFallback: (session, path) => {
         // See below "Manual Client Reset Fallback" section for example

--- a/source/examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
@@ -5,10 +5,10 @@ const config = {
     flexible: true,
     clientReset: {
       mode: "recoverOrDiscardUnsyncedChanges",
-      clientResetBefore: (realm) => {
+      onBefore: (realm) => {
         console.log("Beginning client reset for ", realm.path);
       },
-      clientResetAfter: (beforeRealm, afterRealm) => {
+      onAfter: (beforeRealm, afterRealm) => {
         console.log("Finished client reset for", beforeRealm.path);
         console.log("New realm path", afterRealm.path);
       },

--- a/source/examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
@@ -4,7 +4,7 @@ const config = {
     user: app.currentUser,
     flexible: true,
     clientReset: {
-      mode: "discardUnsyncedChanges",
+      mode: "recoverOrDiscardUnsyncedChanges",
       clientResetBefore: (realm) => {
         console.log("Beginning client reset for ", realm.path);
       },
@@ -15,3 +15,5 @@ const config = {
     },
   },
 };
+
+const realm = await Realm.open(config);

--- a/source/examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
@@ -12,8 +12,9 @@ const config = {
         console.log("Finished client reset for", beforeRealm.path);
         console.log("New realm path", afterRealm.path);
       },
+      onFallback: (session, path) => {
+        // See below "Manual Client Reset Fallback" section for example
+      },
     },
   },
 };
-
-const realm = await Realm.open(config);

--- a/source/examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
@@ -5,12 +5,15 @@ const config = {
     flexible: true,
     clientReset: {
       mode: "recoverUnsyncedChanges",
-      clientResetBefore: (realm) => {
+      onBefore: (realm) => {
         console.log("Beginning client reset for ", realm.path);
       },
-      clientResetAfter: (beforeRealm, afterRealm) => {
+      onAfter: (beforeRealm, afterRealm) => {
         console.log("Finished client reset for", beforeRealm.path);
         console.log("New realm path", afterRealm.path);
+      },
+      onFallback: (session, path) => {
+        return true;
       },
     },
   },

--- a/source/examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
@@ -13,10 +13,8 @@ const config = {
         console.log("New realm path", afterRealm.path);
       },
       onFallback: (session, path) => {
-        return true;
+        // See below "Manual Client Reset Fallback" section for example
       },
     },
   },
 };
-
-const realm = await Realm.open(config);

--- a/source/examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
@@ -6,11 +6,10 @@ const config = {
     clientReset: {
       mode: "recoverUnsyncedChanges",
       onBefore: (realm) => {
-        console.log("Beginning client reset for ", realm.path);
+        // This block could be used for custom recovery, reporting, debugging etc.
       },
       onAfter: (beforeRealm, afterRealm) => {
-        console.log("Finished client reset for", beforeRealm.path);
-        console.log("New realm path", afterRealm.path);
+        // This block could be used for custom recovery, reporting, debugging etc.
       },
       onFallback: (session, path) => {
         // See below "Manual Client Reset Fallback" section for example

--- a/source/examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
+++ b/source/examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
@@ -4,7 +4,7 @@ const config = {
     user: app.currentUser,
     flexible: true,
     clientReset: {
-      mode: "discardUnsyncedChanges",
+      mode: "recoverUnsyncedChanges",
       clientResetBefore: (realm) => {
         console.log("Beginning client reset for ", realm.path);
       },
@@ -15,3 +15,5 @@ const config = {
     },
   },
 };
+
+const realm = await Realm.open(config);

--- a/source/examples/generated/node/client-reset.snippet.recovery-fallback.js
+++ b/source/examples/generated/node/client-reset.snippet.recovery-fallback.js
@@ -1,0 +1,40 @@
+// Must define `realm` at higher scope than `config` so it's accessible
+// from the `onFallback` callback
+let realm;
+
+const config = {
+  schema: [DogSchema],
+  sync: {
+    user: app.currentUser,
+    flexible: true,
+    clientReset: {
+      mode: "recoverOrDiscardUnsyncedChanges", // or "recoverUnsyncedChanges"
+      // can also include `onBefore` and `onAfter` callbacks
+      onFallback: (_session, path) => {
+        try {
+          // Prompt user to perform a client reset immediately. If they don't,
+          // they won't receive any data from the server until they restart the app
+          // and all changes they make will be discarded when the app restarts.
+          const didUserConfirmReset = showUserAConfirmationDialog();
+
+          if (didUserConfirmReset) {
+            // Close and delete old realm from device
+            realm.close();
+            Realm.deleteFile(path);
+
+            // Perform client reset
+            Realm.App.Sync.initiateClientReset(app, path);
+
+            // Navigate the user back to the main page or reopen the
+            // the Realm and reinitialize the current page
+          }
+        } catch (err) {
+          // Reset failed. Notify user that they'll need to
+          // update the app
+        }
+      },
+    },
+  },
+};
+
+realm = await Realm.open(config);

--- a/source/sdk/node/advanced/client-reset-data-recovery.txt
+++ b/source/sdk/node/advanced/client-reset-data-recovery.txt
@@ -10,18 +10,21 @@ Manual Client Reset Data Recovery - Node SDK
    :depth: 3
    :class: singlecol
 
-This page explains how to manually recover unsynced realm data after a client reset.
+This page explains how to manually recover unsynced realm data after a client reset
+using the Manual Recovery client reset mode.
 
 Manual recovery requires significant amounts of code, schema concessions,
 and custom conflict resolution logic.
-You should only perform a manual recovery of unsynced realm data if 
-you cannot lose unsynced data. 
-Otherwise, use the :ref:`discard unsynced changes <node-discard-unsynced-changes>`
-client reset strategy instead.
+You should only perform a manual recovery of unsynced realm data if
+you cannot lose unsynced data and the other automatic client reset methods do not
+meet your use case.
+
+For more information about the other available client reset modes, refer to
+:ref:`Reset a Client Realm <node-client-resets>`.
 
 The specifics of manual recovery depend heavily upon your application
 and your schema. However, there are a few techniques that can help with
-most manual recoveries. The :ref:`Track Changes by Object Strategy section 
+most manual recoveries. The :ref:`Track Changes by Object Strategy section
 <node-client-reset-track-changes-by-object>` demonstrates
 one method of recovering unsynced changes during a client reset.
 
@@ -38,9 +41,9 @@ one method of recovering unsynced changes during a client reset.
 Track Changes by Object Strategy
 --------------------------------
 
-The **track changes by object** manual client reset data recovery strategy 
-lets you recover data already written to the client realm file 
-but not yet synced to the backend. 
+The **track changes by object** manual client reset data recovery strategy
+lets you recover data already written to the client realm file
+but not yet synced to the backend.
 
 In this strategy, you add a "Last Updated Time" to each object model to track
 when each object last changed. We'll watch the

--- a/source/sdk/node/advanced/client-reset-data-recovery.txt
+++ b/source/sdk/node/advanced/client-reset-data-recovery.txt
@@ -1,8 +1,8 @@
 .. _node-advanced-manual-client-reset-data-recovery:
 
-============================================
-Manual Client Reset Data Recovery - Node SDK
-============================================
+===============================================
+Manual Client Reset Data Recovery - Node.js SDK
+===============================================
 
 .. contents:: On this page
    :local:

--- a/source/sdk/node/advanced/client-reset-data-recovery.txt
+++ b/source/sdk/node/advanced/client-reset-data-recovery.txt
@@ -24,7 +24,7 @@ For more information about the other available client reset modes, refer to
 
 The specifics of manual recovery depend heavily upon your application
 and your schema. However, there are a few techniques that can help with
-most manual recoveries. The :ref:`Track Changes by Object Strategy section
+manual recoveries. The :ref:`Track Changes by Object Strategy section
 <node-client-reset-track-changes-by-object>` demonstrates
 one method of recovering unsynced changes during a client reset.
 

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -23,8 +23,8 @@ resets, check out Device Sync :ref:`Client Resets in the App Services documentat
 Client Reset Modes
 ------------------
 
-You can handle client resets in your application using one of the
-available **client reset modes**:
+You can specify which **client reset mode** your app should use
+to restore the realm to a syncable state:
 
 - :ref:`Recover unsynced changes mode <node-recover-unsynced-changes>`:
   When you choose this mode, the client attempts to recover unsynced changes.
@@ -78,11 +78,13 @@ Client Reset with Recovery
 
 Client Recovery is a feature that is enabled by default when you configure Device Sync.
 When Client Recovery is enabled, Realm Database automatically manages the
-client reset process in most cases. When you make schema changes the client
-can recover unsynced changes when there are no schema changes, or non-breaking schema changes.
+client reset process in most cases. The client can recover unsynced changes
+when there are no schema changes, or non-breaking schema changes.
 
-To use Client Recovery, configure your realm with recover unsynced changes or
-recover or discard unsynced changes client reset modes.
+To use Client Recovery, configure your realm with one of the following client reset modes:
+
+- Recover unsynced changes mode
+- Recover or discard unsynced changes
 
 .. include:: /includes/client-recovery-rules.rst
 
@@ -114,10 +116,10 @@ to the ``clientReset`` field of your
 Include these properties in the ``ClientResetConfiguration``:
 
 - ``mode``: Set to ``"recoverUnsyncedChanges"``.
-- ``clientResetBefore``: Optional. Callback function invoked before the SDK executes this mode,
+- ``onBefore``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.
-- ``clientResetAfter``: Optional. Callback function invoked after the SDK successfully
+- ``onAfter``: Optional. Callback function invoked after the SDK successfully
   executes this mode. Provides instances of the realm before and after the client reset.
 - ``onFallback``: Optional. Callback function which the SDK invokes
   only if the automatic recovery fails. For more information, refer to the
@@ -140,6 +142,9 @@ discard unsynced changes but continues to automatically perform the client reset
 Choose this mode when you want to enable automatic client
 recovery to fall back to discard unsynced changes.
 
+Do not use recover or discard unsynced changes mode if your application
+cannot lose local data that has not yet synced to the backend.
+
 To handle client resets with the recover or discard unsynced changes mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
 to the ``clientReset`` field of your
@@ -147,10 +152,10 @@ to the ``clientReset`` field of your
 Include these properties in the ``ClientResetConfiguration``:
 
 - ``mode``: Set to ``"recoverOrDiscardUnsyncedChanges"``.
-- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
+- ``onBefore``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.
-- ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
+- ``onAfter``: Optional. Callback function invoked after the SDK successfully
   executes this mode. Provides instances of the realm before and after the client reset.
 - ``onFallback()``: Optional. Callback function which the SDK invokes
   only if both the automatic recovery and and discarding changes fails.
@@ -252,6 +257,8 @@ Manual Mode
 .. versionchanged:: 10.23.0 onManual callback added
 
 In **manual** mode, you define your own client reset handler.
+You might want to use a manual client reset handler if the Automatic Recovery logic
+does not work for your app and you can't discard unsynced local data.
 
 To handle client resets with manual mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
@@ -273,6 +280,6 @@ Manual Data Recovery
 
 To recover data from a manual client reset requires significant amounts
 of code, schema concessions, and custom conflict resolution logic.
-To learn more about the **manually recover unsynced changes** client reset mode,
+If you need to implement your own custom client reset logic,
 see the :ref:`Advanced Guide to Manual Client Reset Data Recovery
 <node-advanced-manual-client-reset-data-recovery>`.

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -203,7 +203,7 @@ Discard Unsynced Changes Mode
 **Discard Unsynced Changes** mode  permanently deletes all
 local unsynced changes made since the last successful sync.
 You might use this mode when your app requires client recovery logic that is not
-consistent with the :ref:`automatic Client Recovery <node-client-reset-recovery>`,
+consistent with :ref:`automatic Client Recovery <node-client-reset-recovery>`,
 or when you don't want to recover unsynced data.
 
 Do not use discard unsynced changes mode if your application cannot lose local

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -113,7 +113,7 @@ to the ``clientReset`` field of your
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
 Include these properties in the ``ClientResetConfiguration``:
 
-- ``mode``: Set to ``"TODO_RECOVER_USYNCED"``.
+- ``mode``: Set to ``"recoverUnsyncedChanges"``.
 - ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.
@@ -147,7 +147,7 @@ to the ``clientReset`` field of your
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
 Include these properties in the ``ClientResetConfiguration``:
 
-- ``mode``: Set to ``"TODO_RECOVER_OR_DISCARD_USYNCED"``.
+- ``mode``: Set to ``"recoverOrDiscardUnsyncedChanges"``.
 - ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -54,7 +54,7 @@ closing the realm or missing notifications.
 The following client reset modes support automatic client resets:
 
 - Recover unsynced changes mode
-- Recover or discard unsynced Changes mode
+- Recover or discard unsynced changes mode
 - Discard unsynced changes mode
 
 The differences between these modes are based on how they handle
@@ -89,10 +89,10 @@ recover or discard unsynced changes client reset modes.
 For more information about configuring Client Recovery, refer to
 :ref:`Client Recovery <enable-or-disable-recovery-mode>` in the App Services documentation.
 
-Client Recovery cannot occur when your app makes breaking schema changes.
+Client Recovery cannot succeed when your app makes breaking schema changes.
 A breaking change is a change that you can make in your server-side
 schema that requires additional action to handle.
-In this scenario, client reset with fall back to a
+In this scenario, client reset falls back to a
 :ref:`manual error client reset fallback <node-manual-client-reset-fallback>`.
 
 For information on breaking vs. non-breaking schema changes, refer to

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -1,8 +1,8 @@
 .. _node-client-resets:
 
-===============================
-Reset a Client Realm - Node SDK
-===============================
+==================================
+Reset a Client Realm - Node.js SDK
+==================================
 
 .. contents:: On this page
    :local:
@@ -17,24 +17,34 @@ data with the Atlas App Services backend. Clients in this state may continue to
 run and save data locally but cannot send or receive sync changesets
 until they perform a client reset.
 
-You can handle client resets in your application using one of the
-available **client reset modes**:
-
-- TODO: document 2 new modes
-
-- :ref:`Discard Unsynced Changes <node-discard-unsynced-changes>`:
-  Restores the realm to a syncable state by discarding changes made
-  since the last sync.
-
-- :ref:`Manually Recover Unsynced Changes <node-manually-recover-unsynced-changes>`:
-  Downloads a new copy of the realm, and moves the unsyncable realm
-  to a backup. Migrate unsynced data from the backup copy of the
-  realm to the new syncable copy.
-
 To learn about the causes of and modes for handling client
 resets, check out Device Sync :ref:`Client Resets in the App Services documentation <client-resets>`.
 
 .. _node-automatic-vs-manual-client-reset:
+
+Client Reset Modes
+------------------
+
+You can handle client resets in your application using one of the
+available **client reset modes**:
+
+- :ref:`Recover Unsynced Changes mode <node-recover-unsynced-changes>`:
+  When you choose this mode, the client attempts to recover unsynced changes.
+  Choose this mode when you do not want to fall through to discard unsynced changes.
+- :ref:`Recover or Discard Unsynced Changes mode <node-recover-discard-unsynced-changes>`:
+  The client first attempts to recover changes that have not yet synced.
+  If the client cannot recover unsynced  data, it falls through to
+  discard unsynced changes but continues to automatically perform the client reset.
+  Choose this mode when you want to enable automatic client
+  recovery to fall back to discard unsynced changes.
+- :ref:`Discard Unsynced Changes mode <node-discard-unsynced-changes>`:
+  Restores the realm to a syncable state by discarding changes made
+  since the last sync.
+- :ref:`Manual Recovery mode <node-manually-recover-unsynced-changes>`:
+  Downloads a new copy of the realm, and moves the unsyncable realm
+  to a backup. Migrate unsynced data from the backup copy of the
+  realm to the new syncable copy.
+
 
 Automatic vs. Manual Client Reset
 ---------------------------------
@@ -46,115 +56,177 @@ Automatic client reset modes restore your local realm file to a syncable state w
 closing the realm or missing notifications.
 The following client reset modes support automatic client resets:
 
-- TODO: list all JS modes that support automatic
+- Recover Unsynced Changes mode
+- Recover or Discard Unsynced Changes mode
+- Discard Unsynced Changes mode
 
 The differences between these modes are based on how they handle
 changes on the device that have not yet synced to the backend.
-Only ``"manual"`` mode does not perform an automatic client reset.
+Only Manual Recovery mode does not perform an automatic client reset.
 
-Choose ``JS_TODO.recoverUnsyncedChanges`` to handle most client reset
+Choose Recover Unsynced Changes mode to handle most client reset
 scenarios automatically. This attempts to recover unsynced changes when a
 client reset occurs.
 
-In some cases, you may want or need to :ref:`set a manual client reset handler
-<node-manually-recover-unsynced-changes>`. You may want to do this if your app
-requires specific client reset logic that can't be handled automatically.
+If your app requires specific client reset logic that can't be handled automatically,
+you may want or need to :ref:`add a manual client reset handler <node-manually-recover-unsynced-changes>`
+to the automatic client reset mode.
 
-.. _node-handle-schema-changes:
+.. _node-client-reset-recovery:
 
-TODO: refactor section. this pulled pretty directly from swift. kinda confused what to do here. 
+Client Reset with Recovery
+--------------------------
 
-Handle Schema Changes
----------------------
+Client Recovery is a feature that is enabled by default when you configure Device Sync.
+When Client Recovery is enabled, Realm Database automatically manages the
+client reset process in most cases. When you make schema changes the client
+can recover unsynced changes when there are no schema changes, or non-breaking schema changes.
 
-:ref:`Client Recovery <enable-or-disable-recovery-mode>` is a feature that is
-enabled by default when you :ref:`configure Device Sync <enable-sync>`. When
-Client Recovery is enabled, Realm Database can automatically manage the
-client reset process in most cases. When you make schema changes:
+To use Client Recovery, you must use Recover Unsynced Changes or
+Recover or Discard Unsynced Changes client reset mode.
 
-- The client can :ref:`recover unsynced changes <node-recover-unsynced-changes>`
-  when there are no schema changes, or non-breaking schema changes.
-- When you make breaking schema changes, the automatic client reset modes fall
-  back to a manual error handler. You can set a :ref:`manual client
-  reset error handler <node-client-reset-manual-fallback>` for this case.
-  Automatic client recovery cannot occur when your app makes breaking
-  schema changes.
+.. include:: /includes/client-recovery-rules.rst
 
-For information on breaking vs. non-breaking schema changes, see
-:ref:`breaking-change-quick-reference`.
+For more information about configuring Client Recovery, refer to
+:ref:`Client Recovery <enable-or-disable-recovery-mode>` in the App Services documentation.
 
-Client Reset Modes
-------------------
+Client Recovery cannot occur when your app makes breaking schema changes.
+A breaking change is a change that you can make in your server-side
+schema that requires additional action to handle.
+In this scenario, client reset with fall back to a manual error handler.
+In the manual error handler, you can add a :ref:`manual client reset fallback <node-manual-client-reset-fallback>`.
 
-TODO: new mode 1
-~~~~~~~~~~~~~~~~
+For information on breaking vs. non-breaking schema changes, refer to
+:ref:`breaking-change-quick-reference` in the App Services documentation.
 
-TODO
+.. _node-recover-unsynced-changes:
 
-TODO: new mode 2
-~~~~~~~~~~~~~~~~
+Recover Unsynced Changes Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+When you choose this mode, the client attempts to recover unsynced changes with Client Recovery.
+Choose this mode when you do not want to fall through to discard unsynced changes.
+
+To handle client resets with the Discard Unsynced Changes mode,
+pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
+to the ``clientReset`` field of your
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
+Include these properties in the ``ClientResetConfiguration``:
+
+- ``mode``: Set to ``"TODO_RECOVER_USYNCED"``.
+- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
+  when the SDK receives a client reset error from the backend.
+  Provides a copy of the realm.
+- ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
+  executes this mode. Provides instances of the realm before and after the client reset.
+
+The following example implements Recover Unsynced Changes mode:
+
+TODO: literalinclude
+
+There may be times when the client reset operation cannot complete in
+recover unsynced changes mode, like when there are breaking schema changes or
+Client Recovery is disabled in the Device Sync configuration.
+To handle this case, your app can implement a
+:ref:`manual client reset fallback <node-manual-client-reset-fallback>`.
+
+.. _node-recover-discard-unsynced-changes:
+
+Recover or Discard Unsynced Changes Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The client first attempts to recover changes that have not yet synced.
+If the client cannot recover unsynced  data, it falls through to
+discard unsynced changes but continues to automatically perform the client reset.
+Choose this mode when you want to enable automatic client
+recovery to fall back to discard unsynced changes.
+
+To handle client resets with the Discard Unsynced Changes mode,
+pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
+to the ``clientReset`` field of your
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
+Include these properties in the ``ClientResetConfiguration``:
+
+- ``mode``: Set to ``"TODO_RECOVER_OR_DISCARD_USYNCED"``.
+- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
+  when the SDK receives a client reset error from the backend.
+  Provides a copy of the realm.
+- ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
+  executes this mode. Provides instances of the realm before and after the client reset.
+
+The following example implements Recover Unsynced Changes mode:
+
+TODO: literalinclude
+
+There may be times when the client reset operation cannot complete in
+recover unsynced changes mode, like when there are breaking schema changes or
+Client Recovery is disabled in the Device Sync configuration.
+To handle this case, your app can implement a
+:ref:`manual client reset fallback <node-manual-client-reset-fallback>`.
 
 .. _node-discard-unsynced-changes:
 
 Discard Unsynced Changes Mode
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 
 .. versionadded:: 10.11.0
 
-The **discard unsynced changes** client reset strategy helps you perform
-a client reset with minimal code and minimal disruption to your application
-workflow. This strategy restores your local realm to a syncable state without
-closing the realm or missing notifications.
+The Discard Unsynced Changes client reset mode permanently deletes all
+local unsynced changes made since the last successful sync. You might
+use this mode when your app requires client recovery logic that is not
+consistent with the :ref:`Client Recovery Rules <node-client-reset-recovery>`,
+or when you don't want to recover unsynced data.
 
-This strategy comes with a downside: it permanently deletes all
-local unsynced changes made since the last successful sync of the realm.
-Do not use the "discard unsynced changes" strategy if your application
-cannot lose data already written to the client realm file but not yet
-synced to the backend.
+Do not use discard unsynced changes mode if your application cannot lose local
+data that has not yet synced to the backend.
 
-The "discard unsynced changes" strategy can handle every kind of client
-reset error *except* for client resets triggered by
-:ref:`breaking schema changes <destructive-changes-synced-schema>`.
-If your application experiences a breaking schema change, this strategy
-falls back to a mode that mimics the "manually recover unsynced changes"
-strategy.
-
-To handle client resets with the "discard unsynced changes" strategy, 
+To handle client resets with the Discard Unsynced Changes mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
 to the ``clientReset`` field of your
-:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`. 
-Include these properties in the ClientResetConfiguration: 
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
+Include these properties in the ``ClientResetConfiguration``:
 
 - ``mode``: Set to ``"discardLocal"``.
-- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this strategy,
-  when the SDK receives a client reset error from the backend. 
-  Provides a copy of the realm. 
+- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
+  when the SDK receives a client reset error from the backend.
+  Provides a copy of the realm.
 - ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
-  executes this strategy. Provides instances of the realm 
+  executes this mode. Provides instances of the realm
   before and after the client reset.
 
-The following example implements this strategy:
+The following example implements Discard Unsynced Changes mode:
 
 .. literalinclude:: /examples/generated/node/client-reset.snippet.discard-unsynced-changes.js
    :language: javascript
 
+There may be times when the client reset operation cannot complete in
+Discard Unsynced Changes mode, like when there are breaking schema changes.
+To handle this case, your app can implement a :ref:`manual client reset fallback
+<node-manual-client-reset-fallback>`.
 
-TODO: refactor this into the "Manual Client Reset Fallback" section
+.. note:: Discard with Recovery
 
+   If you'd like to attempt to recover unsynced changes, but but discard
+   any changes that cannot be recovered, refer to the
+   :ref:`Recover or Discard Unsynced Changes Mode section <node-recover-discard-unsynced-changes>`.
+
+.. _node-manual-client-reset-fallback:
 .. _node-discard-unsynced-changes-after-breaking-schema-changes:
 
-Discard Unsynced Changes after Breaking Schema Changes
-``````````````````````````````````````````````````````
+Manual Client Reset Fallback
+----------------------------
 
-.. include:: /includes/destructive-schema-change-app-update.rst
+If the client reset operation cannot complete automatically, like when there
+are breaking schema changes, the client reset process falls through to a
+manual error handler. This may occur in any of the automatic client reset modes:
 
-If your application experiences a breaking schema change, the "discard
-unsynced changes" strategy cannot handle the resulting client reset
-automatically. Instead, you must provide a manual client reset
-implementation in the SyncConfiguration ``error()`` callback. The following
-example demonstrates how you can manually handle this error case by
+- Recover Unsynced Changes mode
+- Recover or Discard Unsynced Changes mode
+- Discard Unsynced Changes mode
+
+You must provide a manual client reset implementation
+in the ``SyncConfiguration.error()`` callback.
+The following example demonstrates how you can manually handle this error case by
 discarding all unsynced changes:
 
 .. literalinclude:: /examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
@@ -162,19 +234,11 @@ discarding all unsynced changes:
 
 .. _node-manually-recover-unsynced-changes:
 
-Manually Recovery Mode
-~~~~~~~~~~~~~~~~~~~~~~
+Manual Recovery Mode
+--------------------
 
 Manual recovery requires significant amounts of code, schema concessions,
 and custom conflict resolution logic. To learn more about the **manually
-recover unsynced changes** client reset strategy, see the
+recover unsynced changes** client reset mode, see the
 :ref:`Advanced Guide to Manual Client Reset Data Recovery
 <node-advanced-manual-client-reset-data-recovery>`.
-
-
-.. _node-manual-client-reset-fallback:
-
-Manual Client Reset Fallback
-----------------------------
-
-TODO

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -83,8 +83,8 @@ When Client Recovery is enabled, Realm Database automatically manages the
 client reset process in most cases. When you make schema changes the client
 can recover unsynced changes when there are no schema changes, or non-breaking schema changes.
 
-To use Client Recovery, you must use Recover unsynced changes or
-Recover or Discard Unsynced Changes client reset mode.
+To use Client Recovery, configure your realm with recover unsynced changes or
+recover or discard unsynced changes client reset modes.
 
 .. include:: /includes/client-recovery-rules.rst
 
@@ -94,8 +94,8 @@ For more information about configuring Client Recovery, refer to
 Client Recovery cannot occur when your app makes breaking schema changes.
 A breaking change is a change that you can make in your server-side
 schema that requires additional action to handle.
-In this scenario, client reset with fall back to a manual error handler.
-In the manual error handler, you can add a :ref:`manual client reset fallback <node-manual-client-reset-fallback>`.
+In this scenario, client reset with fall back to a
+:ref:`manual error client reset fallback <node-manual-client-reset-fallback>`.
 
 For information on breaking vs. non-breaking schema changes, refer to
 :ref:`breaking-change-quick-reference` in the App Services documentation.
@@ -109,19 +109,19 @@ When you choose **recover unsynced changes** mode,
 the client attempts to recover unsynced changes with Client Recovery.
 Choose this mode when you do not want to fall through to discard unsynced changes.
 
-To handle client resets with the discard unsynced changes mode,
+To handle client resets with the recover unsynced changes mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
 to the ``clientReset`` field of your
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
 Include these properties in the ``ClientResetConfiguration``:
 
 - ``mode``: Set to ``"recoverUnsyncedChanges"``.
-- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
+- ``clientResetBefore``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.
-- ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
+- ``clientResetAfter``: Optional. Callback function invoked after the SDK successfully
   executes this mode. Provides instances of the realm before and after the client reset.
-- ``onFallback()``: Optional. Callback function which the SDK invokes
+- ``onFallback``: Optional. Callback function which the SDK invokes
   only if the automatic recovery fails. For more information, refer to the
   :ref:`Manual Client Reset Fallback section <node-manual-client-reset-fallback>`.
 
@@ -129,7 +129,6 @@ The following example implements recover unsynced changes mode:
 
 .. literalinclude:: /examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
    :language: js
-   :emphasize-lines: 7
 
 .. _node-recover-discard-unsynced-changes:
 
@@ -143,7 +142,7 @@ discard unsynced changes but continues to automatically perform the client reset
 Choose this mode when you want to enable automatic client
 recovery to fall back to discard unsynced changes.
 
-To handle client resets with the discard unsynced changes mode,
+To handle client resets with the recover or discard unsynced changes mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
 to the ``clientReset`` field of your
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
@@ -180,18 +179,15 @@ You must provide a manual client reset implementation
 in the ``SyncConfiguration.onFallback()`` callback. ``onFallback()`` takes two
 arguments:
 
-- ``session``: :js-sdk:`Session <Realm.App.Sync.Session.html>`. An object representing
+- ``session``: :js-sdk:`Session <Realm.App.Sync.Session.html>` object representing
   the state of the Device Sync session.
-- ``path``: String. Path to the current realm database file.
-
+- ``path``: String with the path to the current realm database file.
 
 The following example demonstrates how you can manually handle this error case by
 discarding all unsynced changes:
 
 .. literalinclude:: /examples/generated/node/client-reset.snippet.recovery-fallback.js
    :language: js
-   :emphasize-lines: 7
-
 
 .. _node-discard-unsynced-changes:
 
@@ -218,10 +214,10 @@ to the ``clientReset`` field of your
 Include these properties in the ``ClientResetConfiguration``:
 
 - ``mode``: Set to ``"discardUnsyncedChanges"``.
-- ``onBefore()``: Optional. Callback function invoked before the SDK executes this mode,
+- ``onBefore``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.
-- ``onAfter()``: Optional. Callback function invoked after the SDK successfully
+- ``onAfter``: Optional. Callback function invoked after the SDK successfully
   executes this mode. Provides instances of the realm
   before and after the client reset.
 
@@ -234,8 +230,6 @@ The following example implements discard unsynced changes mode:
 
 Discard Unsynced Changes after Breaking Schema Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/destructive-schema-change-app-update.rst
 
 If your application experiences a breaking schema change, discard
 unsynced changes mode cannot handle the resulting client reset
@@ -255,13 +249,33 @@ discarding all unsynced changes:
 
 .. _node-manually-recover-unsynced-changes:
 
-Manual Recovery Mode
-~~~~~~~~~~~~~~~~~~~~
+Manual Mode
+-----------
 
 .. versionchanged:: 10.23.0 onManual callback added
 
-Manual recovery requires significant amounts of code, schema concessions,
-and custom conflict resolution logic. To learn more about the **manually
-recover unsynced changes** client reset mode, see the
-:ref:`Advanced Guide to Manual Client Reset Data Recovery
+In **manual** mode, you define your own client reset handler.
+
+To handle client resets with manual mode,
+pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
+to the ``clientReset`` field of your
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
+Include these properties in the ``ClientResetConfiguration``:
+
+- ``mode``: Set to ``"manual"``.
+- ``onManual``: Optional. Callback function invoked when the client reset occurs.
+  Provides information about the sync session and the path to the current realm.
+  If you don't set the ``onManual`` error handler, the client reset error falls
+  back to the general sync error handler.
+
+.. literalinclude:: /examples/generated/node/client-reset.snippet.manual-client-reset-onmanual.js
+   :language: js
+
+Manual Data Recovery
+~~~~~~~~~~~~~~~~~~~~
+
+To recover data from a manual client reset requires significant amounts
+of code, schema concessions, and custom conflict resolution logic.
+To learn more about the **manually recover unsynced changes** client reset mode,
+see the :ref:`Advanced Guide to Manual Client Reset Data Recovery
 <node-advanced-manual-client-reset-data-recovery>`.

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -28,19 +28,19 @@ Client Reset Modes
 You can handle client resets in your application using one of the
 available **client reset modes**:
 
-- :ref:`Recover Unsynced Changes mode <node-recover-unsynced-changes>`:
+- :ref:`Recover unsynced changes mode <node-recover-unsynced-changes>`:
   When you choose this mode, the client attempts to recover unsynced changes.
   Choose this mode when you do not want to fall through to discard unsynced changes.
-- :ref:`Recover or Discard Unsynced Changes mode <node-recover-discard-unsynced-changes>`:
+- :ref:`Recover or discard unsynced changes mode <node-recover-discard-unsynced-changes>`:
   The client first attempts to recover changes that have not yet synced.
   If the client cannot recover unsynced  data, it falls through to
   discard unsynced changes but continues to automatically perform the client reset.
   Choose this mode when you want to enable automatic client
   recovery to fall back to discard unsynced changes.
-- :ref:`Discard Unsynced Changes mode <node-discard-unsynced-changes>`:
+- :ref:`Discard unsynced changes mode <node-discard-unsynced-changes>`:
   Restores the realm to a syncable state by discarding changes made
   since the last sync.
-- :ref:`Manual Recovery mode <node-manually-recover-unsynced-changes>`:
+- :ref:`Manual recovery mode <node-manually-recover-unsynced-changes>`:
   Downloads a new copy of the realm, and moves the unsyncable realm
   to a backup. Migrate unsynced data from the backup copy of the
   realm to the new syncable copy.
@@ -55,15 +55,15 @@ Automatic client reset modes restore your local realm file to a syncable state w
 closing the realm or missing notifications.
 The following client reset modes support automatic client resets:
 
-- Recover Unsynced Changes mode
-- Recover or Discard Unsynced Changes mode
-- Discard Unsynced Changes mode
+- Recover unsynced changes mode
+- Recover or discard unsynced Changes mode
+- Discard unsynced changes mode
 
 The differences between these modes are based on how they handle
 changes on the device that have not yet synced to the backend.
-Only Manual Recovery mode does not perform an automatic client reset.
+Only manual recovery mode does not perform an automatic client reset.
 
-Choose Recover Unsynced Changes mode to handle most client reset
+Choose recover unsynced changes mode to handle most client reset
 scenarios automatically. This attempts to recover unsynced changes when a
 client reset occurs.
 
@@ -83,7 +83,7 @@ When Client Recovery is enabled, Realm Database automatically manages the
 client reset process in most cases. When you make schema changes the client
 can recover unsynced changes when there are no schema changes, or non-breaking schema changes.
 
-To use Client Recovery, you must use Recover Unsynced Changes or
+To use Client Recovery, you must use Recover unsynced changes or
 Recover or Discard Unsynced Changes client reset mode.
 
 .. include:: /includes/client-recovery-rules.rst
@@ -105,11 +105,11 @@ For information on breaking vs. non-breaking schema changes, refer to
 Recover Unsynced Changes Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you choose **Recover Unsynced Changes** mode,
+When you choose **recover unsynced changes** mode,
 the client attempts to recover unsynced changes with Client Recovery.
 Choose this mode when you do not want to fall through to discard unsynced changes.
 
-To handle client resets with the Discard Unsynced Changes mode,
+To handle client resets with the discard unsynced changes mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
 to the ``clientReset`` field of your
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
@@ -125,7 +125,7 @@ Include these properties in the ``ClientResetConfiguration``:
   only if the automatic recovery fails. For more information, refer to the
   :ref:`Manual Client Reset Fallback section <node-manual-client-reset-fallback>`.
 
-The following example implements Recover Unsynced Changes mode:
+The following example implements recover unsynced changes mode:
 
 .. literalinclude:: /examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
    :language: js
@@ -136,14 +136,14 @@ The following example implements Recover Unsynced Changes mode:
 Recover or Discard Unsynced Changes Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In **Recover or Discard Unsynced Changes** mode,
+In **recover or discard unsynced changes** mode,
 the client first attempts to recover changes that have not yet synced.
 If the client cannot recover unsynced  data, it falls through to
 discard unsynced changes but continues to automatically perform the client reset.
 Choose this mode when you want to enable automatic client
 recovery to fall back to discard unsynced changes.
 
-To handle client resets with the Discard Unsynced Changes mode,
+To handle client resets with the discard unsynced changes mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
 to the ``clientReset`` field of your
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
@@ -160,7 +160,7 @@ Include these properties in the ``ClientResetConfiguration``:
   For more information, refer to the :ref:`Manual Client Reset Fallback section
   <node-manual-client-reset-fallback>`.
 
-The following example implements Recover Unsynced Changes mode:
+The following example implements recover unsynced changes mode:
 
 .. literalinclude:: /examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
    :language: js
@@ -174,14 +174,24 @@ Manual Client Reset Fallback
 If the client reset with recovery cannot complete automatically,
 like when there are breaking schema changes, the client reset process falls through
 to a manual error handler. This may occur in either of the client reset with recovery modes,
-Recover Unsynced Changes and Recover or Discard Unsynced Changes.
+recover unsynced changes and recover or discard unsynced changes.
 
 You must provide a manual client reset implementation
-in the ``SyncConfiguration.onFallback()`` callback.
+in the ``SyncConfiguration.onFallback()`` callback. ``onFallback()`` takes two
+arguments:
+
+- ``session``: :js-sdk:`Session <Realm.App.Sync.Session.html>`. An object representing
+  the state of the Device Sync session.
+- ``path``: String. Path to the current realm database file.
+
+
 The following example demonstrates how you can manually handle this error case by
 discarding all unsynced changes:
 
-TODO: literalinclude. still waiting on an example in the JS PR. cannot make example until then.
+.. literalinclude:: /examples/generated/node/client-reset.snippet.recovery-fallback.js
+   :language: js
+   :emphasize-lines: 7
+
 
 .. _node-discard-unsynced-changes:
 
@@ -190,7 +200,7 @@ Discard Unsynced Changes Mode
 
 .. versionadded:: 10.11.0
 
-.. versionchanged:: 10.23.0 Mode renamed from "discardLocal" to "discardUnsyncedChanges". Both currently work, but in a future version, "discardLocal" will be removed.
+.. versionchanged:: 10.23.0 Mode renamed from "discardLocal" to "discardUnsyncedChanges". Both currently work, but in a future version, "discardLocal" will be removed. "clientResetBefore" and "clientResetAfter" callbacks renamed to "onBefore" and "onAfter", respectively.
 
 **Discard Unsynced Changes** mode  permanently deletes all
 local unsynced changes made since the last successful sync.
@@ -201,21 +211,21 @@ or when you don't want to recover unsynced data.
 Do not use discard unsynced changes mode if your application cannot lose local
 data that has not yet synced to the backend.
 
-To handle client resets with the Discard Unsynced Changes mode,
+To handle client resets with the discard unsynced changes mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
 to the ``clientReset`` field of your
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
 Include these properties in the ``ClientResetConfiguration``:
 
 - ``mode``: Set to ``"discardUnsyncedChanges"``.
-- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
+- ``onBefore()``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.
-- ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
+- ``onAfter()``: Optional. Callback function invoked after the SDK successfully
   executes this mode. Provides instances of the realm
   before and after the client reset.
 
-The following example implements Discard Unsynced Changes mode:
+The following example implements discard unsynced changes mode:
 
 .. literalinclude:: /examples/generated/node/client-reset.snippet.discard-unsynced-changes.js
    :language: javascript
@@ -227,8 +237,8 @@ Discard Unsynced Changes after Breaking Schema Changes
 
 .. include:: /includes/destructive-schema-change-app-update.rst
 
-If your application experiences a breaking schema change, the "discard
-unsynced changes" strategy cannot handle the resulting client reset
+If your application experiences a breaking schema change, discard
+unsynced changes mode cannot handle the resulting client reset
 automatically. Instead, you must provide a manual client reset
 implementation in the SyncConfiguration ``error()`` callback. The following
 example demonstrates how you can manually handle this error case by
@@ -241,12 +251,14 @@ discarding all unsynced changes:
 
    If you'd like to attempt to recover unsynced changes, but but discard
    any changes that cannot be recovered, refer to the
-   :ref:`Recover or Discard Unsynced Changes Mode section <node-recover-discard-unsynced-changes>`.
+   :ref:`recover or discard unsynced changes mode section <node-recover-discard-unsynced-changes>`.
 
 .. _node-manually-recover-unsynced-changes:
 
 Manual Recovery Mode
 ~~~~~~~~~~~~~~~~~~~~
+
+.. versionchanged:: 10.23.0 onManual callback added
 
 Manual recovery requires significant amounts of code, schema concessions,
 and custom conflict resolution logic. To learn more about the **manually

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -10,18 +10,17 @@ Reset a Client Realm - Node SDK
    :depth: 2
    :class: singlecol
 
-.. seealso:: Learn More About Client Resets
-
-   To learn about the causes of and strategies for handling client
-   resets, check out the Device Sync :ref:`Client Resets <client-resets>` page.
+.. versionchanged:: TODO: add notes about release specific
 
 A **client reset error** is a scenario where a client realm cannot sync
-data with the application backend. Clients in this state may continue to
+data with the Atlas App Services backend. Clients in this state may continue to
 run and save data locally but cannot send or receive sync changesets
-until they perform a client reset strategy.
+until they perform a client reset.
 
 You can handle client resets in your application using one of the
-available **client reset strategies**:
+available **client reset modes**:
+
+- TODO: document 2 new modes
 
 - :ref:`Discard Unsynced Changes <node-discard-unsynced-changes>`:
   Restores the realm to a syncable state by discarding changes made
@@ -32,11 +31,75 @@ available **client reset strategies**:
   to a backup. Migrate unsynced data from the backup copy of the
   realm to the new syncable copy.
 
+To learn about the causes of and modes for handling client
+resets, check out Device Sync :ref:`Client Resets in the App Services documentation <client-resets>`.
+
+.. _node-automatic-vs-manual-client-reset:
+
+Automatic vs. Manual Client Reset
+---------------------------------
+
+The Realm SDKs provide client reset modes
+that automatically handle most client reset errors.
+
+Automatic client reset modes restore your local realm file to a syncable state without
+closing the realm or missing notifications.
+The following client reset modes support automatic client resets:
+
+- TODO: list all JS modes that support automatic
+
+The differences between these modes are based on how they handle
+changes on the device that have not yet synced to the backend.
+Only ``"manual"`` mode does not perform an automatic client reset.
+
+Choose ``JS_TODO.recoverUnsyncedChanges`` to handle most client reset
+scenarios automatically. This attempts to recover unsynced changes when a
+client reset occurs.
+
+In some cases, you may want or need to :ref:`set a manual client reset handler
+<node-manually-recover-unsynced-changes>`. You may want to do this if your app
+requires specific client reset logic that can't be handled automatically.
+
+.. _node-handle-schema-changes:
+
+TODO: refactor section. this pulled pretty directly from swift. kinda confused what to do here. 
+
+Handle Schema Changes
+---------------------
+
+:ref:`Client Recovery <enable-or-disable-recovery-mode>` is a feature that is
+enabled by default when you :ref:`configure Device Sync <enable-sync>`. When
+Client Recovery is enabled, Realm Database can automatically manage the
+client reset process in most cases. When you make schema changes:
+
+- The client can :ref:`recover unsynced changes <node-recover-unsynced-changes>`
+  when there are no schema changes, or non-breaking schema changes.
+- When you make breaking schema changes, the automatic client reset modes fall
+  back to a manual error handler. You can set a :ref:`manual client
+  reset error handler <node-client-reset-manual-fallback>` for this case.
+  Automatic client recovery cannot occur when your app makes breaking
+  schema changes.
+
+For information on breaking vs. non-breaking schema changes, see
+:ref:`breaking-change-quick-reference`.
+
+Client Reset Modes
+------------------
+
+TODO: new mode 1
+~~~~~~~~~~~~~~~~
+
+TODO
+
+TODO: new mode 2
+~~~~~~~~~~~~~~~~
+
+TODO
 
 .. _node-discard-unsynced-changes:
 
-Discard Unsynced Changes
-------------------------
+Discard Unsynced Changes Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 10.11.0
 
@@ -77,10 +140,13 @@ The following example implements this strategy:
 .. literalinclude:: /examples/generated/node/client-reset.snippet.discard-unsynced-changes.js
    :language: javascript
 
+
+TODO: refactor this into the "Manual Client Reset Fallback" section
+
 .. _node-discard-unsynced-changes-after-breaking-schema-changes:
 
 Discard Unsynced Changes after Breaking Schema Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``````````````````````````````````````````````````````
 
 .. include:: /includes/destructive-schema-change-app-update.rst
 
@@ -96,11 +162,19 @@ discarding all unsynced changes:
 
 .. _node-manually-recover-unsynced-changes:
 
-Manually Recover Unsynced Changes
----------------------------------
+Manually Recovery Mode
+~~~~~~~~~~~~~~~~~~~~~~
 
 Manual recovery requires significant amounts of code, schema concessions,
 and custom conflict resolution logic. To learn more about the **manually
 recover unsynced changes** client reset strategy, see the
 :ref:`Advanced Guide to Manual Client Reset Data Recovery
 <node-advanced-manual-client-reset-data-recovery>`.
+
+
+.. _node-manual-client-reset-fallback:
+
+Manual Client Reset Fallback
+----------------------------
+
+TODO

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -127,7 +127,9 @@ Include these properties in the ``ClientResetConfiguration``:
 
 The following example implements Recover Unsynced Changes mode:
 
-TODO: literalinclude
+.. literalinclude:: /examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
+   :language: js
+   :emphasize-lines: 7
 
 .. _node-recover-discard-unsynced-changes:
 
@@ -160,16 +162,16 @@ Include these properties in the ``ClientResetConfiguration``:
 
 The following example implements Recover Unsynced Changes mode:
 
-TODO: literalinclude
+.. literalinclude:: /examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
+   :language: js
+   :emphasize-lines: 7
 
 .. _node-manual-client-reset-fallback:
 
 Manual Client Reset Fallback
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO: refine copy here
-
-If the client reset with recovery operation cannot complete automatically,
+If the client reset with recovery cannot complete automatically,
 like when there are breaking schema changes, the client reset process falls through
 to a manual error handler. This may occur in either of the client reset with recovery modes,
 Recover Unsynced Changes and Recover or Discard Unsynced Changes.
@@ -179,7 +181,7 @@ in the ``SyncConfiguration.onFallback()`` callback.
 The following example demonstrates how you can manually handle this error case by
 discarding all unsynced changes:
 
-TODO: literalinclude
+TODO: literalinclude. still waiting on an example in the JS PR. cannot make example until then.
 
 .. _node-discard-unsynced-changes:
 
@@ -205,7 +207,7 @@ to the ``clientReset`` field of your
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
 Include these properties in the ``ClientResetConfiguration``:
 
-- ``mode``: Set to ``"discardLocal"``.
+- ``mode``: Set to ``"discardUnsyncedChanges"``.
 - ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -10,8 +10,6 @@ Reset a Client Realm - Node.js SDK
    :depth: 2
    :class: singlecol
 
-.. versionchanged:: TODO: add notes about release specific
-
 A **client reset error** is a scenario where a client realm cannot sync
 data with the Atlas App Services backend. Clients in this state may continue to
 run and save data locally but cannot send or receive sync changesets
@@ -163,7 +161,6 @@ The following example implements recover unsynced changes mode:
 
 .. literalinclude:: /examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
    :language: js
-   :emphasize-lines: 7
 
 .. _node-manual-client-reset-fallback:
 

--- a/source/sdk/node/examples/reset-a-client-realm.txt
+++ b/source/sdk/node/examples/reset-a-client-realm.txt
@@ -45,7 +45,6 @@ available **client reset modes**:
   to a backup. Migrate unsynced data from the backup copy of the
   realm to the new syncable copy.
 
-
 Automatic vs. Manual Client Reset
 ---------------------------------
 
@@ -77,6 +76,8 @@ to the automatic client reset mode.
 Client Reset with Recovery
 --------------------------
 
+.. versionadded:: 10.23.0
+
 Client Recovery is a feature that is enabled by default when you configure Device Sync.
 When Client Recovery is enabled, Realm Database automatically manages the
 client reset process in most cases. When you make schema changes the client
@@ -104,7 +105,8 @@ For information on breaking vs. non-breaking schema changes, refer to
 Recover Unsynced Changes Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you choose this mode, the client attempts to recover unsynced changes with Client Recovery.
+When you choose **Recover Unsynced Changes** mode,
+the client attempts to recover unsynced changes with Client Recovery.
 Choose this mode when you do not want to fall through to discard unsynced changes.
 
 To handle client resets with the Discard Unsynced Changes mode,
@@ -119,23 +121,21 @@ Include these properties in the ``ClientResetConfiguration``:
   Provides a copy of the realm.
 - ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
   executes this mode. Provides instances of the realm before and after the client reset.
+- ``onFallback()``: Optional. Callback function which the SDK invokes
+  only if the automatic recovery fails. For more information, refer to the
+  :ref:`Manual Client Reset Fallback section <node-manual-client-reset-fallback>`.
 
 The following example implements Recover Unsynced Changes mode:
 
 TODO: literalinclude
-
-There may be times when the client reset operation cannot complete in
-recover unsynced changes mode, like when there are breaking schema changes or
-Client Recovery is disabled in the Device Sync configuration.
-To handle this case, your app can implement a
-:ref:`manual client reset fallback <node-manual-client-reset-fallback>`.
 
 .. _node-recover-discard-unsynced-changes:
 
 Recover or Discard Unsynced Changes Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The client first attempts to recover changes that have not yet synced.
+In **Recover or Discard Unsynced Changes** mode,
+the client first attempts to recover changes that have not yet synced.
 If the client cannot recover unsynced  data, it falls through to
 discard unsynced changes but continues to automatically perform the client reset.
 Choose this mode when you want to enable automatic client
@@ -153,16 +153,33 @@ Include these properties in the ``ClientResetConfiguration``:
   Provides a copy of the realm.
 - ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
   executes this mode. Provides instances of the realm before and after the client reset.
+- ``onFallback()``: Optional. Callback function which the SDK invokes
+  only if both the automatic recovery and and discarding changes fails.
+  For more information, refer to the :ref:`Manual Client Reset Fallback section
+  <node-manual-client-reset-fallback>`.
 
 The following example implements Recover Unsynced Changes mode:
 
 TODO: literalinclude
 
-There may be times when the client reset operation cannot complete in
-recover unsynced changes mode, like when there are breaking schema changes or
-Client Recovery is disabled in the Device Sync configuration.
-To handle this case, your app can implement a
-:ref:`manual client reset fallback <node-manual-client-reset-fallback>`.
+.. _node-manual-client-reset-fallback:
+
+Manual Client Reset Fallback
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO: refine copy here
+
+If the client reset with recovery operation cannot complete automatically,
+like when there are breaking schema changes, the client reset process falls through
+to a manual error handler. This may occur in either of the client reset with recovery modes,
+Recover Unsynced Changes and Recover or Discard Unsynced Changes.
+
+You must provide a manual client reset implementation
+in the ``SyncConfiguration.onFallback()`` callback.
+The following example demonstrates how you can manually handle this error case by
+discarding all unsynced changes:
+
+TODO: literalinclude
 
 .. _node-discard-unsynced-changes:
 
@@ -171,10 +188,12 @@ Discard Unsynced Changes Mode
 
 .. versionadded:: 10.11.0
 
-The Discard Unsynced Changes client reset mode permanently deletes all
-local unsynced changes made since the last successful sync. You might
-use this mode when your app requires client recovery logic that is not
-consistent with the :ref:`Client Recovery Rules <node-client-reset-recovery>`,
+.. versionchanged:: 10.23.0 Mode renamed from "discardLocal" to "discardUnsyncedChanges". Both currently work, but in a future version, "discardLocal" will be removed.
+
+**Discard Unsynced Changes** mode  permanently deletes all
+local unsynced changes made since the last successful sync.
+You might use this mode when your app requires client recovery logic that is not
+consistent with the :ref:`automatic Client Recovery <node-client-reset-recovery>`,
 or when you don't want to recover unsynced data.
 
 Do not use discard unsynced changes mode if your application cannot lose local
@@ -199,10 +218,22 @@ The following example implements Discard Unsynced Changes mode:
 .. literalinclude:: /examples/generated/node/client-reset.snippet.discard-unsynced-changes.js
    :language: javascript
 
-There may be times when the client reset operation cannot complete in
-Discard Unsynced Changes mode, like when there are breaking schema changes.
-To handle this case, your app can implement a :ref:`manual client reset fallback
-<node-manual-client-reset-fallback>`.
+.. _node-discard-unsynced-changes-after-breaking-schema-changes:
+
+Discard Unsynced Changes after Breaking Schema Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/destructive-schema-change-app-update.rst
+
+If your application experiences a breaking schema change, the "discard
+unsynced changes" strategy cannot handle the resulting client reset
+automatically. Instead, you must provide a manual client reset
+implementation in the SyncConfiguration ``error()`` callback. The following
+example demonstrates how you can manually handle this error case by
+discarding all unsynced changes:
+
+.. literalinclude:: /examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
+   :language: javascript
 
 .. note:: Discard with Recovery
 
@@ -210,32 +241,10 @@ To handle this case, your app can implement a :ref:`manual client reset fallback
    any changes that cannot be recovered, refer to the
    :ref:`Recover or Discard Unsynced Changes Mode section <node-recover-discard-unsynced-changes>`.
 
-.. _node-manual-client-reset-fallback:
-.. _node-discard-unsynced-changes-after-breaking-schema-changes:
-
-Manual Client Reset Fallback
-----------------------------
-
-If the client reset operation cannot complete automatically, like when there
-are breaking schema changes, the client reset process falls through to a
-manual error handler. This may occur in any of the automatic client reset modes:
-
-- Recover Unsynced Changes mode
-- Recover or Discard Unsynced Changes mode
-- Discard Unsynced Changes mode
-
-You must provide a manual client reset implementation
-in the ``SyncConfiguration.error()`` callback.
-The following example demonstrates how you can manually handle this error case by
-discarding all unsynced changes:
-
-.. literalinclude:: /examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
-   :language: javascript
-
 .. _node-manually-recover-unsynced-changes:
 
 Manual Recovery Mode
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 Manual recovery requires significant amounts of code, schema concessions,
 and custom conflict resolution logic. To learn more about the **manually

--- a/source/sdk/react-native/advanced/client-reset-data-recovery.txt
+++ b/source/sdk/react-native/advanced/client-reset-data-recovery.txt
@@ -24,7 +24,7 @@ For more information about the other available client reset modes, refer to
 
 The specifics of manual recovery depend heavily upon your application
 and your schema. However, there are a few techniques that can help with
-most manual recoveries. The :ref:`Track Changes by Object Strategy section
+manual recoveries. The :ref:`Track Changes by Object Strategy section
 <react-native-client-reset-track-changes-by-object>` demonstrates
 one method of recovering unsynced changes during a client reset.
 

--- a/source/sdk/react-native/advanced/client-reset-data-recovery.txt
+++ b/source/sdk/react-native/advanced/client-reset-data-recovery.txt
@@ -10,18 +10,21 @@ Manual Client Reset Data Recovery - React Native SDK
    :depth: 3
    :class: singlecol
 
-This page explains how to manually recover unsynced realm data after a client reset.
+This page explains how to manually recover unsynced realm data after a client reset
+using the Manual Recovery client reset mode.
 
 Manual recovery requires significant amounts of code, schema concessions,
 and custom conflict resolution logic.
-You should only perform a manual recovery of unsynced realm data if 
-you cannot lose unsynced data. 
-Otherwise, use the :ref:`discard unsynced changes <react-native-discard-unsynced-changes>`
-client reset strategy instead.
+You should only perform a manual recovery of unsynced realm data if
+you cannot lose unsynced data and the other automatic client reset methods do not
+meet your use case.
+
+For more information about the other available client reset modes, refer to
+:ref:`Reset a Client Realm <react-native-client-resets>`.
 
 The specifics of manual recovery depend heavily upon your application
 and your schema. However, there are a few techniques that can help with
-most manual recoveries. The :ref:`Track Changes by Object Strategy section 
+most manual recoveries. The :ref:`Track Changes by Object Strategy section
 <react-native-client-reset-track-changes-by-object>` demonstrates
 one method of recovering unsynced changes during a client reset.
 
@@ -38,9 +41,9 @@ one method of recovering unsynced changes during a client reset.
 Track Changes by Object Strategy
 --------------------------------
 
-The **track changes by object** manual client reset data recovery strategy 
-lets you recover data already written to the client realm file 
-but not yet synced to the backend. 
+The **track changes by object** manual client reset data recovery strategy
+lets you recover data already written to the client realm file
+but not yet synced to the backend.
 
 In this strategy, you add a "Last Updated Time" to each object model to track
 when each object last changed. We'll watch the

--- a/source/sdk/react-native/examples/reset-a-client-realm.txt
+++ b/source/sdk/react-native/examples/reset-a-client-realm.txt
@@ -23,8 +23,8 @@ resets, check out Device Sync :ref:`Client Resets in the App Services documentat
 Client Reset Modes
 ------------------
 
-You can handle client resets in your application using one of the
-available **client reset modes**:
+You can specify which **client reset mode** your app should use
+to restore the realm to a syncable state:
 
 - :ref:`Recover unsynced changes mode <react-native-recover-unsynced-changes>`:
   When you choose this mode, the client attempts to recover unsynced changes.
@@ -78,21 +78,23 @@ Client Reset with Recovery
 
 Client Recovery is a feature that is enabled by default when you configure Device Sync.
 When Client Recovery is enabled, Realm Database automatically manages the
-client reset process in most cases. When you make schema changes the client
-can recover unsynced changes when there are no schema changes, or non-breaking schema changes.
+client reset process in most cases. The client can recover unsynced changes
+when there are no schema changes, or non-breaking schema changes.
 
-To use Client Recovery, configure your realm with recover unsynced changes or
-recover or discard unsynced changes client reset modes.
+To use Client Recovery, configure your realm with one of the following client reset modes:
+
+- Recover unsynced changes mode
+- Recover or discard unsynced changes
 
 .. include:: /includes/client-recovery-rules.rst
 
 For more information about configuring Client Recovery, refer to
 :ref:`Client Recovery <enable-or-disable-recovery-mode>` in the App Services documentation.
 
-Client Recovery cannot occur when your app makes breaking schema changes.
+Client Recovery cannot succeed when your app makes breaking schema changes.
 A breaking change is a change that you can make in your server-side
 schema that requires additional action to handle.
-In this scenario, client reset with fall back to a
+In this scenario, client reset falls back to a
 :ref:`manual error client reset fallback <react-native-manual-client-reset-fallback>`.
 
 For information on breaking vs. non-breaking schema changes, refer to
@@ -114,10 +116,10 @@ to the ``clientReset`` field of your
 Include these properties in the ``ClientResetConfiguration``:
 
 - ``mode``: Set to ``"recoverUnsyncedChanges"``.
-- ``clientResetBefore``: Optional. Callback function invoked before the SDK executes this mode,
+- ``onBefore``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.
-- ``clientResetAfter``: Optional. Callback function invoked after the SDK successfully
+- ``onAfter``: Optional. Callback function invoked after the SDK successfully
   executes this mode. Provides instances of the realm before and after the client reset.
 - ``onFallback``: Optional. Callback function which the SDK invokes
   only if the automatic recovery fails. For more information, refer to the
@@ -140,6 +142,9 @@ discard unsynced changes but continues to automatically perform the client reset
 Choose this mode when you want to enable automatic client
 recovery to fall back to discard unsynced changes.
 
+Do not use recover or discard unsynced changes mode if your application
+cannot lose local data that has not yet synced to the backend.
+
 To handle client resets with the recover or discard unsynced changes mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
 to the ``clientReset`` field of your
@@ -147,10 +152,10 @@ to the ``clientReset`` field of your
 Include these properties in the ``ClientResetConfiguration``:
 
 - ``mode``: Set to ``"recoverOrDiscardUnsyncedChanges"``.
-- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
+- ``onBefore``: Optional. Callback function invoked before the SDK executes this mode,
   when the SDK receives a client reset error from the backend.
   Provides a copy of the realm.
-- ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
+- ``onAfter``: Optional. Callback function invoked after the SDK successfully
   executes this mode. Provides instances of the realm before and after the client reset.
 - ``onFallback()``: Optional. Callback function which the SDK invokes
   only if both the automatic recovery and and discarding changes fails.
@@ -252,6 +257,8 @@ Manual Mode
 .. versionchanged:: 10.23.0 onManual callback added
 
 In **manual** mode, you define your own client reset handler.
+You might want to use a manual client reset handler if the Automatic Recovery logic
+does not work for your app and you can't discard unsynced local data.
 
 To handle client resets with manual mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
@@ -273,6 +280,6 @@ Manual Data Recovery
 
 To recover data from a manual client reset requires significant amounts
 of code, schema concessions, and custom conflict resolution logic.
-To learn more about the **manually recover unsynced changes** client reset mode,
+If you need to implement your own custom client reset logic,
 see the :ref:`Advanced Guide to Manual Client Reset Data Recovery
 <react-native-advanced-manual-client-reset-data-recovery>`.

--- a/source/sdk/react-native/examples/reset-a-client-realm.txt
+++ b/source/sdk/react-native/examples/reset-a-client-realm.txt
@@ -203,7 +203,7 @@ Discard Unsynced Changes Mode
 **Discard Unsynced Changes** mode  permanently deletes all
 local unsynced changes made since the last successful sync.
 You might use this mode when your app requires client recovery logic that is not
-consistent with the :ref:`automatic Client Recovery <react-native-client-reset-recovery>`,
+consistent with :ref:`automatic Client Recovery <react-native-client-reset-recovery>`,
 or when you don't want to recover unsynced data.
 
 Do not use discard unsynced changes mode if your application cannot lose local

--- a/source/sdk/react-native/examples/reset-a-client-realm.txt
+++ b/source/sdk/react-native/examples/reset-a-client-realm.txt
@@ -54,7 +54,7 @@ closing the realm or missing notifications.
 The following client reset modes support automatic client resets:
 
 - Recover unsynced changes mode
-- Recover or discard unsynced Changes mode
+- Recover or discard unsynced changes mode
 - Discard unsynced changes mode
 
 The differences between these modes are based on how they handle

--- a/source/sdk/react-native/examples/reset-a-client-realm.txt
+++ b/source/sdk/react-native/examples/reset-a-client-realm.txt
@@ -10,69 +10,215 @@ Reset a Client Realm - React Native SDK
    :depth: 2
    :class: singlecol
 
-.. seealso:: Learn More About Client Resets
-
-   To learn about the causes of and strategies for handling client
-   resets, check out the Sync :ref:`Client Resets <client-resets>` page.
-
 A **client reset error** is a scenario where a client realm cannot sync
-data with the application backend. Clients in this state may continue to
+data with the Atlas App Services backend. Clients in this state may continue to
 run and save data locally but cannot send or receive sync changesets
-until they perform a client reset strategy.
+until they perform a client reset.
+
+To learn about the causes of and modes for handling client
+resets, check out Device Sync :ref:`Client Resets in the App Services documentation <client-resets>`.
+
+.. _react-native-automatic-vs-manual-client-reset:
+
+Client Reset Modes
+------------------
 
 You can handle client resets in your application using one of the
-available **client reset strategies**:
+available **client reset modes**:
 
-- :ref:`Discard Unsynced Changes <react-native-discard-unsynced-changes>`:
+- :ref:`Recover unsynced changes mode <react-native-recover-unsynced-changes>`:
+  When you choose this mode, the client attempts to recover unsynced changes.
+  Choose this mode when you do not want to fall through to discard unsynced changes.
+- :ref:`Recover or discard unsynced changes mode <react-native-recover-discard-unsynced-changes>`:
+  The client first attempts to recover changes that have not yet synced.
+  If the client cannot recover unsynced  data, it falls through to
+  discard unsynced changes but continues to automatically perform the client reset.
+  Choose this mode when you want to enable automatic client
+  recovery to fall back to discard unsynced changes.
+- :ref:`Discard unsynced changes mode <react-native-discard-unsynced-changes>`:
   Restores the realm to a syncable state by discarding changes made
   since the last sync.
-
-- :ref:`Manually Recover Unsynced Changes <react-native-manually-recover-unsynced-changes>`:
+- :ref:`Manual recovery mode <react-native-manually-recover-unsynced-changes>`:
   Downloads a new copy of the realm, and moves the unsyncable realm
   to a backup. Migrate unsynced data from the backup copy of the
   realm to the new syncable copy.
 
+Automatic vs. Manual Client Reset
+---------------------------------
+
+The Realm SDKs provide client reset modes
+that automatically handle most client reset errors.
+
+Automatic client reset modes restore your local realm file to a syncable state without
+closing the realm or missing notifications.
+The following client reset modes support automatic client resets:
+
+- Recover unsynced changes mode
+- Recover or discard unsynced Changes mode
+- Discard unsynced changes mode
+
+The differences between these modes are based on how they handle
+changes on the device that have not yet synced to the backend.
+Only manual recovery mode does not perform an automatic client reset.
+
+Choose recover unsynced changes mode to handle most client reset
+scenarios automatically. This attempts to recover unsynced changes when a
+client reset occurs.
+
+If your app requires specific client reset logic that can't be handled automatically,
+you may want or need to :ref:`add a manual client reset handler <react-native-manually-recover-unsynced-changes>`
+to the automatic client reset mode.
+
+.. _react-native-client-reset-recovery:
+
+Client Reset with Recovery
+--------------------------
+
+.. versionadded:: 10.23.0
+
+Client Recovery is a feature that is enabled by default when you configure Device Sync.
+When Client Recovery is enabled, Realm Database automatically manages the
+client reset process in most cases. When you make schema changes the client
+can recover unsynced changes when there are no schema changes, or non-breaking schema changes.
+
+To use Client Recovery, configure your realm with recover unsynced changes or
+recover or discard unsynced changes client reset modes.
+
+.. include:: /includes/client-recovery-rules.rst
+
+For more information about configuring Client Recovery, refer to
+:ref:`Client Recovery <enable-or-disable-recovery-mode>` in the App Services documentation.
+
+Client Recovery cannot occur when your app makes breaking schema changes.
+A breaking change is a change that you can make in your server-side
+schema that requires additional action to handle.
+In this scenario, client reset with fall back to a
+:ref:`manual error client reset fallback <react-native-manual-client-reset-fallback>`.
+
+For information on breaking vs. non-breaking schema changes, refer to
+:ref:`breaking-change-quick-reference` in the App Services documentation.
+
+.. _react-native-recover-unsynced-changes:
+
+Recover Unsynced Changes Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you choose **recover unsynced changes** mode,
+the client attempts to recover unsynced changes with Client Recovery.
+Choose this mode when you do not want to fall through to discard unsynced changes.
+
+To handle client resets with the recover unsynced changes mode,
+pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
+to the ``clientReset`` field of your
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
+Include these properties in the ``ClientResetConfiguration``:
+
+- ``mode``: Set to ``"recoverUnsyncedChanges"``.
+- ``clientResetBefore``: Optional. Callback function invoked before the SDK executes this mode,
+  when the SDK receives a client reset error from the backend.
+  Provides a copy of the realm.
+- ``clientResetAfter``: Optional. Callback function invoked after the SDK successfully
+  executes this mode. Provides instances of the realm before and after the client reset.
+- ``onFallback``: Optional. Callback function which the SDK invokes
+  only if the automatic recovery fails. For more information, refer to the
+  :ref:`Manual Client Reset Fallback section <react-native-manual-client-reset-fallback>`.
+
+The following example implements recover unsynced changes mode:
+
+.. literalinclude:: /examples/generated/node/client-reset.snippet.recover-unsynced-changes.js
+   :language: js
+
+.. _react-native-recover-discard-unsynced-changes:
+
+Recover or Discard Unsynced Changes Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In **recover or discard unsynced changes** mode,
+the client first attempts to recover changes that have not yet synced.
+If the client cannot recover unsynced  data, it falls through to
+discard unsynced changes but continues to automatically perform the client reset.
+Choose this mode when you want to enable automatic client
+recovery to fall back to discard unsynced changes.
+
+To handle client resets with the recover or discard unsynced changes mode,
+pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
+to the ``clientReset`` field of your
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
+Include these properties in the ``ClientResetConfiguration``:
+
+- ``mode``: Set to ``"recoverOrDiscardUnsyncedChanges"``.
+- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this mode,
+  when the SDK receives a client reset error from the backend.
+  Provides a copy of the realm.
+- ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
+  executes this mode. Provides instances of the realm before and after the client reset.
+- ``onFallback()``: Optional. Callback function which the SDK invokes
+  only if both the automatic recovery and and discarding changes fails.
+  For more information, refer to the :ref:`Manual Client Reset Fallback section
+  <react-native-manual-client-reset-fallback>`.
+
+The following example implements recover unsynced changes mode:
+
+.. literalinclude:: /examples/generated/node/client-reset.snippet.recover-or-discard-unsynced-changes.js
+   :language: js
+
+.. _react-native-manual-client-reset-fallback:
+
+Manual Client Reset Fallback
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the client reset with recovery cannot complete automatically,
+like when there are breaking schema changes, the client reset process falls through
+to a manual error handler. This may occur in either of the client reset with recovery modes,
+recover unsynced changes and recover or discard unsynced changes.
+
+You must provide a manual client reset implementation
+in the ``SyncConfiguration.onFallback()`` callback. ``onFallback()`` takes two
+arguments:
+
+- ``session``: :js-sdk:`Session <Realm.App.Sync.Session.html>` object representing
+  the state of the Device Sync session.
+- ``path``: String with the path to the current realm database file.
+
+The following example demonstrates how you can manually handle this error case by
+discarding all unsynced changes:
+
+.. literalinclude:: /examples/generated/node/client-reset.snippet.recovery-fallback.js
+   :language: js
 
 .. _react-native-discard-unsynced-changes:
 
-Discard Unsynced Changes
-------------------------
+Discard Unsynced Changes Mode
+-----------------------------
 
 .. versionadded:: 10.11.0
 
-The **discard unsynced changes** client reset strategy helps you perform
-a client reset with minimal code and minimal disruption to your application
-workflow. This strategy restores your local realm to a syncable state without
-closing the realm or missing notifications.
+.. versionchanged:: 10.23.0 Mode renamed from "discardLocal" to "discardUnsyncedChanges". Both currently work, but in a future version, "discardLocal" will be removed. "clientResetBefore" and "clientResetAfter" callbacks renamed to "onBefore" and "onAfter", respectively.
 
-This strategy comes with a downside: it permanently deletes all
-local unsynced changes made since the last successful sync of the realm.
-Do not use the "discard unsynced changes" strategy if your application
-cannot lose data already written to the client realm file but not yet
-synced to the backend.
+**Discard Unsynced Changes** mode  permanently deletes all
+local unsynced changes made since the last successful sync.
+You might use this mode when your app requires client recovery logic that is not
+consistent with the :ref:`automatic Client Recovery <react-native-client-reset-recovery>`,
+or when you don't want to recover unsynced data.
 
-The "discard unsynced changes" strategy can handle every kind of client
-reset error *except* for client resets triggered by
-:ref:`breaking schema changes <destructive-changes-synced-schema>`.
-If your application experiences a breaking schema change, this strategy
-falls back to a mode that mimics the "manually recover unsynced changes"
-strategy.
+Do not use discard unsynced changes mode if your application cannot lose local
+data that has not yet synced to the backend.
 
-To handle client resets with the "discard unsynced changes" strategy, 
+To handle client resets with the discard unsynced changes mode,
 pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
 to the ``clientReset`` field of your
-:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`. 
-Include these properties in the ClientResetConfiguration: 
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
+Include these properties in the ``ClientResetConfiguration``:
 
-- ``mode``: Set to ``"discardLocal"``.
-- ``clientResetBefore()``: Optional. Callback function invoked before the SDK executes this strategy,
-  when the SDK receives a client reset error from the backend. 
-  Provides a copy of the realm. 
-- ``clientResetAfter()``: Optional. Callback function invoked after the SDK successfully
-  executes this strategy. Provides instances of the realm 
+- ``mode``: Set to ``"discardUnsyncedChanges"``.
+- ``onBefore``: Optional. Callback function invoked before the SDK executes this mode,
+  when the SDK receives a client reset error from the backend.
+  Provides a copy of the realm.
+- ``onAfter``: Optional. Callback function invoked after the SDK successfully
+  executes this mode. Provides instances of the realm
   before and after the client reset.
 
-The following example implements this strategy:
+The following example implements discard unsynced changes mode:
 
 .. literalinclude:: /examples/generated/node/client-reset.snippet.discard-unsynced-changes.js
    :language: javascript
@@ -82,10 +228,8 @@ The following example implements this strategy:
 Discard Unsynced Changes after Breaking Schema Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/destructive-schema-change-app-update.rst
-
-If your application experiences a breaking schema change, the "discard
-unsynced changes" strategy cannot handle the resulting client reset
+If your application experiences a breaking schema change, discard
+unsynced changes mode cannot handle the resulting client reset
 automatically. Instead, you must provide a manual client reset
 implementation in the SyncConfiguration ``error()`` callback. The following
 example demonstrates how you can manually handle this error case by
@@ -94,13 +238,41 @@ discarding all unsynced changes:
 .. literalinclude:: /examples/generated/node/client-reset.snippet.discard-unsynced-changes-after-destructive-schema-changes.js
    :language: javascript
 
+.. note:: Discard with Recovery
+
+   If you'd like to attempt to recover unsynced changes, but but discard
+   any changes that cannot be recovered, refer to the
+   :ref:`recover or discard unsynced changes mode section <react-native-recover-discard-unsynced-changes>`.
+
 .. _react-native-manually-recover-unsynced-changes:
 
-Manually Recover Unsynced Changes
----------------------------------
+Manual Mode
+-----------
 
-Manual recovery requires significant amounts of code, schema concessions,
-and custom conflict resolution logic. To learn more about the **manually
-recover unsynced changes** client reset strategy, see the
-:ref:`Advanced Guide to Manual Client Reset Data Recovery
+.. versionchanged:: 10.23.0 onManual callback added
+
+In **manual** mode, you define your own client reset handler.
+
+To handle client resets with manual mode,
+pass a :js-sdk:`ClientResetConfiguration <Realm.App.Sync.html#~ClientResetConfiguration>`
+to the ``clientReset`` field of your
+:js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
+Include these properties in the ``ClientResetConfiguration``:
+
+- ``mode``: Set to ``"manual"``.
+- ``onManual``: Optional. Callback function invoked when the client reset occurs.
+  Provides information about the sync session and the path to the current realm.
+  If you don't set the ``onManual`` error handler, the client reset error falls
+  back to the general sync error handler.
+
+.. literalinclude:: /examples/generated/node/client-reset.snippet.manual-client-reset-onmanual.js
+   :language: js
+
+Manual Data Recovery
+~~~~~~~~~~~~~~~~~~~~
+
+To recover data from a manual client reset requires significant amounts
+of code, schema concessions, and custom conflict resolution logic.
+To learn more about the **manually recover unsynced changes** client reset mode,
+see the :ref:`Advanced Guide to Manual Client Reset Data Recovery
 <react-native-advanced-manual-client-reset-data-recovery>`.

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -241,10 +241,9 @@ in the :swift-sdk:`SyncConfiguration <Structs/SyncConfiguration.html>` to
    Unsynced Changes <ios-recover-unsynced-changes>`.
 
 There may be times when the client reset operation cannot complete in 
-discard unsynced changes mode, like when there are breaking schema changes or
-:ref:`Client Recovery <recover-unsynced-changes>` is disabled in the 
-server-side Device Sync configuration. To handle this case, your app can 
-implement a :ref:`manual client reset fallback <ios-client-reset-manual-fallback>`.
+discard unsynced changes mode, like when there are breaking schema changes.
+To handle this case, your app can  implement a :ref:`manual client reset fallback
+<ios-client-reset-manual-fallback>`.
 
 .. _ios-manual-client-reset-handler:
 .. _ios-manual-mode:


### PR DESCRIPTION
## Pull Request Info

document automatic client reset w recovery for Node.js SDK and React Native SDK.
includes a more or less total refactor of the client reset documentation to accommodate this.

additionally small copy edit fix to Swift SDK client reset docs.

note that the `"discardUnsyncedChanges"` client reset mode doesn't include the `onFallback` callback, unlike the equivalent modes for other SDKs. the docs reflect this accurately.

### Jira

- https://jira.mongodb.org/browse/DOCSP-23425

### Staged Changes (Requires MongoDB Corp SSO)

- [Client Reset Data Recovery (Node.js)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23425/sdk/node/examples/reset-a-client-realm/)
- [Client Reset Data Recovery (React Native)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23425/sdk/react-native/examples/reset-a-client-realm/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
