### PR TITLE
(DOCSP-23501): Add a new Swift Concurrency page to Swift SDK docs

### DIFF
--- a/examples/ios/Examples/Task.swift
+++ b/examples/ios/Examples/Task.swift
@@ -1,3 +1,0 @@
-import RealmSwift
-import XCTest
-

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -42,7 +42,6 @@
 		48BD8FE72580017D009DE2E6 /* OpenCloseRealm.m in Sources */ = {isa = PBXBuildFile; fileRef = 48BD8FE62580017D009DE2E6 /* OpenCloseRealm.m */; };
 		48BD8FEC25800AA3009DE2E6 /* AnonymouslyLoggedInTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 48BD8FEB25800AA3009DE2E6 /* AnonymouslyLoggedInTestCase.m */; };
 		48BF34182511095C004139AF /* RealmApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF34172511095C004139AF /* RealmApp.swift */; };
-		48BF341D25111194004139AF /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF341C25111194004139AF /* Task.swift */; };
 		48BF341F251129AD004139AF /* MyRealmApp.m in Sources */ = {isa = PBXBuildFile; fileRef = 48BF341E251129AD004139AF /* MyRealmApp.m */; };
 		48C072042511B5D5004B02BB /* ManageEmailPasswordUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C072032511B5D5004B02BB /* ManageEmailPasswordUsers.swift */; };
 		48C072062511B6DB004B02BB /* ManageEmailPasswordUsers.m in Sources */ = {isa = PBXBuildFile; fileRef = 48C072052511B6DB004B02BB /* ManageEmailPasswordUsers.m */; };
@@ -180,7 +179,6 @@
 		48BD8FEB25800AA3009DE2E6 /* AnonymouslyLoggedInTestCase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AnonymouslyLoggedInTestCase.m; sourceTree = "<group>"; };
 		48BD8FF025800B4D009DE2E6 /* AnonymouslyLoggedInTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AnonymouslyLoggedInTestCase.h; sourceTree = "<group>"; };
 		48BF34172511095C004139AF /* RealmApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmApp.swift; sourceTree = "<group>"; };
-		48BF341C25111194004139AF /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
 		48BF341E251129AD004139AF /* MyRealmApp.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MyRealmApp.m; sourceTree = "<group>"; };
 		48BF342025112A7F004139AF /* MyRealmApp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyRealmApp.h; sourceTree = "<group>"; };
 		48C072032511B5D5004B02BB /* ManageEmailPasswordUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageEmailPasswordUsers.swift; sourceTree = "<group>"; };
@@ -394,7 +392,6 @@
 				915C667327BAADA100E7BDB4 /* seed.realm */,
 				914601F426A86B9000BC91EA /* Sync.m */,
 				914601F526A86B9000BC91EA /* Sync.swift */,
-				48BF341C25111194004139AF /* Task.swift */,
 				917D8C9E26167B69001B7A61 /* TestingAndDebugging.swift */,
 				48924B8B2514FEFC00CC9567 /* TestSetup.swift */,
 				4898DDAF25A3768600416375 /* Threading.swift */,
@@ -826,7 +823,6 @@
 				91FBD320279865080005C10C /* DeleteUsers.swift in Sources */,
 				91AB03182899660A00A272E8 /* ReadRealmObjects.swift in Sources */,
 				91AB0316289965F800A272E8 /* CreateRealmObjects.swift in Sources */,
-				48BF341D25111194004139AF /* Task.swift in Sources */,
 				48E63FB8252646A700F883B1 /* Authenticate.swift in Sources */,
 				48F38B58252793F600DDEB65 /* ManageApiKeys.swift in Sources */,
 				48637F4F25C8B8EC002209AF /* Migrations.m in Sources */,

--- a/source/sdk/swift.txt
+++ b/source/sdk/swift.txt
@@ -19,6 +19,7 @@ Realm Swift SDK
    CRUD </sdk/swift/crud>
    React to Changes </sdk/swift/react-to-changes>
    SwiftUI </sdk/swift/swiftui>
+   Swift Concurrency </sdk/swift/swift-concurrency>
    Test and Debug </sdk/swift/test-and-debug>
    API Reference </sdk/swift/api-reference>
    Release Notes <https://github.com/realm/realm-swift/releases>

