### PR TITLE
(DOCSP-26118): updated bundle a realm page

### DIFF
--- a/examples/dart/bin/myapp.dart
+++ b/examples/dart/bin/myapp.dart
@@ -23,10 +23,10 @@ void main(List<String> arguments) {
     // You must connect to the Device Sync server with an authenticated
     // user to work with the synced realm.
     final app = App(AppConfiguration(APP_ID));
-    final user = await app.logIn(Credentials.anonymous());
+    // Check if current user exists and log anonymous user if not.
+    final user = app.currentUser ?? await app.logIn(Credentials.anonymous());
 
-    final config =
-        Configuration.flexibleSync(user, [Car.schema], path: 'bundle.realm');
+    final config = Configuration.flexibleSync(user, [Car.schema]);
     final realm = Realm(config);
 
     // Add data to realm
@@ -40,7 +40,14 @@ void main(List<String> arguments) {
     await realm.syncSession.waitForUpload();
     await realm.syncSession.waitForDownload();
 
-    print("Bundled realm location: " + realm.config.path);
+    // Create new configuration for the bundled realm.
+    // You must specify a path separate from the realm you
+    // are copying for Realm.writeCopy() to succeed.
+    final bundledConfig =
+        Configuration.flexibleSync(user, [Car.schema], path: 'bundle.realm');
+    realm.writeCopy(bundledConfig);
+
+    print("Bundled realm location: " + bundledConfig.path);
     realm.close();
     // :snippet-end:
   }

--- a/examples/dart/bin/myapp.dart
+++ b/examples/dart/bin/myapp.dart
@@ -36,10 +36,6 @@ void main(List<String> arguments) {
       realm.add(Car(ObjectId(), "Mercedes", model: 'G Wagon'));
     });
 
-    // Sync changes with the server
-    await realm.syncSession.waitForUpload();
-    await realm.syncSession.waitForDownload();
-
     // Create new configuration for the bundled realm.
     // You must specify a path separate from the realm you
     // are copying for Realm.writeCopy() to succeed.

