### PR TITLE
(DOCSP-26271): Adding link to find App ID to quick start

### DIFF
--- a/source/includes/access-app-id.rst
+++ b/source/includes/access-app-id.rst
@@ -1,0 +1,3 @@
+To use App Services features such as authentication and sync, 
+access your App Services App using your App ID. You can :ref:`find your 
+App ID <find-your-app-id>` in the App Services UI.

--- a/source/sdk/dotnet/quick-start.txt
+++ b/source/sdk/dotnet/quick-start.txt
@@ -150,11 +150,11 @@ the ``ownerId`` as the unique field in the Flexible Sync configuration.
 .. _dotnet-quick-start-init-app:
 
 Initialize the App
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~ 
 
-To use App Services features such as authentication and sync, 
-access your App Services App using your App ID. You can :ref:`find your 
-App ID <find-your-app-id>` in the App Services UI. You then initialize your app: 
+.. include:: /includes/access-app-id.rst
+
+You then initialize your app: 
 
 .. literalinclude:: /examples/generated/dotnet/QuickStartExamples.snippet.initialize-realm.cs
    :language: csharp

--- a/source/sdk/flutter/quick-start.txt
+++ b/source/sdk/flutter/quick-start.txt
@@ -261,9 +261,7 @@ you must configure Device Sync using Atlas App Services:
 Initialize App Services
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-To use App Services features such as authentication and sync, you must
-access your App Services App using your App ID.
-You can :ref:`find your App ID in the App Services UI <find-your-project-or-app-id>`.
+.. include:: /includes/access-app-id.rst
 
 .. literalinclude:: /examples/generated/flutter/quick_start_sync_test.snippet.init-app.dart
    :language: dart

--- a/source/sdk/java/quick-start-sync.txt
+++ b/source/sdk/java/quick-start-sync.txt
@@ -33,9 +33,7 @@ integrated into your app. Before you begin, ensure you have:
 Initialize the App
 ------------------
 
-To use App Services features such as authentication and sync, you must
-access your App using your App ID. You can find your App ID in the
-App Services UI.
+.. include:: /includes/access-app-id.rst
 
 .. tabs-realm-languages::
 

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -140,7 +140,7 @@ completed.
 .. _kotlin-client-quick-start-add-device-sync:
 
 Add Device Sync (Optional)
--------------------------
+--------------------------
 This section illustrates how to authenticate with an Anonymous User, and open a
 Flexible Sync realm to begin syncing data between devices.
 
@@ -156,9 +156,7 @@ The code snippets in this section require the following:
 Initialize the App
 ~~~~~~~~~~~~~~~~~~
 
-To use App Services features such as authentication and sync, you must first access
-your Atlas App Services App using your App ID. You can :ref:`find your App ID in
-the App Services UI <find-your-app-id>`.
+.. include:: /includes/access-app-id.rst
 
 .. literalinclude:: /examples/generated/kotlin/QuickStartTest.snippet.quick-start-initialize-app.kt
    :language: kotlin

--- a/source/sdk/node/quick-start.txt
+++ b/source/sdk/node/quick-start.txt
@@ -49,9 +49,7 @@ the following line to import the SDK.
 Initialize the App
 ------------------
 
-To use Atlas App Services features such as authentication and sync, you must access
-your App using your App ID. You can :ref:`find your App ID in the
-App Services UI <find-your-app-id>`.
+.. include:: /includes/access-app-id.rst
 
 .. tabs-realm-languages::
 

--- a/source/sdk/react-native/quick-start.txt
+++ b/source/sdk/react-native/quick-start.txt
@@ -54,9 +54,7 @@ the following line to import the SDK.
 Initialize the App
 ------------------
 
-To use App Services features such as authentication and sync, you must
-access your App using your App ID. You can find your App ID
-in the App Services UI.
+.. include:: /includes/access-app-id.rst
 
 .. tabs-realm-languages::
 

--- a/source/sdk/swift/quick-start.txt
+++ b/source/sdk/swift/quick-start.txt
@@ -123,9 +123,7 @@ Before you can sync Realm data, you must:
 Initialize the App
 ~~~~~~~~~~~~~~~~~~
 
-To use App Services features such as authentication and sync, 
-access your App Services App using your App ID. You can :ref:`find your 
-App ID <find-your-app-id>` in the App Services UI.
+.. include:: /includes/access-app-id.rst
 
 .. literalinclude:: /examples/generated/code/start/QuickStartFlexSync.snippet.connect-to-backend.swift
    :language: swift

--- a/source/web/quickstart.txt
+++ b/source/web/quickstart.txt
@@ -79,8 +79,7 @@ following import statement:
 Initialize the App
 ------------------
 
-To use App Services features such as user authentication and functions, you must
-access your App using your App ID. You can find your App ID in the App Services UI.
+.. include:: /includes/access-app-id.rst
 
 .. literalinclude:: /examples/generated/web/quick-start.test.snippet.initialize-realm-app.js
    :language: javascript


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-26271

"Find your App ID" procedure should be linked out in every SDK quick start

### Staged Changes

- [Staged Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-26271-app-id/sdk/java/quick-start-sync/#initialize-the-app)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] ~~Create Jira ticket for corresponding docs-app-services update(s), if any~~  _N/A_
- [x] ~~Checked/updated Admin API~~ _N/A_
- [x] ~~Checked/updated CLI reference~~  _N/A_

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
