### PR TITLE
(DOCSP-26115): Flutter copy data to a new realm

### DIFF
--- a/examples/dart/pubspec.lock
+++ b/examples/dart/pubspec.lock
@@ -434,21 +434,21 @@ packages:
       name: realm_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0+rc"
+    version: "0.10.0+rc"
   realm_dart:
     dependency: "direct main"
     description:
       name: realm_dart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0+rc"
+    version: "0.10.0+rc"
   realm_generator:
     dependency: transitive
     description:
       name: realm_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0+rc"
+    version: "0.10.0+rc"
   rxdart:
     dependency: transitive
     description:

--- a/examples/dart/pubspec.yaml
+++ b/examples/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  realm_dart: 0.9.0+rc
+  realm_dart: 0.10.0+rc
   path: ^1.8.2
   dart_jsonwebtoken: ^2.4.2
   faker: ^2.0.0

--- a/examples/dart/test/write_copy_test.dart
+++ b/examples/dart/test/write_copy_test.dart
@@ -1,0 +1,49 @@
+import 'package:test/test.dart';
+import 'package:realm_dart/realm.dart';
+import 'utils.dart';
+
+part 'write_copy_test.g.dart';
+
+@RealmModel()
+class _Person {
+  @PrimaryKey()
+  late String name;
+}
+
+main() {
+  // TODO: figure out how to handle the fact that path needs to be different
+  // even tho in memory. weird to explain. might just want to use sync to local
+  // or smthn.
+  test("Convert in-memory realm to local realm", () {
+    // :snippet-start: in-memory-to-local
+    final inMemoryRealm = Realm(Configuration.inMemory([Person.schema]));
+    inMemoryRealm.write(() {
+      inMemoryRealm.addAll([Person("Tanya"), Person("Greg"), Person("Portia")]);
+    });
+
+    // Copy contents of `inMemoryRealm` to a new realm with `localConfig`.
+    // `localConfig` uses the default file path for local realms.
+    final localConfig =
+        Configuration.local([Person.schema], path: 'local.realm');
+    inMemoryRealm.writeCopy(localConfig);
+    // Close the realm you copy when you're done working with it.
+    inMemoryRealm.close();
+
+    // Open the local realm that the data from `inMemoryRealm`
+    // was just copied to with `localConfig`.
+    final localRealm = Realm(localConfig);
+
+    // Person object for "Tanya" is in `localRealm` because
+    // the data was copied over with `inMemoryRealm.writeCopy()`.
+    final tanya = localRealm.find<Person>("Tanya");
+    // :snippet-end:
+    expect(tanya, isNotNull);
+    expect(tanya, isA<Person>());
+    expect(localRealm.all<Person>().length, 3);
+    cleanUpRealm(localRealm);
+  });
+  test("Convert unencrypted local realm to encrypted local realm", () {
+    // :snippet-start: unencrypted-to-encrypted
+    // :snippet-end:
+  }, skip: 'for now...');
+}

--- a/examples/dart/test/write_copy_test.dart
+++ b/examples/dart/test/write_copy_test.dart
@@ -67,7 +67,7 @@ main() {
     final encryptedRealm = Realm(encryptedConfig);
 
     // Person object for "Harper" is in `localRealm` because
-    // the data was copied over with `inMemoryRealm.writeCopy()`.
+    // the data was copied over with `unencryptedRealm.writeCopy()`.
     final harper = encryptedRealm.find<Person>('Harper');
     // :snippet-end:
     expect(harper, isA<Person>());

--- a/examples/dart/test/write_copy_test.g.dart
+++ b/examples/dart/test/write_copy_test.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'write_copy_test.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class Person extends _Person with RealmEntity, RealmObjectBase, RealmObject {
+  Person(
+    String name,
+  ) {
+    RealmObjectBase.set(this, 'name', name);
+  }
+
+  Person._();
+
+  @override
+  String get name => RealmObjectBase.get<String>(this, 'name') as String;
+  @override
+  set name(String value) => RealmObjectBase.set(this, 'name', value);
+
+  @override
+  Stream<RealmObjectChanges<Person>> get changes =>
+      RealmObjectBase.getChanges<Person>(this);
+
+  @override
+  Person freeze() => RealmObjectBase.freezeObject<Person>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Person._);
+    return const SchemaObject(ObjectType.realmObject, Person, 'Person', [
+      SchemaProperty('name', RealmPropertyType.string, primaryKey: true),
+    ]);
+  }
+}

