### PR TITLE
(DOCSP-27220): Add information about using a synced realm in an App Extension

### DIFF
--- a/source/sdk/swift/app-services/call-a-function.txt
+++ b/source/sdk/swift/app-services/call-a-function.txt
@@ -17,8 +17,9 @@ Call a Function by Name
 
 .. include:: /includes/important-sanitize-client-data-in-functions.rst
 
-Consider a :ref:`Realm function <functions>` named ``concatenate`` that 
-takes two arguments, concatenates them, and returns the result:
+Consider an :ref:`Atlas App Services Function <functions>` named 
+``concatenate`` that takes two arguments, concatenates them, and returns 
+the result:
 
 .. code-block:: javascript
 
@@ -27,7 +28,7 @@ takes two arguments, concatenates them, and returns the result:
      return a + b;
    };
 
-To execute a function from the iOS Client SDK, use the ``functions``
+To execute a function from the Swift SDK, use the ``functions``
 object on the currently logged-in user.
 
 The ``functions`` object has dynamic members corresponding to functions.

--- a/source/sdk/swift/sync/write-to-synced-realm.txt
+++ b/source/sdk/swift/sync/write-to-synced-realm.txt
@@ -304,8 +304,8 @@ If you need to read from or write to a synced realm from an App Extension,
 there are a few recommended alternatives:
 
 - **Offline-first**: pass data on disk to or from the main app
-- **Always up-to-date**: use HTTP to communicate directly with the backing 
-  Atlas collection
+- **Always up-to-date**: communicate directly with the backing 
+  Atlas collection across a network connection
 
 Pass Data On Disk
 `````````````````
@@ -322,14 +322,18 @@ Use HTTP to Communicate with the Backing Atlas Collection
 `````````````````````````````````````````````````````````
 
 If having the information always up-to-date across all devices is the most 
-important consideration for your app, you can write data directly to the 
-backing Atlas collection across the network. For example, you could use 
-:ref:`App Services Functions <ios-call-a-function>` or HTTP calls via the 
-:ref:`Data API <data-api>` or :ref:`GraphQL API <graphql-api>` to 
-read or write data to or from the Atlas collections that back your Device 
-Sync app. Then, any device that has a network connection is always getting 
-the most up-to-date information, without waiting for the user to open your 
-main app as in the option above.
+important consideration for your app, you can read or write data directly 
+to or from the backing Atlas collection across the network. Depending on your 
+needs, you may want to use one of these tools to communicate directly with 
+Atlas:
+
+- Query Atlas with the :ref:`Realm Swift SDK MongoClient <ios-mongodb-data-access>`
+- Pass data to an :ref:`App Services Function <ios-call-a-function>` 
+- Make HTTPS calls with the :ref:`Data API <data-api>` or :ref:`GraphQL API <graphql-api>`
+
+Then, any device that has a network connection is always getting the most 
+up-to-date information, without waiting for the user to open your main app 
+as in the option above.
 
 This option does require your user's device to have a network connection 
 when using the App Extension. As a fallback, you could check for a network

--- a/source/sdk/swift/sync/write-to-synced-realm.txt
+++ b/source/sdk/swift/sync/write-to-synced-realm.txt
@@ -303,8 +303,8 @@ Alternatives to Writing to a Synced Realm in an App Extension
 If you need to read from or write to a synced realm from an App Extension, 
 there are a few recommended alternatives:
 
-- Offline-first: pass data on disk to or from the main app
-- Always up-to-date: use HTTP to communicate directly with the backing 
+- **Offline-first**: pass data on disk to or from the main app
+- **Always up-to-date**: use HTTP to communicate directly with the backing 
   Atlas collection
 
 Pass Data On Disk
@@ -324,10 +324,12 @@ Use HTTP to Communicate with the Backing Atlas Collection
 If having the information always up-to-date across all devices is the most 
 important consideration for your app, you can write data directly to the 
 backing Atlas collection across the network. For example, you could use 