--- a/source/sdk/swift/app-services/call-a-function.txt
+++ b/source/sdk/swift/app-services/call-a-function.txt
@@ -50,6 +50,8 @@ is executed on a non-main global ``DispatchQueue``.
       .. literalinclude:: /examples/generated/code/start/Functions.snippet.call-a-function.m
          :language: objectivec
 
+.. _ios-async-await-call-function:
+
 Async/Await Call a Function
 ---------------------------
 

--- a/source/sdk/swift/realm-files/compacting.txt
+++ b/source/sdk/swift/realm-files/compacting.txt
@@ -149,6 +149,8 @@ For more information about the conditions to execute in the method, see:
       .. literalinclude:: /examples/generated/code/start/Compacting.snippet.compacting.m
         :language: objectivec
 
+.. _ios-compact-a-realm-async:
+
 Compact a Realm Asynchronously
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/sdk/swift/swift-concurrency.txt
+++ b/source/sdk/swift/swift-concurrency.txt
@@ -1,0 +1,199 @@
+.. _swift-concurrency:
+
+=============================
+Swift Concurrency - Swift SDK
+=============================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Swift Concurrency Fundamentals
+------------------------------
+
+Swift's concurrency system provides built-in support for writing asynchronous 
+and parallel code in a structured way. For a detailed overview of the 
+Swift concurrency system, refer to the `Swift Programming Language Concurrency
+topic <https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html>`__.
+
+Developers who want to implement Realm in an app that uses Swift concurrency
+features may have questions around how to use Realm with:
+
+- Async/Await APIs
+- Tasks and TaskGroups
+- Actor isolation
+- Errors related to concurrency code
+
+Realm Concurrency Caveats
+-------------------------
+
+As you implement concurrency features in your app, consider this caveat 
+about Realm's threading model and Swift concurrency threading behaviors.
+
+.. _swift-suspend-execution-with-await:
+
+Suspending Execution with Await
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Anywhere you use the Swift keyword ``await`` marks a possible suspension 
+point in the execution of your code. With Swift 5.7, once your code suspends, 
+subsequent code may not execute on the same thread. This means that 
+anywhere you use ``await`` in your code, the subsequent code could be 
+executed on a different thread than the code that precedes or follows it. 
+
+This is inherently incompatible with Realm's :ref:`live object paradigm 
+<ios-live-object>`. Live objects, collections, and realm instances are
+**thread-confined**: that is, they are only valid on the thread on which 
+they were created. Practically speaking, this means you cannot pass live 
+instances to other threads. However, Realm Database offers several 
+mechanisms for :ref:`sharing objects across threads 
+<ios-communication-across-threads>`. These mechanisms typically require 
+your code to do some explicit handling to safely pass data across threads.
+
+You can use some of these mechanisms, such as :ref:`frozen objects 
+<ios-frozen-objects>` or the :ref:`@ThreadSafe property wrapper 
+<ios-thread-safe-reference>`, to safely use Realm objects and instances 
+across threads with the ``await`` keyword. You can also avoid 
+threading-related issues by marking any asynchronous Realm code with 
+``@MainActor`` to ensure your apps always execute this code on the main 
+thread.
+
+As a general rule, keep in mind that using Realm in an ``await`` context 
+*without* incorporating threading protection may yield inconsistent behavior. 
+Sometimes, the code may succeed. In other cases, it may throw an error 
+related to writing on an incorrect thread.
+
+Async/Await APIs
+----------------
+
+With the caveat of ensuring that you execute asynchronous code on the same 
+thread, many Realm Swift APIs that involve working with :ref:`an Atlas App 
+Services app <ios-application-services>` or a :ref:`synchronized realm 
+<ios-synced-realm>` are compatible with Swift's async/await syntax. For 
+examples, check out:
+
+- :ref:`Async/Await Login <ios-async-await-login>`
+- :ref:`Manage Email/Password Users <ios-manage-email-password-users>`
+- :ref:`Link User Identities - Async/Await <ios-link-user-identities>`
+- :ref:`Open a Synced Realm <ios-flexible-sync-open-realm>`
+- :ref:`Manage Flexible Sync Subscriptions <ios-flexible-sync>`
+- :ref:`Async/Await Call a Serverless Function <ios-async-await-call-function>`
+- :ref:`Async/Await Query MongoDB <ios-mongodb-async-await-query>`
+
+Realm does not provide Swift async/await support for reading or writing objects.
+However, the Realm Swift SDK does provide an API to safely perform background 
+writes without requiring you to use threading protection. For more information, 
+refer to **Perform Background Writes** below.
+
+If you have specific feature requests related to Swift async/await APIs,
+check out the `MongoDB Feedback Engine for Realm 
+<https://feedback.mongodb.com/forums/923521-realm>`_. The Realm Swift SDK
+team plans to continue to develop concurrency-related features based on 
+community feedback and Swift concurrency evolution.
+
+Perform Background Writes
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A commonly requested use case for asynchronous code is to perform write 
+operations in the background without blocking the main thread. While the 
+Realm Swift SDK does not currently support an async/await API for this, it 
+does have an API specifically for performing background writes: ``writeAsync``.
+
+This API allows you to add, update, or delete objects in the background 
+without using frozen objects or passing a thread-safe reference. With this 
+API, waiting to obtain the write lock and committing a transaction occur
+in the background. The write block itself is executed on the calling thread.
+This provides thread-safety without requiring you to manually handle 
+frozen objects or passing references across threads. 
+
+However, while the write block itself is executed, this does block new 
+transactions on the calling thread. This means that a large write using
+the ``writeAsync`` API could block small, quick writes while it executes.
+
+For more information, including a code example, refer to: :ref:`Perform a 
+Background Write <ios-async-write>`.
+
+Tasks and TaskGroups
+--------------------
+
+Swift concurrency provides APIs to manage :apple:`Tasks <documentation/swift/task>` 
+and :apple:`TaskGroups <documentation/swift/taskgroup>`. The `Swift concurrency
+documentation <https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html>`__ 
+defines a task as a unit of work that can be run asynchronously as part of 
+your program. Task allows you to specificially define a unit of asynchronous 
+work. TaskGroup lets you define a collection of Tasks to execute as a unit 
+under the parent TaskGroup. 
+
+Tasks and TaskGroups provide the ability to yield the thread to other 
+important work, or to cancel a long-running task that could be blocking 
+other operations. Because of this, Swift developers may desire to use Tasks
+and TaskGroups to manage realm writes in the background.
+
+However, the thread-confined constraints described in :ref:`Suspending 
+Execution with Await <swift-suspend-execution-with-await>` above apply in
+the Task context. If your Task contains ``await`` points, subsequent code 
+may run or resume on a different thread and violate Realm's thread confinement.
+
+You must annotate functions that you run in a Task context with ``@MainActor`` 
+to ensure code that accesses Realm only runs on the main thread. This negates 
+some of the benefits of using Tasks, and may mean this is not a good design 
+choice for apps that use Realm unless you are using Tasks solely for 
+networking activities like managing users.
+
+Actor Isolation
+---------------
+
+Actor isolation provides the perception of confining Realm access to a 
+dedicated actor, and therefore seems like a safe way to manage Realm 
+access in an asynchronous context.
+
+However, using Realm in a non-``@MainActor`` async function is currently 
+not supported. 
+
+In Swift 5.6, this would often work by coincidence. Execution after an 
+``await`` would continue on whatever thread the awaited thing ran on. 
+Using ``await Realm()`` in an async function would result in the code 
+following that running on the main thread until your next call to an 
+actor-isolated function. 
+
+Swift 5.7 instead hops threads whenever changing actor isolation contexts. 
+An unisolated async function always runs on a background thread instead.
+
+If you have code which uses ``await Realm()`` and works in 5.6, marking 
+the function as ``@MainActor`` will make it work with Swift 5.7. It will 
+function very similarly to what it happened to be doing in 5.6.
+
+The Swift SDK team is working on improving support for actor isolation.
+If you have specific feature requests related to actor isolation,
+check the status of similar feature requests or leave feedback through the 
+`MongoDB Feedback Engine for Realm 
+<https://feedback.mongodb.com/forums/923521-realm>`_.
+
+Errors Related to Concurrency Code
+----------------------------------
+
+Most often, the error you see related to accessing Realm through concurrency
+code is ``Realm accessed from incorrect thread.`` This is due to the 
+thread-isolation issues described on this page.
+
+To avoid threading-related issues in code that uses Swift concurrency features:
+
+- Do not change execution contexts when accessing realm. If you open a realm 
+  on the main thread to provide data for your UI, annotate subsequent functions
+  where you access the realm asynchronously with ``@MainActor`` to ensure it
+  always runs on the main thread. Remember that ``await`` marks a suspension 
+  point that could change to a different thread.
+- Use the ``writeAsync`` API to :ref:`perform a background write 
+  <ios-async-write>`. This manages realm access in a thread-safe way without 
+  requiring you to write specialized code to do it yourself. This is a special
+  API that outsources aspects of the write process - where it is safe to do 
+  so - to run in an async context. You do not use this method with Swift's 
+  ``async/await`` syntax - use this method synchronously in your code.
+- If you want to explicitly write concurrency code where accessing a realm 
+  is done in a thread-safe way, you can explicitly :ref:`pass instances across 
+  threads <ios-thread-safe-reference>` or use :ref:`frozen objects 
+  <ios-frozen-objects>` where applicable to avoid threading-related crashes.
+  This does require a good understanding of realm's threading model, as well
+  as being mindful of Swift concurrency threading behaviors.

