### PR TITLE
(DOCSP-26316): Flutter - new Compact a Realm page

### DIFF
--- a/examples/dart/test/compact_realm_test.dart
+++ b/examples/dart/test/compact_realm_test.dart
@@ -15,7 +15,7 @@ void main() {
         // For convenience, this example defines a const
         // representing a byte to MB conversion for compaction
         // at an arbitrary 10MB file size.
-        const tenMB = 10 * 1024 * 1024;
+        const tenMB = 10 * 1048576;
         return totalSize > tenMB;
       }));
       var realm = Realm(config);
@@ -28,7 +28,7 @@ void main() {
       var config = Configuration.local([Car.schema],
           shouldCompactCallback: ((totalSize, usedSize) {
         // Compact if the file is over 10MB in size and less than 50% 'used'
-        const tenMB = 10 * 1024 * 1024;
+        const tenMB = 10 * 1048576;
         return (totalSize > tenMB) &&
             (usedSize.toDouble() / totalSize.toDouble()) < 0.5;
       }));

--- a/examples/dart/test/compact_realm_test.dart
+++ b/examples/dart/test/compact_realm_test.dart
@@ -1,0 +1,41 @@
+import 'package:test/test.dart';
+import '../bin/models/car.dart';
+import 'package:realm_dart/realm.dart';
+import 'package:path/path.dart' as path;
+import 'dart:io';
+import './utils.dart';
+
+void main() {
+  group('Compact a Realm', () {
+    test('Compact a Realm with callback', () async {
+      // :snippet-start: compact-with-callback
+      var config = Configuration.local([Car.schema],
+          shouldCompactCallback: ((totalSize, usedSize) {
+        // shouldCompactCallback sizes are in bytes.
+        // For convenience, this example defines a const
+        // representing a byte to MB conversion for compaction
+        // at an arbitrary 10MB file size.
+        const tenMB = 10 * 1024 * 1024;
+        return totalSize > tenMB;
+      }));
+      var realm = Realm(config);
+      // :snippet-end:
+      realm.close();
+      await cleanUpRealm(realm);
+    });
+    test('Compact a Realm with callback plus logic', () async {
+      // :snippet-start: compact-with-callback-and-logic
+      var config = Configuration.local([Car.schema],
+          shouldCompactCallback: ((totalSize, usedSize) {
+        // Compact if the file is over 10MB in size and less than 50% 'used'
+        const tenMB = 10 * 1024 * 1024;
+        return (totalSize > tenMB) &&
+            (usedSize.toDouble() / totalSize.toDouble()) < 0.5;
+      }));
+      var realm = Realm(config);
+      // :snippet-end:
+      realm.close();
+      await cleanUpRealm(realm);
+    });
+  });
+}

--- a/source/examples/generated/flutter/compact_realm_test.snippet.compact-with-callback-and-logic.dart
+++ b/source/examples/generated/flutter/compact_realm_test.snippet.compact-with-callback-and-logic.dart
@@ -1,7 +1,7 @@
 var config = Configuration.local([Car.schema],
     shouldCompactCallback: ((totalSize, usedSize) {
   // Compact if the file is over 10MB in size and less than 50% 'used'
-  const tenMB = 10 * 1024 * 1024;
+  const tenMB = 10 * 1048576;
   return (totalSize > tenMB) &&
       (usedSize.toDouble() / totalSize.toDouble()) < 0.5;
 }));

--- a/source/examples/generated/flutter/compact_realm_test.snippet.compact-with-callback-and-logic.dart
+++ b/source/examples/generated/flutter/compact_realm_test.snippet.compact-with-callback-and-logic.dart
@@ -1,0 +1,8 @@
+var config = Configuration.local([Car.schema],
+    shouldCompactCallback: ((totalSize, usedSize) {
+  // Compact if the file is over 10MB in size and less than 50% 'used'
+  const tenMB = 10 * 1024 * 1024;
+  return (totalSize > tenMB) &&
+      (usedSize.toDouble() / totalSize.toDouble()) < 0.5;
+}));
+var realm = Realm(config);

--- a/source/examples/generated/flutter/compact_realm_test.snippet.compact-with-callback.dart
+++ b/source/examples/generated/flutter/compact_realm_test.snippet.compact-with-callback.dart
@@ -1,0 +1,10 @@
+var config = Configuration.local([Car.schema],
+    shouldCompactCallback: ((totalSize, usedSize) {
+  // shouldCompactCallback sizes are in bytes.
+  // For convenience, this example defines a const
+  // representing a byte to MB conversion for compaction
+  // at an arbitrary 10MB file size.
+  const tenMB = 10 * 1024 * 1024;
+  return totalSize > tenMB;
+}));
+var realm = Realm(config);

--- a/source/examples/generated/flutter/compact_realm_test.snippet.compact-with-callback.dart
+++ b/source/examples/generated/flutter/compact_realm_test.snippet.compact-with-callback.dart
@@ -4,7 +4,7 @@ var config = Configuration.local([Car.schema],
   // For convenience, this example defines a const
   // representing a byte to MB conversion for compaction
   // at an arbitrary 10MB file size.
-  const tenMB = 10 * 1024 * 1024;
+  const tenMB = 10 * 1048576;
   return totalSize > tenMB;
 }));
 var realm = Realm(config);

