### PR TITLE
(DOCSP-26794): Flutter Add Sync to App page

### DIFF
--- a/examples/dart/test/access_token_test.dart
+++ b/examples/dart/test/access_token_test.dart
@@ -3,8 +3,6 @@ import 'package:test/test.dart';
 import 'package:realm_dart/realm.dart';
 import 'dart:convert';
 
-import 'sync_multiple_processes_test.dart';
-
 void main() {
   const APP_ID = "example-testers-kvjdy";
   group('Access tokens - ', () {

--- a/examples/dart/test/add_sync_to_app.dart
+++ b/examples/dart/test/add_sync_to_app.dart
@@ -1,0 +1,53 @@
+import 'package:test/test.dart';
+import 'package:realm_dart/realm.dart';
+import 'utils.dart';
+
+part 'add_sync_to_app.g.dart';
+
+@RealmModel()
+class _Car {
+  @MapTo('_id')
+  @PrimaryKey()
+  late ObjectId id;
+
+  late String make;
+  late String? model;
+  late int? miles;
+}
+
+void main() {
+  const APP_ID = "flutter-flexible-luccm";
+
+  test("Add Sync to App", () async {
+    // :snippet-start: connect-to-app
+    final app = App(AppConfiguration(APP_ID));
+    // :snippet-end:
+    // :snippet-start: log-in
+    final user = await app.logIn(Credentials.anonymous());
+    // :snippet-end:
+    // :snippet-start: opened-synced-realm
+    // Configure and open the realm
+    final config = Configuration.flexibleSync(user, [Car.schema]);
+    final realm = Realm(config);
+
+    // Add subscription to sync all Car objects in the realm
+    realm.subscriptions.update((mutableSubscriptions) {
+      mutableSubscriptions.add(realm.all<Car>());
+    });
+    // Sync all subscriptions
+    await realm.subscriptions.waitForSynchronization();
+    // :snippet-end:
+
+    // :snippet-start: write
+    // Write data to realm and it automatically syncs with Atlas
+    // in the background.
+    realm.write(() {
+      realm.add(Car(ObjectId(), 'Toyota', model: 'Rav 4'));
+    });
+    // :snippet-end:
+
+    // clean up
+    realm.write(() => realm.deleteAll<Car>());
+    cleanUpRealm(realm, app);
+  });
+}

--- a/examples/dart/test/add_sync_to_app.g.dart
+++ b/examples/dart/test/add_sync_to_app.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'add_sync_to_app.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
+  Car(
+    ObjectId id,
+    String make, {
+    String? model,
+    int? miles,
+  }) {
+    RealmObjectBase.set(this, '_id', id);
+    RealmObjectBase.set(this, 'make', make);
+    RealmObjectBase.set(this, 'model', model);
+    RealmObjectBase.set(this, 'miles', miles);
+  }
+
+  Car._();
+
+  @override
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
+  @override
+  set id(ObjectId value) => RealmObjectBase.set(this, '_id', value);
+
+  @override
+  String get make => RealmObjectBase.get<String>(this, 'make') as String;
+  @override
+  set make(String value) => RealmObjectBase.set(this, 'make', value);
+
+  @override
+  String? get model => RealmObjectBase.get<String>(this, 'model') as String?;
+  @override
+  set model(String? value) => RealmObjectBase.set(this, 'model', value);
+
+  @override
+  int? get miles => RealmObjectBase.get<int>(this, 'miles') as int?;
+  @override
+  set miles(int? value) => RealmObjectBase.set(this, 'miles', value);
+
+  @override
+  Stream<RealmObjectChanges<Car>> get changes =>
+      RealmObjectBase.getChanges<Car>(this);
+
+  @override
+  Car freeze() => RealmObjectBase.freezeObject<Car>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Car._);
+    return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
+      SchemaProperty('_id', RealmPropertyType.objectid,
+          mapTo: '_id', primaryKey: true),
+      SchemaProperty('make', RealmPropertyType.string),
+      SchemaProperty('model', RealmPropertyType.string, optional: true),
+      SchemaProperty('miles', RealmPropertyType.int, optional: true),
+    ]);
+  }
+}

