### PR TITLE
(DOCSP-26005): make SDK landing pages more uniform

### DIFF
--- a/source/sdk/dotnet.txt
+++ b/source/sdk/dotnet.txt
@@ -74,90 +74,96 @@ Get Started with Realm .NET
 Develop Apps with Realm Database
 --------------------------------
 
-Use free open-source Realm Database as a local object store on a device.
-Use Device Sync to keep data in sync with your MongoDB Atlas cluster and 
-other clients.
-
 .. tabs::
+
 
    .. tab:: Use Realm Database Locally
       :tabid: local-realm
 
-      .. procedure::
+      .. container::
 
-         .. step:: Install the Realm .NET SDK
+         Use free open-source Realm Database as a local object store on a device.
 
-            Use NuGet to :ref:`dotnet-install` in your solution.
+         .. procedure::
 
-            Import Realm in your source files to get started.
+            .. step:: Install the Realm .NET SDK
 
-         .. step:: Define an Object Schema
+               Use NuGet to :ref:`dotnet-install` in your solution.
 
-            Use C# to idiomatically :ref:`define an object schema 
-            <dotnet-define-a-realm-object-schema>`. 
+               Import Realm in your source files to get started.
 
-         .. step:: Open a Realm
+            .. step:: Define an Object Schema
 
-            Realm Database stores objects in realm files on your device, 
-            or you can open an in-memory realm which does not create a file.
-            :ref:`Configure and open a realm <dotnet-open-a-realm>` 
-            to get started reading and writing data.
+               Use C# to idiomatically :ref:`define an object schema 
+               <dotnet-define-a-realm-object-schema>`. 
 
-         .. step:: Read and Write Data
+            .. step:: Open a Realm
 
-            :ref:`Read and write data <dotnet-read-and-write-data>`. 
-            You can :ref:`filter data <dotnet-client-query-engine>` using 
-            idiomatic LINQ Syntax, or Realm Query Language. 
+               Realm Database stores objects in realm files on your device, 
+               or you can open an in-memory realm which does not create a file.
+               :ref:`Configure and open a realm <dotnet-open-a-realm>` 
+               to get started reading and writing data.
 
-         .. step:: React to Changes
+            .. step:: Read and Write Data
 
-            Realm's live objects mean that your data is always up-to-date.
-            You can :ref:`register a notification handler <dotnet-react-to-changes>` 
-            to watch for changes and perform some logic, such as updating 
-            your UI.
+               :ref:`Read and write data <dotnet-read-and-write-data>`. 
+               You can :ref:`filter data <dotnet-client-query-engine>` using 
+               idiomatic LINQ Syntax, or Realm Query Language. 
 
-      .. image:: /images/illustrations/Mobile_hero_green.png
+            .. step:: React to Changes
+
+               Realm's live objects mean that your data is always up-to-date.
+               You can :ref:`register a notification handler <dotnet-react-to-changes>` 
+               to watch for changes and perform some logic, such as updating 
+               your UI.
+
+      .. image:: /images/illustrations/Spot_MauvePurple_Infrastructure_Tech_RealmApp2x.png
          :alt: Realm Mobile Illustration
 
    .. tab:: Sync Data Across Devices
       :tabid: device-sync
 
-      .. procedure::
+      .. container::
 
-         .. step:: Connect to an Atlas App Services App
+         Use Device Sync to keep data in sync with your MongoDB Atlas cluster and
+         other clients.
 
-            Configure :ref:`Device Sync in an App Services App 
-            <realm-sync-get-started>`. Define data access rules. Use 
-            Development Mode to infer your schema from your C# data model.
+         .. procedure::
 
-            Then, :ref:`connect to the backend <dotnet-init-appclient>` from
-            your client.
+            .. step:: Connect to an Atlas App Services App
 
-         .. step:: Authenticate a User
+               Configure :ref:`Device Sync in an App Services App 
+               <realm-sync-get-started>`. Define data access rules. Use 
+               Development Mode to infer your schema from your C# data model.
 
-            Use one of our authentication providers to :ref:`authenticate a 
-            user <dotnet-authenticate>`. App Services provides access
-            to popular authentication providers, such as Apple, Google, or 
-            Facebook. Use our built-in email/password provider to manage 
-            users without a third-party, or use custom JWT authentication to 
-            integrate with other authentication providers. Anonymous authentication
-            provides access without requiring a login or persisting user data.
+               Then, :ref:`connect to the backend <dotnet-init-appclient>` from
+               your client.
 
-         .. step:: Open a Synced Realm
+            .. step:: Authenticate a User
 
-            Instead of opening a local realm, :ref:`configure and open a 
-            synced Realm <dotnet-flexible-sync-open-realm>`. 
-            :ref:`Subscribe to a query <dotnet-sync-add-subscription>` 
-            to determine what data the synced realm can read and write.
+               Use one of our authentication providers to :ref:`authenticate a 
+               user <dotnet-authenticate>`. App Services provides access
+               to popular authentication providers, such as Apple, Google, or 
+               Facebook. Use our built-in email/password provider to manage 
+               users without a third-party, or use custom JWT authentication to 
+               integrate with other authentication providers. Anonymous authentication
+               provides access without requiring a login or persisting user data.
 
-         .. step:: Read and Write Synced Data
+            .. step:: Open a Synced Realm
 
-            The APIs to read and write data from a realm are the same 
-            whether you're using a synced or local realm. Data that you 
-            read and write is automatically kept in sync with your Atlas 
-            cluster and other clients. Apps keep working offline and 
-            deterministically sync changes whenever a network connection is 
-            available. 
+               Instead of opening a local realm, :ref:`configure and open a 
+               synced Realm <dotnet-flexible-sync-open-realm>`. 
+               :ref:`Subscribe to a query <dotnet-sync-add-subscription>` 
+               to determine what data the synced realm can read and write.
+
+            .. step:: Read and Write Synced Data
+
+               The APIs to read and write data from a realm are the same 
+               whether you're using a synced or local realm. Data that you 
+               read and write is automatically kept in sync with your Atlas 
+               cluster and other clients. Apps keep working offline and 
+               deterministically sync changes whenever a network connection is 
+               available. 
 
       .. image:: /images/illustrations/Spot_AzureBlue_Mobile_Tech_RealmSync.png
          :alt: Realm Sync Illustration
@@ -167,16 +173,13 @@ other clients.
 
       .. container::
 
+         Use Atlas App Services in your application with the .NET SDK.
+
          Call Serverless Functions
          ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-         You can :ref:`call serverless Functions <dotnet-call-a-function>` 
+         You can :ref:`call serverless Functions <dotnet-call-a-function>`
          from your client application that run in an App Services backend.
-
-         .. code-block:: csharp
-            :copyable: false
-
-            sum = await user.Functions.CallAsync<int>("sum", 2, 40);
 
          Query MongoDB Atlas
          ~~~~~~~~~~~~~~~~~~~
@@ -184,28 +187,12 @@ other clients.
          You can :ref:`query data stored in MongoDB <dotnet-mongodb-data-access>`
          directly from your client application code.
 
-         .. code-block:: csharp
-            :copyable: false
-
-            mongoClient = user.GetMongoClient("mongodb-atlas");
-            dbPlantInventory = mongoClient.GetDatabase("inventory");
-            plantsCollection = dbPlantInventory.GetCollection<Plant>("plants");
-
-            var petunia = await plantsCollection.FindOneAsync(
-               new { name = "Petunia" },
-               null);
-
          Authenticate Users
          ~~~~~~~~~~~~~~~~~~
 
-         Authenticate users with built-in and third-party :ref:`authentication 
-         providers <dotnet-authenticate>`. Use the authenticated user to 
+         Authenticate users with built-in and third-party :ref:`authentication
+         providers <dotnet-authenticate>`. Use the authenticated user to
          access App Services.
-
-         .. code-block:: csharp
-            :copyable: false
-
-            var user = await app.LogInAsync(Credentials.Anonymous());
 
       .. image:: /images/illustrations/Spot_MauvePurple_APIs_Tech_RealmApp.png
          :alt: App Services Illustration

--- a/source/sdk/dotnet.txt
+++ b/source/sdk/dotnet.txt
@@ -76,7 +76,6 @@ Develop Apps with Realm Database
 
 .. tabs::
 
-
    .. tab:: Use Realm Database Locally
       :tabid: local-realm
 

--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -102,42 +102,30 @@ Develop Apps with Realm Flutter
 
                Install the Realm Flutter SDK into your project with the
                `realm package on pub.dev <https://pub.dev/packages/realm>`__.