--- a/source/sdk/flutter/realm-database.txt
+++ b/source/sdk/flutter/realm-database.txt
@@ -15,6 +15,7 @@ Realm Database Overview - Flutter SDK
    Data Types </sdk/flutter/realm-database/data-types>
    Update a Realm Object Schema </sdk/flutter/realm-database/update-realm-object-schema>
    Freeze Data </sdk/flutter/realm-database/freeze>
+   Compact a Realm </sdk/flutter/realm-database/compact>
    Encrypt a Realm </sdk/flutter/realm-database/encrypt>
    Bundle a Realm </sdk/flutter/realm-database/bundle>
    Database Internals </sdk/flutter/realm-database/database-internals>

--- a/source/sdk/flutter/realm-database/compact.txt
+++ b/source/sdk/flutter/realm-database/compact.txt
@@ -10,25 +10,35 @@ Compact a Realm - Flutter SDK
    :depth: 2
    :class: singlecol
 
+If you want to reduce the size of a realm file to improve performance, you 
+can compact the realm. Compacting a realm reduces the amount of unused 
+empty space within the realm. Every production application should implement 
+compaction to periodically reduce the realm file size.
+
 The size of a Realm Database file is always larger than the total size of 
 the objects stored within it. This architecture enables some of realm's 
-great performance, concurrency, and safety benefits.
+performance, concurrency, and safety benefits.
 
 Realm writes new data within unused space tracked inside the file. In some 
-situations, unused space may comprise a significant portion of a realm file. 
+situations, a realm file may contain a significant amount of unused space. 
 If file size grows large enough to negatively impact performance, you can 
 compact the realm to reduce its file size.
 
-.. tip:: Implement Compaction in Your Production Application
+Compact When Opening a Realm
+----------------------------
 
-   Every production application should implement compaction to periodically 
-   reduce the realm file size.
+.. note::
+
+   You cannot compact a :ref:`Flexible Sync realm <flutter-open-synced-realm>`.
 
 You can define a :flutter-sdk:`shouldCompactCallback() 
 <realm/LocalConfiguration/shouldCompactCallback.html>` as a property of a 
-local realm configuration. This callback takes two ``int`` values representing 
+local realm's ``configuration``. This callback takes two ``int`` values representing 
 the total number of bytes and the used bytes of the realm file on disk. The 
-most basic usage is to define a file size at which compaction should occur.
+callback returns a ``bool``. Compaction only occurs if the ``bool`` returns 
+``true``, and another process is not currently accessing the realm file.
+
+The most basic usage is to define a file size at which compaction should occur.
 
 .. literalinclude:: /examples/generated/flutter/compact_realm_test.snippet.compact-with-callback.dart
    :language: dart

--- a/source/sdk/flutter/realm-database/compact.txt
+++ b/source/sdk/flutter/realm-database/compact.txt
@@ -19,16 +19,16 @@ situations, unused space may comprise a significant portion of a realm file.
 If file size grows large enough to negatively impact performance, you can 
 compact the realm to reduce its file size.
 
-.. tip:: Implement Compacting in Your Production Application
+.. tip:: Implement Compaction in Your Production Application
 
-   Every production application should implement compacting to periodically 
+   Every production application should implement compaction to periodically 
    reduce the realm file size.
 
 You can define a :flutter-sdk:`shouldCompactCallback() 
 <realm/LocalConfiguration/shouldCompactCallback.html>` as a property of a 
-local realm configuration. This callback takes two ints representing the
-total number of bytes and the used bytes of the realm file on disk. The most 
-basic usage is to define a file size at which compaction should occur.
+local realm configuration. This callback takes two ``int`` values representing 
+the total number of bytes and the used bytes of the realm file on disk. The 
+most basic usage is to define a file size at which compaction should occur.
 
 .. literalinclude:: /examples/generated/flutter/compact_realm_test.snippet.compact-with-callback.dart
    :language: dart