-App Services Functions or HTTP calls to read or write data to or from the 
-Atlas collections that back your Device Sync app. Then, any device that has 
-a network connection is always getting the most up-to-date information, 
-without waiting for the user to open your main app as in the option above.
+:ref:`App Services Functions <ios-call-a-function>` or HTTP calls via the 
+:ref:`Data API <data-api>` or :ref:`GraphQL API <graphql-api>` to 
+read or write data to or from the Atlas collections that back your Device 
+Sync app. Then, any device that has a network connection is always getting 
+the most up-to-date information, without waiting for the user to open your 
+main app as in the option above.
 
 This option does require your user's device to have a network connection 
 when using the App Extension. As a fallback, you could check for a network

--- a/source/sdk/swift/sync/write-to-synced-realm.txt
+++ b/source/sdk/swift/sync/write-to-synced-realm.txt
@@ -318,8 +318,8 @@ only write to the synced realm from there. Then, regardless of the device's
 network connectivity, information can be shared any time to or from the App 
 Extension.
 
-Use HTTP to Communicate with the Backing Atlas Collection
-`````````````````````````````````````````````````````````
+Communicate Directly with the Backing Atlas Collection
+``````````````````````````````````````````````````````
 
 If having the information always up-to-date across all devices is the most 
 important consideration for your app, you can read or write data directly 

--- a/source/sdk/swift/sync/write-to-synced-realm.txt
+++ b/source/sdk/swift/sync/write-to-synced-realm.txt
@@ -33,6 +33,12 @@ of the following:
       refer to :ref:`sync-rules` and the :ref:`flexible-sync-permissions-guide`
       in the App Services documentation.
 
+.. warning:: Multiprocess Sync is Not Supported
+
+   Device Sync does not currently support opening or writing to a synced 
+   realm from more than one process. For more information, including 
+   suggested alternatives, refer to: :ref:`multiprocess-sync-not-supported`.
+
 Determining What Data Syncs
 ---------------------------
 
@@ -269,3 +275,61 @@ that the the object does not match the user's role:
        in table \"FlexibleSync_Item\" was denied by write filter in role 
        \"owner-read-write\""
    }
+
+.. _multiprocess-sync-not-supported:
+
+Don't Write to a Synced Realm in an App Extension
+-------------------------------------------------
+
+If you are developing an app that uses App Extensions, such as a Share 
+Extension, avoid writing to a synced realm in that extension. Device Sync
+supports opening a synced realm in at most one process. In practice, this
+means that if your app uses a synced realm in an App Extension, it may 
+crash intermittently.
+
+Crashes Related to Opening a Synced Realm in Multiple Processes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you attempt to open a synced realm in a Share Extension or other App 
+Extension, and that realm is not open in the main app, a write from a Share
+Extension may succeed. However, if the synced realm is already open in the 
+main app, or is syncing data in the background, you may see a crash related 
+to ``Realm::MultiSyncAgents``. In this scenario, you may need to restart 
+the device.
+
+Alternatives to Writing to a Synced Realm in an App Extension
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need to read from or write to a synced realm from an App Extension, 
+there are a few recommended alternatives:
+
+- Offline-first: pass data on disk to or from the main app
+- Always up-to-date: use HTTP to communicate directly with the backing 
+  Atlas collection
+
+Pass Data On Disk
+`````````````````
+
+If offline-first functionality is the most important consideration for your app,
+you can pass data on disk to or from your main app. You could copy objects
+to a non-synced realm and read and share it between apps in an App Group.
+Or you could use an on-disk queue to send the data to or from the main app and 
+only write to the synced realm from there. Then, regardless of the device's 
+network connectivity, information can be shared any time to or from the App 
+Extension.
+
+Use HTTP to Communicate with the Backing Atlas Collection
+`````````````````````````````````````````````````````````
+
+If having the information always up-to-date across all devices is the most 
+important consideration for your app, you can write data directly to the 
+backing Atlas collection across the network. For example, you could use 
+App Services Functions or HTTP calls to read or write data to or from the 
+Atlas collections that back your Device Sync app. Then, any device that has 
+a network connection is always getting the most up-to-date information, 
+without waiting for the user to open your main app as in the option above.
+
+This option does require your user's device to have a network connection 
+when using the App Extension. As a fallback, you could check for a network
+connection. Then, use the on-disk option above in the event that the user's 
+device lacks network connectivity.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-27220

### Staged Changes

- [Write Data to a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27220/sdk/swift/sync/write-to-synced-realm/#don-t-write-to-a-synced-realm-in-an-app-extension): New section "Don't Write to a Synced Realm in an App Extension"

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
