### PR TITLE
Update get started intro section

### DIFF
--- a/source/introduction.txt
+++ b/source/introduction.txt
@@ -112,7 +112,7 @@ with data from your app:
 Get Started with Realm
 ----------------------
 
-Learn more about each Realm SDK:
+Learn more about the Realm SDKs in their documentation:
 
 - :ref:`C++ SDK <cpp-intro>`
 - :ref:`Flutter SDK <flutter-intro>`

--- a/source/introduction.txt
+++ b/source/introduction.txt
@@ -112,7 +112,7 @@ with data from your app:
 Get Started with Realm
 ----------------------
 
-Learn more about the Realm SDKs in their documentation:
+Learn more about the Realm SDKs:
 
 - :ref:`C++ SDK <cpp-intro>`
 - :ref:`Flutter SDK <flutter-intro>`

--- a/source/introduction.txt
+++ b/source/introduction.txt
@@ -112,27 +112,17 @@ with data from your app:
 Get Started with Realm
 ----------------------
 
-Check out our Task Tracker tutorial for any of these platforms:
+Learn more about each Realm SDK:
 
-- :ref:`Android with Kotlin <kotlin-tutorial>`
-- :ref:`Flutter with Dart <flutter-tutorial>`
-- :ref:`iOS with SwiftUI <ios-swift-tutorial>`
-- :ref:`React Native with JavaScript <react-native-tutorial>`
-- :ref:`Xamarin (iOS and Android) with C# <dotnet-tutorial>`
-
-Or start by experimenting with a working Sync-enabled client application
-with a :ref:`template app <template-apps>`.
-
-You can also refer to the documentation for each client SDK:
-
-- :doc:`Flutter SDK </sdk/flutter>` for Flutter
-- :doc:`Java SDK </sdk/java>` for Java
-- :doc:`Kotlin SDK </sdk/kotlin>` for Kotlin
-- :doc:`.NET SDK </sdk/dotnet>` for C# and Xamarin
-- :doc:`Node.js SDK </sdk/node>` for Node.js
-- :doc:`React Native SDK </sdk/react-native>` for TypeScript and JavaScript with React Native
-- :doc:`Swift SDK </sdk/swift>` for Swift and Objective-C
-- :doc:`Web SDK </web>` for browser JavaScript
+- :ref:`C++ SDK <cpp-intro>`
+- :ref:`Flutter SDK <flutter-intro>`
+- :ref:`Java SDK <java-intro>`
+- :ref:`Kotlin SDK <kotlin-intro>`
+- :ref:`.NET SDK <dotnet-intro>`
+- :ref:`Node.js SDK <node-intro>`
+- :ref:`React Native SDK <react-native-intro>`
+- :ref:`Swift SDK <ios-intro>`
+- :ref:`Web SDK <web-intro>`
 
 Summary
 -------


### PR DESCRIPTION
## Pull Request Info

Update 'Get Started with Realm' section of Introduction. Removed outdated references to Task Tracker tutorial. Just redirected users to each SDK's landing page b/c now they've been filled with all kinds of useful introduction/getting started tasks.

### Jira

n/a

### Staged Changes (Requires MongoDB Corp SSO)

- [Introduction](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/intro_tweak/introduction)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
