### PR TITLE
(DOCSP-26785): Add missing SDKs to Realm Studio docs

### DIFF
--- a/source/includes/find-realm-file-flutter.rst
+++ b/source/includes/find-realm-file-flutter.rst
@@ -1,0 +1,8 @@
+.. code-block:: flutter
+
+   // Get on-disk location of the default Realm
+   final storagePath = Configuration.defaultStoragePath;
+   // See value in your application
+   print(storagePath);
+
+   

--- a/source/includes/find-realm-file-kotlin.rst
+++ b/source/includes/find-realm-file-kotlin.rst
@@ -1,6 +1,17 @@
 .. code-block:: kotlin
 
-   // Get on-disk location of the default Realm
-   let realm = try! Realm()
-   print("Realm is located at:", realm.configuration.fileURL!)
+   config = SyncConfiguration.Builder(user, setOf(Item::class))
+      .initialSubscriptions { realm ->
+         add(
+            realm.query<Item>(
+               "owner_id == $0",
+               realmApp.currentUser!!.identity
+            ),
+            "User's Items"
+         )
+      }
+      .build()
+
+   // Log on-disk location of the realm file
+   Log.v("My Tag", "Realm Path: ${config.path}")
    

--- a/source/includes/find-realm-file-kotlin.rst
+++ b/source/includes/find-realm-file-kotlin.rst
@@ -1,0 +1,6 @@
+.. code-block:: kotlin
+
+   // Get on-disk location of the default Realm
+   let realm = try! Realm()
+   print("Realm is located at:", realm.configuration.fileURL!)
+   

--- a/source/studio/modify-schema.txt
+++ b/source/studio/modify-schema.txt
@@ -120,24 +120,28 @@ migration guide.
    .. tab::
       :tabid: android
 
-      :ref:`Schema Versions & Migrations - Java SDK <java-schema-versions-and-migrations>`
+      :ref:`Schema Versions & Migrations - Realm Java SDK <java-schema-versions-and-migrations>`
 
    .. tab::
       :tabid: ios
 
-      :ref:`Schema Versions & Migrations - Swift SDK <ios-schema-versions-and-migrations>`
+      :ref:`Schema Versions & Migrations - Realm Swift SDK <ios-schema-versions-and-migrations>`
 
    .. tab:: 
       :tabid: node
 
-      :ref:`Schema Versions & Migrations - Node.js SDK <node-schema-versions-and-migrations>`
+      :ref:`Schema Versions & Migrations - Realm Node.js SDK <node-schema-versions-and-migrations>`
 
    .. tab:: 
       :tabid: react-native
     
-      :ref:`Schema Versions & Migrations - React Native SDK <react-native-schema-versions-and-migrations>`
+      :ref:`Schema Versions & Migrations - Realm React Native SDK <react-native-schema-versions-and-migrations>`
 
    .. tab:: 
       :tabid: dotnet
 
-      :ref:`Schema Versions & Migrations - .NET SDK <dotnet-schema-versions-and-migrations>`
+      :ref:`Schema Versions & Migrations - Realm .NET SDK <dotnet-schema-versions-and-migrations>`
+   .. tab:: 
+      :tabid: flutter
+
+      :ref:`Schema Versions & Migrations - Realm Flutter SDK <flutter-manually-migrate-schema>`

--- a/source/studio/open-realm-file.txt
+++ b/source/studio/open-realm-file.txt
@@ -63,6 +63,16 @@ To find your default realm file path:
 
       .. include:: /includes/find-realm-file-dotnet.rst
 
+   .. tab:: Flutter
+      :tabid: flutter
+
+      .. include:: /includes/find-realm-file-flutter.rst
+   
+   .. tab:: Kotlin
+      :tabid: kotlin
+
+      .. include:: /includes/find-realm-file-kotlin.rst
+
 Once you know the location of your local realm file, you can browse
 to that location from the :guilabel:`Open Realm file` dialog.
 


### PR DESCRIPTION
## Pull Request Info

The Realm Studio docs were missing some SDKs in tabbed content.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26785

### Staged Changes

- [Open a Realm File](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26785/studio/open-realm-file/#find-a-realm-file). Added code samples for finding a realm (Flutter and Kotlin).
- [Modify Schema in a Realm Studio](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26785/studio/modify-schema/#perform-a-migration). Added a link to Flutter's migration content.

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [ n/a ] Create Jira ticket for corresponding docs-app-services update(s), if any
- [ n/a ] Checked/updated Admin API
- [ n/a ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal in a hat

<img src="https://as1.ftcdn.net/v2/jpg/02/97/16/54/1000_F_297165421_mrG1OM9S47TJtbUL6jOANBbZETn3ekKG.jpg" height="500">
