### PR TITLE
Update the Carthage installation instructions to use xcframeworks

### DIFF
--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -203,15 +203,14 @@ Realm Swift SDK to your project.
          .. step:: Install the Dependencies
 
 
-            From the command line, run ``carthage update`` to fetch
-            the dependencies.
+            From the command line, run ``carthage update --use-xcframeworks``
+            to fetch the dependencies.
 
 
          .. step:: Add the Frameworks to Your Project
 
 
-            Carthage pulls the dependencies into a platform directory
-            (e.g. "Mac" for macOS) within a ``Carthage/Build/``
+            Carthage places the built dependencies in the ``Carthage/Build``
             directory.
 
             Open your project's ``xcodeproj`` file in Xcode. Go to
@@ -219,60 +218,14 @@ Realm Swift SDK to your project.
             name to open the project settings editor. Select the
             :guilabel:`General` tab.
 
-            In Finder, open your target platform's directory within
-            the ``Carthage/Build/`` directory. Drag the
-            ``RealmSwift.framework`` and ``Realm.framework`` files
+            In Finder, open the ``Carthage/Build/`` directory. Drag the
+            ``RealmSwift.xcframework`` and ``Realm.xcframework`` files
             found in that directory to the :guilabel:`Frameworks,
             Libraries, and Embedded Content` section of your
             project's :guilabel:`General` settings.
 
             .. figure:: /images/carthage-add-frameworks.png
-               :alt: Drag the framework files into the Xcode project.
-               :lightbox:
-
-
-         .. step:: Enable the Copy Frameworks Script (iOS, tvOS, and watchOS only)
-
-
-            To work around an `App Store submission bug
-            <http://www.openradar.me/radar?id=6409498411401216>`__
-            for iOS, tvOS, and watchOS apps, you must add a script to
-            copy the frameworks as a build phase.
-
-            In Xcode, select the :guilabel:`Build Phases` tab in the
-            project settings editor. Click the :guilabel:`+` icon and
-            choose "New Run Script Phase" to create a new script. In
-            the source input box for the new script, paste the
-            following snippet:
-
-            .. code-block:: bash
-
-               /usr/local/bin/carthage copy-frameworks
-
-            In the :guilabel:`Input Files` box below the source
-            input box, add the paths to the frameworks for your
-            target platform. If you are not targeting iOS, change
-            "iOS" in the paths below to "tvOS" or "watchOS":
-
-            .. tabs-realm-languages::
-
-              .. tab::
-                  :tabid: swift
-
-                  .. code-block:: text
-
-                     $(SRCROOT)/Carthage/Build/iOS/Realm.framework
-                     $(SRCROOT)/Carthage/Build/iOS/RealmSwift.framework
-
-              .. tab::
-                  :tabid: objective-c
-
-                  .. code-block:: text
-
-                     $(SRCROOT)/Carthage/Build/iOS/Realm.framework
-
-            .. figure:: /images/carthage-build-phase-script.png
-               :alt: Enabling the copy frameworks script in Xcode
+               :alt: Drag the xcframework files into the Xcode project.
                :lightbox:
 
    .. tab:: Static Framework


### PR DESCRIPTION
This is required for simulators on m1 macs and is quite a bit simpler as a bonus.
