### PR TITLE
Update link in Swift docs to point to a more relevant section

### DIFF
--- a/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
@@ -42,8 +42,8 @@ Key Concept: Realm Files
 
 Realm Database stores a binary encoded version of every object and type in a
 realm in a single ``.realm`` file. The file is located at :ref:`a specific 
-path <find-the-default-realm-path>` that you can define when you open the realm.
-You can open, view, and edit the contents of these files with 
+path <ios-default-and-file-url-realm>` that you can define when you open the 
+realm. You can open, view, and edit the contents of these files with 
 :ref:`realm-studio`.
 
 .. see:: Auxiliary Realm Files


### PR DESCRIPTION
## Pull Request Info

This is a quick tweak based on a comment I left on #2325 - changing the link to a more appropriate spot based on language used in context around the link.

### Staged Changes

- [Configure & Open a Realm/Realm Files](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/tweak-swift-file-path-link/sdk/swift/realm-files/configure-and-open-a-realm/#key-concept--realm-files): Changed the "at a specific path" link to point to the Swift docs section about how to define a file URL path for your realm

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
