### PR TITLE
(DOCSP-26512): Info about custom HTTP client for Android <= 7

### DIFF
--- a/examples/dart/test/app_services_test.dart
+++ b/examples/dart/test/app_services_test.dart
@@ -55,6 +55,11 @@ void main() {
         final appConfig = AppConfiguration(appId, httpClient: httpClient);
         return App(appConfig);
       }
+
+      final letsEncryptCertificate = "<LET'S ENCRYPT CERTIFICATE>";
+      final appId = "<YOUR APP ID>";
+
+      final app = createAppWithCustomHttpsClient(letsEncryptCertificate, appId);
       // :snippet-end:
     },
         skip:

--- a/examples/dart/test/app_services_test.dart
+++ b/examples/dart/test/app_services_test.dart
@@ -1,5 +1,7 @@
 import 'package:test/test.dart';
 import 'package:realm_dart/realm.dart';
+import "dart:io";
+import "dart:convert";
 
 void main() {
   const APP_ID = "example-testers-kvjdy";
@@ -23,5 +25,42 @@ void main() {
       expect(app.currentUser, null);
       expect(appConfig.localAppVersion, '2.0');
     });
+
+    test("Custom SSL Certificate", () async {
+      // :snippet-start: custom-ssl-cert
+      // :uncomment-start:
+      // import 'package:realm_dart/realm.dart';
+      // import "dart:io";
+      // import "dart:convert";
+      // :uncomment-end:
+
+      HttpClient createCustomHttpsClient(String cert) {
+        SecurityContext context = SecurityContext.defaultContext;
+        try {
+          final bytes = utf8.encode(cert);
+          context.setTrustedCertificatesBytes(bytes);
+        } on TlsException catch (e) {
+          final message = e.osError?.message ?? "";
+          if (!message.contains('CERT_ALREADY_IN_HASH_TABLE')) {
+            rethrow;
+          }
+        }
+
+        return HttpClient(context: context);
+      }
+
+      App createAppWithCustomHttpsClient(
+          String letsEncryptCertificate, String appId) {
+        HttpClient httpClient = createCustomHttpsClient(letsEncryptCertificate);
+        final appConfig = AppConfiguration(appId, httpClient: httpClient);
+        return App(appConfig);
+      }
+      // :snippet-end:
+    },
+        skip:
+            """Skipping because this is quite challenging to test in our unit test suite
+    because our unit tests use a version of Dart that doesn't require a custom SSL certificate.
+
+    For more information on this, refer to https://stackoverflow.com/questions/69511057/flutter-on-android-7-certificate-verify-failed-with-letsencrypt-ssl-cert-after-s""");
   });
 }

--- a/source/examples/generated/flutter/app_services_test.snippet.custom-ssl-cert.dart
+++ b/source/examples/generated/flutter/app_services_test.snippet.custom-ssl-cert.dart
@@ -1,0 +1,25 @@
+import 'package:realm_dart/realm.dart';
+import "dart:io";
+import "dart:convert";
+
+HttpClient createCustomHttpsClient(String cert) {
+  SecurityContext context = SecurityContext.defaultContext;
+  try {
+    final bytes = utf8.encode(cert);
+    context.setTrustedCertificatesBytes(bytes);
+  } on TlsException catch (e) {
+    final message = e.osError?.message ?? "";
+    if (!message.contains('CERT_ALREADY_IN_HASH_TABLE')) {
+      rethrow;
+    }
+  }
+
+  return HttpClient(context: context);
+}
+
+App createAppWithCustomHttpsClient(
+    String letsEncryptCertificate, String appId) {
+  HttpClient httpClient = createCustomHttpsClient(letsEncryptCertificate);
+  final appConfig = AppConfiguration(appId, httpClient: httpClient);
+  return App(appConfig);
+}

--- a/source/examples/generated/flutter/app_services_test.snippet.custom-ssl-cert.dart
+++ b/source/examples/generated/flutter/app_services_test.snippet.custom-ssl-cert.dart
@@ -23,3 +23,8 @@ App createAppWithCustomHttpsClient(
   final appConfig = AppConfiguration(appId, httpClient: httpClient);
   return App(appConfig);
 }
+
+final letsEncryptCertificate = "<LET'S ENCRYPT CERTIFICATE>";
+final appId = "<YOUR APP ID>";
+
+final app = createAppWithCustomHttpsClient(letsEncryptCertificate, appId);

--- a/source/sdk/flutter/app-services/connect-to-app.txt
+++ b/source/sdk/flutter/app-services/connect-to-app.txt
@@ -57,3 +57,27 @@ You can add optional arguments to the :flutter-sdk:`AppConfiguration <realm/AppC
 
    For most use cases, you only need your application's App ID to connect
    to App Services. The other settings demonstrated here are optional.
+
+.. _flutter-connect-old-android:
+
+Connect Using Android 7 or Older
+--------------------------------
+
+If you are using Android 7 or older, you must add an HTTP client
+with a custom Let's Encrypt Transport Layer Security (TLS) encryption certificate
+to use App Services with the Realm SDK.
+
+This is due to known issue using Flutter on devices using Android 7 or older
+to connect to web servers that use Let's Encrypt TLS certificates.
+As App Services server uses a Let's Encrypt TLS certificate, you must add the custom certificate.
+
+Use the Flutter `SecurityContext <https://api.flutter.dev/flutter/dart-io/SecurityContext-class.html>`__
+library to create the custom certificate.
+
+You can download the Let's Encrypt certificate to add to your app
+by clicking this link: https://letsencrypt.org/certs/lets-encrypt-r3.pem
+
+To set up the custom HTTP client, you can adapt the following code example to your app.
+
+.. literalinclude:: /examples/generated/flutter/app_services_test.snippet.custom-ssl-cert.dart
+   :language: dart

--- a/source/sdk/flutter/app-services/connect-to-app.txt
+++ b/source/sdk/flutter/app-services/connect-to-app.txt
@@ -63,21 +63,18 @@ You can add optional arguments to the :flutter-sdk:`AppConfiguration <realm/AppC
 Connect Using Android 7 or Older
 --------------------------------
 
-If you are using Android 7 or older, you must add an HTTP client
-with a custom Let's Encrypt Transport Layer Security (TLS) encryption certificate
-to use App Services with the Realm SDK.
+To use App Services with the Realm SDK on a device using Android 7 or older,
+you must add an HTTP client with a custom Let's Encrypt Transport Layer Security (TLS) encryption certificate
+to the ``App``.
 
-This is due to known issue using Flutter on devices using Android 7 or older
+This is due to a known issue using Flutter on devices running Android 7 or older
 to connect to web servers that use Let's Encrypt TLS certificates.
 As App Services server uses a Let's Encrypt TLS certificate, you must add the custom certificate.
-
-Use the Flutter `SecurityContext <https://api.flutter.dev/flutter/dart-io/SecurityContext-class.html>`__
-library to create the custom certificate.
 
 You can download the Let's Encrypt certificate to add to your app
 by clicking this link: https://letsencrypt.org/certs/lets-encrypt-r3.pem
 
-To set up the custom HTTP client, you can adapt the following code example to your app.
+To set up the custom HTTP client, adapt the following code example to your app.
 
 .. literalinclude:: /examples/generated/flutter/app_services_test.snippet.custom-ssl-cert.dart
    :language: dart


### PR DESCRIPTION
## Pull Request Info

Add documentation section about custom HTTP client for Android <= 7.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26512

### Staged Changes

- [Connect to App Services > Connect Using Android 7 or Older section](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26512/sdk/flutter/app-services/connect-to-app/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
