### PR TITLE
(DOCSP-27146): Updating Kotlin example in RQL docs

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/RQLTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/RQLTest.kt
@@ -1,10 +1,14 @@
 package com.mongodb.realm.realmkmmapp
 
 import org.mongodb.kbson.ObjectId
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.PrimaryKey
 
 class RQLTest: RealmTest() {
-    class Task() {
-        var id: ObjectId = ObjectId()
+    // :snippet-start: rql-schema-example
+    class Task(): RealmObject {
+        @PrimaryKey
+        var _id: ObjectId = ObjectId()
         lateinit var name: String
         var isComplete: Boolean = false
         var assignee: String? = null
@@ -12,10 +16,12 @@ class RQLTest: RealmTest() {
         var progressMinutes: Int = 0
     }
 
-    class Project() {
-        var id: ObjectId = ObjectId()
+    class Project(): RealmObject {
+        @PrimaryKey
+        var _id: ObjectId = ObjectId()
         lateinit var name: String
         lateinit var tasks: Array<Task>
         var quota: Int? = null
     }
+    // :snippet-end:
 }

--- a/source/examples/generated/kotlin/RQLTest.snippet.rql-schema-example.kt
+++ b/source/examples/generated/kotlin/RQLTest.snippet.rql-schema-example.kt
@@ -1,0 +1,17 @@
+class Task(): RealmObject {
+    @PrimaryKey
+    var _id: ObjectId = ObjectId()
+    lateinit var name: String
+    var isComplete: Boolean = false
+    var assignee: String? = null
+    var priority: Int = 0
+    var progressMinutes: Int = 0
+}
+
+class Project(): RealmObject {
+    @PrimaryKey
+    var _id: ObjectId = ObjectId()
+    lateinit var name: String
+    lateinit var tasks: Array<Task>
+    var quota: Int? = null
+}

--- a/source/realm-query-language.txt
+++ b/source/realm-query-language.txt
@@ -188,25 +188,8 @@ See the schema for these two classes, ``Project`` and ``Task``, below:
    .. tab:: Kotlin SDK
       :tabid: kotlin
 
-      .. code-block:: kotlin
-
-         class Task(): RealmObject {
-           var id: Long = 0 // Kotlin SDK does not yet support ObjectId
-           lateinit var name: String
-           var isComplete: Boolean = false
-           var assignee: String? = null
-           var priority: Int = 0
-           var progressMinutes: Int = 0
-           @LinkingObjects("tasks")
-           val projects: RealmResults<Project>? = null
-         }
-
-         class Project(): RealmObject {
-           var id: Long = 0 // Kotlin SDK does not yet support ObjectId
-           lateinit var name: String
-           lateinit var tasks: Array<Task>
-           var quota: Int? = null
-         }
+      .. literalinclude:: /examples/generated/kotlin/RQLTest.snippet.rql-schema-example.kt
+         :language: kotlin
 
    .. tab:: Flutter SDK
       :tabid: Flutter


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-27146
- Updated Kotlin example to use `ObjectId`   

### Staged Changes

- [Realm Query Language](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-27146-kotlin-rql-update/realm-query-language/#examples-on-this-page) example (Kotlin tab)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
