### PR TITLE
(DOCSP-27434): Fix Rename property code example

### DIFF
--- a/source/examples/generated/flutter/migrations_test.snippet.migrations-rename-property.dart
+++ b/source/examples/generated/flutter/migrations_test.snippet.migrations-rename-property.dart
@@ -1,0 +1,8 @@
+final configWithRenamedAge =
+    Configuration.local([Person.schema, Car.schema],
+        schemaVersion: 2,
+        migrationCallback: ((migration, oldSchemaVersion) {
+  // Between v1 and v2 we renamed the Person 'age' property to 'yearsSinceBirth'
+  migration.renameProperty('Person', 'age', 'yearsSinceBirth');
+}));
+final realmWithRenamedAge = Realm(configWithRenamedAge);

--- a/source/sdk/flutter/model-data/update-realm-object-schema.txt
+++ b/source/sdk/flutter/model-data/update-realm-object-schema.txt
@@ -171,7 +171,7 @@ Rename a Property
 Rename a schema property with :flutter-sdk:`Migration.renameProperty()
 <realm/Migration/renameProperty.html>`.
 
-.. literalinclude:: /examples/generated/flutter/migrations_test.snippet.migration-delete-type.dart
+.. literalinclude:: /examples/generated/flutter/migrations_test.snippet.migrations-rename-property.dart
    :language: dart
 
 .. _flutter-other-migration-tasks:


### PR DESCRIPTION
## Pull Request Info

Fix Rename property code example.

Adding the code bluehawk code example as part of this PR bc was removed as part of recent update to remove unused examples. no new code written here. code example works.

### Jira

- https://jira.mongodb.org/browse/DOCSP-27434

### Staged Changes

- [Update Realm Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27434/sdk/flutter/model-data/update-realm-object-schema#rename-a-property)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
