### PR TITLE
(DOCSP-26274): Update Flutter docs to reference RC release

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -12,7 +12,7 @@ Welcome to the Realm Docs
 
    Introduction </introduction>
    C++ SDK (Alpha) </sdk/cpp>
-   Flutter SDK (Beta) </sdk/flutter>
+   Flutter SDK (RC) </sdk/flutter>
    Java SDK </sdk/java>
    Kotlin SDK </sdk/kotlin>
    .NET SDK </sdk/dotnet>
@@ -115,7 +115,7 @@ and platforms. Each SDK is language-idiomatic and includes:
       Build web applications in JavaScript or TypeScript. Access data with GraphQL and MongoDB queries.
 
    .. card::
-      :headline: Flutter SDK (Beta)
+      :headline: Flutter SDK
       :url: https://www.mongodb.com/docs/realm/sdk/flutter
       :icon: /images/icons/flutter.svg
       :icon-alt: Futter icon

--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -75,7 +75,7 @@ and platforms. Each SDK is language-idiomatic and includes:
       Build web applications in JavaScript or TypeScript. Access data with GraphQL and MongoDB queries.
 
    .. card::
-      :headline: Flutter SDK (Beta)
+      :headline: Flutter SDK
       :url: https://www.mongodb.com/docs/realm/sdk/flutter
       :icon: /images/icons/flutter.svg
       :icon-alt: Futter icon

--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -4,9 +4,9 @@
 
 .. _flutter-intro:
 
-========================
-Realm Flutter SDK (Beta)
-========================
+=====================================
+Realm Flutter SDK (Release Candidate)
+=====================================
 
 .. toctree::
    :titlesonly:
@@ -26,22 +26,13 @@ The Realm Flutter SDK enables client applications written in
 platform to access data stored in realms, sync data with Atlas,
 and use Atlas App Services.
 
-Beta Limitations
-----------------
+Release Candidate Limitations
+-----------------------------
 
-This SDK is currently offered as a **beta** release. We encourage you
-to try out the feature and `give feedback
-<https://feedback.mongodb.com/forums/923521-realm/>`__. However, be
-aware that APIs and functionality are subject to change.
-
-Because this is a beta version of the SDK, functionality is limited and there
-are specific configuration considerations:
-
-- The beta version of the SDK does not yet have certain Realm database features.
-- The SDK doesn't have built-in functionality to interact with all of
-  App Services. Learn more about how to :ref:`use the SDK with currently supported App Services
-  <flutter-application-services>`.
-
+This SDK is currently offered as a **release candidate (RC)**.
+We encourage you to try out the feature and `give feedback
+<https://feedback.mongodb.com/forums/923521-realm/>`__.
+However, be aware that APIs and functionality are subject to change.
 
 .. kicker:: Learning Paths
 

--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -30,7 +30,7 @@ Release Candidate Limitations
 -----------------------------
 
 This SDK is currently offered as a **release candidate (RC)**.
-We encourage you to try out the feature and `give feedback
+We encourage you to try out the features and `give feedback
 <https://feedback.mongodb.com/forums/923521-realm/>`__.
 However, be aware that APIs and functionality are subject to change.
 


### PR DESCRIPTION
## Pull Request Info

Update the docs to refer to Flutter as RC instead of Beta. 

Flutter SDK going RC early November 2022.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26274

### Staged Changes (Requires MongoDB Corp SSO)

- [Flutter SDK landing page](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26274/sdk/flutter)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