--- a/source/sdk/swift/swift-concurrency.txt
+++ b/source/sdk/swift/swift-concurrency.txt
@@ -10,21 +10,10 @@ Swift Concurrency - Swift SDK
    :depth: 2
    :class: singlecol
 
-Swift Concurrency Fundamentals
-------------------------------
-
 Swift's concurrency system provides built-in support for writing asynchronous 
 and parallel code in a structured way. For a detailed overview of the 
 Swift concurrency system, refer to the `Swift Programming Language Concurrency
 topic <https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html>`__.
-
-Developers who want to implement Realm in an app that uses Swift concurrency
-features may have questions around how to use Realm with:
-
-- Async/Await APIs
-- Tasks and TaskGroups
-- Actor isolation
-- Errors related to concurrency code
 
 Realm Concurrency Caveats
 -------------------------
@@ -39,7 +28,7 @@ Suspending Execution with Await
 
 Anywhere you use the Swift keyword ``await`` marks a possible suspension 
 point in the execution of your code. With Swift 5.7, once your code suspends, 
-subsequent code may not execute on the same thread. This means that 
+subsequent code might not execute on the same thread. This means that 
 anywhere you use ``await`` in your code, the subsequent code could be 
 executed on a different thread than the code that precedes or follows it. 
 
@@ -68,8 +57,7 @@ related to writing on an incorrect thread.
 Async/Await APIs
 ----------------
 
