### PR TITLE
(DOCSP-27161): Flutter add App Services to landing page

### DIFF
--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -81,9 +81,8 @@ Get Started with Realm Flutter
 
 .. kicker:: What You Can Do
 
-Develop Apps with Realm Flutter
--------------------------------
-
+Develop Apps with the Realm Flutter SDK
+---------------------------------------
 
 .. tabs::
 
@@ -171,6 +170,33 @@ Develop Apps with Realm Flutter
 
       .. image:: /images/illustrations/Spot_AzureBlue_Mobile_Tech_RealmSync.png
          :alt: Realm Sync Illustration
+
+   .. tab:: Build with Atlas App Services
+      :tabid: app-services
+
+      .. container::
+
+         Call Serverless Functions
+         ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+         You can :ref:`call serverless Atlas Functions <flutter-call-function>`
+         that run in an App Services backend from your client application.
+
+         Query MongoDB Atlas with GraphQL
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+         You can :ref:`query data stored in MongoDB with the Atlas GraphQL API <flutter-graphql-api>`
+         directly from your client application code.
+
+         Authenticate Users
+         ~~~~~~~~~~~~~~~~~~
+
+         Authenticate users with built-in and third-party :ref:`authentication
+         providers <flutter-authenticate>`. Use the authenticated user to
+         access App Services.
+
+      .. image:: /images/illustrations/Spot_MauvePurple_APIs_Tech_RealmApp.png
+         :alt: App Services Illustration
 
 .. kicker:: Essential Documentation
 


### PR DESCRIPTION
## Pull Request Info

Add tab section about Atlas App Services to Flutter SDK landing page

### Jira

- https://jira.mongodb.org/browse/DOCSP-27161

### Staged Changes

- [Flutter SDK (landing page)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27161/sdk/flutter/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
