### PR TITLE
(DOCSP-26588): Removing serverless note from Quick Start pages

### DIFF
--- a/source/sdk/dotnet/quick-start.txt
+++ b/source/sdk/dotnet/quick-start.txt
@@ -115,8 +115,6 @@ You can :ref:`watch a realm, collection, or object for changes
 :dotnet-sdk:`SubscribeForNotifications() <reference/Realms.IRealmCollection-1.html#Realms_IRealmCollection_1_SubscribeForNotifications_Realms_NotificationCallbackDelegate__0__>` 
 method.
 
-.. include:: /includes/serverless-watch-note.rst
-
 Be sure to retain the notification token returned by ``SubscribeForNotifications`` 
 as long as you want to continue watching for changes. When you are done, 
 call the :dotnet-sdk:`Dispose() <reference/Realms.Realm.html#Realms_Realm_Dispose>` method:

--- a/source/sdk/java/quick-start-local.txt
+++ b/source/sdk/java/quick-start-local.txt
@@ -211,7 +211,6 @@ method:
          :language: kotlin
          :copyable: false
 
-.. include:: /includes/serverless-watch-note.rst
 
 Complete Example
 ----------------

--- a/source/sdk/java/quick-start-sync.txt
+++ b/source/sdk/java/quick-start-sync.txt
@@ -298,7 +298,6 @@ method:
          :language: kotlin
          :copyable: false
 
-.. include:: /includes/serverless-watch-note.rst
 
 Log Out
 -------

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -105,7 +105,7 @@ in a write transaction block:
    :language: kotlin
    :copyable: false
 
-
+Watch for Changes
 -----------------
 
 You can :ref:`watch a realm, collection, or object for changes

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -105,7 +105,7 @@ in a write transaction block:
    :language: kotlin
    :copyable: false
 
-Watch for Changes
+
 -----------------
 
 You can :ref:`watch a realm, collection, or object for changes

--- a/source/sdk/node/examples/query-mongodb.txt
+++ b/source/sdk/node/examples/query-mongodb.txt
@@ -345,6 +345,8 @@ the operation that caused the event.
    that allows you to asynchronously pull :manual:`change events
    </reference/change-events/>` for operations as they occur.
 
+.. include:: /includes/serverless-watch-note.rst
+
 .. _node-watch-for-all-changes-in-a-collection:
 .. _node-mongodb-watch-a-collection:
 

--- a/source/sdk/node/quick-start.txt
+++ b/source/sdk/node/quick-start.txt
@@ -423,7 +423,6 @@ You can :ref:`watch a realm, collection, or object for changes
 :js-sdk:`Collection.addListener() <Realm.Collection.html#addListener>`
 methods.
 
-.. include:: /includes/serverless-watch-note.rst
 
 .. tabs-realm-languages::
 

--- a/source/sdk/react-native/app-services/query-mongodb.txt
+++ b/source/sdk/react-native/app-services/query-mongodb.txt
@@ -345,6 +345,8 @@ the operation that caused the event.
    that allows you to asynchronously pull :manual:`change events
    </reference/change-events/>` for operations as they occur.
 
+.. include:: /includes/serverless-watch-note.rst
+
 .. _react-native-watch-for-all-changes-in-a-collection:
 .. _react-native-mongodb-watch-a-collection:
 

--- a/source/sdk/react-native/quick-start.txt
+++ b/source/sdk/react-native/quick-start.txt
@@ -353,7 +353,6 @@ You can :ref:`watch a realm, collection, or object for changes
 :js-sdk:`Collection.addListener() <Realm.Collection.html#addListener>`
 methods.
 
-.. include:: /includes/serverless-watch-note.rst
 
 .. tabs-realm-languages::
 

--- a/source/sdk/swift/quick-start.txt
+++ b/source/sdk/swift/quick-start.txt
@@ -90,8 +90,6 @@ Watch for Changes
 You can :ref:`watch a realm, collection, or object for changes
 <ios-react-to-changes>` with the ``observe`` method.
 
-.. include:: /includes/serverless-watch-note.rst
-
 .. literalinclude:: /examples/generated/code/start/LocalOnlyCompleteQuickStart.snippet.quick-start-local-set-notification-token.swift
    :language: swift
 


### PR DESCRIPTION
## Pull Request Info

### Jira

https://jira.mongodb.org/browse/DOCSP-26588

- Removing serverless note from all SDK Quick Start pages (done as part of a previous [PR](https://github.com/mongodb/docs-realm/pull/1993/files))
- Adding note to any SDK Query MongoDB pages with _Watch for Changes_ section where it's not already there

### Staged Changes

- [various SDK Quick Start and Query MongoDB pages](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-26588-fix-serverless-note/sdk/java/quick-start-sync/#watch-for-changes)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-app-services update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
