### PR TITLE
(DOCSP-26095): Add logical primary key examples to Flutter examples

### DIFF
--- a/examples/dart/bin/models/car.dart
+++ b/examples/dart/bin/models/car.dart
@@ -5,8 +5,9 @@ part 'car.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late String make;
+  late int id;
 
+  late String make;
   late String? model;
   late int? miles;
 }

--- a/examples/dart/bin/models/car.dart
+++ b/examples/dart/bin/models/car.dart
@@ -5,7 +5,7 @@ part 'car.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String make;
   late String? model;

--- a/examples/dart/bin/models/car.g.dart
+++ b/examples/dart/bin/models/car.g.dart
@@ -8,7 +8,7 @@ part of 'car.dart';
 
 class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car(
-    int id,
+    ObjectId id,
     String make, {
     String? model,
     int? miles,
@@ -22,9 +22,9 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get make => RealmObjectBase.get<String>(this, 'make') as String;
@@ -53,7 +53,7 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Car._);
     return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('make', RealmPropertyType.string),
       SchemaProperty('model', RealmPropertyType.string, optional: true),
       SchemaProperty('miles', RealmPropertyType.int, optional: true),

--- a/examples/dart/bin/myapp.dart
+++ b/examples/dart/bin/myapp.dart
@@ -10,8 +10,8 @@ void main(List<String> arguments) {
 
   realm.write(() => realm.deleteAll<Car>()); // :remove:
   realm.write(() {
-    realm.add(Car("Audi", model: 'A8'));
-    realm.add(Car("Mercedes", model: 'G Wagon'));
+    realm.add(Car(ObjectId(), "Audi", model: 'A8'));
+    realm.add(Car(ObjectId(), "Mercedes", model: 'G Wagon'));
   });
   print("Bundled realm location: " + realm.config.path);
   realm.close();

--- a/examples/dart/bundle_example/lib/realm/schemas.dart
+++ b/examples/dart/bundle_example/lib/realm/schemas.dart
@@ -5,7 +5,7 @@ part 'schemas.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String make;
   late String? model;

--- a/examples/dart/bundle_example/lib/realm/schemas.dart
+++ b/examples/dart/bundle_example/lib/realm/schemas.dart
@@ -5,8 +5,9 @@ part 'schemas.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late String make;
+  late int id;
 
+  late String make;
   late String? model;
   late int? miles;
 }

--- a/examples/dart/scripts/delete_realm_files.sh
+++ b/examples/dart/scripts/delete_realm_files.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 # from the dart directory, run ./scripts/delete_realm_files.sh
-rm -rf *.realm.lock *.realm *.realm.note *.realm.management mongodb-realm
+rm -rf *.realm.lock *.realm *.realm.note *.realm.management mongodb-realm *.realm.fresh.lock
 echo 'deleted the realm files'

--- a/examples/dart/test/backlinks_test.dart
+++ b/examples/dart/test/backlinks_test.dart
@@ -26,3 +26,5 @@ class _Task {
   late Iterable<_User> linkedUser;
 }
 // :snippet-end:
+
+main() {}

--- a/examples/dart/test/backlinks_test.dart
+++ b/examples/dart/test/backlinks_test.dart
@@ -6,7 +6,7 @@ part 'backlinks_test.g.dart';
 @RealmModel()
 class _User {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String username;
   // One-to-many relationship that the backlink is created for below.
@@ -16,7 +16,7 @@ class _User {
 @RealmModel()
 class _Task {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String description;
   late bool isComplete;

--- a/examples/dart/test/backlinks_test.g.dart
+++ b/examples/dart/test/backlinks_test.g.dart
@@ -8,7 +8,7 @@ part of 'backlinks_test.dart';
 
 class User extends _User with RealmEntity, RealmObjectBase, RealmObject {
   User(
-    int id,
+    ObjectId id,
     String username, {
     Iterable<Task> tasks = const [],
   }) {
@@ -20,9 +20,9 @@ class User extends _User with RealmEntity, RealmObjectBase, RealmObject {
   User._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get username =>
@@ -49,7 +49,7 @@ class User extends _User with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(User._);
     return const SchemaObject(ObjectType.realmObject, User, 'User', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('username', RealmPropertyType.string),
       SchemaProperty('tasks', RealmPropertyType.object,
           linkTarget: 'Task', collectionType: RealmCollectionType.list),
@@ -59,7 +59,7 @@ class User extends _User with RealmEntity, RealmObjectBase, RealmObject {
 
 class Task extends _Task with RealmEntity, RealmObjectBase, RealmObject {
   Task(
-    int id,
+    ObjectId id,
     String description,
     bool isComplete,
   ) {
@@ -71,9 +71,9 @@ class Task extends _Task with RealmEntity, RealmObjectBase, RealmObject {
   Task._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get description =>
@@ -106,7 +106,7 @@ class Task extends _Task with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Task._);
     return const SchemaObject(ObjectType.realmObject, Task, 'Task', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('description', RealmPropertyType.string),
       SchemaProperty('isComplete', RealmPropertyType.bool),
       SchemaProperty('linkedUser', RealmPropertyType.linkingObjects,

--- a/examples/dart/test/client_reset_test.dart
+++ b/examples/dart/test/client_reset_test.dart
@@ -1,18 +1,32 @@
+import 'dart:io';
+
 import 'package:realm_dart/realm.dart';
 import 'package:test/test.dart';
-import 'schemas.dart';
 import 'utils.dart';
+
+part "client_reset_test.g.dart";
+
+@RealmModel()
+class _Car {
+  @PrimaryKey()
+  @MapTo("_id")
+  late int id;
+
+  late String make;
+  late String? model;
+  late int? miles;
+}
 
 const APP_ID = "flex-config-tester-vwevn";
 main() {
   late App app;
   final schema = [Car.schema];
   late User currentUser;
-  setUpAll(() async {
+  setUp(() async {
     app = App(AppConfiguration(APP_ID));
     currentUser = await app.logIn(Credentials.anonymous());
   });
-  tearDownAll(() async {
+  tearDown(() async {
     await app.currentUser?.logOut();
   });
   group('Client Reset tests', () {
@@ -94,6 +108,7 @@ main() {
       late Realm realm;
 
       final config = Configuration.flexibleSync(currentUser, schema,
+          path: 'fallback.realm', // :remove:
 
           // This example uses the `RecoverOrDiscardUnsyncedChangesHandler`,
           // but the same logic could also be used with the `RecoverUnsyncedChangesHandler`
@@ -122,7 +137,7 @@ main() {
         },
       ));
       // :snippet-end:
-      realm = Realm(config);
+      realm = await Realm.open(config);
       cleanUpRealm(realm);
     });
     test("Manual recovery mode", () async {
@@ -132,6 +147,7 @@ main() {
       late Realm realm;
 
       final config = Configuration.flexibleSync(currentUser, schema,
+          path: 'manual.realm', // :remove:
           clientResetHandler: ManualRecoveryHandler((clientResetError) {
         // You must close the Realm before attempting the client reset.
         realm.close();
@@ -140,7 +156,7 @@ main() {
         clientResetError.resetRealm();
       }));
       // :snippet-end:
-      realm = Realm(config);
+      realm = await Realm.open(config);
       cleanUpRealm(realm);
     });
   });

--- a/examples/dart/test/client_reset_test.dart
+++ b/examples/dart/test/client_reset_test.dart
@@ -10,7 +10,7 @@ part "client_reset_test.g.dart";
 class _Car {
   @PrimaryKey()
   @MapTo("_id")
-  late int id;
+  late ObjectId id;
 
   late String make;
   late String? model;

--- a/examples/dart/test/client_reset_test.g.dart
+++ b/examples/dart/test/client_reset_test.g.dart
@@ -8,7 +8,7 @@ part of 'client_reset_test.dart';
 
 class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car(
-    int id,
+    ObjectId id,
     String make, {
     String? model,
     int? miles,
@@ -22,9 +22,9 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, '_id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, '_id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, '_id', value);
 
   @override
   String get make => RealmObjectBase.get<String>(this, 'make') as String;
@@ -53,7 +53,7 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Car._);
     return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
-      SchemaProperty('_id', RealmPropertyType.int,
+      SchemaProperty('_id', RealmPropertyType.objectid,
           mapTo: '_id', primaryKey: true),
       SchemaProperty('make', RealmPropertyType.string),
       SchemaProperty('model', RealmPropertyType.string, optional: true),

--- a/examples/dart/test/client_reset_test.g.dart
+++ b/examples/dart/test/client_reset_test.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'car.dart';
+part of 'client_reset_test.dart';
 
 // **************************************************************************
 // RealmObjectGenerator
@@ -13,7 +13,7 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
     String? model,
     int? miles,
   }) {
-    RealmObjectBase.set(this, 'id', id);
+    RealmObjectBase.set(this, '_id', id);
     RealmObjectBase.set(this, 'make', make);
     RealmObjectBase.set(this, 'model', model);
     RealmObjectBase.set(this, 'miles', miles);
@@ -22,9 +22,9 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  int get id => RealmObjectBase.get<int>(this, '_id') as int;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(int value) => RealmObjectBase.set(this, '_id', value);
 
   @override
   String get make => RealmObjectBase.get<String>(this, 'make') as String;
@@ -53,7 +53,8 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Car._);
     return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('_id', RealmPropertyType.int,
+          mapTo: '_id', primaryKey: true),
       SchemaProperty('make', RealmPropertyType.string),
       SchemaProperty('model', RealmPropertyType.string, optional: true),
       SchemaProperty('miles', RealmPropertyType.int, optional: true),

--- a/examples/dart/test/compact_realm_test.dart
+++ b/examples/dart/test/compact_realm_test.dart
@@ -45,8 +45,9 @@ void main() {
       // :remove-start:
       // Populate some data in the realm so we can compact it
       final prepareRealm = Realm(config);
-      Car newPrius = Car("Toyota", model: "Prius", miles: 0);
-      Car usedOutback = Car("Subaru", model: "Outback Premium", miles: 61370);
+      Car newPrius = Car(1, "Toyota", model: "Prius", miles: 0);
+      Car usedOutback =
+          Car(2, "Subaru", model: "Outback Premium", miles: 61370);
       prepareRealm.write(() {
         prepareRealm.add<Car>(newPrius);
         prepareRealm.add<Car>(usedOutback);

--- a/examples/dart/test/compact_realm_test.dart
+++ b/examples/dart/test/compact_realm_test.dart
@@ -45,9 +45,9 @@ void main() {
       // :remove-start:
       // Populate some data in the realm so we can compact it
       final prepareRealm = Realm(config);
-      Car newPrius = Car(1, "Toyota", model: "Prius", miles: 0);
+      Car newPrius = Car(ObjectId(), "Toyota", model: "Prius", miles: 0);
       Car usedOutback =
-          Car(2, "Subaru", model: "Outback Premium", miles: 61370);
+          Car(ObjectId(), "Subaru", model: "Outback Premium", miles: 61370);
       prepareRealm.write(() {
         prepareRealm.add<Car>(newPrius);
         prepareRealm.add<Car>(usedOutback);

--- a/examples/dart/test/data_types_test.dart
+++ b/examples/dart/test/data_types_test.dart
@@ -14,7 +14,7 @@ part 'data_types_test.g.dart'; // :remove:
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   String? licensePlate;
   bool isElectric = false;

--- a/examples/dart/test/data_types_test.g.dart
+++ b/examples/dart/test/data_types_test.g.dart
@@ -10,7 +10,7 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   static var _defaultsSet = false;
 
   Car(
-    int id, {
+    ObjectId id, {
     String? licensePlate,
     bool isElectric = false,
     double milesDriven = 0,
@@ -35,9 +35,9 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String? get licensePlate =>
@@ -83,7 +83,7 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Car._);
     return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('licensePlate', RealmPropertyType.string, optional: true),
       SchemaProperty('isElectric', RealmPropertyType.bool),
       SchemaProperty('milesDriven', RealmPropertyType.double),

--- a/examples/dart/test/define_realm_model_test.dart
+++ b/examples/dart/test/define_realm_model_test.dart
@@ -20,8 +20,9 @@ part 'define_realm_model_test.g.dart'; // :remove:
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late String make;
+  late int id;
 
+  late String make;
   late String? model;
   late int? miles;
 }

--- a/examples/dart/test/define_realm_model_test.dart
+++ b/examples/dart/test/define_realm_model_test.dart
@@ -20,7 +20,7 @@ part 'define_realm_model_test.g.dart'; // :remove:
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String make;
   late String? model;

--- a/examples/dart/test/define_realm_model_test.g.dart
+++ b/examples/dart/test/define_realm_model_test.g.dart
@@ -8,7 +8,7 @@ part of 'define_realm_model_test.dart';
 
 class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car(
-    int id,
+    ObjectId id,
     String make, {
     String? model,
     int? miles,
@@ -22,9 +22,9 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get make => RealmObjectBase.get<String>(this, 'make') as String;
@@ -53,7 +53,7 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Car._);
     return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('make', RealmPropertyType.string),
       SchemaProperty('model', RealmPropertyType.string, optional: true),
       SchemaProperty('miles', RealmPropertyType.int, optional: true),

--- a/examples/dart/test/define_realm_model_test.g.dart
+++ b/examples/dart/test/define_realm_model_test.g.dart
@@ -8,16 +8,23 @@ part of 'define_realm_model_test.dart';
 
 class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car(
+    int id,
     String make, {
     String? model,
     int? miles,
   }) {
+    RealmObjectBase.set(this, 'id', id);
     RealmObjectBase.set(this, 'make', make);
     RealmObjectBase.set(this, 'model', model);
     RealmObjectBase.set(this, 'miles', miles);
   }
 
   Car._();
+
+  @override
+  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  @override
+  set id(int value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get make => RealmObjectBase.get<String>(this, 'make') as String;
@@ -46,7 +53,8 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Car._);
     return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
-      SchemaProperty('make', RealmPropertyType.string, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('make', RealmPropertyType.string),
       SchemaProperty('model', RealmPropertyType.string, optional: true),
       SchemaProperty('miles', RealmPropertyType.int, optional: true),
     ]);

--- a/examples/dart/test/define_realm_object_schema_usage_test.dart
+++ b/examples/dart/test/define_realm_object_schema_usage_test.dart
@@ -3,12 +3,12 @@ import 'package:realm_dart/realm.dart';
 // :snippet-start: use-realm-object
 import './schemas.dart';
 
-final hondaCivic = Car(1, 'Honda', model: 'Civic', miles: 99);
+final hondaCivic = Car(ObjectId(), 'Honda', model: 'Civic', miles: 99);
 // :snippet-end:
 void main() {
   // tests the above 'use-realm-object' example, which includes the import statement
   test('test Honda Civic', () {
-    expect(hondaCivic.id, 1);
+    expect(hondaCivic.id, isA<ObjectId>());
     expect(hondaCivic.miles, 99);
     expect(hondaCivic.make, 'Honda');
     expect(hondaCivic.model, 'Civic');

--- a/examples/dart/test/define_realm_object_schema_usage_test.dart
+++ b/examples/dart/test/define_realm_object_schema_usage_test.dart
@@ -3,11 +3,12 @@ import 'package:realm_dart/realm.dart';
 // :snippet-start: use-realm-object
 import './schemas.dart';
 
-final hondaCivic = Car('Honda', model: 'Civic', miles: 99);
+final hondaCivic = Car(1, 'Honda', model: 'Civic', miles: 99);
 // :snippet-end:
 void main() {
   // tests the above 'use-realm-object' example, which includes the import statement
   test('test Honda Civic', () {
+    expect(hondaCivic.id, 1);
     expect(hondaCivic.miles, 99);
     expect(hondaCivic.make, 'Honda');
     expect(hondaCivic.model, 'Civic');

--- a/examples/dart/test/freeze_test.g.dart
+++ b/examples/dart/test/freeze_test.g.dart
@@ -8,7 +8,7 @@ part of 'freeze_test.dart';
 
 class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
   Person(
-    int id,
+    ObjectId id,
     String firstName,
     String lastName, {
     Iterable<String> attributes = const [],
@@ -23,9 +23,9 @@ class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
   Person._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get firstName =>
@@ -58,7 +58,7 @@ class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Person._);
     return const SchemaObject(ObjectType.realmObject, Person, 'Person', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('firstName', RealmPropertyType.string),
       SchemaProperty('lastName', RealmPropertyType.string),
       SchemaProperty('attributes', RealmPropertyType.string,
@@ -69,7 +69,7 @@ class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
 
 class Scooter extends _Scooter with RealmEntity, RealmObjectBase, RealmObject {
   Scooter(
-    int id,
+    ObjectId id,
     String name, {
     Person? owner,
   }) {
@@ -81,9 +81,9 @@ class Scooter extends _Scooter with RealmEntity, RealmObjectBase, RealmObject {
   Scooter._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get name => RealmObjectBase.get<String>(this, 'name') as String;
@@ -108,7 +108,7 @@ class Scooter extends _Scooter with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Scooter._);
     return const SchemaObject(ObjectType.realmObject, Scooter, 'Scooter', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('name', RealmPropertyType.string),
       SchemaProperty('owner', RealmPropertyType.object,
           optional: true, linkTarget: 'Person'),

--- a/examples/dart/test/migrations_test.dart
+++ b/examples/dart/test/migrations_test.dart
@@ -11,7 +11,7 @@ typedef Car = Schemas.Car;
 @MapTo("Person")
 class _PersonV2 {
   @PrimaryKey()
-  late ObjectId id;
+  late String id;
 
   late String fullName;
   late int? yearsSinceBirth;
@@ -27,9 +27,10 @@ void main() {
         Configuration.local([PersonV1.schema, Car.schema], path: realmPath);
     final realmV1 = Realm(configV1);
     realmV1.write(() {
-      realmV1.add<PersonV1>(PersonV1(1, "Lando", "Calrissian", age: 42));
-      realmV1.add<PersonV1>(PersonV1(2, "Boba", "Fett", age: 36));
-      realmV1.add<PersonV1>(PersonV1(3, "Mace", "Windu", age: 40));
+      realmV1
+          .add<PersonV1>(PersonV1(ObjectId(), "Lando", "Calrissian", age: 42));
+      realmV1.add<PersonV1>(PersonV1(ObjectId(), "Boba", "Fett", age: 36));
+      realmV1.add<PersonV1>(PersonV1(ObjectId(), "Mace", "Windu", age: 40));
     });
     realmV1.close();
   });
@@ -76,8 +77,8 @@ void main() {
         newPerson.fullName = oldPerson.dynamic.get<String>("firstName") +
             " " +
             oldPerson.dynamic.get<String>("lastName");
-        final oldIdBytes = oldPerson.dynamic.get<int>("id");
-        newPerson.id = ObjectId.fromValues(0, 0, oldIdBytes);
+        final oldId = oldPerson.dynamic.get<ObjectId>("id");
+        newPerson.id = oldId.toString();
       }
       // :remove-end:
       // Between v1 and v2 we renamed the Person 'age' property to 'yearsSinceBirth'
@@ -113,9 +114,9 @@ void main() {
         newPerson.fullName = oldPerson.dynamic.get<String>("firstName") +
             " " +
             oldPerson.dynamic.get<String>("lastName");
-        // convert `id` from int to ObjectId
-        final oldId = oldPerson.dynamic.get<int>("id");
-        newPerson.id = ObjectId.fromValues(0, 0, oldId);
+        // convert `id` from ObjectId to String
+        final oldId = oldPerson.dynamic.get<ObjectId>("id");
+        newPerson.id = oldId.toString();
       }
       // :remove-start:
       migration.renameProperty('Person', 'age', 'yearsSinceBirth');

--- a/examples/dart/test/migrations_test.g.dart
+++ b/examples/dart/test/migrations_test.g.dart
@@ -9,7 +9,7 @@ part of 'migrations_test.dart';
 class PersonV2 extends _PersonV2
     with RealmEntity, RealmObjectBase, RealmObject {
   PersonV2(
-    ObjectId id,
+    String id,
     String fullName, {
     int? yearsSinceBirth,
   }) {
@@ -21,9 +21,9 @@ class PersonV2 extends _PersonV2
   PersonV2._();
 
   @override
-  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
+  String get id => RealmObjectBase.get<String>(this, 'id') as String;
   @override
-  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
+  set id(String value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get fullName =>
@@ -50,7 +50,7 @@ class PersonV2 extends _PersonV2
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(PersonV2._);
     return const SchemaObject(ObjectType.realmObject, PersonV2, 'Person', [
-      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.string, primaryKey: true),
       SchemaProperty('fullName', RealmPropertyType.string),
       SchemaProperty('yearsSinceBirth', RealmPropertyType.int, optional: true),
     ]);

--- a/examples/dart/test/open_realm_test.dart
+++ b/examples/dart/test/open_realm_test.dart
@@ -31,7 +31,7 @@ void main() {
       test('Configuration readOnly - reading is possible', () async {
         Configuration initConfig = Configuration.local([Car.schema]);
         var realm = Realm(initConfig);
-        realm.write(() => realm.add(Car("Mustang")));
+        realm.write(() => realm.add(Car(1, "Mustang")));
         realm.close();
 
         // :snippet-start: read-only-realm
@@ -57,7 +57,7 @@ void main() {
         var config = Configuration.inMemory([Car.schema]);
         var realm = Realm(config);
         // :snippet-end:
-        realm.write(() => realm.add(Car('Tesla')));
+        realm.write(() => realm.add(Car(2, 'Tesla')));
         expect(Realm.existsSync(config.path), true);
         await cleanUpRealm(realm);
       });
@@ -67,7 +67,7 @@ void main() {
       // :snippet-start: initial-data-callback
       void dataCb(Realm realm) {
         called = true; // :remove:
-        realm.add(Car('Honda'));
+        realm.add(Car(3, 'Honda'));
       }
 
       Configuration config =

--- a/examples/dart/test/open_realm_test.dart
+++ b/examples/dart/test/open_realm_test.dart
@@ -31,7 +31,7 @@ void main() {
       test('Configuration readOnly - reading is possible', () async {
         Configuration initConfig = Configuration.local([Car.schema]);
         var realm = Realm(initConfig);
-        realm.write(() => realm.add(Car(1, "Mustang")));
+        realm.write(() => realm.add(Car(ObjectId(), "Mustang")));
         realm.close();
 
         // :snippet-start: read-only-realm
@@ -57,7 +57,7 @@ void main() {
         var config = Configuration.inMemory([Car.schema]);
         var realm = Realm(config);
         // :snippet-end:
-        realm.write(() => realm.add(Car(2, 'Tesla')));
+        realm.write(() => realm.add(Car(ObjectId(), 'Tesla')));
         expect(Realm.existsSync(config.path), true);
         await cleanUpRealm(realm);
       });
@@ -67,7 +67,7 @@ void main() {
       // :snippet-start: initial-data-callback
       void dataCb(Realm realm) {
         called = true; // :remove:
-        realm.add(Car(3, 'Honda'));
+        realm.add(Car(ObjectId(), 'Honda'));
       }
 
       Configuration config =

--- a/examples/dart/test/quick_start_test.dart
+++ b/examples/dart/test/quick_start_test.dart
@@ -25,7 +25,7 @@ void main() {
       Realm realm = Realm(config);
       Car? addedCar;
       // :snippet-start: create-realm-object
-      final car = Car(3, 'Tesla', model: 'Model S', miles: 42);
+      final car = Car(ObjectId(), 'Tesla', model: 'Model S', miles: 42);
       realm.write(() {
         addedCar = realm.add(car); // :remove:
         // :uncomment-start:
@@ -45,7 +45,7 @@ void main() {
       Realm realm = Realm(config);
 
       realm.write(() {
-        realm.add(Car(4, 'Tesla', model: 'Model Y', miles: 42));
+        realm.add(Car(ObjectId(), 'Tesla', model: 'Model Y', miles: 42));
       });
       // :snippet-start: query-all-realm-objects
       var cars = realm.all<Car>();
@@ -64,8 +64,8 @@ void main() {
       var config = Configuration.local([Car.schema]);
       Realm realm = Realm(config);
       realm.write(() {
-        realm.add(Car(4, 'Tesla', model: 'Model Y', miles: 42));
-        realm.add(Car(5, 'Toyota', model: 'Prius', miles: 99));
+        realm.add(Car(ObjectId(), 'Tesla', model: 'Model Y', miles: 42));
+        realm.add(Car(ObjectId(), 'Toyota', model: 'Prius', miles: 99));
       });
       // :snippet-start: query-realm-objects-with-filter
       var cars = realm.all<Car>().query('make == "Tesla"');
@@ -83,9 +83,9 @@ void main() {
       Realm realm = Realm(config);
       // :snippet-start: query-realm-objects-with-sort
       realm.write(() {
-        realm.add(Car(6, 'BMW', model: 'Z4', miles: 42));
-        realm.add(Car(7, 'Audi', model: 'A8', miles: 99));
-        realm.add(Car(8, 'Mercedes', model: 'G-Wagon', miles: 2));
+        realm.add(Car(ObjectId(), 'BMW', model: 'Z4', miles: 42));
+        realm.add(Car(ObjectId(), 'Audi', model: 'A8', miles: 99));
+        realm.add(Car(ObjectId(), 'Mercedes', model: 'G-Wagon', miles: 2));
       });
       final sortedCars = realm.query<Car>('TRUEPREDICATE SORT(model ASC)');
       for (var car in sortedCars) {
@@ -107,7 +107,7 @@ void main() {
       var config = Configuration.local([Car.schema]);
       Realm realm = Realm(config);
 
-      final car = Car(4, 'Tesla', model: 'Model Y', miles: 42);
+      final car = Car(ObjectId(), 'Tesla', model: 'Model Y', miles: 42);
       realm.write(() {
         realm.add(car);
       });
@@ -129,7 +129,7 @@ void main() {
       var config = Configuration.local([Car.schema]);
       Realm realm = Realm(config);
 
-      final car = Car(4, 'Tesla', model: 'Model Y', miles: 42);
+      final car = Car(ObjectId(), 'Tesla', model: 'Model Y', miles: 42);
       realm.write(() {
         realm.add(car);
       });
@@ -147,8 +147,8 @@ void main() {
       Realm realm = Realm(config);
 
       realm.write(() {
-        realm.add(Car(4, 'Tesla', model: 'Model Y', miles: 42));
-        realm.add(Car(5, 'Toyota', model: 'Prius', miles: 99));
+        realm.add(Car(ObjectId(), 'Tesla', model: 'Model Y', miles: 42));
+        realm.add(Car(ObjectId(), 'Toyota', model: 'Prius', miles: 99));
       });
       var cars = realm.all<Car>();
       // :snippet-start: delete-many-realm-objects

--- a/examples/dart/test/quick_start_test.dart
+++ b/examples/dart/test/quick_start_test.dart
@@ -25,7 +25,7 @@ void main() {
       Realm realm = Realm(config);
       Car? addedCar;
       // :snippet-start: create-realm-object
-      final car = Car('Tesla', model: 'Model S', miles: 42);
+      final car = Car(3, 'Tesla', model: 'Model S', miles: 42);
       realm.write(() {
         addedCar = realm.add(car); // :remove:
         // :uncomment-start:
@@ -45,7 +45,7 @@ void main() {
       Realm realm = Realm(config);
 
       realm.write(() {
-        realm.add(Car('Tesla', model: 'Model Y', miles: 42));
+        realm.add(Car(4, 'Tesla', model: 'Model Y', miles: 42));
       });
       // :snippet-start: query-all-realm-objects
       var cars = realm.all<Car>();
@@ -64,8 +64,8 @@ void main() {
       var config = Configuration.local([Car.schema]);
       Realm realm = Realm(config);
       realm.write(() {
-        realm.add(Car('Tesla', model: 'Model Y', miles: 42));
-        realm.add(Car('Toyota', model: 'Prius', miles: 99));
+        realm.add(Car(4, 'Tesla', model: 'Model Y', miles: 42));
+        realm.add(Car(5, 'Toyota', model: 'Prius', miles: 99));
       });
       // :snippet-start: query-realm-objects-with-filter
       var cars = realm.all<Car>().query('make == "Tesla"');
@@ -83,9 +83,9 @@ void main() {
       Realm realm = Realm(config);
       // :snippet-start: query-realm-objects-with-sort
       realm.write(() {
-        realm.add(Car('BMW', model: 'Z4', miles: 42));
-        realm.add(Car('Audi', model: 'A8', miles: 99));
-        realm.add(Car('Mercedes', model: 'G-Wagon', miles: 2));
+        realm.add(Car(6, 'BMW', model: 'Z4', miles: 42));
+        realm.add(Car(7, 'Audi', model: 'A8', miles: 99));
+        realm.add(Car(8, 'Mercedes', model: 'G-Wagon', miles: 2));
       });
       final sortedCars = realm.query<Car>('TRUEPREDICATE SORT(model ASC)');
       for (var car in sortedCars) {
@@ -107,7 +107,7 @@ void main() {
       var config = Configuration.local([Car.schema]);
       Realm realm = Realm(config);
 
-      final car = Car('Tesla', model: 'Model Y', miles: 42);
+      final car = Car(4, 'Tesla', model: 'Model Y', miles: 42);
       realm.write(() {
         realm.add(car);
       });
@@ -129,7 +129,7 @@ void main() {
       var config = Configuration.local([Car.schema]);
       Realm realm = Realm(config);
 
-      final car = Car('Tesla', model: 'Model Y', miles: 42);
+      final car = Car(4, 'Tesla', model: 'Model Y', miles: 42);
       realm.write(() {
         realm.add(car);
       });
@@ -147,8 +147,8 @@ void main() {
       Realm realm = Realm(config);
 
       realm.write(() {
-        realm.add(Car('Tesla', model: 'Model Y', miles: 42));
-        realm.add(Car('Toyota', model: 'Prius', miles: 99));
+        realm.add(Car(4, 'Tesla', model: 'Model Y', miles: 42));
+        realm.add(Car(5, 'Toyota', model: 'Prius', miles: 99));
       });
       var cars = realm.all<Car>();
       // :snippet-start: delete-many-realm-objects

--- a/examples/dart/test/read_write_data_test.dart
+++ b/examples/dart/test/read_write_data_test.dart
@@ -55,7 +55,7 @@ void main() {
 
     // :snippet-start: return-from-write
     Car fordFusion = realm.write<Car>(() {
-      return realm.add(Car('Ford', model: 'Fusion', miles: 101));
+      return realm.add(Car(1, 'Ford', model: 'Fusion', miles: 101));
     });
     // :snippet-end:
     expect(fordFusion.make, 'Ford');
@@ -68,19 +68,19 @@ void main() {
     final config = Configuration.local([Car.schema]);
     final realm = Realm(config);
     // :snippet-start: upsert
-    // Add Toyota Prius to the realm with primary key `Toyota`
-    Car newPrius = Car("Toyota", model: "Prius", miles: 0);
+    // Add Toyota Prius to the realm with primary key `2`
+    Car newPrius = Car(2, "Toyota", model: "Prius", miles: 0);
     realm.write(() {
       realm.add<Car>(newPrius);
     });
 
-    // Update Toyota Prius's miles in the realm with primary key `Toyota`
-    Car usedPrius = Car("Toyota", model: "Prius", miles: 500);
+    // Update Toyota Prius's miles in the realm with primary key `2`
+    Car usedPrius = Car(2, "Toyota", model: "Prius", miles: 500);
     realm.write(() {
       realm.add<Car>(usedPrius, update: true);
     });
     // :snippet-end:
-    final prius = realm.find<Car>("Toyota");
+    final prius = realm.find<Car>(2);
     expect(prius!.miles, 500);
     cleanUpRealm(realm);
   });
@@ -90,18 +90,18 @@ void main() {
     final realm = Realm(config);
     // :snippet-start: write-async
     // Add Subaru Outback to the realm using `writeAsync`
-    Car newOutback = Car("Subaru", model: "Outback Touring XT", miles: 2);
+    Car newOutback = Car(3, "Subaru", model: "Outback Touring XT", miles: 2);
     realm.writeAsync(() {
       realm.add<Car>(newOutback);
     });
     // :snippet-end:
-    final outback = realm.find<Car>("Subaru");
+    final outback = realm.find<Car>(3);
     expect(outback, isNull);
     expect(realm.isInTransaction, true);
     // let transaction resolve
     await Future.delayed(Duration(milliseconds: 500));
     expect(realm.isInTransaction, false);
-    expect(realm.find<Car>("Subaru")!.miles, 2);
+    expect(realm.find<Car>(3)!.miles, 2);
     cleanUpRealm(realm);
   });
 }

--- a/examples/dart/test/read_write_data_test.dart
+++ b/examples/dart/test/read_write_data_test.dart
@@ -55,7 +55,7 @@ void main() {
 
     // :snippet-start: return-from-write
     Car fordFusion = realm.write<Car>(() {
-      return realm.add(Car(1, 'Ford', model: 'Fusion', miles: 101));
+      return realm.add(Car(ObjectId(), 'Ford', model: 'Fusion', miles: 101));
     });
     // :snippet-end:
     expect(fordFusion.make, 'Ford');
@@ -68,20 +68,21 @@ void main() {
     final config = Configuration.local([Car.schema]);
     final realm = Realm(config);
     // :snippet-start: upsert
-    // Add Toyota Prius to the realm with primary key `2`
-    Car newPrius = Car(2, "Toyota", model: "Prius", miles: 0);
+    final id = ObjectId();
+    // Add Toyota Prius to the realm with primary key `id`
+    Car newPrius = Car(id, "Toyota", model: "Prius", miles: 0);
     realm.write(() {
       realm.add<Car>(newPrius);
     });
 
-    // Update Toyota Prius's miles in the realm with primary key `2`
-    Car usedPrius = Car(2, "Toyota", model: "Prius", miles: 500);
+    // Update Toyota Prius's miles in the realm with primary key `id`
+    Car usedPrius = Car(id, "Toyota", model: "Prius", miles: 500);
     realm.write(() {
       realm.add<Car>(usedPrius, update: true);
     });
     // :snippet-end:
-    final prius = realm.find<Car>(2);
-    expect(prius!.miles, 500);
+    final prius = realm.query<Car>('model == \$0', ["Prius"]).first;
+    expect(prius.miles, 500);
     cleanUpRealm(realm);
   });
 
@@ -90,7 +91,8 @@ void main() {
     final realm = Realm(config);
     // :snippet-start: write-async
     // Add Subaru Outback to the realm using `writeAsync`
-    Car newOutback = Car(3, "Subaru", model: "Outback Touring XT", miles: 2);
+    Car newOutback =
+        Car(ObjectId(), "Subaru", model: "Outback Touring XT", miles: 2);
     realm.writeAsync(() {
       realm.add<Car>(newOutback);
     });
@@ -101,7 +103,8 @@ void main() {
     // let transaction resolve
     await Future.delayed(Duration(milliseconds: 500));
     expect(realm.isInTransaction, false);
-    expect(realm.find<Car>(3)!.miles, 2);
+    expect(realm.query<Car>("model == \$0", ["Outback Touring XT"]).first.miles,
+        2);
     cleanUpRealm(realm);
   });
 }

--- a/examples/dart/test/schemas.dart
+++ b/examples/dart/test/schemas.dart
@@ -8,7 +8,7 @@ part 'schemas.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String make;
   late String? model;
@@ -31,7 +31,7 @@ class _SyncSchema {
 @RealmModel()
 class _Bike {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String name;
   late _Person? owner;
@@ -40,7 +40,7 @@ class _Bike {
 @RealmModel()
 class _Person {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String firstName;
   late String lastName;
@@ -52,7 +52,7 @@ class _Person {
 @RealmModel()
 class _Scooter {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String name;
   late _Person? owner;
@@ -61,7 +61,7 @@ class _Scooter {
 @RealmModel()
 class _ScooterShop {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String name;
   late List<_Scooter> owner;
@@ -71,7 +71,7 @@ class _ScooterShop {
 // :snippet-start: property-annotations
 class _Vehicle {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String? maybeDescription; // optional value
 

--- a/examples/dart/test/schemas.dart
+++ b/examples/dart/test/schemas.dart
@@ -8,8 +8,9 @@ part 'schemas.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late String make;
+  late int id;
 
+  late String make;
   late String? model;
   late int? miles;
 }

--- a/examples/dart/test/schemas.dart
+++ b/examples/dart/test/schemas.dart
@@ -21,7 +21,7 @@ class _Car {
 class _SyncSchema {
   @PrimaryKey()
   @MapTo("_id")
-  late int id;
+  late ObjectId id;
 
   // ... other properties
 }

--- a/examples/dart/test/schemas.g.dart
+++ b/examples/dart/test/schemas.g.dart
@@ -64,7 +64,7 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
 class SyncSchema extends _SyncSchema
     with RealmEntity, RealmObjectBase, RealmObject {
   SyncSchema(
-    int id,
+    ObjectId id,
   ) {
     RealmObjectBase.set(this, '_id', id);
   }
@@ -72,9 +72,9 @@ class SyncSchema extends _SyncSchema
   SyncSchema._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, '_id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, '_id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, '_id', value);
 
   @override
   Stream<RealmObjectChanges<SyncSchema>> get changes =>
@@ -89,7 +89,7 @@ class SyncSchema extends _SyncSchema
     RealmObjectBase.registerFactory(SyncSchema._);
     return const SchemaObject(
         ObjectType.realmObject, SyncSchema, 'SyncSchema', [
-      SchemaProperty('_id', RealmPropertyType.int,
+      SchemaProperty('_id', RealmPropertyType.objectid,
           mapTo: '_id', primaryKey: true),
     ]);
   }

--- a/examples/dart/test/schemas.g.dart
+++ b/examples/dart/test/schemas.g.dart
@@ -8,16 +8,23 @@ part of 'schemas.dart';
 
 class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car(
+    int id,
     String make, {
     String? model,
     int? miles,
   }) {
+    RealmObjectBase.set(this, 'id', id);
     RealmObjectBase.set(this, 'make', make);
     RealmObjectBase.set(this, 'model', model);
     RealmObjectBase.set(this, 'miles', miles);
   }
 
   Car._();
+
+  @override
+  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  @override
+  set id(int value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get make => RealmObjectBase.get<String>(this, 'make') as String;
@@ -46,7 +53,8 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Car._);
     return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
-      SchemaProperty('make', RealmPropertyType.string, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('make', RealmPropertyType.string),
       SchemaProperty('model', RealmPropertyType.string, optional: true),
       SchemaProperty('miles', RealmPropertyType.int, optional: true),
     ]);

--- a/examples/dart/test/schemas.g.dart
+++ b/examples/dart/test/schemas.g.dart
@@ -8,7 +8,7 @@ part of 'schemas.dart';
 
 class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car(
-    int id,
+    ObjectId id,
     String make, {
     String? model,
     int? miles,
@@ -22,9 +22,9 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   Car._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get make => RealmObjectBase.get<String>(this, 'make') as String;
@@ -53,7 +53,7 @@ class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Car._);
     return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('make', RealmPropertyType.string),
       SchemaProperty('model', RealmPropertyType.string, optional: true),
       SchemaProperty('miles', RealmPropertyType.int, optional: true),
@@ -97,7 +97,7 @@ class SyncSchema extends _SyncSchema
 
 class Bike extends _Bike with RealmEntity, RealmObjectBase, RealmObject {
   Bike(
-    int id,
+    ObjectId id,
     String name, {
     Person? owner,
   }) {
@@ -109,9 +109,9 @@ class Bike extends _Bike with RealmEntity, RealmObjectBase, RealmObject {
   Bike._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get name => RealmObjectBase.get<String>(this, 'name') as String;
@@ -136,7 +136,7 @@ class Bike extends _Bike with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Bike._);
     return const SchemaObject(ObjectType.realmObject, Bike, 'Bike', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('name', RealmPropertyType.string),
       SchemaProperty('owner', RealmPropertyType.object,
           optional: true, linkTarget: 'Person'),
@@ -146,7 +146,7 @@ class Bike extends _Bike with RealmEntity, RealmObjectBase, RealmObject {
 
 class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
   Person(
-    int id,
+    ObjectId id,
     String firstName,
     String lastName, {
     int? age,
@@ -160,9 +160,9 @@ class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
   Person._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get firstName =>
@@ -193,7 +193,7 @@ class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Person._);
     return const SchemaObject(ObjectType.realmObject, Person, 'Person', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('firstName', RealmPropertyType.string),
       SchemaProperty('lastName', RealmPropertyType.string),
       SchemaProperty('age', RealmPropertyType.int, optional: true),
@@ -203,7 +203,7 @@ class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
 
 class Scooter extends _Scooter with RealmEntity, RealmObjectBase, RealmObject {
   Scooter(
-    int id,
+    ObjectId id,
     String name, {
     Person? owner,
   }) {
@@ -215,9 +215,9 @@ class Scooter extends _Scooter with RealmEntity, RealmObjectBase, RealmObject {
   Scooter._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get name => RealmObjectBase.get<String>(this, 'name') as String;
@@ -242,7 +242,7 @@ class Scooter extends _Scooter with RealmEntity, RealmObjectBase, RealmObject {
   static SchemaObject _initSchema() {
     RealmObjectBase.registerFactory(Scooter._);
     return const SchemaObject(ObjectType.realmObject, Scooter, 'Scooter', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('name', RealmPropertyType.string),
       SchemaProperty('owner', RealmPropertyType.object,
           optional: true, linkTarget: 'Person'),
@@ -253,7 +253,7 @@ class Scooter extends _Scooter with RealmEntity, RealmObjectBase, RealmObject {
 class ScooterShop extends _ScooterShop
     with RealmEntity, RealmObjectBase, RealmObject {
   ScooterShop(
-    int id,
+    ObjectId id,
     String name, {
     Iterable<Scooter> owner = const [],
   }) {
@@ -266,9 +266,9 @@ class ScooterShop extends _ScooterShop
   ScooterShop._();
 
   @override
-  int get id => RealmObjectBase.get<int>(this, 'id') as int;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, 'id') as ObjectId;
   @override
-  set id(int value) => RealmObjectBase.set(this, 'id', value);
+  set id(ObjectId value) => RealmObjectBase.set(this, 'id', value);
 
   @override
   String get name => RealmObjectBase.get<String>(this, 'name') as String;
@@ -295,7 +295,7 @@ class ScooterShop extends _ScooterShop
     RealmObjectBase.registerFactory(ScooterShop._);
     return const SchemaObject(
         ObjectType.realmObject, ScooterShop, 'ScooterShop', [
-      SchemaProperty('id', RealmPropertyType.int, primaryKey: true),
+      SchemaProperty('id', RealmPropertyType.objectid, primaryKey: true),
       SchemaProperty('name', RealmPropertyType.string),
       SchemaProperty('owner', RealmPropertyType.object,
           linkTarget: 'Scooter', collectionType: RealmCollectionType.list),

--- a/examples/dart/test/utils.dart
+++ b/examples/dart/test/utils.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:realm_dart/realm.dart';
 import 'dart:math';
 
@@ -6,6 +8,7 @@ Future<void> cleanUpRealm(Realm realm, [App? app]) async {
   if (!realm.isClosed) {
     realm.close();
   }
+  sleep(Duration(milliseconds: 250));
   Realm.deleteRealm(realm.config.path);
 }
 

--- a/source/examples/generated/flutter/backlinks_test.snippet.backlink-models.dart
+++ b/source/examples/generated/flutter/backlinks_test.snippet.backlink-models.dart
@@ -1,7 +1,7 @@
 @RealmModel()
 class _User {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String username;
   // One-to-many relationship that the backlink is created for below.
@@ -11,7 +11,7 @@ class _User {
 @RealmModel()
 class _Task {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String description;
   late bool isComplete;

--- a/source/examples/generated/flutter/data_types_test.snippet.data-types-example-model.dart
+++ b/source/examples/generated/flutter/data_types_test.snippet.data-types-example-model.dart
@@ -4,7 +4,7 @@ part 'car.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   String? licensePlate;
   bool isElectric = false;

--- a/source/examples/generated/flutter/define_realm_model_test.snippet.define-model.dart
+++ b/source/examples/generated/flutter/define_realm_model_test.snippet.define-model.dart
@@ -5,8 +5,9 @@ part 'car.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late String make;
+  late int id;
 
+  late String make;
   late String? model;
   late int? miles;
 }

--- a/source/examples/generated/flutter/define_realm_model_test.snippet.define-model.dart
+++ b/source/examples/generated/flutter/define_realm_model_test.snippet.define-model.dart
@@ -5,7 +5,7 @@ part 'car.g.dart';
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String make;
   late String? model;

--- a/source/examples/generated/flutter/define_realm_object_schema_usage_test.snippet.use-realm-object.dart
+++ b/source/examples/generated/flutter/define_realm_object_schema_usage_test.snippet.use-realm-object.dart
@@ -1,3 +1,3 @@
 import './schemas.dart';
 
-final hondaCivic = Car('Honda', model: 'Civic', miles: 99);
+final hondaCivic = Car(1, 'Honda', model: 'Civic', miles: 99);

--- a/source/examples/generated/flutter/define_realm_object_schema_usage_test.snippet.use-realm-object.dart
+++ b/source/examples/generated/flutter/define_realm_object_schema_usage_test.snippet.use-realm-object.dart
@@ -1,3 +1,3 @@
 import './schemas.dart';
 
-final hondaCivic = Car(1, 'Honda', model: 'Civic', miles: 99);
+final hondaCivic = Car(ObjectId(), 'Honda', model: 'Civic', miles: 99);

--- a/source/examples/generated/flutter/freeze_test.snippet.freeze-list-in-realm-object.dart
+++ b/source/examples/generated/flutter/freeze_test.snippet.freeze-list-in-realm-object.dart
@@ -1,4 +1,5 @@
-Person firstPerson = realm.find<Person>(1)!;
+Person firstPerson =
+    realm.query<Person>("firstName = \$0", ["Yoda"]).first;
 
 // Freeze RealmList in a RealmObject
 RealmList<String> firstPersonAttributesFrozen =

--- a/source/examples/generated/flutter/freeze_test.snippet.freeze-realm-object.dart
+++ b/source/examples/generated/flutter/freeze_test.snippet.freeze-realm-object.dart
@@ -1,4 +1,5 @@
-Person person = realm.find(3)!;
+final person = realm.query<Person>(
+    'firstName == \$0 AND lastName == \$1', ["Count", "Dooku"]).first;
 
 // Freeze RealmObject
 final frozenPerson = person.freeze();

--- a/source/examples/generated/flutter/freeze_test.snippet.freeze-realm-results.dart
+++ b/source/examples/generated/flutter/freeze_test.snippet.freeze-realm-results.dart
@@ -1,6 +1,6 @@
 // Add data to the realm
-final maceWindu = Person(1, "Mace", "Windu");
-final jocastaNu = Person(2, "Jocasta", "Nul");
+final maceWindu = Person(ObjectId(), "Mace", "Windu");
+final jocastaNu = Person(ObjectId(), "Jocasta", "Nul");
 realm.write(() => realm.addAll([maceWindu, jocastaNu]));
 
 // Get RealmResults and freeze data

--- a/source/examples/generated/flutter/freeze_test.snippet.freeze-realm.dart
+++ b/source/examples/generated/flutter/freeze_test.snippet.freeze-realm.dart
@@ -1,8 +1,9 @@
 final config = Configuration.local([Person.schema, Scooter.schema]);
 Realm realm = Realm(config);
 // Add scooter ownded by Mace Windu
-final maceWindu = Person(1, "Mace", "Windu");
-final purpleScooter = Scooter(1, "Purple scooter", owner: maceWindu);
+final maceWindu = Person(ObjectId(), "Mace", "Windu");
+final purpleScooter =
+    Scooter(ObjectId(), "Purple scooter", owner: maceWindu);
 realm.write(() {
   realm.add(purpleScooter);
 });
@@ -11,14 +12,19 @@ realm.write(() {
 final frozenRealm = realm.freeze();
 
 // Update data in the realm
-final quiGonJinn = Person(2, "Qui-Gon", "Jinn");
+final quiGonJinn = Person(ObjectId(), "Qui-Gon", "Jinn");
 realm.write(() {
   purpleScooter.owner = quiGonJinn;
 });
 
 // Data changes not in the frozen snapshot
-final purpleScooterFrozen = frozenRealm.find<Scooter>(1);
-print(purpleScooterFrozen!.owner!.firstName); // prints 'Mace'
+final purpleScooterFrozen =
+    frozenRealm.query<Scooter>("name == \$0", ["Purple scooter"]).first;
+print(purpleScooterFrozen.owner!.firstName); // prints 'Mace'
+realm.write(() {
+  realm.deleteAll<Person>();
+  realm.deleteAll<Scooter>();
+});
 realm.close();
 
 // You must also close the frozen realm before exiting the process

--- a/source/examples/generated/flutter/freeze_test.snippet.is-frozen.dart
+++ b/source/examples/generated/flutter/freeze_test.snippet.is-frozen.dart
@@ -7,7 +7,8 @@ print(realm.isFrozen);
 RealmResults people = realm.all<Person>();
 print(people.isFrozen);
 
-Person firstPerson = realm.find<Person>(1)!;
+Person firstPerson =
+    realm.query<Person>("firstName = \$0", ["Yoda"]).first;
 print(firstPerson.isFrozen);
 
 RealmList<String> firstPersonAttributes = firstPerson.attributes;

--- a/source/examples/generated/flutter/migrations_test.snippet.migrations-other.dart
+++ b/source/examples/generated/flutter/migrations_test.snippet.migrations-other.dart
@@ -16,9 +16,9 @@ Configuration configWithChanges =
     newPerson.fullName = oldPerson.dynamic.get<String>("firstName") +
         " " +
         oldPerson.dynamic.get<String>("lastName");
-    // convert `id` from int to ObjectId
-    final oldId = oldPerson.dynamic.get<int>("id");
-    newPerson.id = ObjectId.fromValues(0, 0, oldId);
+    // convert `id` from ObjectId to String
+    final oldId = oldPerson.dynamic.get<ObjectId>("id");
+    newPerson.id = oldId.toString();
   }
 }));
 Realm realmWithChanges = Realm(configWithChanges);

--- a/source/examples/generated/flutter/myapp.snippet.create-bundle.dart
+++ b/source/examples/generated/flutter/myapp.snippet.create-bundle.dart
@@ -4,8 +4,8 @@ LocalConfiguration config =
 Realm realm = Realm(config);
 
 realm.write(() {
-  realm.add(Car("Audi", model: 'A8'));
-  realm.add(Car("Mercedes", model: 'G Wagon'));
+  realm.add(Car(ObjectId(), "Audi", model: 'A8'));
+  realm.add(Car(ObjectId(), "Mercedes", model: 'G Wagon'));
 });
 print("Bundled realm location: " + realm.config.path);
 realm.close();

--- a/source/examples/generated/flutter/open_realm_test.snippet.initial-data-callback.dart
+++ b/source/examples/generated/flutter/open_realm_test.snippet.initial-data-callback.dart
@@ -1,5 +1,5 @@
 void dataCb(Realm realm) {
-  realm.add(Car(3, 'Honda'));
+  realm.add(Car(ObjectId(), 'Honda'));
 }
 
 Configuration config =

--- a/source/examples/generated/flutter/open_realm_test.snippet.initial-data-callback.dart
+++ b/source/examples/generated/flutter/open_realm_test.snippet.initial-data-callback.dart
@@ -1,5 +1,5 @@
 void dataCb(Realm realm) {
-  realm.add(Car('Honda'));
+  realm.add(Car(3, 'Honda'));
 }
 
 Configuration config =

--- a/source/examples/generated/flutter/quick_start_test.snippet.create-realm-object.dart
+++ b/source/examples/generated/flutter/quick_start_test.snippet.create-realm-object.dart
@@ -1,4 +1,4 @@
-final car = Car('Tesla', model: 'Model S', miles: 42);
+final car = Car(3, 'Tesla', model: 'Model S', miles: 42);
 realm.write(() {
   realm.add(car);
 });

--- a/source/examples/generated/flutter/quick_start_test.snippet.create-realm-object.dart
+++ b/source/examples/generated/flutter/quick_start_test.snippet.create-realm-object.dart
@@ -1,4 +1,4 @@
-final car = Car(3, 'Tesla', model: 'Model S', miles: 42);
+final car = Car(ObjectId(), 'Tesla', model: 'Model S', miles: 42);
 realm.write(() {
   realm.add(car);
 });

--- a/source/examples/generated/flutter/quick_start_test.snippet.query-realm-objects-with-sort.dart
+++ b/source/examples/generated/flutter/quick_start_test.snippet.query-realm-objects-with-sort.dart
@@ -1,7 +1,7 @@
 realm.write(() {
-  realm.add(Car(6, 'BMW', model: 'Z4', miles: 42));
-  realm.add(Car(7, 'Audi', model: 'A8', miles: 99));
-  realm.add(Car(8, 'Mercedes', model: 'G-Wagon', miles: 2));
+  realm.add(Car(ObjectId(), 'BMW', model: 'Z4', miles: 42));
+  realm.add(Car(ObjectId(), 'Audi', model: 'A8', miles: 99));
+  realm.add(Car(ObjectId(), 'Mercedes', model: 'G-Wagon', miles: 2));
 });
 final sortedCars = realm.query<Car>('TRUEPREDICATE SORT(model ASC)');
 for (var car in sortedCars) {

--- a/source/examples/generated/flutter/quick_start_test.snippet.query-realm-objects-with-sort.dart
+++ b/source/examples/generated/flutter/quick_start_test.snippet.query-realm-objects-with-sort.dart
@@ -1,7 +1,7 @@
 realm.write(() {
-  realm.add(Car('BMW', model: 'Z4', miles: 42));
-  realm.add(Car('Audi', model: 'A8', miles: 99));
-  realm.add(Car('Mercedes', model: 'G-Wagon', miles: 2));
+  realm.add(Car(6, 'BMW', model: 'Z4', miles: 42));
+  realm.add(Car(7, 'Audi', model: 'A8', miles: 99));
+  realm.add(Car(8, 'Mercedes', model: 'G-Wagon', miles: 2));
 });
 final sortedCars = realm.query<Car>('TRUEPREDICATE SORT(model ASC)');
 for (var car in sortedCars) {

--- a/source/examples/generated/flutter/read_write_data_test.snippet.return-from-write.dart
+++ b/source/examples/generated/flutter/read_write_data_test.snippet.return-from-write.dart
@@ -1,3 +1,3 @@
 Car fordFusion = realm.write<Car>(() {
-  return realm.add(Car('Ford', model: 'Fusion', miles: 101));
+  return realm.add(Car(1, 'Ford', model: 'Fusion', miles: 101));
 });

--- a/source/examples/generated/flutter/read_write_data_test.snippet.return-from-write.dart
+++ b/source/examples/generated/flutter/read_write_data_test.snippet.return-from-write.dart
@@ -1,3 +1,3 @@
 Car fordFusion = realm.write<Car>(() {
-  return realm.add(Car(1, 'Ford', model: 'Fusion', miles: 101));
+  return realm.add(Car(ObjectId(), 'Ford', model: 'Fusion', miles: 101));
 });

--- a/source/examples/generated/flutter/read_write_data_test.snippet.upsert.dart
+++ b/source/examples/generated/flutter/read_write_data_test.snippet.upsert.dart
@@ -1,11 +1,12 @@
-// Add Toyota Prius to the realm with primary key `2`
-Car newPrius = Car(2, "Toyota", model: "Prius", miles: 0);
+final id = ObjectId();
+// Add Toyota Prius to the realm with primary key `id`
+Car newPrius = Car(id, "Toyota", model: "Prius", miles: 0);
 realm.write(() {
   realm.add<Car>(newPrius);
 });
 
-// Update Toyota Prius's miles in the realm with primary key `2`
-Car usedPrius = Car(2, "Toyota", model: "Prius", miles: 500);
+// Update Toyota Prius's miles in the realm with primary key `id`
+Car usedPrius = Car(id, "Toyota", model: "Prius", miles: 500);
 realm.write(() {
   realm.add<Car>(usedPrius, update: true);
 });

--- a/source/examples/generated/flutter/read_write_data_test.snippet.upsert.dart
+++ b/source/examples/generated/flutter/read_write_data_test.snippet.upsert.dart
@@ -1,11 +1,11 @@
-// Add Toyota Prius to the realm with primary key `Toyota`
-Car newPrius = Car("Toyota", model: "Prius", miles: 0);
+// Add Toyota Prius to the realm with primary key `2`
+Car newPrius = Car(2, "Toyota", model: "Prius", miles: 0);
 realm.write(() {
   realm.add<Car>(newPrius);
 });
 
-// Update Toyota Prius's miles in the realm with primary key `Toyota`
-Car usedPrius = Car("Toyota", model: "Prius", miles: 500);
+// Update Toyota Prius's miles in the realm with primary key `2`
+Car usedPrius = Car(2, "Toyota", model: "Prius", miles: 500);
 realm.write(() {
   realm.add<Car>(usedPrius, update: true);
 });

--- a/source/examples/generated/flutter/read_write_data_test.snippet.write-async.dart
+++ b/source/examples/generated/flutter/read_write_data_test.snippet.write-async.dart
@@ -1,5 +1,5 @@
 // Add Subaru Outback to the realm using `writeAsync`
-Car newOutback = Car("Subaru", model: "Outback Touring XT", miles: 2);
+Car newOutback = Car(3, "Subaru", model: "Outback Touring XT", miles: 2);
 realm.writeAsync(() {
   realm.add<Car>(newOutback);
 });

--- a/source/examples/generated/flutter/read_write_data_test.snippet.write-async.dart
+++ b/source/examples/generated/flutter/read_write_data_test.snippet.write-async.dart
@@ -1,5 +1,6 @@
 // Add Subaru Outback to the realm using `writeAsync`
-Car newOutback = Car(3, "Subaru", model: "Outback Touring XT", miles: 2);
+Car newOutback =
+    Car(ObjectId(), "Subaru", model: "Outback Touring XT", miles: 2);
 realm.writeAsync(() {
   realm.add<Car>(newOutback);
 });

--- a/source/examples/generated/flutter/schemas.snippet.create-realm-model.dart
+++ b/source/examples/generated/flutter/schemas.snippet.create-realm-model.dart
@@ -1,8 +1,9 @@
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late String make;
+  late int id;
 
+  late String make;
   late String? model;
   late int? miles;
 }

--- a/source/examples/generated/flutter/schemas.snippet.create-realm-model.dart
+++ b/source/examples/generated/flutter/schemas.snippet.create-realm-model.dart
@@ -1,7 +1,7 @@
 @RealmModel()
 class _Car {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String make;
   late String? model;

--- a/source/examples/generated/flutter/schemas.snippet.many-to-many-models.dart
+++ b/source/examples/generated/flutter/schemas.snippet.many-to-many-models.dart
@@ -1,7 +1,7 @@
 @RealmModel()
 class _Scooter {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String name;
   late _Person? owner;
@@ -10,7 +10,7 @@ class _Scooter {
 @RealmModel()
 class _ScooterShop {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String name;
   late List<_Scooter> owner;

--- a/source/examples/generated/flutter/schemas.snippet.many-to-one-models.dart
+++ b/source/examples/generated/flutter/schemas.snippet.many-to-one-models.dart
@@ -1,7 +1,7 @@
 @RealmModel()
 class _Bike {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String name;
   late _Person? owner;
@@ -10,7 +10,7 @@ class _Bike {
 @RealmModel()
 class _Person {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String firstName;
   late String lastName;

--- a/source/examples/generated/flutter/schemas.snippet.property-annotations.dart
+++ b/source/examples/generated/flutter/schemas.snippet.property-annotations.dart
@@ -1,6 +1,6 @@
 class _Vehicle {
   @PrimaryKey()
-  late int id;
+  late ObjectId id;
 
   late String? maybeDescription; // optional value
 


### PR DESCRIPTION
## Pull Request Info

Add logical primary keys to Flutter SDK examples. used `int` PKs.

Note to reviewer: I reviewed all the copy around the changed code examples to check if any copy changes needed. didn't see anything. but could be something to look for in the review.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26095

### Staged Changes (Requires MongoDB Corp SSO)

- [changes throughout the flutter section, but only to code examples](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26095/sdk/flutter)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
