### PR TITLE
(DOCSP-24154) [BAAS] Support new IN syntax in RQL for Flexible Sync

### DIFF
--- a/examples/node/Examples/realm-query-language.js
+++ b/examples/node/Examples/realm-query-language.js
@@ -274,7 +274,7 @@ describe("Realm Query Language Reference", () => {
 
     const sortedUniqueAliTasks = tasks.filtered(
       // :snippet-start: sort-distinct-limit
-      "assignee = 'Ali' SORT(priority DESC) DISTINCT(name) LIMIT(5)"
+      "assignee == 'Ali' SORT(priority DESC) DISTINCT(name) LIMIT(5)"
       // :snippet-end:
     );
     expect(sortedUniqueAliTasks.length).toBe(1);

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.sort-distinct-limit.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.sort-distinct-limit.js
@@ -1,1 +1,1 @@
-"assignee = 'Ali' SORT(priority DESC) DISTINCT(name) LIMIT(5)"
+"assignee == 'Ali' SORT(priority DESC) DISTINCT(name) LIMIT(5)"

--- a/source/includes/flex-sync-limitations.rst
+++ b/source/includes/flex-sync-limitations.rst
@@ -14,9 +14,6 @@ Unsupported Query Operators in Flexible Sync
    * - Operator Type
      - Unsupported Operators
 
-   * - Comparison Operators
-     - ``in``
-
    * - String Operators
      - ``in``
 
@@ -35,8 +32,23 @@ Flexible Sync only supports ``@count`` for array fields.
 List Queries
 ~~~~~~~~~~~~
 
-Flexible Sync does not support querying on lists of data using the
-``IN`` operator.
+Flexible Sync supports querying lists using the ``IN`` operator.
+
+You can query a list of constants to see if it contains the value of a
+queryable field:
+
+.. code-block:: javascript
+   
+   // Query a constant list for a queryable field value
+   "priority IN { 1, 2, 3 }"
+
+If a queryable field has an array value, you can query to see if it
+contains a constant value:
+
+.. code-block:: javascript
+   
+   // Query an array-valued queryable field for a constant value
+   "'comedy' IN genres"
 
 Embedded or Linked Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/includes/flex-sync-limitations.rst
+++ b/source/includes/flex-sync-limitations.rst
@@ -14,9 +14,6 @@ Unsupported Query Operators in Flexible Sync
    * - Operator Type
      - Unsupported Operators
 
-   * - String Operators
-     - ``in``
-
    * - Aggregate Operators
      - ``@avg``, ``@count``, ``@max``, ``@min``, ``@sum``
 

--- a/source/includes/flex-sync-limitations.rst
+++ b/source/includes/flex-sync-limitations.rst
@@ -51,4 +51,4 @@ Embedded or Linked Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Flexible Sync does not support querying on properties in Embedded Objects 
-or links. For example, ``obj1.field = "foo"``.
+or links. For example, ``obj1.field == "foo"``.

--- a/source/realm-query-language.txt
+++ b/source/realm-query-language.txt
@@ -337,7 +337,7 @@ values.
    * - | ``IN``
      - Evaluates to ``true`` if the left-hand expression is in the
        right-hand list. This is equivalent to and used as a shorthand
-       for ``= ANY``.
+       for ``== ANY``.
 
    * - | ``<``
      - Evaluates to ``true`` if the left-hand numerical or date expression

--- a/source/realm-query-language.txt
+++ b/source/realm-query-language.txt
@@ -336,8 +336,8 @@ values.
 
    * - | ``IN``
      - Evaluates to ``true`` if the left-hand expression is in the
-       right-hand list or string. This is equivalent to and used as a
-       shorthand for ``= ANY``.
+       right-hand list. This is equivalent to and used as a shorthand
+       for ``= ANY``.
 
    * - | ``<``
      - Evaluates to ``true`` if the left-hand numerical or date expression

--- a/source/realm-query-language.txt
+++ b/source/realm-query-language.txt
@@ -334,9 +334,10 @@ values.
        For dates, this evaluates to ``true`` if the left-hand date is later than
        or the same as the right-hand date.
 
-   * - ``IN``
+   * - | ``IN``
      - Evaluates to ``true`` if the left-hand expression is in the
-       right-hand list or string.
+       right-hand list or string. This is equivalent to and used as a
+       shorthand for ``= ANY``.
 
    * - | ``<``
      - Evaluates to ``true`` if the left-hand numerical or date expression

--- a/source/realm-query-language.txt
+++ b/source/realm-query-language.txt
@@ -438,10 +438,6 @@ Regex-like wildcards allow more flexibility in search.
        but only matches if the right-hand string expression is found
        at the beginning of the left-hand string expression.
 
-   * - | ``IN``
-     - Evaluates to ``true`` if the left-hand string expression is found
-       anywhere in the right-hand string expression.
-
    * - | ``CONTAINS``
      - Evaluates to ``true`` if the right-hand string expression
        is found anywhere in the left-hand string expression.


### PR DESCRIPTION
## Pull Request Info

### Jira

- (DOCSP-24154) [BAAS] Support new IN syntax in RQL for Flexible Sync

### Staged Changes (Requires MongoDB Corp SSO)

- [Realm Query Language](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/rql-in/realm-query-language/#list-queries)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
