### PR TITLE
(DOCSP-15827): Fix version number in KMM Install code sample

### DIFF
--- a/source/sdk/kotlin/install/kotlin-multiplatform.txt
+++ b/source/sdk/kotlin/install/kotlin-multiplatform.txt
@@ -138,7 +138,7 @@ Installation
              kotlin("multiplatform")
              kotlin("native.cocoapods")
              id("com.android.library")
-             id("io.realm.kotlin") version "1.4.0"
+             id("io.realm.kotlin") version "{+kotlin-sdk-version+}"
          }
 
          version = "1.0"

--- a/source/sdk/kotlin/install/kotlin-multiplatform.txt
+++ b/source/sdk/kotlin/install/kotlin-multiplatform.txt
@@ -15,7 +15,7 @@ Additionally, Kotlin Multiplatform projects require the following:
   Studio. Follow the instructions in the `KMM documentation
   <https://kotlinlang.org/docs/mobile/create-first-app.html>`__.
 
-For more details on setting up your KMM environment, see `the official Kotlin
+For more details on setting up your KMM environment, refer to the `official Kotlin
 Multiplatform documentation
 <https://kotlinlang.org/docs/multiplatform-mobile-setup.html>`__. To verify your
 environment setup, follow Kotlin's `guide to checking your
@@ -49,7 +49,7 @@ Installation
              kotlin("multiplatform")
              kotlin("native.cocoapods")
              id("com.android.library")
-             id("io.realm.kotlin") version "1.4.0"
+             id("io.realm.kotlin") version "{+kotlin-sdk-version+}"
          }
 
          version = "1.0"


### PR DESCRIPTION
## Pull Request Info

Correcting version number in KMM Install sample, as reported in https://github.com/realm/realm-kotlin/issues/1224

### Jira

- https://jira.mongodb.org/browse/DOCSP-15827

### Staged Changes

- [Install (Kotlin Multiplatform) - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-15827-version-number-fix/sdk/kotlin/install/kotlin-multiplatform/#installation)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
