### PR TITLE
(DOCSP-27502): C++: Update the path example and related text

### DIFF
--- a/examples/cpp/examples.cpp
+++ b/examples/cpp/examples.cpp
@@ -151,20 +151,19 @@ TEST_CASE("open a default realm", "[realm]") {
     // :snippet-end:
 }
 
-#if 0
 TEST_CASE("open a realm at a path", "[realm]") {
     // Construct an arbitrary path to use in the example
-        // :snippet-start: open-realm-at-path
-    auto relative_realm_path = "custom_path_directory/";
-    std::filesystem::create_directories(relative_realm_path); // :remove:
-    // Construct a path, and then convert it to a string so you can append a name for the realm file
-    auto path = std::filesystem::current_path().append(relative_realm_path).string();
-    /* Add a name for the file. When you provide a path, the `db_config` 
-     * constructor removes the last path element and makes that 
-     * the realm file name. */
-    path = path + "dog_objects";
-    auto config = realm::db_config{ path = path };
-    auto realm = realm::open<Dog>(config);
+    // :snippet-start: open-realm-at-path
+    auto relative_realm_path_directory = "custom_path_directory/";
+    std::filesystem::create_directories(relative_realm_path_directory); // :remove:
+    // Construct a path
+    std::filesystem::path path = std::filesystem::current_path().append(relative_realm_path_directory);
+    // Add a name for the realm file
+    path =  path.append("dog_objects");
+    // Add the .realm extension
+    path = path.replace_extension("realm");
+    // Open a realm at the path
+    auto realm = realm::open<Dog>({ path });
     // :snippet-end:
     SECTION("Test code example functions as intended + teardown") {
         // Write something to the realm to confirm this worked as expected.
@@ -181,7 +180,6 @@ TEST_CASE("open a realm at a path", "[realm]") {
         });
     }
 }
-#endif
 
 TEST_CASE("open a synced realm", "[realm][sync]") {
     // :snippet-start: open-a-synced-realm

--- a/source/examples/generated/cpp/examples.snippet.open-realm-at-path.cpp
+++ b/source/examples/generated/cpp/examples.snippet.open-realm-at-path.cpp
@@ -1,9 +1,9 @@
-auto relative_realm_path = "custom_path_directory/";
-// Construct a path, and then convert it to a string so you can append a name for the realm file
-auto path = std::filesystem::current_path().append(relative_realm_path).string();
-/* Add a name for the file. When you provide a path, the `db_config` 
- * constructor removes the last path element and makes that 
- * the realm file name. */
-path = path + "dog_objects";
-auto config = realm::db_config{ path = path };
-auto realm = realm::open<Dog>(config);
+auto relative_realm_path_directory = "custom_path_directory/";
+// Construct a path
+std::filesystem::path path = std::filesystem::current_path().append(relative_realm_path_directory);
+// Add a name for the realm file
+path =  path.append("dog_objects");
+// Add the .realm extension
+path = path.replace_extension("realm");
+// Open a realm at the path
+auto realm = realm::open<Dog>({ path });

--- a/source/sdk/cpp.txt
+++ b/source/sdk/cpp.txt
@@ -7,6 +7,7 @@ C++ SDK (Alpha)
 .. toctree::
    :titlesonly:
 
+   Why Realm Database? </sdk/cpp/realm-database>
    Install Realm </sdk/cpp/install>
    Model Data </sdk/cpp/model-data>
    Configure & Open a Realm </sdk/cpp/realm-files/configure-and-open-a-realm>

--- a/source/sdk/cpp/install.txt
+++ b/source/sdk/cpp/install.txt
@@ -161,7 +161,8 @@ app:
      )
 
 - Ensure that the git submodules are initialized inside of the ``realm-cpp`` folder before building. 
-- When instantiating the Realm or the Realm App, you must pass the ``filesDir.path`` to the ``path`` parameter in the respective constructors. 
+- When instantiating the Realm or the Realm App, you must pass the ``filesDir.path`` as the ``path`` 
+  parameter in the respective constructor or realm open template. 
 
 For an example of how to use the Realm C++ SDK Alpha in an Android app, refer to
 the :github:`Android RealmExample App <realm/realm-cpp/tree/main/examples/Android>`

--- a/source/sdk/cpp/realm-database.txt
+++ b/source/sdk/cpp/realm-database.txt
@@ -10,6 +10,11 @@ Realm Database - C++ SDK (Alpha)
    :depth: 2
    :class: singlecol
 
+.. note:: The Realm C++ SDK is Currently in Alpha
+
+   While the Realm C++ SDK is in alpha, some of the features listed on this
+   page are not yet implemented or fully supported in this SDK. 
+
 .. include:: /includes/realm-database.rst
 
 Realm vs Other Databases

