### PR TITLE
Removed note related to old versions

### DIFF
--- a/source/sdk/dotnet/install.txt
+++ b/source/sdk/dotnet/install.txt
@@ -129,13 +129,6 @@ Realm supports the following platforms for developing Realm apps for iOS and
 .NET devices:
 
 - Xamarin.iOS for iOS 9 or later, using native UI or Xamarin Forms
-  
-  .. note:: Use Latest Xamarin.iOS Version
-  
-     Starting with version 10.3.0 of the Realm .NET SDK, you must use 
-     `Xamarin.iOS version 14.14.2.5 <https://learn.microsoft.com/en-us/xamarin/ios/release-notes/14/14.14#march-2-2021---xamarinios-141425>`__ 
-     or later.
-
 - Xamarin.Android for API level 16 or later, using native UI or Xamarin Forms 
 - Xamarin.Mac for macOS 10.11 or later, using native UI or Xamarin Forms 
 - .NET Framework 4.6.1 or later for Windows 8.1 or later 


### PR DESCRIPTION
I am just removing a note that is related to versions of Xamarin.iOS and Realm that are now more than 1 year old, so it can be safely removed.
