### PR TITLE
Fix Readability workflow

### DIFF
--- a/.github/workflows/readability.yml
+++ b/.github/workflows/readability.yml
@@ -38,11 +38,10 @@ jobs:
             node ./docdoctor getReadabilityText "$file"
           done
       - name: Setup Python
-        uses: actions/setup-python@v4.1.0
+        uses: actions/setup-python@v4.3.0
         with:
           # We need Python version 3.5 or greater for rglob.
-          python-version: "3.6"
-          architecture: "x64"
+          python-version: "3.9"
       - name: Install textstat
         run: pip install textstat
       - name: Create scores directory and save PR number.


### PR DESCRIPTION
In an attempt to fix the readability workflow check, I'm updating the workflow to a more recent version of the setup-python GitHub action, updating to a newer version of Python, and removing the x64 architecture since that's the default when unspecified. 🤞 