--- a/examples/dart/bin/myapp.dart
+++ b/examples/dart/bin/myapp.dart
@@ -29,7 +29,8 @@ void main(List<String> arguments) async {
     final config = Configuration.flexibleSync(user, [Car.schema]);
     final realm = Realm(config);
 
-    // Add subscription that's the same as the one in your main app
+    // Add subscription that match the data being added
+    // and your app's backend permissions.
     realm.subscriptions.update((mutableSubscriptions) {
       mutableSubscriptions.add(realm.all<Car>());
     });

--- a/examples/dart/bin/myapp.dart
+++ b/examples/dart/bin/myapp.dart
@@ -15,6 +15,35 @@ void main(List<String> arguments) {
   print("Bundled realm location: " + realm.config.path);
   realm.close();
   // :snippet-end:
+  Future<void> createSyncedBundle() async {
+    final APP_ID = '';
+    // :snippet-start: create-synced-bundle
+    print("Bundling synced realm");
+
+    // You must connect to the Device Sync server with an authenticated
+    // user to work with the synced realm.
+    final app = App(AppConfiguration(APP_ID));
+    final user = await app.logIn(Credentials.anonymous());
+
+    final config =
+        Configuration.flexibleSync(user, [Car.schema], path: 'bundle.realm');
+    final realm = Realm(config);
+
+    // Add data to realm
+    realm.write(() => realm.deleteAll<Car>()); // :remove:
+    realm.write(() {
+      realm.add(Car(ObjectId(), "Audi", model: 'A8'));
+      realm.add(Car(ObjectId(), "Mercedes", model: 'G Wagon'));
+    });
+
+    // Sync changes with the server
+    await realm.syncSession.waitForUpload();
+    await realm.syncSession.waitForDownload();
+
+    print("Bundled realm location: " + realm.config.path);
+    realm.close();
+    // :snippet-end:
+  }
 
   Realm.shutdown();
 }

--- a/source/examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
+++ b/source/examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
@@ -1,8 +1,12 @@
-final app = App(AppConfiguration(APP_ID));
-final user = await app.logIn(Credentials.anonymous());
 print("Bundling synced realm");
-final config =
-    Configuration.flexibleSync(user, [Car.schema], path: 'bundle.realm');
+
+// You must connect to the Device Sync server with an authenticated
+// user to work with the synced realm.
+final app = App(AppConfiguration(APP_ID));
+// Check if current user exists and log anonymous user if not.
+final user = app.currentUser ?? await app.logIn(Credentials.anonymous());
+
+final config = Configuration.flexibleSync(user, [Car.schema]);
 final realm = Realm(config);
 
 // Add data to realm
@@ -15,5 +19,12 @@ realm.write(() {
 await realm.syncSession.waitForUpload();
 await realm.syncSession.waitForDownload();
 
-print("Bundled realm location: " + realm.config.path);
+// Create new configuration for the bundled realm.
+// You must specify a path separate from the realm you
+// are copying for Realm.writeCopy() to succeed.
+final bundledConfig =
+    Configuration.flexibleSync(user, [Car.schema], path: 'bundle.realm');
+realm.writeCopy(bundledConfig);
+
+print("Bundled realm location: " + bundledConfig.path);
 realm.close();

--- a/source/examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
+++ b/source/examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
@@ -1,0 +1,19 @@
+final app = App(AppConfiguration(APP_ID));
+final user = await app.logIn(Credentials.anonymous());
+print("Bundling synced realm");
+final config =
+    Configuration.flexibleSync(user, [Car.schema], path: 'bundle.realm');
+final realm = Realm(config);
+
+// Add data to realm
+realm.write(() {
+  realm.add(Car(ObjectId(), "Audi", model: 'A8'));
+  realm.add(Car(ObjectId(), "Mercedes", model: 'G Wagon'));
+});
+
+// Sync changes with the server
+await realm.syncSession.waitForUpload();
+await realm.syncSession.waitForDownload();
+
+print("Bundled realm location: " + realm.config.path);
+realm.close();

--- a/source/examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
+++ b/source/examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
@@ -15,10 +15,6 @@ realm.write(() {
   realm.add(Car(ObjectId(), "Mercedes", model: 'G Wagon'));
 });
 
-// Sync changes with the server
-await realm.syncSession.waitForUpload();
-await realm.syncSession.waitForDownload();
-
 // Create new configuration for the bundled realm.
 // You must specify a path separate from the realm you
 // are copying for Realm.writeCopy() to succeed.

--- a/source/examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
+++ b/source/examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
@@ -9,7 +9,8 @@ final user = app.currentUser ?? await app.logIn(Credentials.anonymous());
 final config = Configuration.flexibleSync(user, [Car.schema]);
 final realm = Realm(config);
 
-// Add subscription that's the same as the one in your main app
+// Add subscription that match the data being added
+    // and your app's backend permissions.
 realm.subscriptions.update((mutableSubscriptions) {
   mutableSubscriptions.add(realm.all<Car>());
 });

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -117,7 +117,7 @@ To bundle a synced realm, perform the following:
 #. Use :flutter-sdk:`Realm.writeCopy() <realm/Realm/writeCopy.html>` to create
    a new version of the synced realm. You **must** use ``Realm.writeCopy()``
    to bundle the synced realm because the method removes metadata that associates
-   the realm with the user in the configuration, which allows other users
+   the realm with the user, which allows other users
    to open the realm file as well.
 
 .. literalinclude:: /examples/generated/flutter/myapp.snippet.create-synced-bundle.dart

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -22,6 +22,9 @@ refer to the :ref:`Bundle a Synced Realm <flutter-bundle-synced-realm>` section.
    You can also add data to your realm the first time an application opens it
    using the :ref:`initial data callback function <flutter-initial-data-callback>`.
 
+Bundle a Local Realm
+--------------------
+
 .. procedure::
 
    .. step:: Create a Realm File for Bundling
@@ -118,7 +121,7 @@ To bundle a synced realm, perform the following:
 
 #. Connect to your App Services App and authenticate a user.
 #. Add a subscription to the realm. You need a subscription to write to a synced realm.
-#. Add Data to the synced realm.
+#. Add data to the synced realm.
 #. Wait for all local changes to synchronize with the Device Sync server.
 #. Use :flutter-sdk:`Realm.writeCopy() <realm/Realm/writeCopy.html>` to create
    a new version of the synced realm. You **must** use ``Realm.writeCopy()``

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -103,11 +103,17 @@ You should only bundle a synced realm if your use case meets the following crite
 - The initial bundled data is very large **and** app is being used in a situation
   with limited internet bandwidth, so an initial data download using sync subscriptions
   would take too long.
+- All app users have backend permission to view the data included in the bundle.
+  If a user doesn't have permission to view this data, it will be removed from
+  their device when the realm sync with Atlas via a :ref:`compensating write error
+  <flutter-compensating-writes>`.
 
 To bundle a synced realm, perform the following:
 
 #. Connect to your App and authenticate a user to use Device Sync.
+#. Add a subscription to the realm. You need a subscription to write to a synced realm.
 #. Add Data to the synced realm.
+#. Sync all changes with the Device Sync server.
 #. Use :flutter-sdk:`Realm.writeCopy() <realm/Realm/writeCopy.html>` to create
    a new version of the synced realm. You **must** use ``Realm.writeCopy()``
    to bundle the synced realm because the method removes metadata that associates

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -14,6 +14,9 @@ You might want to seed your mobile app with some initial data that will be avail
 to users on the initial launch of the app. To do this, you can bundle an existing
 realm database file in your Flutter app.
 
+If your app uses a synced realm, you may not want to bundle it. For more information,
+refer to the :ref:`Bundle a Synced Realm <flutter-bundle-synced-realm>` section.
+
 .. tip:: Consider Initial Data Callback
 
    You can also add data to your realm the first time an application opens it
@@ -92,8 +95,11 @@ the first time they open the bundled realm file. The client reset causes
 the application to download the full state of the realm from the application backend.
 This negates the advantages of bundling a realm file.
 
-Rather than bundling a synced realm, you can bootstrap application data using
-sync subscriptions. To learn more, refer to :ref:`Manage Sync Subscriptions
+Rather than bundling a synced realm, you can populate your application with data
+using sync subscriptions. If you add data using sync subscriptions,
+you do not need to be concerned with data being older than the client maximum online time
+while taking advantage of Flexible Sync's :ref:`trimming <trimming>` feature.
+To learn more about using sync subscriptions, refer to :ref:`Manage Sync Subscriptions
 <flutter-flexible-sync-manage-subscriptions>`.
 
 You should only bundle a synced realm if your use case meets the following criteria:
@@ -110,10 +116,10 @@ You should only bundle a synced realm if your use case meets the following crite
 
 To bundle a synced realm, perform the following:
 
-#. Connect to your App and authenticate a user to use Device Sync.
+#. Connect to your App Services App and authenticate a user.
 #. Add a subscription to the realm. You need a subscription to write to a synced realm.
 #. Add Data to the synced realm.
-#. Sync all changes with the Device Sync server.
+#. Wait for all local changes to synchronize with the Device Sync server.
 #. Use :flutter-sdk:`Realm.writeCopy() <realm/Realm/writeCopy.html>` to create
    a new version of the synced realm. You **must** use ``Realm.writeCopy()``
    to bundle the synced realm because the method removes metadata that associates

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -19,9 +19,36 @@ realm database file in your Flutter app.
    You can also add data to your realm the first time an application opens it
    using the :ref:`initial data callback function <flutter-initial-data-callback>`.
 
+.. important:: Bundling Synced Realms
+
+   If your backend application has enabled :ref:`advanced backend compaction
+   <advanced-backend-compaction>` by configuring a
+   :ref:`client maximum offline time <client-maximum-offline-time>`,
+   users could experience a client reset the first time they open the
+   bundled realm file. This can happen if the bundled realm file was
+   generated more than **client maximum offline time** days before the user syncs
+   the realm for the first time.
+
+   Applications experiencing a client reset will download the full state of the
+   realm from the application backend. This negates the
+   advantages of bundling a realm file. To prevent client resets and
+   preserve the advantages of realm file bundling:
+
+   - Avoid using a client maximum offline time in applications that
+     bundle a synchronized realm.
+
+   - If your application does use a client maximum offline time, ensure
+     that your application download always includes a recently synced
+     realm file. Generate a new file each application version,
+     and ensure that no version ever stays current for more than
+     **client maximum offline time** number of days.
+
+
 .. procedure::
 
    .. step:: Create a Realm File for Bundling
+
+      TODO: use writeCopy()
 
       Create a new project with the same :ref:`Realm object schema
       <flutter-define-realm-object-schema>` as your production app.
@@ -31,8 +58,27 @@ realm database file in your Flutter app.
       Get the path to the realm file with the :flutter-sdk:`Realm.config.path <realm/Configuration/path.html>`
       property.
 
-      .. literalinclude:: /examples/generated/flutter/myapp.snippet.create-bundle.dart
-         :language: dart
+      .. tabs::
+
+         .. tab:: Local Realm
+            :tabid: copy_local
+
+            .. literalinclude:: /examples/generated/flutter/myapp.snippet.create-bundle.dart
+               :language: dart
+
+         .. tab:: Synced Realm
+            :tabid: copy_synced
+
+            Before you bundle a synced realm, you must connect to your App and
+            authenticate a user to use Device Sync.
+
+            You must also ensure that there are no pending sync processes.
+            You do this by calling :flutter-sdk:`Realm.syncSession.waitForUpload()
+            <realm/Session/waitForUpload.html>`
+            and :flutter-sdk:`Realm.syncSession.waitForDownload() <realm/Session/waitForDownload.html>`.
+
+            .. literalinclude:: /examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
+               :language: dart
 
       .. tip:: Create Bundled Realm with Dart Standalone SDK
 

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -99,8 +99,8 @@ sync subscriptions. To learn more, refer to :ref:`Manage Sync Subscriptions
 You should only bundle a synced realm if your use case meets the following criteria:
 
 - You can ensure that the users have a version of the app with the bundled synced realm
-  that is less old than the client maximum offline time.
-- The initial bundled data is very large **and** app is being used in a situation
+  that was created more recently than the client maximum offline time.
+- The initial bundled data is very large **and** the app is being used in a situation
   with limited internet bandwidth, so an initial data download using sync subscriptions
   would take too long.
 - All app users have backend permission to view the data included in the bundle.

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -19,30 +19,6 @@ realm database file in your Flutter app.
    You can also add data to your realm the first time an application opens it
    using the :ref:`initial data callback function <flutter-initial-data-callback>`.
 
-.. important:: Bundling Synced Realms
-
-   If your backend application has enabled :ref:`advanced backend compaction
-   <advanced-backend-compaction>` by configuring a
-   :ref:`client maximum offline time <client-maximum-offline-time>`,
-   users could experience a client reset the first time they open the
-   bundled realm file. This can happen if the bundled realm file was
-   generated more than **client maximum offline time** days before the user syncs
-   the realm for the first time.
-
-   Applications experiencing a client reset will download the full state of the
-   realm from the application backend. This negates the
-   advantages of bundling a realm file. To prevent client resets and
-   preserve the advantages of realm file bundling:
-
-   - Avoid using a client maximum offline time in applications that
-     bundle a synchronized realm.
-
-   - If your application does use a client maximum offline time, ensure
-     that your application download always includes a recently synced
-     realm file. Generate a new file each application version,
-     and ensure that no version ever stays current for more than
-     **client maximum offline time** number of days.
-
 .. procedure::
 
    .. step:: Create a Realm File for Bundling

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -48,8 +48,6 @@ realm database file in your Flutter app.
 
    .. step:: Create a Realm File for Bundling
 
-      TODO: use writeCopy()
-
       Create a new project with the same :ref:`Realm object schema
       <flutter-define-realm-object-schema>` as your production app.
       :ref:`Open an existing realm <flutter-open-realm>` with the data

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -43,7 +43,6 @@ realm database file in your Flutter app.
      and ensure that no version ever stays current for more than
      **client maximum offline time** number of days.
 
-
 .. procedure::
 
    .. step:: Create a Realm File for Bundling
@@ -56,27 +55,8 @@ realm database file in your Flutter app.
       Get the path to the realm file with the :flutter-sdk:`Realm.config.path <realm/Configuration/path.html>`
       property.
 
-      .. tabs::
-
-         .. tab:: Local Realm
-            :tabid: copy_local
-
-            .. literalinclude:: /examples/generated/flutter/myapp.snippet.create-bundle.dart
-               :language: dart
-
-         .. tab:: Synced Realm
-            :tabid: copy_synced
-
-            Before you bundle a synced realm, you must connect to your App and
-            authenticate a user to use Device Sync.
-
-            You must also ensure that there are no pending sync processes.
-            You do this by calling :flutter-sdk:`Realm.syncSession.waitForUpload()
-            <realm/Session/waitForUpload.html>`
-            and :flutter-sdk:`Realm.syncSession.waitForDownload() <realm/Session/waitForDownload.html>`.
-
-            .. literalinclude:: /examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
-               :language: dart
+      .. literalinclude:: /examples/generated/flutter/myapp.snippet.create-bundle.dart
+         :language: dart
 
       .. tip:: Create Bundled Realm with Dart Standalone SDK
 
@@ -123,3 +103,45 @@ realm database file in your Flutter app.
       .. literalinclude:: /examples/generated/flutter/main.snippet.include-bundled-realm.dart
          :language: dart
          :caption: lib/main.dart
+
+.. _flutter-bundle-synced-realm:
+
+Bundle a Synced Realm
+---------------------
+
+In most cases, you should **not** bundle a synced realm. If the bundled realm
+was last updated further in the past than :ref:`client maximum offline time
+<client-maximum-offline-time>`, the user experiences a client reset
+the first time they open the bundled realm file. The client reset causes
+the application to download the full state of the realm from the application backend.
+This negates the advantages of bundling a realm file.
+
+Rather than bundling a synced realm, you can bootstrap application data using
+sync subscriptions. To learn more, refer to :ref:`Manage Sync Subscriptions
+<flutter-flexible-sync-manage-subscriptions>`.
+
+You should only bundle a synced realm if your use case meets the following criteria:
+
+- You can ensure that the users have a version of the app with the bundled synced realm
+  that is less old than the client maximum offline time.
+- The initial bundled data is very large **and** app is being used in a situation
+  with limited internet bandwidth, so an initial data download using sync subscriptions
+  would take too long.
+
+To bundle a synced realm, perform the following:
+
+#. Connect to your App and authenticate a user to use Device Sync.
+#. Ensure that there are no pending sync processes.
+   Do this by calling :flutter-sdk:`Realm.syncSession.waitForUpload() <realm/Session/waitForUpload.html>`
+   and :flutter-sdk:`Realm.syncSession.waitForDownload() <realm/Session/waitForDownload.html>`.
+#. Use :flutter-sdk:`Realm.writeCopy() <realm/Realm/writeCopy.html>` to create
+   a new version of the synced realm. You **must** use ``Realm.writeCopy()``
+   to bundle the synced realm because the method removes metadata that associates
+   the realm with the user in the configuration, which allows other users
+   to open the realm file as well.
+
+.. literalinclude:: /examples/generated/flutter/myapp.snippet.create-synced-bundle.dart
+   :language: dart
+
+After you create the bundled realm, follow the instructions from the above sections
+**Bundle a Realm File in Your Production Application** and **Open a Realm from a Bundled Realm File**.

--- a/source/sdk/flutter/realm-database/realm-files/bundle.txt
+++ b/source/sdk/flutter/realm-database/realm-files/bundle.txt
@@ -107,9 +107,7 @@ You should only bundle a synced realm if your use case meets the following crite
 To bundle a synced realm, perform the following:
 
 #. Connect to your App and authenticate a user to use Device Sync.
-#. Ensure that there are no pending sync processes.
-   Do this by calling :flutter-sdk:`Realm.syncSession.waitForUpload() <realm/Session/waitForUpload.html>`
-   and :flutter-sdk:`Realm.syncSession.waitForDownload() <realm/Session/waitForDownload.html>`.
+#. Add Data to the synced realm.
 #. Use :flutter-sdk:`Realm.writeCopy() <realm/Realm/writeCopy.html>` to create
    a new version of the synced realm. You **must** use ``Realm.writeCopy()``
    to bundle the synced realm because the method removes metadata that associates


### PR DESCRIPTION
## Pull Request Info

update the bundle a realm page to talk about synced realm.

> **Note**
>
> The ticket specified to use Realm.writeCopy() for this, but based upon my understanding of that API and creating realms generally, I think it's actually more straightforward to just have the user create and copy a realm, as documented here. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-26118

### Staged Changes

- [Bundle a Realm (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26118/sdk/flutter/realm-database/realm-files/bundle)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
