### PR TITLE
(DOCSP-26797): Flutter - Improve sync subscription documentation

### DIFF
--- a/examples/dart/test/write_to_synced_realm_test.dart
+++ b/examples/dart/test/write_to_synced_realm_test.dart
@@ -59,13 +59,13 @@ main() async {
     realm.write(() {
       // WRITE SUCCEEDS
       // `newCar` is successfully written to the realm and synced to Atlas
-      // because it's data matches the subscription query and it's `ownerId` field
-      // matches the user ID.
+      // because it's data matches the subscription query (miles < 100)
+      // and it's `ownerId` field matches the user ID.
       final newCar = Car(ObjectId(), userId, 'Toyota', miles: 2);
       realm.add(newCar);
 
       // WRITE REVERTED BY COMPENSATING WRITE ERROR
-      // `oldCar` is initially written to the realm, then later removed
+      // `oldCar` is initially written to the realm, then removed upon synchronization
       // in a compensating write when the server processes the write.
       // This is because the `miles` property of `oldCar` doesn't match
       // the subscription query, which is only for cars with less than 100 miles.
@@ -73,7 +73,7 @@ main() async {
       realm.add(oldCar);
 
       // WRITE REVERTED BY PERMISSION ERROR
-      // `otherUsersCar` is initially written to the realm, then later removed
+      // `otherUsersCar` is initially written to the realm, then removed upon synchronization
       // because it's `ownerId` property doesn't match the user ID of the user
       // making the request.
       final otherUsersCar = Car(ObjectId(), 'someOtherId', 'Ford');

--- a/examples/dart/test/write_to_synced_realm_test.dart
+++ b/examples/dart/test/write_to_synced_realm_test.dart
@@ -1,0 +1,104 @@
+import 'package:test/test.dart';
+import 'package:realm_dart/realm.dart';
+
+import 'utils.dart';
+
+part 'write_to_synced_realm_test.g.dart';
+
+// TODO: add a different APP_ID here from what otherwise using b/c of different
+// permissions and queryable field
+const APP_ID = '';
+
+// :snippet-start: realm-model
+@RealmModel()
+class _Car {
+  @MapTo("_id")
+  @PrimaryKey()
+  late ObjectId id;
+
+  // This is the queryable field
+  late String ownerId;
+  late String make;
+  late String? model;
+  late int? miles;
+}
+// :snippet-end:
+
+main() async {
+  // :snippet-start: subscription-setup
+  final app = App(AppConfiguration(APP_ID));
+  final user = await app.logIn(Credentials.anonymous());
+  final config = Configuration.flexibleSync(user, [Car.schema]);
+  final realm = Realm(config);
+
+  // Add subscriptions
+  realm.subscriptions.update((mutableSubscriptions) {
+    // Get Cars from Atlas that match the Realm Query Language query.
+    // Uses the queryable field `miles`.
+    final newCarQuery = realm.query<Car>("miles < 100 OR miles == \$0", [null]);
+    mutableSubscriptions.add(newCarQuery, name: "new-car-subscription");
+  });
+  await realm.subscriptions.waitForSynchronization();
+  // :snippet-end:
+  tearDownAll(() async {
+    cleanUpRealm(realm, app);
+  });
+
+  // TODO: make real test
+  test("Write to a synced realm", () async {
+    // :snippet-start: write-synced-realm
+    // Per the Device Sync permissions, users can only read and write data
+    // where the `Car.ownerId` property matches their own user ID.
+    final userId = user.id;
+
+    realm.write(() {
+      // WRITE SUCCEEDS
+      // `newCar` is successfully written to the realm and synced to Atlas
+      // because it's data matches the subscription query and it's `ownerId` field
+      // matches the user ID.
+      final newCar = Car(ObjectId(), userId, 'Toyota', miles: 2);
+      realm.add(newCar);
+
+      // WRITE REVERTED BY COMPENSATING WRITE ERROR
+      // `oldCar` is initially written to the realm, then later removed
+      // in a compensating write when the server processes the write.
+      // This is because the `miles` property of `oldCar` doesn't match
+      // the subscription query, which is only for cars with less than 100 miles.
+      final oldCar = Car(ObjectId(), userId, 'Honda', miles: 90000);
+      realm.add(oldCar);
+
+      // WRITE REVERTED BY PERMISSION ERROR
+      // `otherUsersCar` is initially written to the realm, then later removed
+      // because it's `ownerId` property doesn't match the user ID of the user
+      // making the request.
+      final otherUsersCar = Car(ObjectId(), 'someOtherId', 'Ford');
+      realm.add(otherUsersCar);
+    });
+    // :snippet-end:
+  });
+  // TODO: make real test
+  test("Compensating writes", () async {
+    // :snippet-start: compensating-write
+    final carId = ObjectId();
+    final ownerId = app.currentUser!.id;
+
+    realm.write(() {
+      // `oldCar` is initially written to the realm, then later removed
+      // in a compensating write when the server processes the write.
+      // This is because the `miles` property of `oldCar` doesn't match
+      // the subscription query, which is only for cars with less than 100 miles.
+      final oldCar = Car(carId, ownerId, 'Honda', miles: 90000);
+      realm.add(oldCar);
+    });
+
+    // Let changes sync to and from server
+    await realm.syncSession.waitForUpload();
+    await realm.syncSession.waitForDownload();
+
+    final noCar = realm.find(carId);
+    // The Car is no longer in the realm because of the compensating write
+    // from the server.
+    expect(noCar, isNull);
+    // :snippet-end:
+  });
+}

--- a/examples/dart/test/write_to_synced_realm_test.g.dart
+++ b/examples/dart/test/write_to_synced_realm_test.g.dart
@@ -1,0 +1,71 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'write_to_synced_realm_test.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class Car extends _Car with RealmEntity, RealmObjectBase, RealmObject {
+  Car(
+    ObjectId id,
+    String ownerId,
+    String make, {
+    String? model,
+    int? miles,
+  }) {
+    RealmObjectBase.set(this, '_id', id);
+    RealmObjectBase.set(this, 'ownerId', ownerId);
+    RealmObjectBase.set(this, 'make', make);
+    RealmObjectBase.set(this, 'model', model);
+    RealmObjectBase.set(this, 'miles', miles);
+  }
+
+  Car._();
+
+  @override
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
+  @override
+  set id(ObjectId value) => RealmObjectBase.set(this, '_id', value);
+
+  @override
+  String get ownerId => RealmObjectBase.get<String>(this, 'ownerId') as String;
+  @override
+  set ownerId(String value) => RealmObjectBase.set(this, 'ownerId', value);
+
+  @override
+  String get make => RealmObjectBase.get<String>(this, 'make') as String;
+  @override
+  set make(String value) => RealmObjectBase.set(this, 'make', value);
+
+  @override
+  String? get model => RealmObjectBase.get<String>(this, 'model') as String?;
+  @override
+  set model(String? value) => RealmObjectBase.set(this, 'model', value);
+
+  @override
+  int? get miles => RealmObjectBase.get<int>(this, 'miles') as int?;
+  @override
+  set miles(int? value) => RealmObjectBase.set(this, 'miles', value);
+
+  @override
+  Stream<RealmObjectChanges<Car>> get changes =>
+      RealmObjectBase.getChanges<Car>(this);
+
+  @override
+  Car freeze() => RealmObjectBase.freezeObject<Car>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Car._);
+    return const SchemaObject(ObjectType.realmObject, Car, 'Car', [
+      SchemaProperty('_id', RealmPropertyType.objectid,
+          mapTo: '_id', primaryKey: true),
+      SchemaProperty('ownerId', RealmPropertyType.string),
+      SchemaProperty('make', RealmPropertyType.string),
+      SchemaProperty('model', RealmPropertyType.string, optional: true),
+      SchemaProperty('miles', RealmPropertyType.int, optional: true),
+    ]);
+  }
+}

--- a/source/examples/generated/flutter/write_to_synced_realm_test.snippet.compensating-write.dart
+++ b/source/examples/generated/flutter/write_to_synced_realm_test.snippet.compensating-write.dart
@@ -1,0 +1,20 @@
+final carId = ObjectId();
+final ownerId = app.currentUser!.id;
+
+realm.write(() {
+  // `oldCar` is initially written to the realm, then later removed
+  // in a compensating write when the server processes the write.
+  // This is because the `miles` property of `oldCar` doesn't match
+  // the subscription query, which is only for cars with less than 100 miles.
+  final oldCar = Car(carId, ownerId, 'Honda', miles: 90000);
+  realm.add(oldCar);
+});
+
+// Let changes sync to and from server
+await realm.syncSession.waitForUpload();
+await realm.syncSession.waitForDownload();
+
+final noCar = realm.find(carId);
+// The Car is no longer in the realm because of the compensating write
+// from the server.
+expect(noCar, isNull);

--- a/source/examples/generated/flutter/write_to_synced_realm_test.snippet.compensating-write.dart
+++ b/source/examples/generated/flutter/write_to_synced_realm_test.snippet.compensating-write.dart
@@ -14,7 +14,7 @@ realm.write(() {
 await realm.syncSession.waitForUpload();
 await realm.syncSession.waitForDownload();
 
-final noCar = realm.find(carId);
-// The Car is no longer in the realm because of the compensating write
-// from the server.
+final noCar = realm.find<Car>(carId);
+// The Car is no longer in the realm because of
+// the compensating write from the server.
 expect(noCar, isNull);

--- a/source/examples/generated/flutter/write_to_synced_realm_test.snippet.realm-model.dart
+++ b/source/examples/generated/flutter/write_to_synced_realm_test.snippet.realm-model.dart
@@ -1,0 +1,12 @@
+@RealmModel()
+class _Car {
+  @MapTo("_id")
+  @PrimaryKey()
+  late ObjectId id;
+
+  // This is the queryable field
+  late String ownerId;
+  late String make;
+  late String? model;
+  late int? miles;
+}

--- a/source/examples/generated/flutter/write_to_synced_realm_test.snippet.subscription-setup.dart
+++ b/source/examples/generated/flutter/write_to_synced_realm_test.snippet.subscription-setup.dart
@@ -1,0 +1,13 @@
+final app = App(AppConfiguration(APP_ID));
+final user = await app.logIn(Credentials.anonymous());
+final config = Configuration.flexibleSync(user, [Car.schema]);
+final realm = Realm(config);
+
+// Add subscriptions
+realm.subscriptions.update((mutableSubscriptions) {
+  // Get Cars from Atlas that match the Realm Query Language query.
+  // Uses the queryable field `miles`.
+  final newCarQuery = realm.query<Car>("miles < 100 OR miles == \$0", [null]);
+  mutableSubscriptions.add(newCarQuery, name: "new-car-subscription");
+});
+await realm.subscriptions.waitForSynchronization();

--- a/source/examples/generated/flutter/write_to_synced_realm_test.snippet.subscription-setup.dart
+++ b/source/examples/generated/flutter/write_to_synced_realm_test.snippet.subscription-setup.dart
@@ -7,6 +7,7 @@ final realm = Realm(config);
 realm.subscriptions.update((mutableSubscriptions) {
   // Get Cars from Atlas that match the Realm Query Language query.
   // Uses the queryable field `miles`.
+  // Query matches cars with less than 100 miles or `null` miles.
   final newCarQuery = realm.query<Car>("miles < 100 OR miles == \$0", [null]);
   mutableSubscriptions.add(newCarQuery, name: "new-car-subscription");
 });

--- a/source/examples/generated/flutter/write_to_synced_realm_test.snippet.write-synced-realm.dart
+++ b/source/examples/generated/flutter/write_to_synced_realm_test.snippet.write-synced-realm.dart
@@ -1,0 +1,27 @@
+// Per the Device Sync permissions, users can only read and write data
+// where the `Car.ownerId` property matches their own user ID.
+final userId = user.id;
+
+realm.write(() {
+  // WRITE SUCCEEDS
+  // `newCar` is successfully written to the realm and synced to Atlas
+  // because it's data matches the subscription query and it's `ownerId` field
+  // matches the user ID.
+  final newCar = Car(ObjectId(), userId, 'Toyota', miles: 2);
+  realm.add(newCar);
+
+  // WRITE REVERTED BY COMPENSATING WRITE ERROR
+  // `oldCar` is initially written to the realm, then later removed
+  // in a compensating write when the server processes the write.
+  // This is because the `miles` property of `oldCar` doesn't match
+  // the subscription query, which is only for cars with less than 100 miles.
+  final oldCar = Car(ObjectId(), userId, 'Honda', miles: 90000);
+  realm.add(oldCar);
+
+  // WRITE REVERTED BY PERMISSION ERROR
+  // `otherUsersCar` is initially written to the realm, then later removed
+  // because it's `ownerId` property doesn't match the user ID of the user
+  // making the request.
+  final otherUsersCar = Car(ObjectId(), 'someOtherId', 'Ford');
+  realm.add(otherUsersCar);
+});

--- a/source/examples/generated/flutter/write_to_synced_realm_test.snippet.write-synced-realm.dart
+++ b/source/examples/generated/flutter/write_to_synced_realm_test.snippet.write-synced-realm.dart
@@ -5,13 +5,13 @@ final userId = user.id;
 realm.write(() {
   // WRITE SUCCEEDS
   // `newCar` is successfully written to the realm and synced to Atlas
-  // because it's data matches the subscription query and it's `ownerId` field
-  // matches the user ID.
+  // because it's data matches the subscription query (miles < 100)
+  // and it's `ownerId` field matches the user ID.
   final newCar = Car(ObjectId(), userId, 'Toyota', miles: 2);
   realm.add(newCar);
 
   // WRITE REVERTED BY COMPENSATING WRITE ERROR
-  // `oldCar` is initially written to the realm, then later removed
+  // `oldCar` is initially written to the realm, then removed upon synchronization
   // in a compensating write when the server processes the write.
   // This is because the `miles` property of `oldCar` doesn't match
   // the subscription query, which is only for cars with less than 100 miles.
@@ -19,7 +19,7 @@ realm.write(() {
   realm.add(oldCar);
 
   // WRITE REVERTED BY PERMISSION ERROR
-  // `otherUsersCar` is initially written to the realm, then later removed
+  // `otherUsersCar` is initially written to the realm, then removed upon synchronization
   // because it's `ownerId` property doesn't match the user ID of the user
   // making the request.
   final otherUsersCar = Car(ObjectId(), 'someOtherId', 'Ford');

--- a/source/sdk/flutter/sync.txt
+++ b/source/sdk/flutter/sync.txt
@@ -10,6 +10,7 @@ Device Sync - Flutter SDK
    Add Sync to an App </sdk/flutter/sync/add-sync-to-app>
    Open Synced Realm </sdk/flutter/sync/open-synced-realm>
    Manage Subscriptions </sdk/flutter/sync/manage-sync-subscriptions>
+   Write Data to a Synced Realm </sdk/flutter/sync/write-to-synced-realm>
    Manage Sync Session </sdk/flutter/sync/manage-sync-session>
    Sync Multiple Processes </sdk/flutter/sync/sync-multiple-processes>
    Handle Sync Errors </sdk/flutter/sync/handle-sync-errors>

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -73,7 +73,9 @@ When the data matches the subscription, and the authenticated user has the
 appropriate permissions, Device Sync syncs the backend data with the client app.
 
 Subscription sets persist across sessions even if you no longer include
-the subscription in your code. You must explicitly remove a subscription
+the subscription in your code.
+Subscription information is stored in the synced realm's database file.
+You must explicitly remove a subscription
 for it to stop attempting to sync matching data.
 
 You can specify a string name for your subscription. If you do not give your

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -37,11 +37,11 @@ Align Subscriptions with Backend App
 Your client-side subscription queries must align with the Device Sync configuration
 in your backend App Services App.
 
-You subscription queries must have one of the following structures:
+You subscription queries can either:
 
-- Query all objects of a type.
+- **Query all objects of a type.**
   Create the query using :flutter-sdk:`Realm.all() <realm/Realm/all.html>`.
-- Query objects that match backend App's queryable fields.
+- **Query objects that match backend App's queryable fields.**
   Create the query using :flutter-sdk:`Realm.query() <realm/Realm/query.html>`
   and a Realm Query Language query that includes one or more queryable fields.
   The Realm SDK throws an error if you try to create a subscription using fields

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -235,6 +235,78 @@ An exception may occur if:
 .. literalinclude:: /examples/generated/flutter/manage_sync_subscription_test.snippet.wait-for-subscription-change.dart
    :language: dart
 
+.. _flutter-align-subscription-with-app:
+
+Align Subscriptions with App Backend
+------------------------------------
+
+Your client-side subscription queries must align with the Device Sync configuration
+in your backend App Services App.
+
+You subscription queries must have one of the following structures:
+
+- Query all objects of a type.
+  Create the query using :flutter-sdk:`Realm.all() <realm/Realm/all.html>`.
+- Query objects that match backend App's queryable fields.
+  Create the query using :flutter-sdk:`Realm.query() <realm/Realm/query.html>`
+  and a Realm Query Language query that includes one or more queryable fields.
+  The Realm SDK throws an error if you try to create a subscription using fields
+  that are not queryable.
+
+  - To learn more about configuring queryable fields,
+    refer to :ref:`Queryable Fields <queryable-fields>` in the App Services documentation.
+  - To learn more about the limitations of using Realm Query Language with Flexible Sync,
+    refer to the :ref:`Flexible Sync RQL Limitations
+    <flutter-flexible-sync-rql-limitations>` section.
+
+The following example includes Realm SDK client code that works with a backend App
+configuration that has ``miles`` as a queryable field.
+
+TODO: bluehawkify
+
+.. code-block:: dart
+
+   // The rest of the example uses RealmObjects generated from these RealmModels
+   @RealmModel()
+   class _Car {
+      @PrimaryKey()
+      late ObjectId id;
+
+      late String make;
+      late String? model;
+      late int? miles;
+   }
+
+   @RealmModel()
+   class _Driver {
+      @PrimaryKey()
+      late ObjectId id;
+
+      late String firstName;
+      late String lastName;
+   }
+
+   // ... instantiate App and log in user
+
+   final app = App(AppConfiguration(APP_ID));
+   final user = await app.logIn(Credentials.anonymous());
+   final config = Configuration.flexibleSync([Car.schema, Driver.schema], user);
+   final realm = Realm(config);
+
+   // Add subscriptions
+   realm.subscriptions.update((mutableSubscriptions) {
+      // Get all Driver objects from Atlas.
+      // Does not use queryable fields.
+      final allDrivers = realm.all<Driver>()
+      mutableSubscriptions.add(allDrivers, "all-drivers");
+
+      // Get Cars from Atlas that match the Realm Query Language query.
+      // Uses the queryable field `miles`.
+      final newCarQuery = realm.query<Car>("miles < 100 OR miles == \$0", [null]);
+      mutableSubscriptions.add(newCarQuery, "new-car-subscription");
+   });
+   await realm.subscriptions.waitForSynchronization();
+
 .. _flutter-flexible-sync-rql-limitations:
 
 Flexible Sync RQL Limitations

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -61,7 +61,7 @@ client application can query. In the client application, use the
 :flutter-sdk:`Realm.subscriptions <realm/Realm/subscriptions.html>` property to
 manage a set of subscriptions to specific queries on queryable fields.
 
-You can:
+You can do the following with your subscriptions:
 
 - Get a list of all subscriptions
 - Add subscriptions
@@ -71,6 +71,10 @@ You can:
 
 When the data matches the subscription, and the authenticated user has the
 appropriate permissions, Device Sync syncs the backend data with the client app.
+
+Subscription sets persist across sessions even if you no longer include
+the subscription in your code. You must explicitly remove a subscription
+for it to stop attempting to sync matching data.
 
 You can specify a string name for your subscription. If you do not give your
 subscription a name, the name is set to ``null``.

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -29,6 +29,30 @@ To use Flexible Sync in a Flutter application:
 #. :ref:`Authenticate a user <flutter-authenticate>` in the client
 #. :ref:`Open the synced realm <flutter-open-synced-realm>` in the client
 
+.. _flutter-align-subscription-with-app:
+
+Align Subscriptions with Backend App
+------------------------------------
+
+Your client-side subscription queries must align with the Device Sync configuration
+in your backend App Services App.
+
+You subscription queries must have one of the following structures:
+
+- Query all objects of a type.
+  Create the query using :flutter-sdk:`Realm.all() <realm/Realm/all.html>`.
+- Query objects that match backend App's queryable fields.
+  Create the query using :flutter-sdk:`Realm.query() <realm/Realm/query.html>`
+  and a Realm Query Language query that includes one or more queryable fields.
+  The Realm SDK throws an error if you try to create a subscription using fields
+  that are not queryable.
+
+  - To learn more about configuring queryable fields,
+    refer to :ref:`Queryable Fields <queryable-fields>` in the App Services documentation.
+  - To learn more about the limitations of using Realm Query Language with Flexible Sync,
+    refer to the :ref:`Flexible Sync RQL Limitations
+    <flutter-flexible-sync-rql-limitations>` section.
+
 Manage Your Subscriptions
 -------------------------
 
@@ -234,78 +258,6 @@ An exception may occur if:
 
 .. literalinclude:: /examples/generated/flutter/manage_sync_subscription_test.snippet.wait-for-subscription-change.dart
    :language: dart
-
-.. _flutter-align-subscription-with-app:
-
-Align Subscriptions with App Backend
-------------------------------------
-
-Your client-side subscription queries must align with the Device Sync configuration
-in your backend App Services App.
-
-You subscription queries must have one of the following structures:
-
-- Query all objects of a type.
-  Create the query using :flutter-sdk:`Realm.all() <realm/Realm/all.html>`.
-- Query objects that match backend App's queryable fields.
-  Create the query using :flutter-sdk:`Realm.query() <realm/Realm/query.html>`
-  and a Realm Query Language query that includes one or more queryable fields.
-  The Realm SDK throws an error if you try to create a subscription using fields
-  that are not queryable.
-
-  - To learn more about configuring queryable fields,
-    refer to :ref:`Queryable Fields <queryable-fields>` in the App Services documentation.
-  - To learn more about the limitations of using Realm Query Language with Flexible Sync,
-    refer to the :ref:`Flexible Sync RQL Limitations
-    <flutter-flexible-sync-rql-limitations>` section.
-
-The following example includes Realm SDK client code that works with a backend App
-configuration that has ``miles`` as a queryable field.
-
-TODO: bluehawkify
-
-.. code-block:: dart
-
-   // The rest of the example uses RealmObjects generated from these RealmModels
-   @RealmModel()
-   class _Car {
-      @PrimaryKey()
-      late ObjectId id;
-
-      late String make;
-      late String? model;
-      late int? miles;
-   }
-
-   @RealmModel()
-   class _Driver {
-      @PrimaryKey()
-      late ObjectId id;
-
-      late String firstName;
-      late String lastName;
-   }
-
-   // ... instantiate App and log in user
-
-   final app = App(AppConfiguration(APP_ID));
-   final user = await app.logIn(Credentials.anonymous());
-   final config = Configuration.flexibleSync([Car.schema, Driver.schema], user);
-   final realm = Realm(config);
-
-   // Add subscriptions
-   realm.subscriptions.update((mutableSubscriptions) {
-      // Get all Driver objects from Atlas.
-      // Does not use queryable fields.
-      final allDrivers = realm.all<Driver>()
-      mutableSubscriptions.add(allDrivers, "all-drivers");
-
-      // Get Cars from Atlas that match the Realm Query Language query.
-      // Uses the queryable field `miles`.
-      final newCarQuery = realm.query<Car>("miles < 100 OR miles == \$0", [null]);
-      mutableSubscriptions.add(newCarQuery, "new-car-subscription");
-   });
-   await realm.subscriptions.waitForSynchronization();
 
 .. _flutter-flexible-sync-rql-limitations:
 

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -19,8 +19,9 @@ refer to :ref:`Read & Write Data <flutter-read-write-data>`.
 Examples on This Page
 ---------------------
 
-The examples on this page use a app with the following Device Sync configuration
-and Realm SDK data model and subscriptions.
+The examples on this page use an Atlas App Services App with the following 
+Device Sync configuration and a client app with the following Realm SDK 
+data model and subscriptions.
 
 Device Sync is configured with the following queryable fields:
 
@@ -55,7 +56,8 @@ The examples on this page use the following schema:
 .. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.realm-model.dart
    :language: dart
 
-Using that schema, the examples use the following realm and subscription query:
+Using that schema, the examples configure the synced realm to 
+synchronize objects matching this subscription query:
 
 .. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.subscription-setup.dart
    :language: dart
@@ -86,11 +88,12 @@ of the following:
 Compensating Writes
 -------------------
 
-Compensating write errors occur when you write data to a realm locally
+Compensating write errors occur when you write data to a realm 
 that doesn't align with the realm's sync subscriptions.
 
 Because the client realm has no concept of "illegal" writes,
-the write always initially succeeds locally.
+the write initially succeeds until realm resolves the changeset
+with the App Services backend.
 Upon sync, the server will notice the illegal write. The server then undoes the change.
 The undo operation, called a "compensating write", syncs back to the client
 so the client's realm no longer has the illegal write.

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -94,15 +94,17 @@ Compensating Writes
 Compensating write errors occur when you write data to a realm
 that doesn't align with the realm's sync subscriptions.
 
-Because the client realm has no concept of "illegal" writes,
-the write initially succeeds until realm resolves the changeset
-with the App Services backend.
-Upon sync, the server applies the rules and permissions, then
-determines that the user does not have authorization to perform the write.
-The server sends a revert operation, called a "compensating write", back to the client.
-The client's realm then reverts the illegal write operation.
-Any client-side writes to a given object between an illegal write to that object
-and the corresponding compensating write will be lost.
+When you write data that doesn't match a subscription, the following occurs:
+
+#. Because the client realm has no concept of "illegal" writes,
+   the write initially succeeds until realm resolves the changeset
+   with the App Services backend.
+#. Upon sync, the server applies the rules and permissions.
+   The server determines that the user does not have authorization to perform the write.
+#. The server sends a revert operation, called a "compensating write", back to the client.
+#. The client's realm reverts the illegal write operation.
+#. Any client-side writes to a given object between an illegal write to that object
+   and the corresponding compensating write will be lost.
 
 .. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.compensating-write.dart
    :language: dart

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -4,11 +4,17 @@
 Write Data to a Synced Realm - Flutter SDK
 ==========================================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
 When writing data to a synced realm using Flexible Sync, you can use the same APIs
 as writing to a local realm database. However, there are some differences
 in behavior to keep in mind as you develop your application.
-For more information on reading and writing data to a realm,
-refer to :ref:`Read & Write Data <flutter-read-write-data>`
+To learn more about reading and writing data to a realm,
+refer to :ref:`Read & Write Data <flutter-read-write-data>`.
 
 Examples on This Page
 ---------------------
@@ -58,7 +64,7 @@ Write to a Synced Realm
 -----------------------
 
 When you write to a synced realm, your write operations must match *both*
-of the following criteria:
+of the following:
 
 - **The sync subscription query.**
     - If your write operation doesn't match
@@ -83,12 +89,12 @@ Compensating Writes
 Compensating write errors occur when you write data to a realm locally
 that doesn't align with the realm's sync subscriptions.
 
-Because the local realm has no concept of "illegal" writes,
+Because the client realm has no concept of "illegal" writes,
 the write always initially succeeds locally.
 Upon sync, the server will notice the illegal write. The server then undoes the change.
 The undo operation, called a "compensating write", syncs back to the client
 so the client's realm no longer has the illegal write.
-Any local writes to a given object between an illegal write to that object
+Any client-side writes to a given object between an illegal write to that object
 and the corresponding compensating write will be lost.
 
 To learn more about compensating write errors and other Device Sync error types,

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -103,8 +103,9 @@ When you write data that doesn't match a subscription, the following occurs:
    The server determines that the user does not have authorization to perform the write.
 #. The server sends a revert operation, called a "compensating write", back to the client.
 #. The client's realm reverts the illegal write operation.
-#. Any client-side writes to a given object between an illegal write to that object
-   and the corresponding compensating write will be lost.
+
+Any client-side writes to a given object between an illegal write to that object
+and the corresponding compensating write will be lost.
 
 .. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.compensating-write.dart
    :language: dart

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -97,10 +97,10 @@ that doesn't align with the realm's sync subscriptions.
 Because the client realm has no concept of "illegal" writes,
 the write initially succeeds until realm resolves the changeset
 with the App Services backend.
-Upon sync, the server applies the rules and permissions,
-determines that the user does not have authorization to perform the write, and reverts it.
-The revert operation, called a "compensating write", syncs back to the client
-so the client's realm no longer has the illegal write.
+Upon sync, the server applies the rules and permissions, then
+determines that the user does not have authorization to perform the write.
+The server sends a revert operation, called a "compensating write", back to the client.
+The client's realm then reverts the illegal write operation.
 Any client-side writes to a given object between an illegal write to that object
 and the corresponding compensating write will be lost.
 

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -8,10 +8,40 @@ When writing data to a synced realm using Flexible Sync, you can use the same AP
 as writing to a local realm database. However, there are some differences
 in behavior to keep in mind as you develop your application.
 For more information on reading and writing data to a realm,
-refer to the page https://www.mongodb.com/docs/realm/sdk/flutter/read-and-write-data/.
+refer to :ref:`Read & Write Data <flutter-read-write-data>`
 
 Examples on This Page
 ---------------------
+
+The examples on this page use a app with the following Device Sync configuration
+and Realm SDK data model and subscriptions.
+
+Device Sync is configured with the following queryable fields:
+
+- ``_id`` (always included)
+- ``ownerId``
+
+Device Sync has permissions configured to let users read and write only their own
+data:
+
+.. code-block:: json
+   :emphasize-lines: 5-13
+
+   {
+     "rules": {},
+     "defaultRoles": [
+       {
+         "name": "owner-read-write",
+         "applyWhen": {},
+         "read": {
+           "ownerId": "%%user.id"
+         },
+         "write": {
+           "ownerId": "%%user.id"
+         }
+       }
+     ]
+   }
 
 The examples on this page use the following schema, realm, and subscription query.
 
@@ -23,6 +53,7 @@ The examples on this page use the following schema, realm, and subscription quer
       @PrimaryKey()
       late ObjectId id;
 
+      late String ownerId;
       late String make;
       late String? model;
       late int? miles;
@@ -47,23 +78,44 @@ The examples on this page use the following schema, realm, and subscription quer
 Write to a Synced Realm
 -----------------------
 
-When you write to a synced realm, your write operations must match the query
-in the sync subscription. If your write operation doesn't match the subscription,
-the write fails with a compensating write error.
-To learn more about compensating write errors and how to avoid them,
-refer to the :ref:`Compensating Writes <flutter-compensating-writes>` section.
+When you write to a synced realm, your write operations must match with *both*
+of the following criteria:
+
+- **The sync subscription query**. If your write operation doesn't match
+  the query in the subscription, the write fails with a compensating write error.
+    - To learn more about compensating write errors and how to avoid them,
+      refer to the :ref:`Compensating Writes <flutter-compensating-writes>` section.
+- **The Device Sync permissions** in your App Services App.
+  If your try to write data that doesn't match the Device Sync permissions expression,
+  the write fails with a permission denied error.
+    - To learn more about configuring Device Sync permissions for your app,
+      refer to :ref:`sync-rules` and the :ref:`flexible-sync-permissions-guide`
+      in the App Services documentation.
 
 .. code-block:: dart
+
+   // Per the Device Sync permissions, users can only read and write data
+   // where the `Car.ownerId` property matches their own user ID.
+   final userId = app.currentUser!.id;
 
    realm.write((){
     // `oldCar` is initially written to the realm, then later removed
     // in a compensating write when the server processes the write.
     // This is because the `miles` property of `oldCar` doesn't match
     // the subscription query, which is only for cars with less than 100 miles.
-    final oldCar = Car(ObjectId(), 'Honda', miles: 90000);
-    // `newCar` is written to the realm and synced to Atlas because it's data
-    // matches the subscription query.
-    final newCar = Car(ObjectId(), 'Toyota', miles: 2);
+    final oldCar = Car(ObjectId(), userId, 'Honda', miles: 90000);
+    realm.add(oldCar);
+
+    // `otherUsersCar` is initially written to the realm, then later removed
+    // because it's `ownerId` property doesn't match the user ID of the user
+    // making the request.
+    final otherUsersCar = Car(ObjectId(), 'someOtherId', 'Ford');
+    realm.add(otherUsersCar);
+
+    // `newCar` is successfully written to the realm and synced to Atlas
+    // because it's data matches the subscription query and it's `ownerId` field
+    // matches the user ID.
+    final newCar = Car(ObjectId(), userId, 'Toyota', miles: 2);
     realm.add(newCar);
    });
 
@@ -83,20 +135,20 @@ so the client's realm no longer has the illegal write.
 Any local writes to a given object between an illegal write to that object
 and the corresponding compensating write will be lost.
 
-TODO: find out if compensating writes also relates to query filters
-
 To learn more about compensating write errors and other Device Sync error types,
 refer to :ref:`sync-errors` in the App Services documentation.
 
 .. code-block:: dart
 
    final carId = ObjectId();
+   final ownerId = app.currentUser!.id;
+
    realm.write(() {
     // `oldCar` is initially written to the realm, then later removed
     // in a compensating write when the server processes the write.
     // This is because the `miles` property of `oldCar` doesn't match
     // the subscription query, which is only for cars with less than 100 miles.
-    final oldCar = Car(carId, 'Honda', miles: 90000);
+    final oldCar = Car(carId, ownerId, 'Honda', miles: 90000);
     realm.add(oldCar);
    });
 

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -11,7 +11,7 @@ Write Data to a Synced Realm - Flutter SDK
    :class: singlecol
 
 When writing data to a synced realm using Flexible Sync, you can use the same APIs
-as writing to a local realm database. However, there are some differences
+as writing to a local realm. However, there are some differences
 in behavior to keep in mind as you develop your application.
 To learn more about reading and writing data to a realm,
 refer to :ref:`Read & Write Data <flutter-read-write-data>`.
@@ -69,16 +69,19 @@ When you write to a synced realm, your write operations must match *both*
 of the following:
 
 - **The sync subscription query.**
-    - If your write operation doesn't match
-      the query in the subscription, the write fails with a compensating write error.
+    - If your write operation doesn't match the query in the subscription,
+      the write reverts with a non-fatal compensating write error (ErrorCompensatingWrite).
     - To learn more about compensating write errors and how to avoid them,
       refer to the :ref:`Compensating Writes <flutter-compensating-writes>` section.
 - **The Device Sync permissions** in your App Services App.
     - If your try to write data that doesn't match the Device Sync permissions expression,
-      the write fails with a permission denied error.
+      the write reverts with a non-fatal permission denied error (ErrorPermissionDenied).
     - To learn more about configuring Device Sync permissions for your app,
       refer to :ref:`sync-rules` and the :ref:`flexible-sync-permissions-guide`
       in the App Services documentation.
+
+To learn more about permission denied errors, compensating write errors
+and other Device Sync error types, refer to :ref:`sync-errors` in the App Services documentation.
 
 .. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.write-synced-realm.dart
    :language: dart
@@ -88,20 +91,18 @@ of the following:
 Compensating Writes
 -------------------
 
-Compensating write errors occur when you write data to a realm 
+Compensating write errors occur when you write data to a realm
 that doesn't align with the realm's sync subscriptions.
 
 Because the client realm has no concept of "illegal" writes,
 the write initially succeeds until realm resolves the changeset
 with the App Services backend.
-Upon sync, the server will notice the illegal write. The server then undoes the change.
-The undo operation, called a "compensating write", syncs back to the client
+Upon sync, the server applies the rules and permissions,
+determines that the user does not have authorization to perform the write, and reverts it.
+The revert operation, called a "compensating write", syncs back to the client
 so the client's realm no longer has the illegal write.
 Any client-side writes to a given object between an illegal write to that object
 and the corresponding compensating write will be lost.
-
-To learn more about compensating write errors and other Device Sync error types,
-refer to :ref:`sync-errors` in the App Services documentation.
 
 .. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.compensating-write.dart
    :language: dart

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -1,0 +1,110 @@
+.. _flutter-write-synced-realm:
+
+==========================================
+Write Data to a Synced Realm - Flutter SDK
+==========================================
+
+When writing data to a synced realm using Flexible Sync, you can use the same APIs
+as writing to a local realm database. However, there are some differences
+in behavior to keep in mind as you develop your application.
+For more information on reading and writing data to a realm,
+refer to the page https://www.mongodb.com/docs/realm/sdk/flutter/read-and-write-data/.
+
+Examples on This Page
+---------------------
+
+The examples on this page use the following schema, realm, and subscription query.
+
+.. code-block:: dart
+
+   // The rest of the example uses RealmObjects generated from these RealmModels
+   @RealmModel()
+   class _Car {
+      @PrimaryKey()
+      late ObjectId id;
+
+      late String make;
+      late String? model;
+      late int? miles;
+   }
+
+   // ... instantiate App and log in user
+
+   final app = App(AppConfiguration(APP_ID));
+   final user = await app.logIn(Credentials.anonymous());
+   final config = Configuration.flexibleSync([Car.schema], user);
+   final realm = Realm(config);
+
+   // Add subscriptions
+   realm.subscriptions.update((mutableSubscriptions) {
+      // Get Cars from Atlas that match the Realm Query Language query.
+      // Uses the queryable field `miles`.
+      final newCarQuery = realm.query<Car>("miles < 100 OR miles == \$0", [null]);
+      mutableSubscriptions.add(newCarQuery, "new-car-subscription");
+   });
+   await realm.subscriptions.waitForSynchronization();
+
+Write to a Synced Realm
+-----------------------
+
+When you write to a synced realm, your write operations must match the query
+in the sync subscription. If your write operation doesn't match the subscription,
+the write fails with a compensating write error.
+To learn more about compensating write errors and how to avoid them,
+refer to the :ref:`Compensating Writes <flutter-compensating-writes>` section.
+
+.. code-block:: dart
+
+   realm.write((){
+    // `oldCar` is initially written to the realm, then later removed
+    // in a compensating write when the server processes the write.
+    // This is because the `miles` property of `oldCar` doesn't match
+    // the subscription query, which is only for cars with less than 100 miles.
+    final oldCar = Car(ObjectId(), 'Honda', miles: 90000);
+    // `newCar` is written to the realm and synced to Atlas because it's data
+    // matches the subscription query.
+    final newCar = Car(ObjectId(), 'Toyota', miles: 2);
+    realm.add(newCar);
+   });
+
+.. _flutter-compensating-writes:
+
+Compensating Writes
+-------------------
+
+Compensating write errors occur when you write data to a realm locally
+that doesn't align with the realm's sync subscriptions.
+
+Because the local realm has no concept of "illegal" writes,
+the write always initially succeeds locally.
+Upon sync, the server will notice the illegal write. The server then undoes the change.
+The undo operation, called a "compensating write", syncs back to the client
+so the client's realm no longer has the illegal write.
+Any local writes to a given object between an illegal write to that object
+and the corresponding compensating write will be lost.
+
+TODO: find out if compensating writes also relates to query filters
+
+To learn more about compensating write errors and other Device Sync error types,
+refer to :ref:`sync-errors` in the App Services documentation.
+
+.. code-block:: dart
+
+   final carId = ObjectId();
+   realm.write(() {
+    // `oldCar` is initially written to the realm, then later removed
+    // in a compensating write when the server processes the write.
+    // This is because the `miles` property of `oldCar` doesn't match
+    // the subscription query, which is only for cars with less than 100 miles.
+    final oldCar = Car(carId, 'Honda', miles: 90000);
+    realm.add(oldCar);
+   });
+
+   // Let changes sync to and from server
+   await realm.syncSession.waitForUpload();
+   await realm.syncSession.waitForDownload();
+
+   final noCar = realm.find(carId);
+   // The Car is no longer in the realm because of the compensating write
+   // from the server.
+   expect(noCar, isNull);

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -19,6 +19,7 @@ and Realm SDK data model and subscriptions.
 Device Sync is configured with the following queryable fields:
 
 - ``_id`` (always included)
+- ``miles``
 - ``ownerId``
 
 Device Sync has permissions configured to let users read and write only their own

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -43,81 +43,36 @@ data:
      ]
    }
 
-The examples on this page use the following schema, realm, and subscription query.
+The examples on this page use the following schema:
 
-.. code-block:: dart
+.. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.realm-model.dart
+   :language: dart
 
-   // The rest of the example uses RealmObjects generated from these RealmModels
-   @RealmModel()
-   class _Car {
-      @PrimaryKey()
-      late ObjectId id;
+Using that schema, the examples use the following realm and subscription query:
 
-      late String ownerId;
-      late String make;
-      late String? model;
-      late int? miles;
-   }
-
-   // ... instantiate App and log in user
-
-   final app = App(AppConfiguration(APP_ID));
-   final user = await app.logIn(Credentials.anonymous());
-   final config = Configuration.flexibleSync([Car.schema], user);
-   final realm = Realm(config);
-
-   // Add subscriptions
-   realm.subscriptions.update((mutableSubscriptions) {
-      // Get Cars from Atlas that match the Realm Query Language query.
-      // Uses the queryable field `miles`.
-      final newCarQuery = realm.query<Car>("miles < 100 OR miles == \$0", [null]);
-      mutableSubscriptions.add(newCarQuery, "new-car-subscription");
-   });
-   await realm.subscriptions.waitForSynchronization();
+.. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.subscription-setup.dart
+   :language: dart
 
 Write to a Synced Realm
 -----------------------
 
-When you write to a synced realm, your write operations must match with *both*
+When you write to a synced realm, your write operations must match *both*
 of the following criteria:
 
-- **The sync subscription query**. If your write operation doesn't match
-  the query in the subscription, the write fails with a compensating write error.
+- **The sync subscription query.**
+    - If your write operation doesn't match
+      the query in the subscription, the write fails with a compensating write error.
     - To learn more about compensating write errors and how to avoid them,
       refer to the :ref:`Compensating Writes <flutter-compensating-writes>` section.
 - **The Device Sync permissions** in your App Services App.
-  If your try to write data that doesn't match the Device Sync permissions expression,
-  the write fails with a permission denied error.
+    - If your try to write data that doesn't match the Device Sync permissions expression,
+      the write fails with a permission denied error.
     - To learn more about configuring Device Sync permissions for your app,
       refer to :ref:`sync-rules` and the :ref:`flexible-sync-permissions-guide`
       in the App Services documentation.
 
-.. code-block:: dart
-
-   // Per the Device Sync permissions, users can only read and write data
-   // where the `Car.ownerId` property matches their own user ID.
-   final userId = app.currentUser!.id;
-
-   realm.write((){
-    // `oldCar` is initially written to the realm, then later removed
-    // in a compensating write when the server processes the write.
-    // This is because the `miles` property of `oldCar` doesn't match
-    // the subscription query, which is only for cars with less than 100 miles.
-    final oldCar = Car(ObjectId(), userId, 'Honda', miles: 90000);
-    realm.add(oldCar);
-
-    // `otherUsersCar` is initially written to the realm, then later removed
-    // because it's `ownerId` property doesn't match the user ID of the user
-    // making the request.
-    final otherUsersCar = Car(ObjectId(), 'someOtherId', 'Ford');
-    realm.add(otherUsersCar);
-
-    // `newCar` is successfully written to the realm and synced to Atlas
-    // because it's data matches the subscription query and it's `ownerId` field
-    // matches the user ID.
-    final newCar = Car(ObjectId(), userId, 'Toyota', miles: 2);
-    realm.add(newCar);
-   });
+.. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.write-synced-realm.dart
+   :language: dart
 
 .. _flutter-compensating-writes:
 
@@ -138,25 +93,5 @@ and the corresponding compensating write will be lost.
 To learn more about compensating write errors and other Device Sync error types,
 refer to :ref:`sync-errors` in the App Services documentation.
 
-.. code-block:: dart
-
-   final carId = ObjectId();
-   final ownerId = app.currentUser!.id;
-
-   realm.write(() {
-    // `oldCar` is initially written to the realm, then later removed
-    // in a compensating write when the server processes the write.
-    // This is because the `miles` property of `oldCar` doesn't match
-    // the subscription query, which is only for cars with less than 100 miles.
-    final oldCar = Car(carId, ownerId, 'Honda', miles: 90000);
-    realm.add(oldCar);
-   });
-
-   // Let changes sync to and from server
-   await realm.syncSession.waitForUpload();
-   await realm.syncSession.waitForDownload();
-
-   final noCar = realm.find(carId);
-   // The Car is no longer in the realm because of the compensating write
-   // from the server.
-   expect(noCar, isNull);
+.. literalinclude:: /examples/generated/flutter/write_to_synced_realm_test.snippet.compensating-write.dart
+   :language: dart

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -33,7 +33,6 @@ Device Sync has permissions configured to let users read and write only their ow
 data:
 
 .. code-block:: json
-   :emphasize-lines: 5-13
 
    {
      "rules": {},


### PR DESCRIPTION
## Pull Request Info

- Add new page about constraints on writing data when writing to a synced realm
- add a conceptual section to 'Manage Sync Subscriptions' page about how subscriptions need to align with backend.
- add bit of info about how subscription sets persist across sessions. 

Note: also created the Bushicorp app write-flex-sync-data-hvpxi to have a dedicated app for the permissions required by this PR.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26797

### Staged Changes

- [Write to a Synced Realm (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26797/sdk/flutter/sync/write-to-synced-realm/)
- [Manage Sync Subscriptions (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26797/sdk/flutter/sync/manage-sync-subscriptions/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
