### PR TITLE
(DOCSP-25427): Add App Group corresponding to tvOS test to fix tvOS test failure

### DIFF
--- a/examples/ios/Examples/OpenCloseRealm.swift
+++ b/examples/ios/Examples/OpenCloseRealm.swift
@@ -44,14 +44,14 @@ class OpenCloseRealm: XCTestCase {
         // :snippet-end:
     }
 
-//    func testTvOs() {
-//        // :snippet-start: tvos-share-path
-//        let fileUrl = FileManager.default
-//            .containerURL(forSecurityApplicationGroupIdentifier: "group.com.mongodb.realm.examples.extension")!
-//            .appendingPathComponent("Library/Caches/default.realm")
-//        // :snippet-end:
-//        print(fileUrl)
-//    }
+    func testTvOs() {
+        // :snippet-start: tvos-share-path
+        let fileUrl = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: "group.com.mongodb.realm.examples.extension")!
+            .appendingPathComponent("Library/Caches/default.realm")
+        // :snippet-end:
+        print(fileUrl)
+    }
 
     func testHandleError() {
         // :snippet-start: handle-error

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -242,6 +242,7 @@
 		917E73E526B8A9F80068242A /* MongoDBRemoteAccess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MongoDBRemoteAccess.swift; sourceTree = "<group>"; };
 		917E73E626B8A9F80068242A /* MongoDBRemoteAccessAggregate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MongoDBRemoteAccessAggregate.swift; sourceTree = "<group>"; };
 		9185DB1825E82C0300AF1389 /* LocalOnlyCompleteQuickStart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalOnlyCompleteQuickStart.swift; sourceTree = "<group>"; };
+		91A09A33290AF9410009FD7E /* RealmExamplesHostApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RealmExamplesHostApp.entitlements; sourceTree = "<group>"; };
 		91AB031328981BF700A272E8 /* DeleteRealmFiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteRealmFiles.swift; sourceTree = "<group>"; };
 		91AB0315289965F800A272E8 /* CreateRealmObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRealmObjects.swift; sourceTree = "<group>"; };
 		91AB03172899660A00A272E8 /* ReadRealmObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadRealmObjects.swift; sourceTree = "<group>"; };
@@ -450,6 +451,7 @@
 		48DBFACD25101C3100391E2B = {
 			isa = PBXGroup;
 			children = (
+				91A09A33290AF9410009FD7E /* RealmExamplesHostApp.entitlements */,
 				4896EE4D2510514B00D1FABF /* Examples */,
 				4803B325251068F800CCAF97 /* HostApp */,
 				91713AFA28AC3D8200519F9D /* SwiftUICatalog */,
@@ -1033,8 +1035,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_ENTITLEMENTS = RealmExamplesHostApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_EXPAND_BUILD_SETTINGS = YES;
 				INFOPLIST_FILE = HostApp/Info.plist;
@@ -1059,8 +1063,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_ENTITLEMENTS = RealmExamplesHostApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_EXPAND_BUILD_SETTINGS = YES;
 				INFOPLIST_FILE = HostApp/Info.plist;

--- a/examples/ios/RealmExamplesHostApp.entitlements
+++ b/examples/ios/RealmExamplesHostApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.mongodb.realm.examples.extension</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Pull Request Info

This PR adds an App Group corresponding to the `tvOS` test: `group.com.mongodb.realm.examples.extension`

Fixes a build failure related to finding nil when unwrapping because this App Group did not exist.

### Jira

- https://jira.mongodb.org/browse/DOCSP-25247

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
