### PR TITLE
(DOCSP-27498): C++: Update object models and related examples for CRTP

### DIFF
--- a/examples/cpp/define-object-model.cpp
+++ b/examples/cpp/define-object-model.cpp
@@ -2,6 +2,12 @@
 #include <string>
 #include <cpprealm/sdk.hpp>
 
+// :replace-start: {
+//   "terms": {
+//     "ToOneRelationship_": ""
+//   }
+// }
+
 // :snippet-start: model-with-embedded-object
 // Inherit from realm::embedded_object to declare an embedded object
 struct ContactDetails : realm::embedded_object<ContactDetails> { // :emphasize:
@@ -16,13 +22,13 @@ struct ContactDetails : realm::embedded_object<ContactDetails> { // :emphasize:
 };
 
 struct Business : realm::object<Business> {
-//    realm::persisted<std::string> _id;
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> name;
     // Unlike to-one relationships, an embedded object can be a required property
     realm::persisted<ContactDetails> contactDetails; // :emphasize:
 
     static constexpr auto schema = realm::schema("Business",
-//        realm::property<&Business::_id, true>("_id"),
+        realm::property<&Business::_id, true>("_id"),
         realm::property<&Business::name>("name"),
         realm::property<&Business::contactDetails>("contactDetails")); // :emphasize:
 };
@@ -30,7 +36,7 @@ struct Business : realm::object<Business> {
 
 // :snippet-start: model-with-ignored-field
 struct Employee : realm::object<Employee> {
-//    realm::persisted<realm::uuid> _id;
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> firstName;
     realm::persisted<std::string> lastName;
     // Omitting the `realm::persisted` annotation means
@@ -40,13 +46,39 @@ struct Employee : realm::object<Employee> {
     // Your schema consists of properties that you want realm to store.
     // Omit properties that you want to ignore from the schema.
     static constexpr auto schema = realm::schema("Employee",
-//        realm::property<&Employee::_id, true>("_id"),
+        realm::property<&Employee::_id, true>("_id"),
         realm::property<&Employee::firstName>("firstName"),
         realm::property<&Employee::lastName>("lastName"));
 };
 // :snippet-end:
-                                          
+
 // :snippet-start: to-one-relationship
+struct ToOneRelationship_FavoriteToy : realm::object<ToOneRelationship_FavoriteToy> {
+    realm::persisted<int64_t> _id;
+    realm::persisted<std::string> name;
+
+    static constexpr auto schema = realm::schema("ToOneRelationship_FavoriteToy",
+        realm::property<&ToOneRelationship_FavoriteToy::_id, true>("_id"),
+        realm::property<&ToOneRelationship_FavoriteToy::name>("name"));
+};
+
+struct ToOneRelationship_Dog : realm::object<ToOneRelationship_Dog> {
+    realm::persisted<int64_t> _id;
+    realm::persisted<std::string> name;
+    realm::persisted<int64_t> age;
+    // To-one relationship objects must be optional
+    realm::persisted<std::optional<ToOneRelationship_FavoriteToy>> favoriteToy;
+
+    static constexpr auto schema = realm::schema("ToOneRelationship_Dog",
+        realm::property<&ToOneRelationship_Dog::_id, true>("_id"),
+        realm::property<&ToOneRelationship_Dog::name>("name"),
+        realm::property<&ToOneRelationship_Dog::age>("age"),
+        realm::property<&ToOneRelationship_Dog::favoriteToy>("favoriteToy"));
+};
+// :snippet-end:
+
+#if 0
+// Temporarily removing this model as doubles are causing an error                                     
 struct GPSCoordinates: realm::object<GPSCoordinates> {
     realm::persisted<double> latitude;
     realm::persisted<double> longitude;
@@ -57,21 +89,21 @@ struct GPSCoordinates: realm::object<GPSCoordinates> {
 };
 
 struct PointOfInterest : realm::object<PointOfInterest> {
-//    realm::persisted<realm::uuid> _id;
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> name;
     // To-one relationship objects must be optional
     realm::persisted<std::optional<GPSCoordinates>> gpsCoordinates;
 
     static constexpr auto schema = realm::schema("PointOfInterest",
-//        realm::property<&PointOfInterest::_id, true>("_id"),
+        realm::property<&PointOfInterest::_id, true>("_id"),
         realm::property<&PointOfInterest::name>("name"),
         realm::property<&PointOfInterest::gpsCoordinates>("gpsCoordinates"));
 };
-// :snippet-end:
+#endif
 
 // :snippet-start: to-many-relationship
 struct Company : realm::object<Company> {
-//    realm::persisted<realm::uuid> _id;
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> name;
     // To-many relationships are a list, represented here as a
     // vector container whose value type is the Realm object
@@ -79,7 +111,7 @@ struct Company : realm::object<Company> {
     realm::persisted<std::vector<Employee>> employees;
 
     static constexpr auto schema = realm::schema("Company",
-//        realm::property<&Company::_id, true>("_id"),
+        realm::property<&Company::_id, true>("_id"),
         realm::property<&Company::name>("name"),
         realm::property<&Company::employees>("employees"));
 };
@@ -90,7 +122,10 @@ TEST_CASE("create an embedded object", "[model][write]") {
     // :snippet-start: create-embedded-object
     auto realm = realm::open<Business, ContactDetails>();
 
-    auto business = Business { .name = "MongoDB" };
+    // auto business = Business { ._id = 789012, .name = "MongoDB" };
+    auto business = Business();
+    business._id = 789012;
+    business.name = "MongoDB";
     business.contactDetails = ContactDetails { 
         .emailAddress = "email@example.com", 
         .phoneNumber = "123-456-7890"
@@ -117,6 +152,7 @@ TEST_CASE("create object with ignored property", "[model][write]") {
     auto realm = realm::open<Employee>();
 
     auto employee = Employee { 
+        ._id = 12345,
         .firstName = "Leslie", 
         .lastName = "Knope", 
         .jobTitle_notPersisted = "Organizer-In-Chief" };
@@ -141,9 +177,42 @@ TEST_CASE("create object with ignored property", "[model][write]") {
     });
 };
 
-#if 0
 TEST_CASE("create object with to-one relationship", "[model][write][relationship]") {
     // :snippet-start: create-object-with-to-one-relationship
+    auto realm = realm::open<ToOneRelationship_Dog, ToOneRelationship_FavoriteToy>();
+
+    auto favoriteToy = ToOneRelationship_FavoriteToy { .name = "Wubba" };
+    auto dog = ToOneRelationship_Dog { .name = "Lita", .age = 10 };
+    dog.favoriteToy = favoriteToy;
+
+    realm.write([&realm, &dog] {
+        realm.add(dog);
+    });
+    // :snippet-end:
+
+    SECTION("Test code example functions as intended") {
+        auto dogs = realm.objects<ToOneRelationship_Dog>();
+        auto namedLita = dogs.where([](auto &dog) {
+            return dog.name == "Lita";
+        });
+        CHECK(namedLita.size() >= 1);
+        auto lita = namedLita[0];
+        std::cout << "Dog's name is " << lita.name << "\n";
+        REQUIRE(lita.name == "Lita");
+        auto litaFavoriteToy = dog.favoriteToy;
+        auto favoriteToyName = litaFavoriteToy->name;
+        std::cout << "Lita's favorite toy: " << favoriteToyName << "\n";
+        REQUIRE(favoriteToyName == "Wubba");
+    }
+    // Clean up after the test
+    realm.write([&realm, &dog] {
+        realm.remove(dog);
+    });
+};
+
+#if 0
+// Temporarily removing this since the related model has been removed
+TEST_CASE("create object with to-one relationship", "[model][write][relationship]") {
     auto realm = realm::open<PointOfInterest, GPSCoordinates>();
 
     auto gpsCoordinates = GPSCoordinates { .latitude = 36.0554, .longitude = 112.1401 };
@@ -153,7 +222,6 @@ TEST_CASE("create object with to-one relationship", "[model][write][relationship
     realm.write([&realm, &pointOfInterest] {
         realm.add(pointOfInterest);
     });
-    // :snippet-end:
 
     SECTION("Test code example functions as intended") {
         auto pointsOfInterest = realm.objects<PointOfInterest>();
@@ -162,9 +230,9 @@ TEST_CASE("create object with to-one relationship", "[model][write][relationship
         });
         CHECK(namedGrandCanyonVillage.size() >= 1);
         auto grandCanyonVillage = namedGrandCanyonVillage[0];
-        std::cout << "Point of Interest: " << grandCanyonVillage->name << "\n";
-        REQUIRE(grandCanyonVillage->name == "Grand Canyon Village");
-        auto const &theseGpsCoordinates = *(grandCanyonVillage->gpsCoordinates);
+        std::cout << "Point of Interest: " << grandCanyonVillage.name << "\n";
+        REQUIRE(grandCanyonVillage.name == "Grand Canyon Village");
+        auto const &theseGpsCoordinates = *(grandCanyonVillage.gpsCoordinates);
         static_assert(std::is_same_v<decltype(theseGpsCoordinates), std::optional<GPSCoordinates> const &>, "Dereference fail!"); // :remove:
         auto latitude = *(theseGpsCoordinates->latitude);
         static_assert(std::is_same_v<decltype(latitude), double>, "Dereference fail!"); // :remove:
@@ -183,14 +251,17 @@ TEST_CASE("create object with to-many relationship", "[model][write][relationshi
     auto realm = realm::open<Company, Employee>();
 
     auto employee1 = Employee {
+        ._id = 23456,
         .firstName = "Pam",
         .lastName = "Beesly" };
     
     auto employee2 = Employee {
+        ._id = 34567,
         .firstName = "Jim",
         .lastName = "Halpert" };
 
     auto company = Company {
+        ._id = 45678,
         .name = "Dunder Mifflin"
     };
     
@@ -269,3 +340,4 @@ TEST_CASE("update an embedded object", "[model][update]") {
     });
 }
 #endif
+// :replace-end:

--- a/examples/cpp/examples.cpp
+++ b/examples/cpp/examples.cpp
@@ -24,7 +24,6 @@ struct SyncDog : realm::object<SyncDog> {
 
 // :snippet-start: define-models
 // :snippet-start: single-object-model
-// Define your models like regular structs.
 struct Dog : realm::object<Dog> {
     realm::persisted<std::string> name;
     realm::persisted<int64_t> age;
@@ -36,7 +35,7 @@ struct Dog : realm::object<Dog> {
 // :snippet-end:
 
 struct Person : realm::object<Person> {
-    realm::persisted<std::string> _id;
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> name;
     realm::persisted<int64_t> age;
 

--- a/source/examples/generated/cpp/define-object-model.snippet.check-size-and-access-results.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.check-size-and-access-results.cpp
@@ -1,5 +1,7 @@
 auto companies = realm.objects<Company>();
-auto namedDunderMifflin = companies.where("name == $0", {"Dunder Mifflin"});
+auto namedDunderMifflin = companies.where([](auto &company) {
+    return company.name == "Dunder Mifflin";
+});
 CHECK(namedDunderMifflin.size() >= 1);
-auto dunderMifflin = namedDunderMifflin[0];
-std::cout << "Company named: " << dunderMifflin->name << "\n";
+Company dunderMifflin = namedDunderMifflin[0];
+std::cout << "Company named: " << dunderMifflin.name << "\n";

--- a/source/examples/generated/cpp/define-object-model.snippet.create-embedded-object.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.create-embedded-object.cpp
@@ -1,12 +1,12 @@
 auto realm = realm::open<Business, ContactDetails>();
 
-auto business = Business { .name = "MongoDB" };
+auto business = Business();
+business._id = 789012;
+business.name = "MongoDB";
 business.contactDetails = ContactDetails { 
     .emailAddress = "email@example.com", 
     .phoneNumber = "123-456-7890"
 };
-
-std::cout << "Business: " << business << "\n";
 
 realm.write([&realm, &business] {
     realm.add(business);

--- a/source/examples/generated/cpp/define-object-model.snippet.create-object-with-to-many-relationship.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.create-object-with-to-many-relationship.cpp
@@ -1,14 +1,17 @@
 auto realm = realm::open<Company, Employee>();
 
 auto employee1 = Employee {
+    ._id = 23456,
     .firstName = "Pam",
     .lastName = "Beesly" };
 
 auto employee2 = Employee {
+    ._id = 34567,
     .firstName = "Jim",
     .lastName = "Halpert" };
 
 auto company = Company {
+    ._id = 45678,
     .name = "Dunder Mifflin"
 };
 

--- a/source/examples/generated/cpp/define-object-model.snippet.create-object-with-to-one-relationship.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.create-object-with-to-one-relationship.cpp
@@ -1,9 +1,9 @@
-auto realm = realm::open<PointOfInterest, GPSCoordinates>();
+auto realm = realm::open<Dog, FavoriteToy>();
 
-auto gpsCoordinates = GPSCoordinates { .latitude = 36.0554, .longitude = 112.1401 };
-auto pointOfInterest = PointOfInterest { .name = "Grand Canyon Village" };
-pointOfInterest.gpsCoordinates = gpsCoordinates;
+auto favoriteToy = FavoriteToy { .name = "Wubba" };
+auto dog = Dog { .name = "Lita", .age = 10 };
+dog.favoriteToy = favoriteToy;
 
-realm.write([&realm, &pointOfInterest] {
-    realm.add(pointOfInterest);
+realm.write([&realm, &dog] {
+    realm.add(dog);
 });

--- a/source/examples/generated/cpp/define-object-model.snippet.filter-using-type-safe-query.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.filter-using-type-safe-query.cpp
@@ -1,1 +1,3 @@
-auto namedDunderMifflin = companies.where("name == $0", {"Dunder Mifflin"});
+auto namedDunderMifflin = companies.where([](auto &company) {
+    return company.name == "Dunder Mifflin";
+});

--- a/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp
@@ -13,8 +13,7 @@ struct ContactDetails : realm::embedded_object<ContactDetails> {
 struct Business : realm::object<Business> {
     realm::persisted<int64_t> _id;
     realm::persisted<std::string> name;
-    // Unlike to-one relationships, an embedded object can be a required property
-    realm::persisted<ContactDetails> contactDetails; 
+    realm::persisted<std::optional<ContactDetails>> contactDetails; 
 
     static constexpr auto schema = realm::schema("Business",
         realm::property<&Business::_id, true>("_id"),

--- a/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp
@@ -1,5 +1,5 @@
 // Inherit from realm::embedded_object to declare an embedded object
-struct ContactDetails : realm::embedded_object { 
+struct ContactDetails : realm::embedded_object<ContactDetails> { 
     // Because ContactDetails is an embedded object, it cannot have its own _id
     // It does not have a lifecycle outside of the top-level object
     realm::persisted<std::string> emailAddress;
@@ -10,8 +10,8 @@ struct ContactDetails : realm::embedded_object {
         realm::property<&ContactDetails::phoneNumber>("phoneNumber"));
 };
 
-struct Business : realm::object {
-    realm::persisted<std::string> _id;
+struct Business : realm::object<Business> {
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> name;
     // Unlike to-one relationships, an embedded object can be a required property
     realm::persisted<ContactDetails> contactDetails; 

--- a/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp.rst
+++ b/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp.rst
@@ -1,8 +1,8 @@
-.. code-block:: cpp
-   :emphasize-lines: 2, 17, 22
+.. code-block:: text
+   :emphasize-lines: 2, 16, 21
 
    // Inherit from realm::embedded_object to declare an embedded object
-   struct ContactDetails : realm::embedded_object { 
+   struct ContactDetails : realm::embedded_object<ContactDetails> { 
        // Because ContactDetails is an embedded object, it cannot have its own _id
        // It does not have a lifecycle outside of the top-level object
        realm::persisted<std::string> emailAddress;
@@ -13,11 +13,10 @@
            realm::property<&ContactDetails::phoneNumber>("phoneNumber"));
    };
 
-   struct Business : realm::object {
-       realm::persisted<std::string> _id;
+   struct Business : realm::object<Business> {
+       realm::persisted<int64_t> _id;
        realm::persisted<std::string> name;
-       // Unlike to-one relationships, an embedded object can be a required property
-       realm::persisted<ContactDetails> contactDetails; 
+       realm::persisted<std::optional<ContactDetails>> contactDetails; 
 
        static constexpr auto schema = realm::schema("Business",
            realm::property<&Business::_id, true>("_id"),

--- a/source/examples/generated/cpp/define-object-model.snippet.model-with-ignored-field.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.model-with-ignored-field.cpp
@@ -1,5 +1,5 @@
-struct Employee : realm::object {
-    realm::persisted<realm::uuid> _id;
+struct Employee : realm::object<Employee> {
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> firstName;
     realm::persisted<std::string> lastName;
     // Omitting the `realm::persisted` annotation means

--- a/source/examples/generated/cpp/define-object-model.snippet.to-many-relationship.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.to-many-relationship.cpp
@@ -1,5 +1,5 @@
-struct Company : realm::object {
-    realm::persisted<realm::uuid> _id;
+struct Company : realm::object<Company> {
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> name;
     // To-many relationships are a list, represented here as a
     // vector container whose value type is the Realm object

--- a/source/examples/generated/cpp/define-object-model.snippet.to-one-relationship.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.to-one-relationship.cpp
@@ -1,20 +1,22 @@
-struct GPSCoordinates: realm::object {
-    realm::persisted<double> latitude;
-    realm::persisted<double> longitude;
+struct FavoriteToy : realm::object<FavoriteToy> {
+    realm::persisted<int64_t> _id;
+    realm::persisted<std::string> name;
 
-    static constexpr auto schema = realm::schema("GPSCoordinates",
-        realm::property<&GPSCoordinates::latitude>("latitude"),
-        realm::property<&GPSCoordinates::longitude>("longitude"));
+    static constexpr auto schema = realm::schema("FavoriteToy",
+        realm::property<&FavoriteToy::_id, true>("_id"),
+        realm::property<&FavoriteToy::name>("name"));
 };
 
-struct PointOfInterest : realm::object {
-    realm::persisted<realm::uuid> _id;
+struct Dog : realm::object<Dog> {
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> name;
+    realm::persisted<int64_t> age;
     // To-one relationship objects must be optional
-    realm::persisted<std::optional<GPSCoordinates>> gpsCoordinates;
+    realm::persisted<std::optional<FavoriteToy>> favoriteToy;
 
-    static constexpr auto schema = realm::schema("PointOfInterest",
-        realm::property<&PointOfInterest::_id, true>("_id"),
-        realm::property<&PointOfInterest::name>("name"),
-        realm::property<&PointOfInterest::gpsCoordinates>("gpsCoordinates"));
+    static constexpr auto schema = realm::schema("Dog",
+        realm::property<&Dog::_id, true>("_id"),
+        realm::property<&Dog::name>("name"),
+        realm::property<&Dog::age>("age"),
+        realm::property<&Dog::favoriteToy>("favoriteToy"));
 };

--- a/source/examples/generated/cpp/define-object-model.snippet.update-embedded-object.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.update-embedded-object.cpp
@@ -2,7 +2,7 @@ auto businesses = realm.objects<Business>();
 auto mongoDBPointer = businesses[0];
 
 realm.write([&realm, &mongoDBPointer] {
-    (*mongoDBPointer->contactDetails).emailAddress = "info@example.com";
+    mongoDBPointer.contactDetails->emailAddress = "info@example.com";
 });
 
-std::cout << "New email address: " << (*mongoDBPointer->contactDetails).emailAddress << "\n";
+std::cout << "New email address: " << mongoDBPointer.contactDetails->emailAddress << "\n";

--- a/source/examples/generated/cpp/examples.snippet.define-models.cpp
+++ b/source/examples/generated/cpp/examples.snippet.define-models.cpp
@@ -1,17 +1,16 @@
-// Define your models like regular structs.
-struct Dog : realm::object {
+struct Dog : realm::object<Dog> {
     realm::persisted<std::string> name;
-    realm::persisted<int> age;
+    realm::persisted<int64_t> age;
 
     static constexpr auto schema = realm::schema("Dog",
         realm::property<&Dog::name>("name"),
         realm::property<&Dog::age>("age"));
 };
 
-struct Person : realm::object {
-    realm::persisted<std::string> _id;
+struct Person : realm::object<Person> {
+    realm::persisted<int64_t> _id;
     realm::persisted<std::string> name;
-    realm::persisted<int> age;
+    realm::persisted<int64_t> age;
 
     // Create relationships by pointing an Object field to another Class
     realm::persisted<std::optional<Dog>> dog;

--- a/source/examples/generated/cpp/examples.snippet.open-a-synced-realm.cpp
+++ b/source/examples/generated/cpp/examples.snippet.open-a-synced-realm.cpp
@@ -1,6 +1,6 @@
 auto app = realm::App(APP_ID);
 // Ensure anonymous authentication is enabled in the App Services App
-auto user = app.login(realm::App::Credentials::anonymous()).get_future().get();
+auto user = app.login(realm::App::credentials::anonymous()).get_future().get();
 auto sync_config = user.flexible_sync_configuration();
 // Note that get_future().get() blocks this thread until the promise - 
 // in this case, the task kicked off by the call to async_open - is resolved

--- a/source/examples/generated/cpp/examples.snippet.single-object-model.cpp
+++ b/source/examples/generated/cpp/examples.snippet.single-object-model.cpp
@@ -1,7 +1,6 @@
-// Define your models like regular structs.
-struct Dog : realm::object {
+struct Dog : realm::object<Dog> {
     realm::persisted<std::string> name;
-    realm::persisted<int> age;
+    realm::persisted<int64_t> age;
 
     static constexpr auto schema = realm::schema("Dog",
         realm::property<&Dog::name>("name"),

--- a/source/examples/generated/cpp/examples.snippet.update-an-object.cpp
+++ b/source/examples/generated/cpp/examples.snippet.update-an-object.cpp
@@ -1,15 +1,17 @@
 // Query for the object you want to update
 auto dogs = realm.objects<Dog>();
-auto dogsNamedMaui = dogs.where("name == $0", {"Maui"});
+// auto dogsNamedMaui = dogs.where("name == $0", {"Maui"});
+auto dogsNamedMaui = dogs.where([](auto &dog) {
+    return dog.name == "Maui";
+});
 CHECK(dogsNamedMaui.size() >= 1);
-// Access an object in the results set. 
-auto mauiPointer = dogsNamedMaui[0];
+// Access an object in the results set.
+auto maui = dogsNamedMaui[0];
 
-std::cout << "Dog " << mauiPointer->name << " is " << mauiPointer->age << " years old\n";
+std::cout << "Dog " << maui.name << " is " << maui.age << " years old\n";
 
 // Assign a new value to a member of the object in a write transaction
-realm.write([&realm, &mauiPointer] {
-    mauiPointer->age = 2;
+int64_t newAge = 2;
+realm.write([&realm, &maui, &newAge] {
+    maui.age = newAge;
 });
-
-std::cout << "Dog " << mauiPointer->name << " is " << mauiPointer->age << " years old\n";

--- a/source/sdk/cpp/model-data/object-models.txt
+++ b/source/sdk/cpp/model-data/object-models.txt
@@ -84,7 +84,10 @@ Define a New Object Type
 ------------------------
 
 You can define your models as classes or structs that inherit from 
-:cpp-sdk:`realm::object <structrealm_1_1object.html>`.
+:cpp-sdk:`realm::object <structrealm_1_1object.html>`. The Realm C++ SDK
+uses `CRTP <https://en.cppreference.com/w/cpp/language/crtp>`__ to simplify
+working with Realm objects. With this implementation, you pass the object's
+type as a template paramater when you declare your object struct.
 
 You must declare any property you want to store (persist) in a realm as 
 :cpp-sdk:`realm::persisted <structrealm_1_1persisted.html>`. Your model 

--- a/source/sdk/cpp/model-data/relationships.txt
+++ b/source/sdk/cpp/model-data/relationships.txt
@@ -74,8 +74,8 @@ Define a To-One Relationship
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A **to-one** relationship maps one property to a single instance of
-another object type. For example, you can model a point of interest having 
-at most one set of location coordinates as a to-one relationship.
+another object type. For example, you can model a dog having at most one 
+favorite toy as a to-one relationship.
 
 Setting a relationship field to null removes the connection between objects. 
 Realm does not delete the referenced object, though, unless it is 
@@ -85,7 +85,7 @@ Realm does not delete the referenced object, though, unless it is
 
 .. literalinclude:: /examples/generated/cpp/define-object-model.snippet.to-one-relationship.cpp
    :language: cpp
-   :emphasize-lines: 14
+   :emphasize-lines: 15
 
 .. _cpp-define-a-to-many-relationship-property:
 

--- a/source/sdk/cpp/model-data/supported-types.txt
+++ b/source/sdk/cpp/model-data/supported-types.txt
@@ -99,10 +99,7 @@ Property Cheat Sheet
 
           realm::persisted<std::optional<MyClass>> opt_obj_name;
    * - User-defined Embedded Object
-     - .. code-block:: cpp
-          :copyable: false
-
-          realm::persisted<MyEmbeddedClass> embedded_obj_name;
+     - N/A
      - .. code-block:: cpp
           :copyable: false
 


### PR DESCRIPTION
## Pull Request Info

DO NOT MERGE until realm-cpp merges PR # 42

### Jira

- https://jira.mongodb.org/browse/DOCSP-27498

### Staged Changes

- [Object Types and Schemas](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27498/sdk/cpp/model-data/object-models/): Update object models for CRTP, add info to "Define a New Object Type" around CRTP
- [Supported Data Types](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27498/sdk/cpp/model-data/supported-types/): Remove required embedded object, as I was only able to get an embedded object to work as an optional
- [Relationships](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27498/sdk/cpp/model-data/relationships/): Update models for CRTP, change to-one relationship model to dog/favorite toy as doubles from the PointOfInterest/GPSCoordinates example are currently not working 
- [CRUD/Create](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27498/sdk/cpp/crud/create/): Update models for CRTP, change PK to `int64_t` as other PK types are not currently working
- [CRUD/Read](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27498/sdk/cpp/crud/read/): Update query syntax
- [CRUD/Update](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27498/sdk/cpp/crud/update/): Update models for CRTP, update query syntax, show dot notation to access properties instead of member-of operator where applicable

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
