### PR TITLE
(DOCSP-27332): Regenerating Kotlin Open a Realm code

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/QuickStartTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/QuickStartTest.kt
@@ -118,12 +118,16 @@ class QuickStartTest: RealmTest() {
 
 
         // :snippet-start: quick-start-open-a-local-realm
+        // :uncomment-start:
+        // val config = RealmConfiguration.create(schema = setOf(Item::class))
+        // val realm: Realm = Realm.open(config)
+        // :uncomment-end:
+        // :remove-start:
         val config = RealmConfiguration.Builder(schema = setOf(Item::class))
-            // :remove-start:
             .directory("/tmp/")
             .name(getRandom())
-            // :remove-end:
             .build()
+        // :remove-end:
         val realm: Realm = Realm.open(config)
         // :remove-start:
         // insert some sample data

--- a/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-local-realm.kt
+++ b/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-local-realm.kt
@@ -1,3 +1,3 @@
-val config = RealmConfiguration.create(schema = setOf(Item::class))
+val config = RealmConfiguration.Builder(schema = setOf(Item::class))
     .build()
 val realm: Realm = Realm.open(config)

--- a/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-local-realm.kt
+++ b/source/examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-local-realm.kt
@@ -1,3 +1,2 @@
-val config = RealmConfiguration.Builder(schema = setOf(Item::class))
-    .build()
+val config = RealmConfiguration.create(schema = setOf(Item::class))
 val realm: Realm = Realm.open(config)

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -61,6 +61,12 @@ to generate an instance of that realm:
    :language: kotlin
    :copyable: false
 
+You can open a realm using the
+`RealmConfiguration.create() <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-companion/create.html>`__
+function if no configuration parameters are passed. Only default values are used to open the realm. 
+Otherwise, you must build the configuration
+using `RealmConfiguration.builder() <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-builder/index.html>`__.  
+
 Create, Read, Update, and Delete Objects
 ----------------------------------------
 

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -61,12 +61,9 @@ to generate an instance of that realm:
    :language: kotlin
    :copyable: false
 
-You can also open a realm using the
+To open a realm using only default properties, you can use the
 `RealmConfiguration.create() <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-companion/create.html>`__
-function if no configuration parameters are passed. The realm is opened using default values. 
-
-Otherwise, you must build the configuration using the specified parameters
-with `RealmConfiguration.Builder.build() <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-builder/index.html>`__.  
+function.   
 
 Create, Read, Update, and Delete Objects
 ----------------------------------------

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -60,9 +60,9 @@ to generate an instance of that realm:
    :copyable: false
 
 For more information on how to control the specifics of the
-`RealmConfiguration <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__ 
+`RealmConfiguration <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__
 you would like to open (e.g. name, location, schema version), refer to 
-:ref:`Open & Close a Realm <kotlin-open-and-close-a-realm>`.
+:ref:`Open & Close a Realm <kotlin-open-a-realm>`.
 
 Create, Read, Update, and Delete Objects
 ----------------------------------------

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -61,11 +61,12 @@ to generate an instance of that realm:
    :language: kotlin
    :copyable: false
 
-You can open a realm using the
+You can also open a realm using the
 `RealmConfiguration.create() <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-companion/create.html>`__
-function if no configuration parameters are passed. Only default values are used to open the realm. 
-Otherwise, you must build the configuration
-using `RealmConfiguration.builder() <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-builder/index.html>`__.  
+function if no configuration parameters are passed. The realm is opened using default values. 
+
+Otherwise, you must build the configuration using the specified parameters
+with `RealmConfiguration.Builder.build() <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-builder/index.html>`__.  
 
 Create, Read, Update, and Delete Objects
 ----------------------------------------

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -49,21 +49,20 @@ that represents Todo items in a Todo list app.
 Open a Realm
 ------------
 
-Use `RealmConfiguration
-<{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__
-to control the specifics of the realm you
-would like to open, including the name, location, and schema.
-Pass your configuration to the `Realm factory constructor
-<{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__
+Use 
+`RealmConfiguration.create() <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-companion/create.html>`__ 
+to open a realm using default parameters. Pass your configuration to the 
+`Realm factory constructor <{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__
 to generate an instance of that realm:
 
 .. literalinclude:: /examples/generated/kotlin/QuickStartTest.snippet.quick-start-open-a-local-realm.kt
    :language: kotlin
    :copyable: false
 
-To open a realm using only default properties, you can use the
-`RealmConfiguration.create() <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-companion/create.html>`__
-function.   
+For more information on how to control the specifics of the
+`RealmConfiguration <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__ 
+you would like to open (e.g. name, location, schema version), refer to 
+:ref:`Open & Close a Realm <kotlin-open-and-close-a-realm>`.
 
 Create, Read, Update, and Delete Objects
 ----------------------------------------


### PR DESCRIPTION
## Pull Request Info
Regenerated the `open-a-realm` snippet and added small blurb about using `RealmConfiguration.create()` (per [Kotlin Sync Feedback Document changes](https://github.com/mongodb/docs-realm/pull/2405#discussion_r1049208862) PR)

### Jira

- https://jira.mongodb.org/browse/DOCSP-27332

### Staged Changes

- [Kotlin Quick Start: Open a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-27332-open-realm-fix/sdk/kotlin/quick-start/#open-a-realm)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