--- a/source/examples/generated/flutter/add_sync_to_app.snippet.connect-to-app.dart
+++ b/source/examples/generated/flutter/add_sync_to_app.snippet.connect-to-app.dart
@@ -1,0 +1,1 @@
+final app = App(AppConfiguration(APP_ID));

--- a/source/examples/generated/flutter/add_sync_to_app.snippet.log-in.dart
+++ b/source/examples/generated/flutter/add_sync_to_app.snippet.log-in.dart
@@ -1,0 +1,1 @@
+final user = await app.logIn(Credentials.anonymous());

--- a/source/examples/generated/flutter/add_sync_to_app.snippet.opened-synced-realm.dart
+++ b/source/examples/generated/flutter/add_sync_to_app.snippet.opened-synced-realm.dart
@@ -1,0 +1,10 @@
+// Configure and open the realm
+final config = Configuration.flexibleSync(user, [Car.schema]);
+final realm = Realm(config);
+
+// Add subscription to sync all Car objects in the realm
+realm.subscriptions.update((mutableSubscriptions) {
+  mutableSubscriptions.add(realm.all<Car>());
+});
+// Sync all subscriptions
+await realm.subscriptions.waitForSynchronization();

--- a/source/examples/generated/flutter/add_sync_to_app.snippet.write.dart
+++ b/source/examples/generated/flutter/add_sync_to_app.snippet.write.dart
@@ -1,0 +1,5 @@
+// Write data to realm and it automatically syncs with Atlas
+// in the background.
+realm.write(() {
+  realm.add(Car(ObjectId(), 'Toyota', model: 'Rav 4'));
+});

--- a/source/sdk/flutter/sync.txt
+++ b/source/sdk/flutter/sync.txt
@@ -7,6 +7,7 @@ Device Sync - Flutter SDK
 .. toctree::
    :titlesonly:
 
+   Add Sync to an App </sdk/flutter/sync/add-sync-to-app>
    Open Synced Realm </sdk/flutter/sync/open-synced-realm>
    Manage Sync Session </sdk/flutter/sync/manage-sync-session>
    Sync Multiple Processes </sdk/flutter/sync/sync-multiple-processes>

--- a/source/sdk/flutter/sync/add-sync-to-app.txt
+++ b/source/sdk/flutter/sync/add-sync-to-app.txt
@@ -46,7 +46,7 @@ Set up Device Sync
 
    .. step:: Open a Synced Realm
 
-      Use a Flexible Sync configuration to :ref:`open the realm as a synced realm <flutter-open-close-realm>`.
+      Use a Flexible Sync configuration to :ref:`open the realm as a synced realm <flutter-open-synced-realm>`.
       Also :ref:`add a subscription <flutter-flexible-sync-manage-subscriptions>`
       to synchronize data matching the subscription query.
 

--- a/source/sdk/flutter/sync/add-sync-to-app.txt
+++ b/source/sdk/flutter/sync/add-sync-to-app.txt
@@ -13,8 +13,20 @@ Add Device Sync to an App - Flutter SDK
 
 .. procedure::
 
-   .. step:: Connect to the App Services backend
+   .. step:: Set up Atlas Device Sync in App Services
 
+      Before you can use Device Sync with the Realm Flutter SDK, you must create
+      an Atlas App Services App with Device Sync and authentication enabled.
+
+      To learn how to set up Device Sync in your App, refer to :ref:`TODO:`
+      in the App Services documentation.
+
+      To set up authentication, refer to :ref:`TODO:` in the App Services documentation.
+   
+   .. step:: Connect to the App Services Backend
+
+      Initialize the an :flutter-sdk`App <TODO:>` instance to connect
+      to your App Services App.
       Pass the App ID for your App, which you can :ref:`find in the App Services UI
       <find-your-app-id>`.
 
