### PR TITLE
(DOCSP-26796): Add synced realm content to sync landing page

### DIFF
--- a/source/sdk/flutter/sync.txt
+++ b/source/sdk/flutter/sync.txt
@@ -30,6 +30,37 @@ to use :ref:`Flexible Sync <flexible-sync>`.
 
    The Flutter SDK does not support :ref:`Partition-Based Sync <partition-based-sync>`.
 
+.. _flutter-synced-realm:
+
+Synced Realms
+-------------
+
+You can configure a realm to automatically synchronize data between many devices
+that each have their own local copy of the data. Synced realms use a different
+configuration than local-only realms and require an Atlas App Services
+backend to handle the synchronization process.
+
+Applications can always create, modify, and delete synced realm objects locally,
+even when offline. Whenever a network connection is available, the Realm Flutter SDK
+opens a connection to an application server and syncs changes to and from other
+clients. The :ref:`Atlas Device Sync protocol <sync-protocol>` and server-side
+operational transforms guarantee that all fully synced instances of a realm see
+exactly the same data, even if some changes occurred offline and/or were
+received out of order.
+
+Synced Realms vs. Non-Synced Realms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Synced realms differ from non-synced local Realm Database in a couple of ways:
+
+- Synced realms attempt to sync changes with your backend App Services App,
+  whereas non-synced realms do not.
+- Synced realms can be accessed by authenticated users, while non-synced
+  realms have no concept of users or authentication.
+
+You can copy data from a non-synced Realm Database to a synced realm,
+and vice versa, but you cannot sync a non-synced Realm Database.
+
 .. _flutter-flexible-sync-fundamentals:
 
 What is Flexible Sync?


### PR DESCRIPTION
## Pull Request Info

Add synced realm overview content to Flutter Sync landing page.

(taken and adapted from [.NET docs](https://www.mongodb.com/docs/realm/sdk/dotnet/sync/configure-and-open-a-synced-realm/#key-concept--synced-realms))

### Jira

- https://jira.mongodb.org/browse/DOCSP-26796

### Staged Changes

- [Sync Data (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26796/sdk/flutter/sync/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