--- a/source/examples/generated/flutter/write_copy_test.snippet.in-memory-to-local.dart
+++ b/source/examples/generated/flutter/write_copy_test.snippet.in-memory-to-local.dart
@@ -1,0 +1,24 @@
+// Create in-memory realm and add data to it.
+// Note that even though the realm is in-memory, it still has a file path.
+// This is because in-memory realms still use memory-mapped files
+// for their operations; they just don't persist data across launches.
+final inMemoryRealm =
+    Realm(Configuration.inMemory([Person.schema], path: 'inMemory.realm'));
+inMemoryRealm.write(() {
+  inMemoryRealm.addAll([Person("Tanya"), Person("Greg"), Person("Portia")]);
+});
+
+// Copy contents of `inMemoryRealm` to a new realm with `localConfig`.
+// `localConfig` uses the default file path for local realms.
+final localConfig = Configuration.local([Person.schema]);
+inMemoryRealm.writeCopy(localConfig);
+// Close the realm you just copied when you're done working with it.
+inMemoryRealm.close();
+
+// Open the local realm that the data from `inMemoryRealm`
+// was just copied to with `localConfig`.
+final localRealm = Realm(localConfig);
+
+// Person object for "Tanya" is in `localRealm` because
+// the data was copied over with `inMemoryRealm.writeCopy()`.
+final tanya = localRealm.find<Person>("Tanya");

--- a/source/examples/generated/flutter/write_copy_test.snippet.unencrypted-to-encrypted.dart
+++ b/source/examples/generated/flutter/write_copy_test.snippet.unencrypted-to-encrypted.dart
@@ -1,0 +1,25 @@
+// Create unencrypted realm and add data to it.
+final unencryptedRealm = Realm(Configuration.local([Person.schema]));
+unencryptedRealm.write(() => unencryptedRealm.addAll([
+      Person("Daphne"),
+      Person("Harper"),
+      Person("Ethan"),
+      Person("Cameron")
+    ]));
+
+// Create encryption key and encrypted realm.
+final key = List<int>.generate(64, (i) => Random().nextInt(256));
+final encryptedConfig = Configuration.local([Person.schema],
+    path: 'encrypted.realm', encryptionKey: key);
+// Copy the data from `unencryptedRealm` to a new realm with
+// the `encryptedConfig`. The data is encrypted as part of the copying.
+unencryptedRealm.writeCopy(encryptedConfig);
+// Close the realm you just copied when you're done working with it.
+unencryptedRealm.close();
+
+// Open the new encrypted realm with `encryptedConfig`.
+final encryptedRealm = Realm(encryptedConfig);
+
+// Person object for "Harper" is in `localRealm` because
+// the data was copied over with `inMemoryRealm.writeCopy()`.
+final harper = encryptedRealm.find<Person>('Harper');

--- a/source/examples/generated/flutter/write_copy_test.snippet.unencrypted-to-encrypted.dart
+++ b/source/examples/generated/flutter/write_copy_test.snippet.unencrypted-to-encrypted.dart
@@ -21,5 +21,5 @@ unencryptedRealm.close();
 final encryptedRealm = Realm(encryptedConfig);
 
 // Person object for "Harper" is in `localRealm` because
-// the data was copied over with `inMemoryRealm.writeCopy()`.
+// the data was copied over with `unencryptedRealm.writeCopy()`.
 final harper = encryptedRealm.find<Person>('Harper');

--- a/source/sdk/flutter/realm-database/configure-and-open.txt
+++ b/source/sdk/flutter/realm-database/configure-and-open.txt
@@ -199,7 +199,6 @@ To copy data from an existing realm to a new realm with different
 configuration options, pass the new configuration to
 :flutter-sdk:`Realm.writeCopy() <TODO: add link>`.
 
