### PR TITLE
Corrected QuickStart page for .NET

### DIFF
--- a/source/examples/generated/dotnet/Program.snippet.read-filter.cs
+++ b/source/examples/generated/dotnet/Program.snippet.read-filter.cs
@@ -1,5 +1,5 @@
 var lessExpensiveGuitars = realm.All<Guitar>().Where(g => g.Price < 400);
 
-var guitarsSortedByMake = realm.All<Guitar>().OrderBy(g => g.Make);
+var guitarsSortedByMaker = realm.All<Guitar>().OrderBy(g => g.Maker);
 
 var specifiGuitarById = realm.Find<Guitar>(someGuitarId);

--- a/source/examples/generated/dotnet/Program.snippet.update.cs
+++ b/source/examples/generated/dotnet/Program.snippet.update.cs
@@ -1,6 +1,6 @@
 var davidsStrat = realm.All<Guitar>().FirstOrDefault(
     g => g.Owner == "D. Gilmour"
-    && g.Make == "Fender"
+    && g.Maker == "Fender"
     && g.Model == "Stratocaster");
 
 realm.Write(() =>

--- a/source/examples/generated/dotnet/Program.snippet.write.cs
+++ b/source/examples/generated/dotnet/Program.snippet.write.cs
@@ -2,7 +2,7 @@ realm.Write(() =>
 {
     realm.Add(new Guitar()
     {
-        Make = "Gibson",
+        Maker = "Gibson",
         Model = "Les Paul Custom",
         Price = 649.99,
         Owner = "N. Young"

--- a/source/examples/generated/dotnet/Task.snippet.task-object-model.cs
+++ b/source/examples/generated/dotnet/Task.snippet.task-object-model.cs
@@ -3,7 +3,7 @@ using Realms;
 
 namespace Examples.Models
 {
-    public class Task : RealmObject
+    public class TaskItem : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
@@ -23,12 +23,5 @@ namespace Examples.Models
         [MapTo("status")]
         [Required]
         public string Status { get; set; }
-    }
-
-    public enum TaskStatus
-    {
-        Open,
-        InProgress,
-        Complete
     }
 }

--- a/source/sdk/dotnet/quick-start.txt
+++ b/source/sdk/dotnet/quick-start.txt
@@ -44,10 +44,10 @@ to and from App Services.
    :dotnet-sdk:`EmbeddedObject <reference/Realms.EmbeddedObject.html>`, or 
    :dotnet-sdk:`AsymmetricObject <reference/Realms.AsymmetricObject.html>`.
 
-The following code shows how to define an object model for a ``Task`` object. In 
-this example, we have marked the ``Id`` field as the Primary Key, marked the 
-``Name`` and ``Status`` properties as "required", and are using the ``MapTo`` 
-attribute so we can use .NET-friendly casing on our property names.
+The following code shows how to define an object model for a ``TaskItem`` object. In 
+this example, we have marked the ``Id`` field as the Primary Key and marked the 
+``Name`` and ``Status`` properties as `Required`, and are using the `MapTo` attribute
+ so we can use .NET-friendly casing on our property names when using Device Sync.
 
 .. literalinclude:: /examples/generated/dotnet/Task.snippet.task-object-model.cs
    :language: csharp
@@ -91,7 +91,7 @@ You can retrieve a live :ref:`collection <dotnet-client-collections>` of all
    :language: csharp
 
 You can filter the collection by using the 
-`Linq <https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/>`_ 
+`LINQ <https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/>`_ 
 syntax:
 
 .. literalinclude:: /examples/generated/dotnet/Program.snippet.read-filter.cs


### PR DESCRIPTION
I have corrected some small things and changed the name of the example object, given that `Task` has a specific meaning in .NET and it could be confusing. I'm definitely open to other names, this was just an example. 

Also I'm not sure if in a quick start page we should show `MapTo` attributes that are probably not very important when just starting, and that developer will probably start to use only when looking at sync. For the same reason if we want a very slim quick start we could also remove the `partition` property and change `ObjectId` to `Guid`, given that the first is a new type for a newcomer and just adds to the confusion. Those are my two cents 😁 Obviously if we want to show already how to work with sync then this doesn't matter, but definitely we need to change the name and remove that enum that wasn't being used