### PR TITLE
Fixing article typo in Flutter docs

### DIFF
--- a/source/sdk/flutter/app-services.txt
+++ b/source/sdk/flutter/app-services.txt
@@ -64,7 +64,7 @@ To learn how to set up authentication in your app, refer to
 Device Sync
 -----------
 
-Device Sync adds data synchronization between a App Services backend and
+Device Sync adds data synchronization between an App Services backend and
 client devices on top of all of the functionality of Realm Database.
 When you use Realm Database with Sync, realms exist on device
 just like when you only use Realm Database. However, changes to

--- a/source/sdk/flutter/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/model-data/define-realm-object-schema.txt
@@ -138,8 +138,8 @@ Create Model
 Using Schemas with Device Sync
 ------------------------------
 
-A **App Services Schema** is a list of valid object schemas that
-each define an object type that a App may persist.
+An **App Services Schema** is a list of valid object schemas that
+each define an object type that an App may persist.
 All synced objects in a realm must conform to the App Services Schema.
 
 Client applications provide a Object Schema when they open a realm. If a

--- a/source/sdk/java/api/io/realm/mongodb/AppConfiguration.txt
+++ b/source/sdk/java/api/io/realm/mongodb/AppConfiguration.txt
@@ -22,7 +22,7 @@ io.realm.mongodb
  | 		io.realm.mongodb.AppConfiguration
 
 
-An AppConfiguration is used to setup a MongoDB Realm application.Instances of a AppConfiguration can only created by using the :ref:`AppConfiguration.Builder <io_realm_mongodb_AppConfiguration_Builder>` and calling its :ref:`AppConfiguration.Builder.build() <io_realm_mongodb_AppConfiguration_Builder_build__>`  method.
+An AppConfiguration is used to setup a MongoDB Realm application.Instances of an AppConfiguration can only created by using the :ref:`AppConfiguration.Builder <io_realm_mongodb_AppConfiguration_Builder>` and calling its :ref:`AppConfiguration.Builder.build() <io_realm_mongodb_AppConfiguration_Builder_build__>`  method.
 
 
 


### PR DESCRIPTION
## Pull Request Info

No Jira - Fixing small article typo found in Flutter docs ("a App" > "an App")

### Staged Changes

- [Define a Realm Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/flutter-define-rom-typo/sdk/flutter/model-data/define-realm-object-schema/#using-schemas-with-device-sync)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
