### PR TITLE
Point to the correct Realm Kotlin dependency when used across Gradle Modules

### DIFF
--- a/source/sdk/kotlin/install/kotlin-multiplatform.txt
+++ b/source/sdk/kotlin/install/kotlin-multiplatform.txt
@@ -270,8 +270,14 @@ Installation
    .. code-block:: kotlin
       :copyable: false
 
+      // If only using the local database
       dependencies {
-         compileOnly("io.realm.kotlin:library:{+kotlin-sdk-version+}")
+         compileOnly("io.realm.kotlin:library-base:{+kotlin-sdk-version+}")
+      }
+
+      // If using Device Sync
+      dependencies {
+         compileOnly("io.realm.kotlin:library-sync:{+kotlin-sdk-version+}")
       }
 
 After updating the Gradle configuration,


### PR DESCRIPTION
The callout to manually including the Realm Kotlin SDK dependency when used across modules where pointing to a non-existing dependency.