-
-               Import Realm in your project files to get started.
-
-               For more information, see :ref:`Install Realm for Flutter <flutter-install>`.
+               To get started, :ref:`install the Realm Flutter SDK <flutter-install>`.
 
             .. step:: Define an Object Schema
 
-               Use Dart to define a data schema for your realm database.
-
-               For more information, see :ref:`Define a Realm Object Schema
-               <flutter-define-realm-object-schema>`.
+               Use Dart to idiomatically :ref:`define a Realm object schema <flutter-define-realm-object-schema>`.
 
             .. step:: Open a Realm
 
                Open a realm before you begin using it. You can configure it to do things
                like populate initial data on load, be encrypted, and more.
-
-               For more information, see :ref:`Open a Realm <flutter-open-realm>`.
+               To get started, :ref:`open and configure a realm <node-open-close-realm>`.
 
             .. step:: Read and Write Data
 
-               Create, read, update, and delete objects in the realm. You can also
-               filter data in your queries using Realm Query Language.
-
-               For more information, see :ref:`Read and Write Data <flutter-read-write-data>`.
+               You can :ref:`create, read, update, and delete objects <flutter-read-write-data>`
+               from a realm. Construct complex queries to :ref:`filter data in a realm <flutter-filter-results>`.
 
             .. step:: React to Changes
 
                Realm's live objects mean that your data is always up-to-date.
