### PR TITLE
Add info about cancellationToken

### DIFF
--- a/source/sdk/dotnet/fundamentals/write-transactions.txt
+++ b/source/sdk/dotnet/fundamentals/write-transactions.txt
@@ -75,8 +75,8 @@ The following code shows how to use both approaches:
 
    As with most C# async methods, the 
    :dotnet-sdk:`WriteAsync <reference/Realms.Realm.html#Realms_Realm_WriteAsync_System_Action_System_Threading_CancellationToken_>`,
-   :dotnet-sdk:`BeginWriteAsync() <reference/Realms.Realm.html#Realms_Realm_BeginWriteAsync_System_Threading_CancellationToken_>`,
-   and :dotnet-sdk:`CommitAsync() <reference/Realms.Transaction.html#Realms_Transaction_CommitAsync_System_Threading_CancellationToken_>`
+   :dotnet-sdk:`BeginWriteAsync <reference/Realms.Realm.html#Realms_Realm_BeginWriteAsync_System_Threading_CancellationToken_>`,
+   and :dotnet-sdk:`CommitAsync <reference/Realms.Transaction.html#Realms_Transaction_CommitAsync_System_Threading_CancellationToken_>`
    methods can take a 
    `CancellationToken <https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken?view=net-6.0>`_ 
    as a parameter, providing you with the option cancel the thread before 

--- a/source/sdk/dotnet/fundamentals/write-transactions.txt
+++ b/source/sdk/dotnet/fundamentals/write-transactions.txt
@@ -51,18 +51,20 @@ Initiate a Transaction
 The .NET SDK provides a simple API you can use for most writes.  The 
 :dotnet-sdk:`Write() <reference/Realms.Realm.html#Realms_Realm_Write__1_System_Func___0__>` and
 :dotnet-sdk:`WriteAsync() <reference/Realms.Realm.html#Realms_Realm_WriteAsync_System_Action_System_Threading_CancellationToken_>` and
-methods wrap all commands into a single transaction and then commits the 
+methods wrap all commands into a single transaction and then commit the 
 transaction. 
 
-The ``Write()`` and ``WriteAsync`` methods are shorthand for using the 
+The ``Write()`` and ``WriteAsync()`` methods are shorthand for using the 
 :dotnet-sdk:`BeginWrite() <reference/Realms.Realm.html#Realms_Realm_BeginWrite>` and
 :dotnet-sdk:`Transaction.Commit() <reference/Realms.Transaction.html#Realms_Transaction_Commit>`
-methods, and their ``Async`` counterparts. In most cases, using ``Write()`` will 
-meet your needs, but if you need finer control over the transaction, 
-use ``BeginWrite()`` with one of the 
-``Transaction`` methods (:dotnet-sdk:`Commit() <reference/Realms.Transaction.html#Realms_Transaction_Commit>`,
-:dotnet-sdk:`Dispose() <reference/Realms.Transaction.html#Realms_Transaction_Dispose>`, or 
-:dotnet-sdk:`Rollback() <reference/Realms.Transaction.html#Realms_Transaction_Rollback>`). 
+methods, and their ``Async`` counterparts. In most cases, either of these two write 
+methods will meet your needs. If you need finer control over the transaction, 
+use ``BeginWrite()`` with one of these ``Transaction`` methods:
+
+- :dotnet-sdk:`Commit() <reference/Realms.Transaction.html#Realms_Transaction_Commit>`
+- :dotnet-sdk:`Dispose() <reference/Realms.Transaction.html#Realms_Transaction_Dispose>`
+- :dotnet-sdk:`Rollback() <reference/Realms.Transaction.html#Realms_Transaction_Rollback>`
+
 The following code shows how to use both approaches:
 
 .. literalinclude:: /examples/generated/dotnet/WriteExamples.snippet.create.cs
@@ -79,5 +81,5 @@ The following code shows how to use both approaches:
    and :dotnet-sdk:`CommitAsync <reference/Realms.Transaction.html#Realms_Transaction_CommitAsync_System_Threading_CancellationToken_>`
    methods can take a 
    `CancellationToken <https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken?view=net-6.0>`_ 
-   as a parameter, providing you with the option cancel the thread before 
+   as a parameter, providing you with the option to cancel the operation before 
    the process completes.

--- a/source/sdk/dotnet/fundamentals/write-transactions.txt
+++ b/source/sdk/dotnet/fundamentals/write-transactions.txt
@@ -49,15 +49,17 @@ Initiate a Transaction
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The .NET SDK provides a simple API you can use for most writes.  The 
-:dotnet-sdk:`Write() <reference/Realms.Realm.html#Realms_Realm_Write__1_System_Func___0__>` 
-method wraps all commands into a single transaction and then commits the 
+:dotnet-sdk:`Write() <reference/Realms.Realm.html#Realms_Realm_Write__1_System_Func___0__>` and
+:dotnet-sdk:`WriteAsync() <reference/Realms.Realm.html#Realms_Realm_WriteAsync_System_Action_System_Threading_CancellationToken_>` and
+methods wrap all commands into a single transaction and then commits the 
 transaction. 
 
-The ``Write()`` method is shorthand for using the 
+The ``Write()`` and ``WriteAsync`` methods are shorthand for using the 
 :dotnet-sdk:`BeginWrite() <reference/Realms.Realm.html#Realms_Realm_BeginWrite>` and
 :dotnet-sdk:`Transaction.Commit() <reference/Realms.Transaction.html#Realms_Transaction_Commit>`
-methods. In most cases, using ``Write()`` will meet your needs, but if you need 
-finer control over the transaction, use ``BeginWrite()`` with one of the 
+methods, and their ``Async`` counterparts. In most cases, using ``Write()`` will 
+meet your needs, but if you need finer control over the transaction, 
+use ``BeginWrite()`` with one of the 
 ``Transaction`` methods (:dotnet-sdk:`Commit() <reference/Realms.Transaction.html#Realms_Transaction_Commit>`,
 :dotnet-sdk:`Dispose() <reference/Realms.Transaction.html#Realms_Transaction_Dispose>`, or 
 :dotnet-sdk:`Rollback() <reference/Realms.Transaction.html#Realms_Transaction_Rollback>`). 
@@ -69,3 +71,13 @@ The following code shows how to use both approaches:
 .. literalinclude:: /examples/generated/dotnet/WriteExamples.snippet.create-long-hand.cs
    :language: csharp
 
+.. note:: CancellationTokens
+
+   As with most C# async methods, the 
+   :dotnet-sdk:`WriteAsync <reference/Realms.Realm.html#Realms_Realm_WriteAsync_System_Action_System_Threading_CancellationToken_>`,
+   :dotnet-sdk:`BeginWriteAsync() <reference/Realms.Realm.html#Realms_Realm_BeginWriteAsync_System_Threading_CancellationToken_>`,
+   and :dotnet-sdk:`CommitAsync() <reference/Realms.Transaction.html#Realms_Transaction_CommitAsync_System_Threading_CancellationToken_>`
+   methods can take a 
+   `CancellationToken <https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken?view=net-6.0>`_ 
+   as a parameter, providing you with the option cancel the thread before 
+   the process completes.


### PR DESCRIPTION
## Pull Request Info

Added a note indicating that the new methods take a cancellationToken. Since these methods use the token as all other C# async methods do, no need to add explanation or code example to our docs.


### Jira

https://jira.mongodb.org/browse/DOCSP-22721

### Staged Changes (Requires MongoDB Corp SSO)

https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/cancel_token/sdk/dotnet/fundamentals/write-transactions/