--- a/source/sdk/flutter/realm-database/compact.txt
+++ b/source/sdk/flutter/realm-database/compact.txt
@@ -1,0 +1,41 @@
+.. _flutter-compact:
+
+=============================
+Compact a Realm - Flutter SDK
+=============================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+The size of a Realm Database file is always larger than the total size of 
+the objects stored within it. This architecture enables some of realm's 
+great performance, concurrency, and safety benefits.
+
+Realm writes new data within unused space tracked inside file. In some 
+situations, unused space may comprise a significant portion of a realm file. 
+If file size grows large enough to negatively impact performance, you can 
+compact the realm to reduce its file size.
+
+.. tip:: Implement Compacting in Your Production Application
+
+   Every production application should implement compacting to periodically 
+   reduce the realm file size.
+
+You can define a :flutter-sdk:`shouldCompactCallback() 
+<realm/LocalConfiguration/shouldCompactCallback.html>` as a property of a 
+local realm configuration. This callback takes two ints representing the
+total number of bytes and the used bytes of the realm file on disk. The most 
+basic usage is to define a file size at which compaction should occur.
+
+.. literalinclude:: /examples/generated/flutter/compact_realm_test.snippet.compact-with-callback.dart
+   :language: dart
+
+You can define more complex logic if you need to optimize performance for 
+different use cases. For example, you could set a threshold for compaction
+when a certain percentage of the file size is used.
+
+.. literalinclude:: /examples/generated/flutter/compact_realm_test.snippet.compact-with-callback-and-logic.dart
+   :language: dart

--- a/source/sdk/flutter/realm-database/compact.txt
+++ b/source/sdk/flutter/realm-database/compact.txt
@@ -14,7 +14,7 @@ The size of a Realm Database file is always larger than the total size of
 the objects stored within it. This architecture enables some of realm's 
 great performance, concurrency, and safety benefits.
 
-Realm writes new data within unused space tracked inside file. In some 
+Realm writes new data within unused space tracked inside the file. In some 
 situations, unused space may comprise a significant portion of a realm file. 
 If file size grows large enough to negatively impact performance, you can 
 compact the realm to reduce its file size.

--- a/source/sdk/flutter/realm-database/compact.txt
+++ b/source/sdk/flutter/realm-database/compact.txt
@@ -24,19 +24,26 @@ situations, a realm file may contain a significant amount of unused space.
 If file size grows large enough to negatively impact performance, you can 
 compact the realm to reduce its file size.
 
-Compact When Opening a Realm
-----------------------------
+Compacting a realm can be an expensive operation that can block the UI thread. 
+Optimize compacting to balance frequency with performance gains. If your 
+application runs in a resource-constrained environment, you may want to 
+compact when you reach a certain file size or when the file size negatively 
+impacts performance.
 
 .. note::
 
    You cannot compact a :ref:`Flexible Sync realm <flutter-open-synced-realm>`.
 
+Compact When Opening a Realm
+----------------------------
+
 You can define a :flutter-sdk:`shouldCompactCallback() 
 <realm/LocalConfiguration/shouldCompactCallback.html>` as a property of a 
-local realm's ``configuration``. This callback takes two ``int`` values representing 
-the total number of bytes and the used bytes of the realm file on disk. The 
-callback returns a ``bool``. Compaction only occurs if the ``bool`` returns 
-``true``, and another process is not currently accessing the realm file.
+realm's :flutter-sdk:`LocalConfiguration <realm/LocalConfiguration-class.html>`. 
+This callback takes two ``int`` values representing the total number of 
+bytes and the used bytes of the realm file on disk. The callback returns 
+a ``bool``. Compaction only occurs if the ``bool`` returns ``true`` and 
+another process is not currently accessing the realm file.
 
 The most basic usage is to define a file size at which compaction should occur.
 

--- a/source/sdk/flutter/realm-database/open-and-close-a-realm.txt
+++ b/source/sdk/flutter/realm-database/open-and-close-a-realm.txt
@@ -150,6 +150,14 @@ Encrypt a Realm
 
 You can encrypt your local realm to ensure data security. For more information,
 see :ref:`Encrypt a Realm <flutter-encrypt>`.
+
+Compact a Realm
+~~~~~~~~~~~~~~~
+
+You can reduce the local realm file size to improve performance and manage file
+size in a resource-constrained environment. For more information, refer to 
+:ref:`Compact a Realm <flutter-compact>`.
+
 .. _flutter-close-realm:
 
 Close a Realm


### PR DESCRIPTION
## Pull Request Info

This adds a page for compacting a Realm, showing the use of the `shouldCompactCallback()` API that is currently available.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26316

### Staged Changes (Requires MongoDB Corp SSO)

- [Compact a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24586/sdk/flutter/realm-database/compact/): New page
- [Open & Close a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-24586/sdk/flutter/realm-database/open-and-close-a-realm/#compact-a-realm): New subsection mentioning compacting a realm and linking to the new page

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