-               You can register a notification handler
-               to watch for changes and perform logic like updating
-               your UI.
+               Register a change listener to :ref:`react to changes and perform logic like updating
+               your UI <flutter-react-to-changes>`.
 
-               For more information, see :ref:`React to Changes <flutter-react-to-changes>`.
-
-      .. image:: /images/illustrations/Mobile_hero_green.png
+      .. image:: /images/illustrations/Spot_MauvePurple_Infrastructure_Tech_RealmApp2x.png
          :alt: Realm Mobile Illustration
 
    .. tab:: Sync Data Across Devices
@@ -152,34 +140,28 @@ Develop Apps with Realm Flutter
 
             .. step:: Configure Atlas Device Sync
 
-               Configure Device Sync in an Atlas App Services App.
-               Define data access rules. Use Development Mode to infer your schema
-               from your Dart data model.
-
-               For more information, see :ref:`Device Sync Overview <sync-overview>`.
+               Configure :ref:`Device Sync in an App Services App <realm-sync-get-started>`.
+               Define data access rules or use Development Mode to infer a schema
+               from your client's data model.
 
             .. step:: Connect to an Atlas App Services App
 
-               Connect to the App with Device Sync from your
-               client before you can sync data
-
-               For more information, :ref:`Connect to App Services <flutter-connect-to-backend>`.
+               To use the App Services App with Device Sync in your Flutter app,
+               :ref:`connect to the backend App <flutter-connect-to-backend>`.
 
             .. step:: Authenticate a User
 
