### PR TITLE
(DOCSP-26899): Clarify "completed" subscription state

### DIFF
--- a/source/includes/note-sync-state-complete.rst
+++ b/source/includes/note-sync-state-complete.rst
@@ -1,7 +1,8 @@
 .. note:: Subscription State "Complete"
 
-   The subscription set state called "complete" does not mean "sync is done" or
-   "all documents have been synced". "Complete" means:
+   The subscription set state "complete" does not mean "sync is done" or "all
+   documents have been synced". "Complete" means the following two things have
+   happened:
    
    - The subscription has become the active subscription set that is currently
      being synchronized with the server.

--- a/source/includes/note-sync-state-complete.rst
+++ b/source/includes/note-sync-state-complete.rst
@@ -9,3 +9,6 @@
      was sent to the server* are now on the local device. Note that this does
      not necessarily include all documents that currently match the
      subscription.
+  
+   The Realm SDK does not provide a way to check whether all documents that
+   match a subscription have synced to the device.

--- a/source/includes/note-sync-state-complete.rst
+++ b/source/includes/note-sync-state-complete.rst
@@ -1,0 +1,11 @@
+.. note:: Subscription State "Complete"
+
+   The subscription set state called "complete" does not mean "sync is done" or
+   "all documents have been synced". "Complete" means:
+   
+   - The subscription has become the active subscription set that is currently
+     being synchronized with the server.
+   - The documents that matched the subscription *at the time the subscription
+     was sent to the server* are now on the local device. Note that this does
+     not necessarily include all documents that currently match the
+     subscription.

--- a/source/sdk/dotnet/sync/flexible-sync.txt
+++ b/source/sdk/dotnet/sync/flexible-sync.txt
@@ -284,6 +284,21 @@ An exception may occur if:
 .. literalinclude:: /examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.wait-for-synchronization.cs
    :language: csharp
 
+Subscription State
+~~~~~~~~~~~~~~~~~~
+
+Use the :dotnet-sdk:`SubscriptionSet.State
+<reference/Realms.Sync.SubscriptionSet.html#Realms_Sync_SubscriptionSet_State>`
+property to read the current state of the subscription set.
+
+The ``Superseded`` state is a :dotnet-sdk:`SubscriptionSetState
+<reference/Realms.Sync.SubscriptionSetState.html>` that can occur when another
+thread updates a subscription on a different instance of the subscription set.
+If the state becomes ``Superseded``, you must obtain a new instance of the
+subscription set before you can update it.
+
+.. include:: /includes/note-sync-state-complete.rst
+
 .. _dotnet-flexible-sync-rql-limitations:
 
 Flexible Sync RQL Limitations

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -265,6 +265,20 @@ An exception may occur if:
 .. literalinclude:: /examples/generated/flutter/manage_sync_subscription_test.snippet.wait-for-subscription-change.dart
    :language: dart
 
+Subscription State
+~~~~~~~~~~~~~~~~~~
+
+Use the :flutter-sdk:`Realm.subscriptions.state <SubscriptionSet/state.html>`
+property to read the current state of the subscription set.
+
+The ``superseded`` state is a :flutter-sdk:`SubscriptionSetState
+<SubscriptionSetState.html>` that can occur when another thread updates a
+subscription on a different instance of the subscription set. If the state
+becomes ``superseded``, you must obtain a new instance of the subscription set
+before you can update it.
+
+.. include:: /includes/note-sync-state-complete.rst
+
 .. _flutter-flexible-sync-rql-limitations:
 
 Flexible Sync RQL Limitations

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -268,11 +268,11 @@ An exception may occur if:
 Subscription State
 ~~~~~~~~~~~~~~~~~~
 
