### PR TITLE
(DOCSP-27372) Add Node.js user metadata page

### DIFF
--- a/examples/node/Examples/authenticate.js
+++ b/examples/node/Examples/authenticate.js
@@ -283,8 +283,14 @@ describe("user authentication", () => {
   });
 
   test("read user metadata", async () => {
-    const email = "someone@example.com";
-    const password = "pa55w0rd!";
+    const randomInt = Math.floor(Math.random() * Math.floor(200000));
+    const email = "someone" + randomInt.toString() + "@example.com";
+    const password = "passw0rd";
+
+    await app.emailPasswordAuth.registerUser({
+      email: email,
+      password: password,
+    });
 
     // :snippet-start: user-metadata
     try {
@@ -303,7 +309,9 @@ describe("user authentication", () => {
     const userEmail = app.currentUser.profile.email;
     // :snippet-end:
 
-    expect(userProfile.email).toBe("someone@example.com");
+    expect(userEmail).toBe(email);
+
+    await app.deleteUser(app.currentUser);
   });
 });
 

--- a/examples/node/Examples/authenticate.js
+++ b/examples/node/Examples/authenticate.js
@@ -199,3 +199,23 @@ describe("User Sessions", () => {
     expect(token).not.toBe(undefined);
   });
 })
+
+describe("User Metadata", () => {
+  test("read user metadata", async () => {
+    const email = "stanley.session@example.com";
+    const password = "pa55w0rd!";
+    try {
+      await app.logIn(Realm.Credentials.emailPassword(email, password));
+    } catch (err) {
+      await app.emailPasswordAuth.registerUser({ email, password });
+      await app.logIn(Realm.Credentials.emailPassword(email, password));
+    }
+    
+    const userProfile = app.currentUser.profile;
+
+    console.debug(userProfile)
+    console.debug(userProfile.email)
+
+    expect(userProfile.email).toBe("stanley.session@example.com");
+  });
+})

--- a/examples/node/Examples/authenticate.js
+++ b/examples/node/Examples/authenticate.js
@@ -264,6 +264,7 @@ describe("user authentication", () => {
       console.error(err.message);
     }
   });