-               Use one of the App Services authentication providers to authenticate a
-               user. App Services includes custom JWT, Facebook, Google, Apple,
-               anonymous, and built-in email/password authentication providers.
-
-               For more information, see :ref:`Authenticate Users <flutter-authenticate>`.
+               App Services provides access to custom JWT authentication,
+               our built-in email/password provider, anonymous
+               authentication, and popular
+               authentication providers like Apple, Google, and Facebook.
+               Use these providers to :ref:`authenticate a user in your client <flutter-authenticate>`.
 
             .. step:: Open a Synced Realm
 
-               Configure and open a synced Realm.
-               Then, subscribe to a query to determine what data the synced realm
-               can read and write.
-
-               For more information, see :ref:`Open a Synced Realm <flutter-open-synced-realm>`.
+               To get started syncing data, :ref:`open a synced realm <flutter-open-synced-realm>`.
+               To determine what data a synced realm can read and write,
+               :ref:`subscribe to a query <flutter-flexible-sync-manage-subscriptions>`.
 
             .. step:: Read and Write Synced Data
 

--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -107,12 +107,12 @@ Develop Apps with Realm Flutter
 
                Use Dart to idiomatically :ref:`define a Realm object schema <flutter-define-realm-object-schema>`.
 
-            .. step:: Open a Realm
+            .. step:: Configure & Open a Realm
 
                You can configure your realm to do things
                like populate initial data on load, be encrypted, and more.
                To begin working with your data,
-               :ref:`configure and open a realm <ios-configure-and-open-a-realm>`.
+               :ref:`configure and open a realm <flutter-open-close-realm>`.
 
             .. step:: Read and Write Data
 

--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -100,9 +100,8 @@ Develop Apps with Realm Flutter
 
             .. step:: Install the Realm Flutter SDK
 
-               Install the Realm Flutter SDK into your project with the
-               `realm package on pub.dev <https://pub.dev/packages/realm>`__.
                To get started, :ref:`install the Realm Flutter SDK <flutter-install>`.
+               Then, import the Realm SDK in your project files.
 
             .. step:: Define an Object Schema
 
@@ -110,9 +109,10 @@ Develop Apps with Realm Flutter
 
             .. step:: Open a Realm
 
-               Open a realm before you begin using it. You can configure it to do things
+               You can configure your realm to do things
                like populate initial data on load, be encrypted, and more.
-               To get started, :ref:`open and configure a realm <node-open-close-realm>`.
+               To begin working with your data,
+               :ref:`configure and open a realm <ios-configure-and-open-a-realm>`.
 
             .. step:: Read and Write Data
 

--- a/source/sdk/java.txt
+++ b/source/sdk/java.txt
@@ -54,7 +54,7 @@ other clients.
          .. step:: Install the Realm Java SDK
 
             Use the Gradle build system to
-            :ref:`java-install` in your project.
+            :ref:`install the Realm Java SDK in your project <java-install>`.
 
          .. step:: Define an Object Schema
 
@@ -65,8 +65,8 @@ other clients.
 
             Realm Database stores objects in realm files on your device, 
             or you can open an in-memory realm which does not create a file.
-            :ref:`Configure and open a realm <java-open-close-realm>` 
-            to get started reading and writing data.
+            To get started reading and writing data,
+            :ref:`configure and open a realm <java-open-close-realm>`.
 
          .. step:: Read and Write Data
 