--- a/source/sdk/cpp/realm-database.txt
+++ b/source/sdk/cpp/realm-database.txt
@@ -1,0 +1,76 @@
+.. _cpp-realm-database:
+
+================================
+Realm Database - C++ SDK (Alpha)
+================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/realm-database.rst
+
+Realm vs Other Databases
+------------------------
+
+The Realm data model is similar to both relational and
+document databases but has distinct differences from both. To underscore
+these differences, it's helpful to highlight what a realm **is
+not**:
+
+A realm is not a single, application-wide database.
+    Applications based on other database systems generally store all of their
+    data in a single database. Apps often split data across multiple
+    realms to organize data more efficiently and to enforce access controls.
+
+A realm is not a relational table.
+    Normalized tables in relational databases only store one type of
+    information, such as street addresses or items in a store inventory. A
+    realm can contain any number of object types that are relevant to a
+    given domain.
+
+A realm is not a collection of schemaless documents.
+    Document databases don't necessarily enforce a strict schema for the data in
+    each collection. While similar to documents in form, every Realm object
+    conforms to a schema for a specific object type in the realm. An object
+    cannot contain a property that is not described by its schema.
+
+.. _cpp-realm-database-reads:
+.. _cpp-live-queries:
+
+Live Queries
+------------
+
+You can read back the data that you have :ref:`stored
+<cpp-write-transactions>` in Realm Database by finding,
+filtering, and sorting objects.
+
+To get the best performance from Realm as your app grows and your
+queries become more complex, design your app's data access patterns
+around a solid understanding of Realm Database :ref:`read
+characteristics <cpp-realm-read-characteristics>`.
+
+.. _cpp-live-object:
+
+Live Object
+~~~~~~~~~~~
+
+All Realm objects are **live objects**, which means they
+automatically update whenever they're modified. Realm emits a
+notification event whenever any property changes.
+
+You can use live objects to work with object-oriented data natively
+without an :wikipedia:`ORM <Object-relational_mapping>` tool. Live
+objects are direct proxies to the underlying stored data, which means
+that a live object doesn't directly contain data. Instead, a live object
+always references the most up-to-date data on disk and :wikipedia:`lazy
+loads <Lazy_loading>` property values when you access them from a
+collection. This means that a realm can contain many objects but only 
+pay the performance cost for data that the application is actually using.
+
+Valid write operations on a live object automatically persist to the
+realm and propagate to any other synced clients. You do not need to
+call an update method, modify the realm, or otherwise "push"
+updates.

--- a/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
@@ -39,9 +39,7 @@ You can open, view, and edit the contents of these files with
    
    Realm Database creates additional files for each realm.
    To learn more about these files, see :ref:`Realm Database Internals
-   <ios-realm-database>`. Deleting these files has important implications.
-   For more information about deleting ``.realm`` or auxiliary files, see: 
-   :ref:`Delete a Realm <swift-delete-a-realm>`
+   <cpp-realm-database>`.
 
 .. _cpp-synced-realm:
 
@@ -113,10 +111,8 @@ current directory.
 Open a Realm at a File Path
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you need to open a realm at a specific file path, you can construct a 
-:cpp-sdk:`db_config <structrealm_1_1db__config.html>` with a specific string 
-path for your realm file. The ``db_config`` constructor removes the last 
-path element and uses it as the name for your realm file.
+If you need to open a realm at a specific file path, you can pass a path 
+to the realm open template.
 
 .. literalinclude:: /examples/generated/cpp/examples.snippet.open-realm-at-path.cpp
    :language: cpp
@@ -124,9 +120,8 @@ path element and uses it as the name for your realm file.
 .. tip:: Building an Android App
 
    When building an Android app that uses the Realm C++ SDK Alpha, 
-   you must pass the ``filesDir.path`` to the ``path`` parameter in the 
-   :cpp-sdk:`db_config <structrealm_1_1db__config.html>` constructor. For 
-   more information, refer to: :ref:`cpp-build-android-app`.
+   you must pass the ``filesDir.path`` as the ``path`` parameter when you
+   open the realm. For more information, refer to: :ref:`cpp-build-android-app`.
 
 .. _cpp-open-synced-realm:
 


### PR DESCRIPTION
## Pull Request Info

DO NOT MERGE until realm-cpp merges PR # 42. Once that happens & the API reference docs update, the `async_open` link on this page will break and need to be updated before merging this.

### Jira

- https://jira.mongodb.org/browse/DOCSP-27502

### Staged Changes

- [Configure & Open a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27502/sdk/cpp/realm-files/configure-and-open-a-realm/#open-a-realm-at-a-file-path): Update the path example, tweak related text
- [Why Realm Database?](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27502/sdk/cpp/realm-database/): Ported page from Swift because it contains relevant info about realm file stuff, removed some links to pages that don't exist yet in C++ SDK docs
- [Install](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27502/sdk/cpp/install/#build-an-android-app): Minor tweaks to the "Build an Android App" section to reflect that you can pass a path as a param to the realm open template

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
