### PR TITLE
(DOCSP-26187): Update ThreadSafe wrapper Parameter example to work with Swift actors

### DIFF
--- a/examples/ios/Examples/Threading.swift
+++ b/examples/ios/Examples/Threading.swift
@@ -236,34 +236,39 @@ class Threading: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
-//    func testThreadSafeWrapperParameter() async {
-//        let expectation = XCTestExpectation(description: "it completes")
-//        func someLongCallToGetNewName() async -> String {
-//            return "Test"
-//        }
-//
-//        // :snippet-start: threadsafe-wrapper-function-parameter
-//        func loadNameInBackground(@ThreadSafe person: ThreadingExamples_Person?) async {
-//            let newName = await someLongCallToGetNewName()
-//            let realm = try! await Realm()
-//            try! realm.write {
-//                person?.name = newName
-//            }
-//            expectation.fulfill() // :remove:
-//        }
-//
-//        let realm = try! await Realm()
-//
-//        let person = ThreadingExamples_Person(name: "Jane")
-//        try! realm.write {
-//            realm.add(person)
-//        }
-//        await loadNameInBackground(person: person)
-//        // :snippet-end:
-//
-//        XCTAssertEqual(person.name, "Test")
-//        wait(for: [expectation], timeout: 10)
-//    }
+    func testThreadSafeWrapperParameter() async {
+        let expectation = XCTestExpectation(description: "it completes")
+        // :snippet-start: threadsafe-wrapper-function-parameter
+        func someLongCallToGetNewName() async -> String {
+            return "Janet"
+        }
+        
+        @MainActor
+        func loadNameInBackground(@ThreadSafe person: ThreadingExamples_Person?) async {
+            let newName = await someLongCallToGetNewName()
+            let realm = try! await Realm()
+            try! realm.write {
+                person?.name = newName
+            }
+            expectation.fulfill() // :remove:
+        }
+
+        @MainActor
+        func createAndUpdatePerson() async {
+            let realm = try! await Realm()
+            
+            let person = ThreadingExamples_Person(name: "Jane")
+            try! realm.write {
+                realm.add(person)
+            }
+            await loadNameInBackground(person: person)
+            XCTAssertEqual(person.name, "Janet") // :remove:
+        }
+        
+        await createAndUpdatePerson()
+        // :snippet-end:
+        wait(for: [expectation], timeout: 10)
+    }
 
     func testWriteAsyncExtension() {
         let expectation = XCTestExpectation(description: "it completes")

--- a/source/examples/generated/code/start/Threading.snippet.threadsafe-wrapper-function-parameter.swift
+++ b/source/examples/generated/code/start/Threading.snippet.threadsafe-wrapper-function-parameter.swift
@@ -1,3 +1,8 @@
+func someLongCallToGetNewName() async -> String {
+    return "Janet"
+}
+
+@MainActor
 func loadNameInBackground(@ThreadSafe person: Person?) async {
     let newName = await someLongCallToGetNewName()
     let realm = try! await Realm()
@@ -6,10 +11,15 @@ func loadNameInBackground(@ThreadSafe person: Person?) async {
     }
 }
 
-let realm = try! await Realm()
-
-let person = Person(name: "Jane")
-try! realm.write {
-    realm.add(person)
+@MainActor
+func createAndUpdatePerson() async {
+    let realm = try! await Realm()
+    
+    let person = Person(name: "Jane")
+    try! realm.write {
+        realm.add(person)
+    }
+    await loadNameInBackground(person: person)
 }
-await loadNameInBackground(person: person)
+
+await createAndUpdatePerson()


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-26187

### Staged Changes (Requires MongoDB Corp SSO)

- [Threading - Use the ThreadSafe Wrapper](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26187/sdk/swift/crud/threading/#use-the--threadsafe-wrapper): Update the example in the "example" box showing how to use `@ThreadSafe` on a function parameter

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