--- a/source/sdk/java.txt
+++ b/source/sdk/java.txt
@@ -83,7 +83,7 @@ other clients.
             <java-react-to-changes>` to watch for changes and perform some 
             logic, such as updating your UI.
 
-      .. image:: /images/illustrations/Mobile_hero_green.png
+      .. image:: /images/illustrations/Spot_MauvePurple_Infrastructure_Tech_RealmApp2x.png
          :alt: Realm Mobile Illustration
 
    .. tab:: Sync Data Across Devices

--- a/source/sdk/kotlin.txt
+++ b/source/sdk/kotlin.txt
@@ -112,7 +112,7 @@ other clients.
             to watch for changes and perform some logic, such as updating 
             your UI.
 
-      .. image:: /images/illustrations/Mobile_hero_green.png
+      .. image:: /images/illustrations/Spot_MauvePurple_Infrastructure_Tech_RealmApp2x.png
          :alt: Realm Mobile Illustration
 
    .. tab:: Sync Data Across Devices

--- a/source/sdk/node.txt
+++ b/source/sdk/node.txt
@@ -63,7 +63,10 @@ Develop Apps with Realm
 
           .. step:: Configure & Open a Realm
 
-             To get started reading and writing data, :ref:`open and configure a realm <node-open-close-realm>`.
+             You can configure your realm to do things
+             like populate initial data on load, be encrypted, and more.
+             To begin working with your data,
+             :ref:`configure and open a realm <node-open-close-realm>`.
 
           .. step:: Read and Write Data
 

--- a/source/sdk/react-native.txt
+++ b/source/sdk/react-native.txt
@@ -82,44 +82,35 @@ clients.
   .. tab:: Use Realm Database Locally
       :tabid: local-realm
 
-      .. procedure::
+      .. container::
 
-         .. step:: Install the Realm React Native SDK
+        Use open-source Realm Database to store data on a device.
 
-            Set up your project with React Native and Realm.
-            See :ref:`Install React Native <react-native-install>` to get started.
+        .. procedure::
 
-         .. step:: Define an Object Schema
+          .. step:: Install the Realm React Native SDK
 
-            Use JavaScript to :ref:`define an object schema
-            <react-native-define-a-realm-object-schema>`.
+              Set up your project with React Native and Realm.
+              To get started, :ref:`install the Realm React Native SDK <react-native-install>`.
 
-         .. step:: Open a Realm
+          .. step:: Define an Object Schema
 
-            Realm Database stores objects on your device. :ref:`Configure
-            and open a realm <react-native-open-close-realm>` to get
-            started reading and writing data.
+              Use JavaScript to idiomatically :ref:`define a Realm object schema <react-native-define-a-realm-object-schema>`.
 
-         .. step:: Read and Write Data
+          .. step:: Configure & Open a Realm
 
-            You can create, read, update, and delete objects from the
-            realm.
+             To get started reading and writing data, :ref:`open and configure a realm <react-native-open-close-realm>`.
 
-            For more information, see :ref:`Read & Write Data
-            <react-native-read-and-write-data>` and :ref:`Query Data
-            <react-native-query-data>`.
+          .. step:: Read and Write Data
 
+              You can :ref:`create, read, update, and delete objects <react-native-read-and-write-data>`
+              from a realm. Construct complex queries to :ref:`filter data in a realm <react-native-query-data>`.
 
-         .. step:: React to Changes
+          .. step:: React to Changes
 
-            Realm's live objects mean that your data is always up-to-date.
-            You can register a change listener, a notification handler
-            that watches for changes and performs logic like updating
-            your UI.
-
-            For more information, visit :ref:`React to Changes
-            <react-native-react-to-changes>`.
-
+              Realm's live objects mean that your data is always up-to-date.
+              Register a change listener to :ref:`react to changes and perform logic like updating
+              your UI <react-native-react-to-changes>`.
 
       .. image:: /images/illustrations/Spot_MauvePurple_Infrastructure_Tech_RealmApp2x.png
          :alt: Realm Mobile Illustration
@@ -127,48 +118,42 @@ clients.
   .. tab:: Sync Data Across Devices
       :tabid: device-sync
 
-      .. procedure::
+      .. container::
 
-         .. step:: Connect to an Atlas App Services App
+         Use Device Sync to keep data in sync with your MongoDB Atlas cluster and other
+         clients.
 
-            Configure :ref:`Device Sync in an App Services App
-            <realm-sync-get-started>`. Define data access rules or use
-            Development Mode to infer a schema from your client's data model.
+         .. procedure::
 
-            Then, :ref:`connect to the backend
-            <react-native-connect-to-mongodb-realm-backend-app>`
-            from your client.
+            .. step:: Connect to an Atlas App Services App
 
-         .. step:: Authenticate a User
+               Configure :ref:`Device Sync in an App Services App <realm-sync-get-started>`.
+               Define data access rules or use Development Mode to infer a schema
+               from your client's data model.
+               Then, :ref:`connect to the backend App from your React Native App <react-native-connect-to-mongodb-realm-backend-app>`.
 
-            App Services provides access to custom JWT authentication,
-            our built-in email/password provider, anonymous
-            authentication, and popular
-            authentication providers like Apple, Google, and Facebook.
+            .. step:: Authenticate a User
 
-            For more information, see :ref:`Authenticate Users
-            <react-native-authenticate-users>`.
+               App Services provides access to custom JWT authentication,
+               our built-in email/password provider, anonymous
+               authentication, and popular
+               authentication providers like Apple, Google, and Facebook.
+               Use these providers to :ref:`authenticate a user in your client <react-native-authenticate-users>`.
 
-         .. step:: Open a Synced Realm
+            .. step:: Open a Synced Realm
 
-            A synced realm allows you to access data across devices.
-            To determine what data a synced realm can read and write,
-            subscribe to a query.
+               To get started syncing data, :ref:`open a synced realm <react-native-open-a-synced-realm>`.
+               To determine what data a synced realm can read and write,
+               :ref:`subscribe to a query <react-native-sync-subscribe-to-queryable-fields>`.
 
-            For more information, see :ref:`Open & Close a Realm
-            <react-native-open-close-realm>` and :ref:`Subscribe to
-            Queryable Fields <react-native-sync-subscribe-to-queryable-fields>`.
+            .. step:: Read and Write Synced Data
 
-         .. step:: Read and Write Synced Data
-
-            The APIs for reading and writing data are the same for both synced
-            and local realms. Data that you read and write is automatically kept
-            in sync with your Atlas cluster and other clients.
-            Apps keep working offline and sync changes when a network connection
-            is available.
-
-            For more information on reading and writing data, see
-            :ref:`Read & Write Data <react-native-read-and-write-data>`.
+               The :ref:`APIs for reading and writing data <react-native-read-and-write-data>`
+               are the same for both synced and local realms.
+               Data that you read and write is automatically kept
+               in sync with your Atlas cluster and other clients.
+               Apps keep working offline and sync changes when a network connection
+               is available.
 
       .. image:: /images/illustrations/Spot_AzureBlue_Mobile_Tech_RealmSync.png
          :alt: Realm Sync Illustration
@@ -178,48 +163,25 @@ clients.
 
       .. container::
 
+         Use Atlas App Services in your React Native application with the Realm SDK.
+
          Call Serverless Functions
          ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-         You can :ref:`call serverless Functions <react-native-call-a-function>`
-         from your client application that run in an App Services backend.
-
-         .. code-block:: javascript
-            :copyable: false
-
-            const myFunctionResult =
-            await user.functions.myServerlessFunction(
-               arguments
-            );
+         To invoke serverless backend logic from your React Native client,
+         :ref:`call Atlas Functions <react-native-call-a-function>`.
 
          Query MongoDB Atlas
          ~~~~~~~~~~~~~~~~~~~
 
-         You can :ref:`query data stored in MongoDB <react-native-mongodb-remote-access>`
-         directly from your client application code.
-
-         .. code-block:: javascript
-            :copyable: false
-
-            const mongodb = app.currentUser.mongoClient("mongodb-atlas");
-            const animals = mongodb.db("example").collection("animals");
-
-            const cheetah = await animals.findOne({ name: "cheetah" });
+         Query data stored in MongoDB directly from your client application code
+         with :ref:`MongoDB Data Access <react-native-mongodb-remote-access>`.
 
          Authenticate Users
          ~~~~~~~~~~~~~~~~~~
 
-         Authenticate users with built-in and third-party :ref:`authentication
-         providers <react-native-authenticate-users>`. Use the authenticated user
-         to access App Services.
-
-         .. code-block:: javascript
-            :copyable: false
-
-            const jwt = await authenticateWithExternalSystem();
-            const credentials = Realm.Credentials.jwt(jwt);
-
-            const user = await app.logIn(credentials);
+         Authenticate users with built-in and third-party :ref:`authentication providers <react-native-authenticate-users>`.
+         Access App Services with authenticated users.
 
       .. image:: /images/illustrations/Spot_MauvePurple_APIs_Tech_RealmApp.png
          :alt: App Services Illustration

--- a/source/sdk/react-native.txt
+++ b/source/sdk/react-native.txt
@@ -99,7 +99,10 @@ clients.
 
           .. step:: Configure & Open a Realm
 
-             To get started reading and writing data, :ref:`open and configure a realm <react-native-open-close-realm>`.
+             You can configure your realm to do things
+             like populate initial data on load, be encrypted, and more.
+             To begin working with your data,
+             :ref:`configure and open a realm <react-native-open-close-realm>`.
 
           .. step:: Read and Write Data
 

--- a/source/sdk/swift.txt
+++ b/source/sdk/swift.txt
@@ -120,7 +120,7 @@ other clients.
             to :ref:`update Views when data changes 
             <swiftui-update-ui-when-objects-change>`.
 
-      .. image:: /images/illustrations/Mobile_hero_green.png
+      .. image:: /images/illustrations/Spot_MauvePurple_Infrastructure_Tech_RealmApp2x.png
          :alt: Realm Mobile Illustration
 
    .. tab:: Sync Data Across Devices
@@ -182,7 +182,7 @@ other clients.
             :caption: SwiftUI Property Wrappers Offer Realm/SwiftUI Integration
             :copyable: false
 
-      .. image:: /images/illustrations/Sports_hero_green.png
+      .. image:: /images/illustrations/Spot_MauvePurple_Logic_Tech_RealmApp2x.png
          :alt: Realm Mobile Illustration
 
    .. tab:: Build with Atlas App Services
@@ -196,26 +196,11 @@ other clients.
          You can :ref:`call serverless Functions <ios-call-a-function>` 
          from your client application that run in an App Services backend.
 
-         .. code-block:: swift
-            :copyable: false
-
-            let myFunctionResult = try await user.functions.myServerlessFunction(arguments)
-
          Query MongoDB Atlas
          ~~~~~~~~~~~~~~~~~~~
 
          You can :ref:`query data stored in MongoDB <ios-mongodb-remote-access>`
          directly from your client application code.
-
-         .. code-block:: swift
-            :copyable: false
-
-            let client = app.currentUser!.mongoClient("mongodb-atlas")
-            let database = client.database(named: "products")
-            let collection = database.collection(withName: "coffee_drinks")
-
-            let queryFilter: Document = ["name": "Maple Latte"]
-            let queryResult = try await collection.findOneDocument(filter: queryFilter)
 
          Authenticate Users
          ~~~~~~~~~~~~~~~~~~
@@ -223,12 +208,6 @@ other clients.
          Authenticate users with built-in and third-party :ref:`authentication 
          providers <ios-authenticate-users>`. Use the authenticated user to 
          access App Services.
-
-         .. code-block:: swift
-            :copyable: false
-
-            let app = App(id: YOUR_APP_SERVICES_APP_ID)
-            let user = try await app.login(credentials: .anonymous)
 
       .. image:: /images/illustrations/Spot_MauvePurple_APIs_Tech_RealmApp.png
          :alt: App Services Illustration

--- a/source/sdk/swift.txt
+++ b/source/sdk/swift.txt
@@ -173,9 +173,9 @@ other clients.
       .. container::
 
          The Realm Swift SDK offers property wrappers and convenience features 
-         designed to make it easier to work with Realm in SwiftUI. Check out the 
-         :ref:`SwiftUI documentation <ios-swiftui-examples>` for example View code 
-         that demonstrates common Realm SwiftUI patterns.
+         designed to make it easier to work with Realm in SwiftUI.
+         For example View code that demonstrates common Realm SwiftUI patterns,
+         check out the :ref:`SwiftUI documentation <ios-swiftui-examples>`.
 
          .. literalinclude:: /examples/generated/swiftui/FilterData.snippet.searchable.swift
             :language: swift

--- a/source/web.txt
+++ b/source/web.txt
@@ -89,24 +89,21 @@ and more.
 
          .. step:: Connect to an Atlas App Services App
 
-            Connect to your App Services App from the browser using the Web SDK.
-
-            For more information, see :ref:`Initialize the App Client <web-init-appclient>`.
+            To access your App Services App from the browser, :ref:`initialize the App client
+            <web-init-appclient>`.
 
          .. step:: Authenticate a User
 
-            Use one of the App Services authentication providers to authenticate a
-            user. App Services includes custom JWT, Facebook, Google, Apple,
+            To authenticate a user, usee one of the :ref:`App Services authentication providers <web-authenticate>`.
+            App Services includes custom JWT, Facebook, Google, Apple,
             anonymous, and built-in email/password authentication providers.
-
-            For more information, see :ref:`Authenticate Users <web-authenticate>`.
 
          .. step:: Query MongoDB
 
             Query MongoDB directly from the browser using your authenticated user.
             The user can only access data that they're authorized to.
 
-            For more information, see the :ref:`Query MongoDB documentation <web-query-mongodb>`.
+            For more information, refer to :ref:`Query MongoDB <web-query-mongodb>`.
 
       .. image:: /images/illustrations/Spot_BrightYellow_Query_Tech_Compass.png
          :alt: Query MongoDB Illustration
@@ -118,29 +115,24 @@ and more.
 
          .. step:: Configure Atlas GraphQL API
 
-            Configure the GraphQL API in Atlas App Services.
-            The GraphQL API automatically generates a hosted endpoint
-            with GraphQL queries and mutations based on JSON schemas
+            The :ref:`Atlas GraphQL API <graphql-api>` automatically generates
+            a hosted endpoint with GraphQL queries and mutations based on JSON schemas
             for the documents in your database.
 
             Configure App Services Authentication with data access rules to
             control which users have access to what data.
-
-            For more information, see :ref:`Atlas GraphQL API <graphql-api>`.
+            Configure the GraphQL API in Atlas App Services.
 
          .. step:: Connect to Atlas App Services
 
-            Connect to your App Services App from the browser using the Web SDK.
-
-            For more information, see :ref:`Initialize the App Client <web-init-appclient>`.
+            To access your App Services App from the browser, :ref:`initialize the App client
+            <web-init-appclient>`.
 
          .. step:: Authenticate a User
 
-            Use one of the App Services authentication providers to authenticate a
-            user. App Services includes custom JWT, Facebook, Google, Apple,
+            To authenticate a user, usee one of the :ref:`App Services authentication providers <web-authenticate>`.
+            App Services includes custom JWT, Facebook, Google, Apple,
             anonymous, and built-in email/password authentication providers.
-
-            For more information, see :ref:`Authenticate Users <web-authenticate>`.
 
          .. step:: Query the GraphQL API
 


### PR DESCRIPTION
## Pull Request Info

Made new SDK landing pages more uniform in following ways:

- same images for relevant similar sections
- removed code examples for working with app services
- standardized general phrasing to remove "For more information..." in each step.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26005

### Staged Changes (Requires MongoDB Corp SSO)

- [changes across all SDK landing pages](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26005/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
