### PR TITLE
Fixing link to Kotlin Tutorial page

### DIFF
--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -214,5 +214,5 @@ application that integrates Realm Database and Atlas Device Sync into a
 customizable android app.
 
 Alternatively, if you are interested in a guided experience, you can read our
-:ref:`Android with Kotlin SDK tutorial <tutorial>` that expands on the template
+:ref:`Android with Kotlin SDK tutorial <kotlin-tutorial>` that expands on the template
 app. 


### PR DESCRIPTION
## Pull Request Info

No Jira 

> "tutorial" brings us to https://www.mongodb.com/docs/manual/tutorial/#std-label-tutorial rather than https://www.mongodb.com/docs/atlas/app-services/tutorial/kotlin/

### Staged Changes

- [Quick Start - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fix-kotlin-link/sdk/kotlin/quick-start/#next--check-out-the-template-apps-and-tutorial)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