@@ -23,21 +35,20 @@ Add Device Sync to an App - Flutter SDK
 
    .. step:: Authenticate a user
 
-      :ref:`Authenticate a user <flutter-authenticate>` in your client 
-      project. Here, we'll use :ref:`anonymous authentication 
-      <flutter-login-anonymous>`. 
+      :ref:`Authenticate a user <flutter-authenticate>` in your client project.
+      This example uses :ref:`anonymous authentication <flutter-login-anonymous>`.
 
       .. literalinclude:: /examples/generated/dotnet/AuthenticationExamples.snippet.logon_anon.cs
         :language: csharp
 
    .. step:: Open a Synced Realm
 
-      To open the realm as a synced realm, 
-      you can specify whether a synced realm should download data before 
-      it opens. Here, we use a :ref:`Flexible Sync configuration 
+      To open the realm as a synced realm,
+      you can specify whether a synced realm should download data before it opens.
+      Here, we use a :ref:`Flexible Sync configuration
       <flutter-flexible-sync-open-realm>` and specify that the SDK
       should always download the most recent updates before opening the realm.
-      We also :ref:`bootstrap the realm with an initial subscription 
+      We also :ref:`bootstrap the realm with an initial subscription
       <flutter-sync-add-subscription>`.
 
       .. literalinclude:: /examples/generated/dotnet/FlexibleSyncExamples.snippet.bootstrap-a-subscription.cs
@@ -46,11 +57,11 @@ Add Device Sync to an App - Flutter SDK
 Use the Realm
 -------------
 
-The syntax to :ref:`read <flutter-realm-database-reads>`, :ref:`write
+The syntax to :ref:`read <flutter-read-data>`, :ref:`write
 <flutter-write-operations>`, and
 :ref:`watch for changes <flutter-react-to-changes>` on a
-synced realm is identical to the syntax for non-synced realms. While 
-you work with local data, a background thread efficiently integrates, 
+synced realm is identical to the syntax for non-synced realms.
+While you work with local data, a background thread efficiently integrates,
 uploads, and downloads changesets.
 
 The following code creates a new ``Task`` object and writes it to the realm:
@@ -58,10 +69,7 @@ The following code creates a new ``Task`` object and writes it to the realm:
 .. literalinclude:: /examples/generated/dotnet/QuickStartExamples.snippet.create.cs
    :language: csharp
 
-.. important:: When Using Sync, Avoid Writes on the Main Thread
+Further Reading
+---------------
 