-Use the :flutter-sdk:`Realm.subscriptions.state <SubscriptionSet/state.html>`
+Use the :flutter-sdk:`Realm.subscriptions.state <realm/SubscriptionSet/state.html>`
 property to read the current state of the subscription set.
 
 The ``superseded`` state is a :flutter-sdk:`SubscriptionSetState
-<SubscriptionSetState.html>` that can occur when another thread updates a
+<realm/SubscriptionSetState.html>` that can occur when another thread updates a
 subscription on a different instance of the subscription set. If the state
 becomes ``superseded``, you must obtain a new instance of the subscription set
 before you can update it.

--- a/source/sdk/java/examples/flexible-sync.txt
+++ b/source/sdk/java/examples/flexible-sync.txt
@@ -218,6 +218,8 @@ You can use subscription state to:
 You can access the state of your application's subscription set using
 :java-sdk:`SubscriptionSet.getState() <io/realm/mongodb/sync/SubscriptionSet.html#getState()>`.
 
+.. include:: /includes/note-sync-state-complete.rst
+
 Superseded
 ``````````
 

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -119,7 +119,8 @@ Use the `SubscriptionSet.state
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-subscription-set/index.html#-508547000%2FProperties%2F645295071>`__
 property to read the current state of the subscription set.
 
-``SUPERCEDED`` (sic -- note alternate spelling) is a ``SubscriptionSetState``
+``SUPERCEDED`` (sic -- note alternate spelling) is a `SubscriptionSetState
+<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-subscription-set-state/index.html>`__
 that can occur when another thread writes a subscription on a different instance
 of the subscription set. If the state becomes ``SUPERCEDED``, you must obtain a
 new instance of the subscription set before you can write to it.

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -112,27 +112,19 @@ You can also use `SubscriptionSet.waitForSynchronization()
 to delay execution until subscription sync completes after instantiating
 a sync connection.
 
-``SubscriptionSet.State`` Enum
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Subscription Set State
+~~~~~~~~~~~~~~~~~~~~~~
 
-Additionally, you can watch the state of the subscription set with the 
-`SubscriptionSetState
-<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-subscription-set-state/index.html>`__
-enum. You can use subscription state to:
+Use the `SubscriptionSet.state
+<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-subscription-set/index.html#-508547000%2FProperties%2F645295071>`__
+property to read the current state of the subscription set.
 
-- Show a progress indicator while data is downloading
-- Find out when a subscription set becomes superseded
+``SUPERCEDED`` (sic -- note alternate spelling) is a ``SubscriptionSetState``
+that can occur when another thread writes a subscription on a different instance
+of the subscription set. If the state becomes ``SUPERCEDED``, you must obtain a
+new instance of the subscription set before you can write to it.
 
-You can access the state of your application's subscription set using
-``SubscriptionSet.state``.
-
-Superceded
-~~~~~~~~~~
-
-``SUPERCEDED`` is a ``SubscriptionSetState`` that can occur when another
-thread writes a subscription on a different instance of the 
-subscription set. If the state becomes ``SUPERCEDED``, you must obtain 
-a new instance of the subscription set before you can write to it.
+.. include:: /includes/note-sync-state-complete.rst
 
 .. _kotlin-update-subscriptions-with-new-query:
 

--- a/source/sdk/node/examples/flexible-sync.txt
+++ b/source/sdk/node/examples/flexible-sync.txt
@@ -193,6 +193,8 @@ To the status of subscriptions, log the value of the subscription's
 .. literalinclude:: /examples/generated/node/flexible-sync.snippet.log-subscription-state.js 
     :language: javascript
 
+.. include:: /includes/note-sync-state-complete.rst
+
 Update Subscriptions with a New Query
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can update a named subscription with a new query. To update a subscriptions

--- a/source/sdk/react-native/sync-data/flexible-sync.txt
+++ b/source/sdk/react-native/sync-data/flexible-sync.txt
@@ -193,6 +193,8 @@ To the status of subscriptions, log the value of the subscription's
 .. literalinclude:: /examples/generated/node/flexible-sync.snippet.log-subscription-state.js 
     :language: javascript
 
+.. include:: /includes/note-sync-state-complete.rst
+
 Update Subscriptions with a New Query
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can update a named subscription with a new query. To update a subscriptions

--- a/source/sdk/swift/sync/flexible-sync.txt
+++ b/source/sdk/swift/sync/flexible-sync.txt
@@ -260,18 +260,18 @@ error if the update cannot complete successfully.
 
 .. include:: /includes/swift-concurrency-mainactor.rst
 
-SyncSubscriptionState Enum
-``````````````````````````
+Subscription Set State
+~~~~~~~~~~~~~~~~~~~~~~
 
