### PR TITLE
(DOCSP-26766): [Swift] Get a User Access Token

### DIFF
--- a/examples/ios/Examples/Authenticate.swift
+++ b/examples/ios/Examples/Authenticate.swift
@@ -329,11 +329,13 @@ class Authenticate: XCTestCase {
         // :snippet-end:
         
         do {
+            // :snippet-start: get-user-access-token
             let app = App(id: YOUR_APP_SERVICES_APP_ID)
             let user = try await app.login(credentials: Credentials.anonymous)
-            let refreshedAccessToken = try await getValidAccessToken(user: user)
+            let accessToken = try await getValidAccessToken(user: user)
+            // :snippet-end:
         } catch {
-            print("Failed to log in user: \(error.localizedDescription)")
+            print("Failed to authenticate user: \(error.localizedDescription)")
         }
     }
 

--- a/examples/ios/Examples/Authenticate.swift
+++ b/examples/ios/Examples/Authenticate.swift
@@ -317,6 +317,25 @@ class Authenticate: XCTestCase {
         print("Successfully opened realm: \(realm)")
         // :snippet-end:
     }
+    
+    func testGetUserAccessToken() async throws {
+        // :snippet-start: refresh-user-access-token-function
+        func getValidAccessToken(user: User) async throws -> String {
+            // An already logged in user's access token might be stale. To
+            // guarantee that the token is valid, refresh it if necessary.
+            try await user.refreshCustomData()
+            return user.accessToken!
+        }
+        // :snippet-end:
+        
+        do {
+            let app = App(id: YOUR_APP_SERVICES_APP_ID)
+            let user = try await app.login(credentials: Credentials.anonymous)
+            let refreshedAccessToken = try await getValidAccessToken(user: user)
+        } catch {
+            print("Failed to log in user: \(error.localizedDescription)")
+        }
+    }
 
     override func tearDown() {
         guard app.currentUser != nil else {

--- a/source/examples/generated/code/start/Authenticate.snippet.get-user-access-token.swift
+++ b/source/examples/generated/code/start/Authenticate.snippet.get-user-access-token.swift
@@ -1,0 +1,3 @@
+let app = App(id: YOUR_APP_SERVICES_APP_ID)
+let user = try await app.login(credentials: Credentials.anonymous)
+let accessToken = try await getValidAccessToken(user: user)

--- a/source/examples/generated/code/start/Authenticate.snippet.refresh-user-access-token-function.swift
+++ b/source/examples/generated/code/start/Authenticate.snippet.refresh-user-access-token-function.swift
@@ -1,0 +1,6 @@
+func getValidAccessToken(user: User) async throws -> String {
+    // An already logged in user's access token might be stale. To
+    // guarantee that the token is valid, refresh it if necessary.
+    try await user.refreshCustomData()
+    return user.accessToken!
+}

--- a/source/sdk/swift/users/authenticate-users.txt
+++ b/source/sdk/swift/users/authenticate-users.txt
@@ -174,6 +174,21 @@ Offline Login
 .. literalinclude:: /examples/generated/code/start/Authenticate.snippet.offline-login.swift
    :language: swift
 
+.. _ios-get-a-user-access-token:
+
+Get a User Access Token
+-----------------------
+
+.. include:: /includes/user-access-token.rst
+
+You can call :swift-sdk:`.refreshCustomData() 
+<Extensions/User.html#/s:So7RLMUserC10RealmSwiftE17refreshCustomData7Combine6FutureCySDys11AnyHashableVypGs5Error_pGyF>`
+on a logged-in user to refresh the user's auth session. Then, return the 
+``.accessToken`` as a string you can use in your code.
+
+.. literalinclude:: /examples/generated/code/start/Authenticate.snippet.refresh-user-access-token-function.swift
+   :language: swift
+
 .. _ios-logout:
 
 Log Out

--- a/source/sdk/swift/users/authenticate-users.txt
+++ b/source/sdk/swift/users/authenticate-users.txt
@@ -179,14 +179,27 @@ Offline Login
 Get a User Access Token
 -----------------------
 
-.. include:: /includes/user-access-token.rst
+The Realm SDK automatically manages access tokens, refreshes them when they 
+expire, and includes a valid access token for the current user with each 
+request. 
+
+If you send requests outside of the SDK - for example, through the :ref:`GraphQL 
+API <graphql-api>` - then you must include the user's access token with 
+each request. In this scenario, you must manually refresh the token when 
+it expires. Access tokens expire after 30 minutes.
 
 You can call :swift-sdk:`.refreshCustomData() 
 <Extensions/User.html#/s:So7RLMUserC10RealmSwiftE17refreshCustomData7Combine6FutureCySDys11AnyHashableVypGs5Error_pGyF>`
 on a logged-in user to refresh the user's auth session. Then, return the 
-``.accessToken`` as a string you can use in your code.
+``.accessToken`` as a string you can use in your code. You might use a 
+function similar to this to fetch an access token:
 
 .. literalinclude:: /examples/generated/code/start/Authenticate.snippet.refresh-user-access-token-function.swift
+   :language: swift
+
+Which requires a logged-in user:
+
+.. literalinclude:: /examples/generated/code/start/Authenticate.snippet.get-user-access-token.swift
    :language: swift
 
 .. _ios-logout:


### PR DESCRIPTION
## Pull Request Info

Note for reviewer: the CI is failing to build properly, so the failure here doesn't reflect a test failure - it's an issue with the build script. The test did pass locally: 

```shell
Test Suite 'Authenticate' passed at 2022-12-01 16:36:31.424.
	 Executed 13 tests, with 0 failures (0 unexpected) in 4.627 (4.631) seconds
Test Suite 'RealmExamples.xctest' passed at 2022-12-01 16:36:31.425.
	 Executed 13 tests, with 0 failures (0 unexpected) in 4.627 (4.632) seconds
Test Suite 'Selected tests' passed at 2022-12-01 16:36:31.425.
	 Executed 13 tests, with 0 failures (0 unexpected) in 4.627 (4.633) seconds
```

### Jira

- https://jira.mongodb.org/browse/DOCSP-26766

### Staged Changes

- [Authenticate Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26766/sdk/swift/users/authenticate-users/#get-a-user-access-token): New "Get a User Access Token" section

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
