### PR TITLE
Web TOC fixes

### DIFF
--- a/source/web.txt
+++ b/source/web.txt
@@ -18,11 +18,11 @@ Realm Web SDK
    User Management </web/users>
    Query MongoDB </web/mongodb>
    Apollo GraphQL Client (React) </web/graphql-apollo-react>
+   Next.js Integration Guide </web/nextjs>
    SDK Telemetry </web/telemetry>
    API Reference </web/api-reference>
    Upgrade from Stitch to Realm </web/migrate>
    Release Notes <https://github.com/realm/realm-js/releases>
-   Next.js Integration Guide </web/nextjs>
 
 
 The Realm Web SDK lets browser-based applications access

--- a/source/web/users.txt
+++ b/source/web/users.txt
@@ -13,6 +13,7 @@ Manage Users - Web SDK
    Work with Multiple Users </web/work-with-multiple-users>
    Access Custom User Data </web/access-custom-user-data>
    Link User Identities </web/link-identities>
+   Create & Manage User API Keys </web/create-manage-api-keys>
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
## Pull Request Info

Couple small fixes in Web SDK TOC:

- move Next.js guide up to more visible location
- Add API key management page to TOC (mistake that not currently in there)

### Jira

n/a

### Staged Changes

- [Web SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/web_mng_api_key_auth/web)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