-You can watch the state of the subscription set with the
-:swift-sdk:`SyncSubscriptionState
+Use the :swift-sdk:`SubscriptionSet.state
+<Structs/SyncSubscriptionSet.html#/s:10RealmSwift19SyncSubscriptionSetV5stateAA0cD5StateOvp`
+property to read the current state of the subscription set.
+
+The ``superseded`` state is a :swift-sdk:`SyncSubscriptionState
 <Enums/SyncSubscriptionState.html#/s:10RealmSwift21SyncSubscriptionStateO8completeyA2CmF>`
-enum.
-
-The ``superseded`` state is a ``SyncSubscriptionState`` that can occur when
-another thread updates a subscription on a different instance of the
-subscription set. If the state becomes ``superseded``, you must obtain a new
-instance of the subscription set before you can update it.
+that can occur when another thread updates a subscription on a different
+instance of the subscription set. If the state becomes ``superseded``, you must
+obtain a new instance of the subscription set before you can update it.
 
 .. include:: /includes/note-sync-state-complete.rst
 

--- a/source/sdk/swift/sync/flexible-sync.txt
+++ b/source/sdk/swift/sync/flexible-sync.txt
@@ -263,23 +263,17 @@ error if the update cannot complete successfully.
 SyncSubscriptionState Enum
 ``````````````````````````
 
-Additionally, you can watch the state of the subscription set with the 
-``SyncSubscriptionState`` enum. You can use subscription state to:
+You can watch the state of the subscription set with the
+:swift-sdk:`SyncSubscriptionState
+<Enums/SyncSubscriptionState.html#/s:10RealmSwift21SyncSubscriptionStateO8completeyA2CmF>`
+enum.
 
-- Show a progress indicator while data is downloading
-- Find out when a subscription set becomes superseded
-- Wait for a subscription that has been persisted locally to sync with
-  the server
-- Watch for errors
+The ``superseded`` state is a ``SyncSubscriptionState`` that can occur when
+another thread updates a subscription on a different instance of the
+subscription set. If the state becomes ``superseded``, you must obtain a new
+instance of the subscription set before you can update it.
 
-
-Superseded
-``````````
-
-The ``superseded`` state is a ``SyncSubscriptionState`` that can occur when 
-another thread updates a subscription on a different instance of the 
-subscription set. If the state becomes ``superseded``, you must obtain 
-a new instance of the subscription set before you can update it.
+.. include:: /includes/note-sync-state-complete.rst
 
 .. _ios-update-subscriptions-with-new-query:
 

--- a/source/sdk/swift/sync/flexible-sync.txt
+++ b/source/sdk/swift/sync/flexible-sync.txt
@@ -264,7 +264,7 @@ Subscription Set State
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Use the :swift-sdk:`SubscriptionSet.state
-<Structs/SyncSubscriptionSet.html#/s:10RealmSwift19SyncSubscriptionSetV5stateAA0cD5StateOvp`
+<Structs/SyncSubscriptionSet.html#/s:10RealmSwift19SyncSubscriptionSetV5stateAA0cD5StateOvp>`
 property to read the current state of the subscription set.
 
 The ``superseded`` state is a :swift-sdk:`SyncSubscriptionState


### PR DESCRIPTION
## Pull Request Info

- Adds a note to detail the completed state in general. Included the note on each relevant SDK.
- Clarified and tightened up the various sections on subscription states.
- Added links to SDK reference manual if needed.
- Debated whether to add a Table for this listing all of the states, but that info is already in the SDK reference docs.


### Jira

- https://jira.mongodb.org/browse/DOCSP-26899

### Staged Changes

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/subscriptions-state/sdk/dotnet/sync/flexible-sync/#subscription-state
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/subscriptions-state/sdk/flutter/sync/manage-sync-subscriptions/#subscription-state
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/subscriptions-state/sdk/kotlin/sync/subscribe/#subscription-set-state
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/subscriptions-state/sdk/react-native/sync-data/flexible-sync/#check-the-status-of-subscriptions
- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/subscriptions-state/sdk/swift/sync/flexible-sync/#subscription-set-state

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-app-services update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