-   The fact that Realm performs sync integrations on a background thread means
-   that if you write to your realm on the main thread, there's a small chance your UI
-   could appear to hang as it waits for the background sync thread to finish a write
-   transaction. Therefore, it's a best practice :ref:`not to write on the main thread
-   when using Device Sync <flutter-threading-three-rules>`.
+TODO: add links to relevant pages

--- a/source/sdk/flutter/sync/add-sync-to-app.txt
+++ b/source/sdk/flutter/sync/add-sync-to-app.txt
@@ -11,24 +11,29 @@ Add Device Sync to an App - Flutter SDK
    :class: singlecol
 
 
+Set up Device Sync
+------------------
+
 .. procedure::
 
-   .. step:: Set up Atlas Device Sync in App Services
+   .. step:: Configure Atlas Device Sync in App Services
 
       Before you can use Device Sync with the Realm Flutter SDK, you must create
       an Atlas App Services App with Device Sync and authentication enabled.
 
-      To learn how to set up Device Sync in your App, refer to :ref:`TODO:`
+      To learn how to set up Device Sync in your App, refer to :ref:`realm-sync-get-started`
       in the App Services documentation.
 
-      To set up authentication, refer to :ref:`TODO:` in the App Services documentation.
+      To set up authentication, refer to :ref:`users-and-authentication` in the App Services documentation.
    
    .. step:: Connect to the App Services Backend
 
-      Initialize the an :flutter-sdk`App <TODO:>` instance to connect
+      Initialize the an :flutter-sdk:`App <realm/App/App.html>` instance to connect
       to your App Services App.
       Pass the App ID for your App, which you can :ref:`find in the App Services UI
       <find-your-app-id>`.
+
+      TODO: flutterify
 
       .. literalinclude:: /examples/generated/dotnet/QuickStartExamples.snippet.initialize-realm.cs
         :language: csharp
@@ -38,18 +43,18 @@ Add Device Sync to an App - Flutter SDK
       :ref:`Authenticate a user <flutter-authenticate>` in your client project.
       This example uses :ref:`anonymous authentication <flutter-login-anonymous>`.
 
+      TODO: flutterify
+
       .. literalinclude:: /examples/generated/dotnet/AuthenticationExamples.snippet.logon_anon.cs
         :language: csharp
 
    .. step:: Open a Synced Realm
 
-      To open the realm as a synced realm,
-      you can specify whether a synced realm should download data before it opens.
-      Here, we use a :ref:`Flexible Sync configuration
-      <flutter-flexible-sync-open-realm>` and specify that the SDK
-      should always download the most recent updates before opening the realm.
-      We also :ref:`bootstrap the realm with an initial subscription
-      <flutter-sync-add-subscription>`.
+      Use a Flexible Sync configuration to :ref:`open the realm as a synced realm <flutter-open-close-realm>`.
+      Also :ref:`add a subscription <flutter-flexible-sync-manage-subscriptions>`
+      to synchronize data matching the subscription query.
+
+      TODO: flutterify
 
       .. literalinclude:: /examples/generated/dotnet/FlexibleSyncExamples.snippet.bootstrap-a-subscription.cs
         :language: csharp
@@ -61,15 +66,12 @@ The syntax to :ref:`read <flutter-read-data>`, :ref:`write
 <flutter-write-operations>`, and
 :ref:`watch for changes <flutter-react-to-changes>` on a
 synced realm is identical to the syntax for non-synced realms.
-While you work with local data, a background thread efficiently integrates,
+While you work with local data, a background thread integrates,
 uploads, and downloads changesets.
 
 The following code creates a new ``Task`` object and writes it to the realm:
 
+TODO: flutterify
+
 .. literalinclude:: /examples/generated/dotnet/QuickStartExamples.snippet.create.cs
    :language: csharp
-
-Further Reading
----------------
-
-TODO: add links to relevant pages

--- a/source/sdk/flutter/sync/add-sync-to-app.txt
+++ b/source/sdk/flutter/sync/add-sync-to-app.txt
@@ -1,0 +1,67 @@
+.. _flutter-add-sync-to-app:
+
+=======================================
+Add Device Sync to an App - Flutter SDK
+=======================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 3
+   :class: singlecol
+
+
+.. procedure::
+
+   .. step:: Connect to the App Services backend
+
+      Pass the App ID for your App, which you can :ref:`find in the App Services UI
+      <find-your-app-id>`.
+
+      .. literalinclude:: /examples/generated/dotnet/QuickStartExamples.snippet.initialize-realm.cs
+        :language: csharp
+
+   .. step:: Authenticate a user
+
+      :ref:`Authenticate a user <flutter-authenticate>` in your client 
+      project. Here, we'll use :ref:`anonymous authentication 
+      <flutter-login-anonymous>`. 
+
+      .. literalinclude:: /examples/generated/dotnet/AuthenticationExamples.snippet.logon_anon.cs
+        :language: csharp
+
+   .. step:: Open a Synced Realm
+
+      To open the realm as a synced realm, 
+      you can specify whether a synced realm should download data before 
+      it opens. Here, we use a :ref:`Flexible Sync configuration 
+      <flutter-flexible-sync-open-realm>` and specify that the SDK
+      should always download the most recent updates before opening the realm.
+      We also :ref:`bootstrap the realm with an initial subscription 
+      <flutter-sync-add-subscription>`.
+
+      .. literalinclude:: /examples/generated/dotnet/FlexibleSyncExamples.snippet.bootstrap-a-subscription.cs
+        :language: csharp
+
+Use the Realm
+-------------
+
+The syntax to :ref:`read <flutter-realm-database-reads>`, :ref:`write
+<flutter-write-operations>`, and
+:ref:`watch for changes <flutter-react-to-changes>` on a
+synced realm is identical to the syntax for non-synced realms. While 
+you work with local data, a background thread efficiently integrates, 
+uploads, and downloads changesets.
+
+The following code creates a new ``Task`` object and writes it to the realm:
+
+.. literalinclude:: /examples/generated/dotnet/QuickStartExamples.snippet.create.cs
+   :language: csharp
+
+.. important:: When Using Sync, Avoid Writes on the Main Thread
+
+   The fact that Realm performs sync integrations on a background thread means
+   that if you write to your realm on the main thread, there's a small chance your UI
+   could appear to hang as it waits for the background sync thread to finish a write
+   transaction. Therefore, it's a best practice :ref:`not to write on the main thread
+   when using Device Sync <flutter-threading-three-rules>`.

--- a/source/sdk/flutter/sync/add-sync-to-app.txt
+++ b/source/sdk/flutter/sync/add-sync-to-app.txt
@@ -33,20 +33,16 @@ Set up Device Sync
       Pass the App ID for your App, which you can :ref:`find in the App Services UI
       <find-your-app-id>`.
 
-      TODO: flutterify
-
-      .. literalinclude:: /examples/generated/dotnet/QuickStartExamples.snippet.initialize-realm.cs
-        :language: csharp
+      .. literalinclude:: /examples/generated/flutter/add_sync_to_app.snippet.connect-to-app.dart
+        :language: dart
 
    .. step:: Authenticate a user
 
       :ref:`Authenticate a user <flutter-authenticate>` in your client project.
       This example uses :ref:`anonymous authentication <flutter-login-anonymous>`.
 
-      TODO: flutterify
-
-      .. literalinclude:: /examples/generated/dotnet/AuthenticationExamples.snippet.logon_anon.cs
-        :language: csharp
+      .. literalinclude:: /examples/generated/flutter/add_sync_to_app.snippet.log-in.dart
+        :language: dart
 
    .. step:: Open a Synced Realm
 
@@ -54,10 +50,8 @@ Set up Device Sync
       Also :ref:`add a subscription <flutter-flexible-sync-manage-subscriptions>`
       to synchronize data matching the subscription query.
 
-      TODO: flutterify
-
-      .. literalinclude:: /examples/generated/dotnet/FlexibleSyncExamples.snippet.bootstrap-a-subscription.cs
-        :language: csharp
+      .. literalinclude:: /examples/generated/flutter/add_sync_to_app.snippet.opened-synced-realm.dart
+        :language: dart
 
 Use the Realm
 -------------
@@ -69,9 +63,7 @@ synced realm is identical to the syntax for non-synced realms.
 While you work with local data, a background thread integrates,
 uploads, and downloads changesets.
 
-The following code creates a new ``Task`` object and writes it to the realm:
+The following code creates a new ``Car`` object and writes it to the realm:
 
-TODO: flutterify
-
-.. literalinclude:: /examples/generated/dotnet/QuickStartExamples.snippet.create.cs
-   :language: csharp
+.. literalinclude:: /examples/generated/flutter/add_sync_to_app.snippet.write.dart
+   :language: dart


### PR DESCRIPTION
## Pull Request Info

Flutter Add Sync to App page

### Jira

- https://jira.mongodb.org/browse/DOCSP-26794

### Staged Changes

- [Add Sync to App (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26794/sdk/flutter/sync/add-sync-to-app)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
