### PR TITLE
(DOCSP-26357): Document the ability to rename a property in Swift

### DIFF
--- a/examples/ios/Examples/ObjectModels.swift
+++ b/examples/ios/Examples/ObjectModels.swift
@@ -3,7 +3,8 @@
 //     "ObjectModelsExamples_": "",
 //     "ObjectModelsObjcDynamicExamples_": "",
 //     "OptionalRequiredPropertyExample_": "",
-//     "OptionalRequiredPropertyObjcDynamicExample_": ""
+//     "OptionalRequiredPropertyObjcDynamicExample_": "",
+//     "ObjectModelsExamplesRename_": ""
 //   }
 // }
 import XCTest
@@ -173,11 +174,30 @@ class ObjectModelsObjcDynamicExamples_Task: Object {
 }
 // :snippet-end:
 
+// :snippet-start: rename-a-property
+class ObjectModelsExamplesRename_Person: Object {
+    @Persisted var firstName = ""
+    @Persisted var lastName = ""
+    
+    override class public func propertiesMapping() -> [String : String] {
+        ["firstName": "first_name",
+         "lastName": "last_name"]
+    }
+}
+// :snippet-end:
+
 class ObjectModelsExamples_MyModel: Object {
     @Persisted var someProperty = 0
 }
 
 class ObjectModels: XCTestCase {
+    override func tearDown() {
+        let realm = try! Realm()
+        try! realm.write {
+            realm.deleteAll()
+        }
+    }
+    
     func testGenericCollectionFunc() {
         // :snippet-start: generic-collection
         func operateOn<C: RealmCollection>(collection: C) {
@@ -207,6 +227,21 @@ class ObjectModels: XCTestCase {
             }
         }
         // :snippet-end:
+    }
+    
+    func testPropertiesMapping() {
+        let person = ObjectModelsExamplesRename_Person(value: ["firstName": "Jon", "lastName": "Snow"])
+
+        let realm = try! Realm()
+        try! realm.write {
+            realm.add(person)
+        }
+        
+        let people = realm.objects(ObjectModelsExamplesRename_Person.self)
+        let specificPerson = people.where {
+            $0.firstName == "Jon"
+        }.first!
+        XCTAssertNotNil(specificPerson)
     }
 }
 

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1588,8 +1588,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
-				kind = exactVersion;
-				version = 10.32.0;
+				branch = "dp/custom-column-names";
+				kind = branch;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1588,8 +1588,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
-				branch = "dp/custom-column-names";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.33.0;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/source/examples/generated/code/start/ObjectModels.snippet.rename-a-property.swift
+++ b/source/examples/generated/code/start/ObjectModels.snippet.rename-a-property.swift
@@ -1,0 +1,9 @@
+class Person: Object {
+    @Persisted var firstName = ""
+    @Persisted var lastName = ""
+    
+    override class public func propertiesMapping() -> [String : String] {
+        ["firstName": "first_name",
+         "lastName": "last_name"]
+    }
+}

--- a/source/sdk/swift/model-data/define-model/object-models.txt
+++ b/source/sdk/swift/model-data/define-model/object-models.txt
@@ -594,26 +594,26 @@ Declare Enum Properties
 
 .. _swift-rename-property:
 
-Rename a Property
-~~~~~~~~~~~~~~~~~
+Remap a Property Name
+~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 10.3x.x
+.. versionadded:: 10.33.0
 
 You can map the public name of a property in your object model to a different
 private name to store in the realm. You might want to do this if your 
 Device Sync schema property names use snake case, for example, while your 
 project uses Swift-idiomatic camel case.
 
-To do this, use the :swift-sdk:`propertiesMapping() <>` API. Declare the name
-you want to use in your project as the ``@Persisted`` property on the object 
-model. Then, pass a dictionary containing the public and private values 
-for the property names to the ``propertiesMapping()`` API.
+Declare the name you want to use in your project as the ``@Persisted`` 
+property on the object model. Then, pass a dictionary containing the 
+public and private values for the property names via the 
+``propertiesMapping()`` function.
 
 In this example, ``firstName`` is the public property name we use in the code 
 throughout the project to perform CRUD operations. Using the ``propertiesMapping()``
-API, we map that to store values using the private property name ``first_name`` 
-in the realm. If we write to a synced realm, the Sync schema sees the 
-values stored using the private property name ``first_name``.
+function, we map that to store values using the private property name 
+``first_name`` in the realm. If we write to a synced realm, the Sync 
+schema sees the values stored using the private property name ``first_name``.
 
 .. literalinclude:: /examples/generated/code/start/ObjectModels.snippet.rename-a-property.swift
    :language: swift

--- a/source/sdk/swift/model-data/define-model/object-models.txt
+++ b/source/sdk/swift/model-data/define-model/object-models.txt
@@ -592,6 +592,32 @@ Declare Enum Properties
 
          `RealmEnum <https://www.mongodb.com/docs/realm-sdks/swift/10.9.0/Protocols.html#/s:10RealmSwift0A4EnumP>`_
 
+.. _swift-rename-property:
+
+Rename a Property
+~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 10.3x.x
+
+You can map the public name of a property in your object model to a different
+private name to store in the realm. You might want to do this if your 
+Device Sync schema property names use snake case, for example, while your 
+project uses Swift-idiomatic camel case.
+
+To do this, use the :swift-sdk:`propertiesMapping() <>` API. Declare the name
+you want to use in your project as the ``@Persisted`` property on the object 
+model. Then, pass a dictionary containing the public and private values 
+for the property names to the ``propertiesMapping()`` API.
+
+In this example, ``firstName`` is the public property name we use in the code 
+throughout the project to perform CRUD operations. Using the ``propertiesMapping()``
+API, we map that to store values using the private property name ``first_name`` 
+in the realm. If we write to a synced realm, the Sync schema sees the 
+values stored using the private property name ``first_name``.
+
+.. literalinclude:: /examples/generated/code/start/ObjectModels.snippet.rename-a-property.swift
+   :language: swift
+
 .. _ios-define-and-use-class-projections:
 .. _swift-define-class-projection:
 


### PR DESCRIPTION
## Pull Request Info

The eng PR that implements this functionality is still in review. Waiting for SDK release for this feature. Prior to merging:
- [x] Point SPM to the released version of the SDK instead of the custom column names branch it's pointed at currently
- [x] Add the release version to the `.. _versionadded::` directive in ln 600
- [x] Add a link to the API in the generated docs in ln 607

### Jira

- https://jira.mongodb.org/browse/DOCSP-26357

### Staged Changes (Requires MongoDB Corp SSO)

- [Object Models - Swift SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26357/sdk/swift/model-data/define-model/object-models/#rename-a-property): New "Rename a Property" section

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
