### PR TITLE
(DOCSP-26329): Flutter: Add documentation for embedded object parent property

### DIFF
--- a/examples/dart/test/data_types_test.dart
+++ b/examples/dart/test/data_types_test.dart
@@ -153,6 +153,12 @@ main() {
     expect(realm.dynamic.all("Address").query("state == 'NY'").length, 0);
     // :remove-end:
 
+    // You can access the parent object from an embedded object.
+    final thePersonObject = joesNewHome.parent;
+    // :remove-start:
+    expect(thePersonObject, isNotNull);
+    // :remove-end:
+
     // Delete embedded object from parent object.
     realm.write(() => realm.delete(joe.address!));
     expect(joe.address, isNull); // :remove:

--- a/source/examples/generated/flutter/data_types_test.snippet.embedded-object-examples.dart
+++ b/source/examples/generated/flutter/data_types_test.snippet.embedded-object-examples.dart
@@ -22,6 +22,9 @@ realm.write(() {
   joe.address = joesNewHome;
 });
 
+// You can access the parent object from an embedded object.
+final thePersonObject = joesNewHome.parent;
+
 // Delete embedded object from parent object.
 realm.write(() => realm.delete(joe.address!));
 

--- a/source/sdk/flutter/realm-database/data-types.txt
+++ b/source/sdk/flutter/realm-database/data-types.txt
@@ -131,6 +131,9 @@ The ``_Address`` model is embedded within the ``_Person`` model.
 .. literalinclude:: /examples/generated/flutter/data_types_test.snippet.embedded-object-model.dart
    :language: dart
 
+You can use the :flutter-sdk:`parent <realm/EmbeddedObjectExtension/parent.html>`
+property to access the parent of the embedded object. 
+
 The following example shows the unique considerations when working with embedded objects.
 The example uses the ``Address`` embedded object generated from the ``_Address``
 ``RealmModel`` in the above schema.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-26329

### Staged Changes (Requires MongoDB Corp SSO)

- [Data Types/Embedded Objects](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26329/sdk/flutter/realm-database/data-types/#embedded-objects): Update example to show accessing the parent from an embedded object, link to property in API reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