-With the caveat of ensuring that you execute asynchronous code on the same 
-thread, many Realm Swift APIs that involve working with :ref:`an Atlas App 
+Many Realm Swift APIs that involve working with :ref:`an Atlas App 
 Services app <ios-application-services>` or a :ref:`synchronized realm 
 <ios-synced-realm>` are compatible with Swift's async/await syntax. For 
 examples, check out:
@@ -96,7 +84,7 @@ community feedback and Swift concurrency evolution.
 Perform Background Writes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A commonly requested use case for asynchronous code is to perform write 
+A commonly-requested use case for asynchronous code is to perform write 
 operations in the background without blocking the main thread. While the 
 Realm Swift SDK does not currently support an async/await API for this, it 
 does have an API specifically for performing background writes: ``writeAsync``.
@@ -104,7 +92,7 @@ does have an API specifically for performing background writes: ``writeAsync``.
 This API allows you to add, update, or delete objects in the background 
 without using frozen objects or passing a thread-safe reference. With this 
 API, waiting to obtain the write lock and committing a transaction occur
-in the background. The write block itself is executed on the calling thread.
+in the background. The write block itself runs on the calling thread.
 This provides thread-safety without requiring you to manually handle 
 frozen objects or passing references across threads. 
 
@@ -112,8 +100,7 @@ However, while the write block itself is executed, this does block new
 transactions on the calling thread. This means that a large write using
 the ``writeAsync`` API could block small, quick writes while it executes.
 
-For more information, including a code example, refer to: :ref:`Perform a 
-Background Write <ios-async-write>`.
+For more information, including a code example, refer to: :ref:`ios-async-write`.
 
 Tasks and TaskGroups
 --------------------
@@ -127,14 +114,14 @@ work. TaskGroup lets you define a collection of Tasks to execute as a unit
 under the parent TaskGroup. 
 
 Tasks and TaskGroups provide the ability to yield the thread to other 
-important work, or to cancel a long-running task that could be blocking 
-other operations. Because of this, Swift developers may desire to use Tasks
+important work or to cancel a long-running task that could be blocking 
+other operations. To get these benefits, you may be tempted to use Tasks
 and TaskGroups to manage realm writes in the background.
 
 However, the thread-confined constraints described in :ref:`Suspending 
 Execution with Await <swift-suspend-execution-with-await>` above apply in
 the Task context. If your Task contains ``await`` points, subsequent code 
-may run or resume on a different thread and violate Realm's thread confinement.
+might run or resume on a different thread and violate Realm's thread confinement.
 
 You must annotate functions that you run in a Task context with ``@MainActor`` 
 to ensure code that accesses Realm only runs on the main thread. This negates 
@@ -163,7 +150,7 @@ An unisolated async function always runs on a background thread instead.
 
 If you have code which uses ``await Realm()`` and works in 5.6, marking 
 the function as ``@MainActor`` will make it work with Swift 5.7. It will 
-function very similarly to what it happened to be doing in 5.6.
+function how it did - unintentionally - in 5.6.
 
 The Swift SDK team is working on improving support for actor isolation.
 If you have specific feature requests related to actor isolation,
@@ -180,7 +167,7 @@ thread-isolation issues described on this page.
 
 To avoid threading-related issues in code that uses Swift concurrency features:
 
-- Do not change execution contexts when accessing realm. If you open a realm 
+- Do not change execution contexts when accessing a realm. If you open a realm 
   on the main thread to provide data for your UI, annotate subsequent functions
   where you access the realm asynchronously with ``@MainActor`` to ensure it
   always runs on the main thread. Remember that ``await`` marks a suspension 
@@ -195,5 +182,5 @@ To avoid threading-related issues in code that uses Swift concurrency features:
   is done in a thread-safe way, you can explicitly :ref:`pass instances across 
   threads <ios-thread-safe-reference>` or use :ref:`frozen objects 
   <ios-frozen-objects>` where applicable to avoid threading-related crashes.
-  This does require a good understanding of realm's threading model, as well
+  This does require a good understanding of Realm's threading model, as well
   as being mindful of Swift concurrency threading behaviors.

--- a/source/sdk/swift/swift-concurrency.txt
+++ b/source/sdk/swift/swift-concurrency.txt
@@ -115,7 +115,7 @@ under the parent TaskGroup.
 
 Tasks and TaskGroups provide the ability to yield the thread to other 
 important work or to cancel a long-running task that could be blocking 
-other operations. To get these benefits, you may be tempted to use Tasks
+other operations. To get these benefits, you might be tempted to use Tasks
 and TaskGroups to manage realm writes in the background.
 
 However, the thread-confined constraints described in :ref:`Suspending 

--- a/source/sdk/swift/users/authenticate-users.txt
+++ b/source/sdk/swift/users/authenticate-users.txt
@@ -149,6 +149,8 @@ If you have enabled :ref:`Sign-in with Apple authentication
 
 .. include:: /includes/authorization-appleidcredential-string.rst
 
+.. _ios-async-await-login:
+
 Async/Await Login
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Pull Request Info

The original scope for this Jira ticket was to document what you can do with Realm in a Swift `Task`. After looking around at various discussions in the community, I've expanded this to incorporate general guidance on using Realm with Swift concurrency features.

### Jira

- https://jira.mongodb.org/browse/DOCSP-23501

### Staged Changes (Requires MongoDB Corp SSO)

- [Swift Concurrency](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-23501/sdk/swift/swift-concurrency/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