+
   test("Delete user", async () => {
     const credentials = Realm.Credentials.anonymous();
     await app.logIn(credentials);
@@ -280,11 +281,35 @@ describe("user authentication", () => {
     ).length;
     expect(postDeleteMatchesLen).toBe(0);
   });
+
+  test("read user metadata", async () => {
+    const email = "someone@example.com";
+    const password = "pa55w0rd!";
+
+    // :snippet-start: user-metadata
+    try {
+    // :replace-start: {
+    //    "terms": {
+    //       "email": "<email>",
+    //       "password": "<password>"
+    //    }
+    // }
+      await app.logIn(Realm.Credentials.emailPassword(email, password));
+    // :replace-end:
+    } catch (err) {
+      console.error("Failed to log in", err.message);
+    }
+    
+    const userEmail = app.currentUser.profile.email;
+    // :snippet-end:
+
+    expect(userProfile.email).toBe("someone@example.com");
+  });
 });
 
 describe("User Sessions", () => {
   test("Get a User Access Token", async () => {
-    const email = "stanley.session@example.com";
+    const email = "someone@example.com";
     const password = "pa55w0rd!";
     try {
       await app.logIn(Realm.Credentials.emailPassword(email, password));
@@ -303,25 +328,5 @@ describe("User Sessions", () => {
     // :snippet-end:
     const token = await getValidAccessToken(app.currentUser);
     expect(token).not.toBe(undefined);
-  });
-})
-
-describe("User Metadata", () => {
-  test("read user metadata", async () => {
-    const email = "stanley.session@example.com";
-    const password = "pa55w0rd!";
-    try {
-      await app.logIn(Realm.Credentials.emailPassword(email, password));
-    } catch (err) {
-      await app.emailPasswordAuth.registerUser({ email, password });
-      await app.logIn(Realm.Credentials.emailPassword(email, password));
-    }
-    
-    const userProfile = app.currentUser.profile;
-
-    console.debug(userProfile)
-    console.debug(userProfile.email)
-
-    expect(userProfile.email).toBe("stanley.session@example.com");
   });
 })

--- a/source/examples/generated/node/authenticate.snippet.user-metadata.js
+++ b/source/examples/generated/node/authenticate.snippet.user-metadata.js
@@ -1,0 +1,7 @@
+try {
+  await app.logIn(Realm.Credentials.<email>Password(<email>, <password>));
+} catch (err) {
+  console.error("Failed to log in", err.message);
+}
+
+const userEmail = app.currentUser.profile.email;

--- a/source/includes/configure-user-metadata.rst
+++ b/source/includes/configure-user-metadata.rst
@@ -1,0 +1,13 @@
+You can only read user metadata from the client app that you have configured
+on the App Services application.
+
+You can configure the :ref:`user metadata <user-metadata>` you request from 
+an authentication provider. You do this directly on the authentication 
+provider's configuration. For more details on which metadata fields you 
+can use, see the provider details:
+
+- OAuth 2.0 (:ref:`Facebook <facebook-authentication>` & :ref:`Google <google-authentication>`)
+- :ref:`Custom JWT <custom-jwt-authentication>`
+
+You can change which metadata fields you have configured by :ref:`editing the 
+provider's configuration <configure-user-metadata-on-the-backend>`.

--- a/source/includes/stale-user-metadata.rst
+++ b/source/includes/stale-user-metadata.rst
@@ -1,0 +1,8 @@
+.. warning:: User Metadata May Be Stale
+   
+   Atlas App Services fetches the most recent version of user metadata when a user
+   logs in. If the user changes their email address or profile photo with a 
+   login provider, for example, those changes do not update in user metadata 
+   until the user logs in again. Because we cache credentials and enable you 
+   to bypass the login flow, user metadata may become stale unless you 
+   force the user to log in again.

--- a/source/includes/update-user-metadata.rst
+++ b/source/includes/update-user-metadata.rst
@@ -1,0 +1,6 @@
+User metadata that you access through the authentication provider is read-only
+data. You cannot update or edit user metadata that comes from this source.
+
+If you would like to give a user the option the update their metadata from 
+within your client app, use :ref:`custom user data <custom-user-data>`, 
+instead.

--- a/source/sdk/dotnet/manage-users/user-metadata.txt
+++ b/source/sdk/dotnet/manage-users/user-metadata.txt
@@ -30,21 +30,18 @@ the metatdata:
 User metadata options vary depending on which provider you're using and
 :ref:`which metadata fields you enable <configure-user-metadata-on-the-backend>`. 
 
-.. warning:: User Metadata May Be Stale
-   
-   Atlas App Services fetches the most recent version of user metadata when a user
-   logs in. If the user changes their email address or profile photo with a 
-   login provider, for example, those changes do not update in user metadata 
-   until the user logs in again. Because we cache credentials and enable you 
-   to bypass the login flow, user metadata may become stale unless you 
-   force the user to log in again.
-
+.. include:: /includes/stale-user-metadata.rst
 
 .. _dotnet-configure-user-metadata:
+
+Configure User Metadata
+-----------------------
+
+.. include:: /includes/configure-user-metadata.rst
+
+.. _dotnet-update-user-metadata:
 
 Update User Metadata
 --------------------
 
-User metadata is read-only data. You cannot update or edit it. If you want 
-to create editable user data, use :ref:`custom user data <custom-user-data>`  
-instead.
+.. include:: /includes/update-user-metadata.rst

--- a/source/sdk/flutter/users/user-metadata.txt
+++ b/source/sdk/flutter/users/user-metadata.txt
@@ -30,21 +30,18 @@ the metatdata:
 User metadata options vary depending on which provider you're using and
 :ref:`which metadata fields you enable <configure-user-metadata-on-the-backend>`.
 
-.. warning:: User Metadata May Be Stale
-   
-   Atlas App Services fetches the most recent version of user metadata when a user
-   logs in. If the user changes their email address or profile photo with a
-   login provider, for example, those changes do not update in user metadata
-   until the user logs in again. Because Realm caches credentials and enables you
-   to bypass the login flow, user metadata may become stale unless you
-   force the user to log in again.
-
+.. include:: /includes/stale-user-metadata.rst
 
 .. _flutter-configure-user-metadata:
+
+Configure User Metadata
+-----------------------
+
+.. include:: /includes/configure-user-metadata.rst
+
+.. _flutter-update-user-metadata:
 
 Update User Metadata
 --------------------
 
-User metadata is read-only data. You cannot update or edit it. If you want
-to create editable user data, use :ref:`custom user data <flutter-custom-user-data>`
-instead.
+.. include:: /includes/update-user-metadata.rst

--- a/source/sdk/node/examples.txt
+++ b/source/sdk/node/examples.txt
@@ -14,6 +14,7 @@ Usage Examples - Node.js SDK
    Modify an Object Schema </sdk/node/examples/modify-an-object-schema>
    Connect to an Atlas App Services backend </sdk/node/examples/connect-to-app-services-backend>
    Create & Delete Users </sdk/node/examples/create-delete-users>
+   Access User Metadata </sdk/node/examples/user-metadata>
    Authenticate Users </sdk/node/examples/authenticate-users>
    Sync Changes Between Devices </sdk/node/examples/sync-changes-between-devices>
    Flexible Sync </sdk/node/examples/flexible-sync>

--- a/source/sdk/node/examples/user-metadata.txt
+++ b/source/sdk/node/examples/user-metadata.txt
@@ -22,10 +22,8 @@ edit user metadata through a ``User`` object.
 To read the data, access the ``profile`` property on the ``User`` object 
 of a logged-in user:
 
-.. TODO: update for node
-
-.. .. literalinclude:: /examples/generated/code/start/Authenticate.snippet.read-user-metadata.swift
-..    :language: swift
+.. literalinclude:: /examples/generated/node/authenticate.snippet.user-metadata.js
+   :language: js
 
 User metadata options vary depending on which provider you're using and
 :ref:`which metadata fields you enable <configure-user-metadata-on-the-backend>`. 

--- a/source/sdk/node/examples/user-metadata.txt
+++ b/source/sdk/node/examples/user-metadata.txt
@@ -1,4 +1,4 @@
-.. _ios-user-metadata:
+.. _node-user-metadata:
 
 =========================
 User Metadata - Swift SDK
@@ -10,7 +10,7 @@ User Metadata - Swift SDK
    :depth: 2
    :class: singlecol
 
-.. _ios-read-user-metadata:
+.. _node-read-user-metadata:
 
 Read a User's Metadata
 ----------------------
@@ -22,6 +22,8 @@ edit user metadata through a ``User`` object.
 To read the data, access the ``profile`` property on the ``User`` object 
 of a logged-in user:
 
+.. TODO: update for node
+
 .. literalinclude:: /examples/generated/code/start/Authenticate.snippet.read-user-metadata.swift
    :language: swift
 
@@ -30,14 +32,14 @@ User metadata options vary depending on which provider you're using and
 
 .. include:: /includes/stale-user-metadata.rst
 
-.. _ios-configure-user-metadata:
+.. _node-configure-user-metadata:
 
 Configure User Metadata
 -----------------------
 
 .. include:: /includes/configure-user-metadata.rst
 
-.. _ios-update-user-metadata:
+.. _node-update-user-metadata:
 
 Update User Metadata
 --------------------

--- a/source/sdk/node/examples/user-metadata.txt
+++ b/source/sdk/node/examples/user-metadata.txt
@@ -1,8 +1,8 @@
 .. _node-user-metadata:
 
-=========================
-User Metadata - Swift SDK
-=========================
+===========================
+User Metadata - Node.js SDK
+===========================
 
 .. contents:: On this page
    :local:
@@ -24,8 +24,8 @@ of a logged-in user:
 
 .. TODO: update for node
 
-.. literalinclude:: /examples/generated/code/start/Authenticate.snippet.read-user-metadata.swift
-   :language: swift
+.. .. literalinclude:: /examples/generated/code/start/Authenticate.snippet.read-user-metadata.swift
+..    :language: swift
 
 User metadata options vary depending on which provider you're using and
 :ref:`which metadata fields you enable <configure-user-metadata-on-the-backend>`. 


### PR DESCRIPTION
## Pull Request Info

In addition to adding a new user metadata page for the Node.js SDK, I abstracted the generic info that applies across SDKs into some new includes files. These chunks don't have any SDK-specific content so it'll be easier to maintain them in one spot.

### Jira

- https://jira.mongodb.org/browse/DOCSP-27372

### Staged Changes

- [User Metadata](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27372/sdk/node/examples/user-metadata/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