-TODO: validate if this is true (lifted from JS
 In the new realm's configuration, you *must* specify the ``path``.
 
 If you write the copied realm to a realm file that already exists,
@@ -221,6 +220,16 @@ types:
 
 You **cannot** convert from a ``LocalConfiguration`` or a ``InMemoryConfiguration``
 to a ``FlexibleSyncConfiguration``.
+
+Some additional considerations to keep in mind while using ``Realm.writeTo()``:
+
+#. The destination file should not already exist.
+#. Copying realm is not allowed within a write transaction or during migration.
+#. When using synced Realm, it is required that all local changes are synchronized
+   with the server before the copy can be written.
+   This is to be sure that the file can be used as a starting point
+   for a newly installed application.
+   The method throws if there are pending uploads.
 
 The following example copies the data from a realm with a ``LocalConfiguration``
 to a new realm with a ``FlexibleSyncConfiguration``.

--- a/source/sdk/flutter/realm-database/configure-and-open.txt
+++ b/source/sdk/flutter/realm-database/configure-and-open.txt
@@ -220,10 +220,10 @@ to a ``FlexibleSyncConfiguration``.
 Some additional considerations to keep in mind while using ``Realm.writeCopy()``:
 
 #. The destination file  cannot already exist.
-#. Copying realm is not allowed within a write transaction or during migration.
+#. Copying a realm is not allowed within a write transaction or during migration.
 #. When using  Device Sync, you must sync all local changes with the server
    before the copy is written. This ensures that the file can be used
-   as a starting point for a newly installed application.
+   as a starting point for a newly-installed application.
    The ``Realm.writeCopy()`` throws if there are pending uploads.
 
 The following example copies the data from a realm with a ``InMemoryConfiguration``

--- a/source/sdk/flutter/realm-database/configure-and-open.txt
+++ b/source/sdk/flutter/realm-database/configure-and-open.txt
@@ -230,7 +230,8 @@ Some additional considerations to keep in mind while using ``Realm.writeCopy()``
 The following example copies the data from a realm with a ``InMemoryConfiguration``
 to a new realm with a ``LocalConfiguration``.
 
-TODO: code example
+.. literalinclude:: /examples/generated/flutter/write_copy_test.snippet.in-memory-to-local.dart
+   :language: dart
 
 You can also :ref:`include a new encryption key <flutter-encrypt>`
 in the copied realm's configuration or remove the encryption key from the new configuration.
@@ -238,4 +239,5 @@ in the copied realm's configuration or remove the encryption key from the new co
 The following example copies data from an **unencrypted** realm with a ``LocalConfiguration``
 to an **encrypted** realm with a ``LocalConfiguration``.
 
-TODO: code example
+.. literalinclude:: /examples/generated/flutter/write_copy_test.snippet.unencrypted-to-encrypted.dart
+   :language: dart

--- a/source/sdk/flutter/realm-database/configure-and-open.txt
+++ b/source/sdk/flutter/realm-database/configure-and-open.txt
@@ -219,13 +219,12 @@ to a ``FlexibleSyncConfiguration``.
 
 Some additional considerations to keep in mind while using ``Realm.writeCopy()``:
 
-#. The destination file should not already exist.
+#. The destination file  cannot already exist.
 #. Copying realm is not allowed within a write transaction or during migration.
-#. When using synced Realm, it is required that all local changes are synchronized
-   with the server before the copy can be written.
-   This is to be sure that the file can be used as a starting point
-   for a newly installed application.
-   The method throws if there are pending uploads.
+#. When using  Device Sync, you must sync all local changes with the server
+   before the copy is written. This ensures that the file can be used
+   as a starting point for a newly installed application.
+   The ``Realm.writeCopy()`` throws if there are pending uploads.
 
 The following example copies the data from a realm with a ``InMemoryConfiguration``
 to a new realm with a ``LocalConfiguration``.

--- a/source/sdk/flutter/realm-database/configure-and-open.txt
+++ b/source/sdk/flutter/realm-database/configure-and-open.txt
@@ -189,3 +189,48 @@ Close a Realm
       .. code-block:: dart
 
          Realm.shutdown();
+
+.. _flutter-copy-data-into-new-realm:
+
+Copy Data into a New Realm
+--------------------------
+
+To copy data from an existing realm to a new realm with different
+configuration options, pass the new configuration to
+:flutter-sdk:`Realm.writeCopy() <TODO: add link>`.
+
+TODO: validate if this is true (lifted from JS
+In the new realm's configuration, you *must* specify the ``path``.
+
+If you write the copied realm to a realm file that already exists,
+the data is written object by object. The copy operation replaces objects
+if there already exists objects for given primary keys.
+The schemas of the realm you copy and the realm you are writing to must be
+compatible for the copy operation to succeed.
+Only objects in the schemas of both configurations are copied over.
+
+Using ``Realm.writeCopy()``, you can convert between the following
+:flutter-sdk:`Configuration <realm/Configuration-class.html>`
+types:
+
+- ``LocalConfiguration`` to ``LocalConfiguration``
+- ``FlexibleSyncConfiguration`` to ``FlexibleSyncConfiguration``
+- ``FlexibleSyncConfiguration`` to ``LocalConfiguration``
+- ``LocalConfiguration`` to read-only ``LocalConfiguration``
+- ``InMemoryConfiguration`` to ``LocalConfiguration``
+
+You **cannot** convert from a ``LocalConfiguration`` or a ``InMemoryConfiguration``
+to a ``FlexibleSyncConfiguration``.
+
+The following example copies the data from a realm with a ``LocalConfiguration``
+to a new realm with a ``FlexibleSyncConfiguration``.
+
+TODO: code example
+
+You can also :ref:`include a new encryption key <flutter-encrypt>`
+in the copied realm's configuration or remove the encryption key from the new configuration.
+
+The following example copies data from an unencrypted realm with a ``LocalConfiguration``
+to an encrypted realm with a ``FlexibleSyncConfiguration``.
+
+TODO: code example

--- a/source/sdk/flutter/realm-database/configure-and-open.txt
+++ b/source/sdk/flutter/realm-database/configure-and-open.txt
@@ -46,7 +46,7 @@ refer to :ref:`Open a Synced Realm <flutter-open-synced-realm>`.
 Open an In-Memory Realm
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-To create a realm that runs entirely in memory without being persisted to a file,
+To create a realm that runs in memory without being persisted,
 create your ``Configuration`` with :flutter-sdk:`Configuration.inMemory() <realm/Configuration/inMemory.html>`.
 You must provide a list of schemas as an argument.
 In-memory realms **cannot** also be read-only.

--- a/source/sdk/flutter/realm-database/configure-and-open.txt
+++ b/source/sdk/flutter/realm-database/configure-and-open.txt
@@ -197,16 +197,10 @@ Copy Data into a New Realm
 
 To copy data from an existing realm to a new realm with different
 configuration options, pass the new configuration to
-:flutter-sdk:`Realm.writeCopy() <TODO: add link>`.
+:flutter-sdk:`Realm.writeCopy() <realm/Realm/writeCopy.html>`.
 
 In the new realm's configuration, you *must* specify the ``path``.
-
-If you write the copied realm to a realm file that already exists,
-the data is written object by object. The copy operation replaces objects
-if there already exists objects for given primary keys.
-The schemas of the realm you copy and the realm you are writing to must be
-compatible for the copy operation to succeed.
-Only objects in the schemas of both configurations are copied over.
+You **cannot** write to a path that already contains a file.
 
 Using ``Realm.writeCopy()``, you can convert between the following
 :flutter-sdk:`Configuration <realm/Configuration-class.html>`
@@ -214,14 +208,16 @@ types:
 
 - ``LocalConfiguration`` to ``LocalConfiguration``
 - ``FlexibleSyncConfiguration`` to ``FlexibleSyncConfiguration``
+- ``InMemoryConfiguration`` to ``InMemoryConfiguration``
+- ``LocalConfiguration`` to read-only ``LocalConfiguration`` and vice versa
+- ``InMemoryConfiguration`` to ``LocalConfiguration`` and vice versa
 - ``FlexibleSyncConfiguration`` to ``LocalConfiguration``
-- ``LocalConfiguration`` to read-only ``LocalConfiguration``
-- ``InMemoryConfiguration`` to ``LocalConfiguration``
+- ``FlexibleSyncConfiguration`` to ``InMemoryConfiguration``
 
 You **cannot** convert from a ``LocalConfiguration`` or a ``InMemoryConfiguration``
 to a ``FlexibleSyncConfiguration``.
 
-Some additional considerations to keep in mind while using ``Realm.writeTo()``:
+Some additional considerations to keep in mind while using ``Realm.writeCopy()``:
 
 #. The destination file should not already exist.
 #. Copying realm is not allowed within a write transaction or during migration.
@@ -231,15 +227,15 @@ Some additional considerations to keep in mind while using ``Realm.writeTo()``:
    for a newly installed application.
    The method throws if there are pending uploads.
 
-The following example copies the data from a realm with a ``LocalConfiguration``
-to a new realm with a ``FlexibleSyncConfiguration``.
+The following example copies the data from a realm with a ``InMemoryConfiguration``
+to a new realm with a ``LocalConfiguration``.
 
 TODO: code example
 
 You can also :ref:`include a new encryption key <flutter-encrypt>`
 in the copied realm's configuration or remove the encryption key from the new configuration.
 
-The following example copies data from an unencrypted realm with a ``LocalConfiguration``
-to an encrypted realm with a ``FlexibleSyncConfiguration``.
+The following example copies data from an **unencrypted** realm with a ``LocalConfiguration``
+to an **encrypted** realm with a ``LocalConfiguration``.
 
 TODO: code example


### PR DESCRIPTION
## Pull Request Info

Flutter copy data to a new realm

### Jira

- https://jira.mongodb.org/browse/DOCSP-26115

### Staged Changes

- [Configure and Open a Realm (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26115/sdk/flutter/realm-database/configure-and-open/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
