### PR TITLE
Update C++ code examples for C++ SDK primary key fix

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        08b3c0056877118f385e27c1d6e332f1df39f02d
+  GIT_TAG        ec62f7f40c445b1a5894191ae0c4bbcd93d9c191
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/define-object-model.cpp
+++ b/examples/cpp/define-object-model.cpp
@@ -22,7 +22,7 @@ struct ContactDetails : realm::embedded_object<ContactDetails> { // :emphasize:
 };
 
 struct Business : realm::object<Business> {
-    realm::persisted<realm::object_id> _id;
+    realm::persisted<realm::object_id> _id{realm::object_id::generate()};
     realm::persisted<std::string> name;
     realm::persisted<std::optional<ContactDetails>> contactDetails; // :emphasize:
 
@@ -159,7 +159,6 @@ TEST_CASE("create an embedded object", "[model][write]") {
     auto realm = realm::open<Business, ContactDetails>();
 
     auto business = Business();
-    business._id = realm::object_id::generate();
     business.name = "MongoDB";
     business.contactDetails = ContactDetails { 
         .emailAddress = "email@example.com", 
@@ -352,7 +351,6 @@ TEST_CASE("update an embedded object", "[model][update]") {
     auto realm = realm::open<Business, ContactDetails>();
 
     auto business = Business { 
-        ._id = realm::object_id::generate(), 
         .name = "MongoDB" 
     };
     

--- a/examples/cpp/define-object-model.cpp
+++ b/examples/cpp/define-object-model.cpp
@@ -22,7 +22,7 @@ struct ContactDetails : realm::embedded_object<ContactDetails> { // :emphasize:
 };
 
 struct Business : realm::object<Business> {
-    realm::persisted<int64_t> _id;
+    realm::persisted<realm::object_id> _id;
     realm::persisted<std::string> name;
     realm::persisted<std::optional<ContactDetails>> contactDetails; // :emphasize:
 
@@ -53,7 +53,7 @@ struct Employee : realm::object<Employee> {
 
 // :snippet-start: to-one-relationship
 struct ToOneRelationship_FavoriteToy : realm::object<ToOneRelationship_FavoriteToy> {
-    realm::persisted<int64_t> _id;
+    realm::persisted<realm::uuid> _id;
     realm::persisted<std::string> name;
 
     static constexpr auto schema = realm::schema("ToOneRelationship_FavoriteToy",
@@ -62,7 +62,7 @@ struct ToOneRelationship_FavoriteToy : realm::object<ToOneRelationship_FavoriteT
 };
 
 struct ToOneRelationship_Dog : realm::object<ToOneRelationship_Dog> {
-    realm::persisted<int64_t> _id;
+    realm::persisted<realm::uuid> _id;
     realm::persisted<std::string> name;
     realm::persisted<int64_t> age;
     // To-one relationship objects must be optional
@@ -159,7 +159,7 @@ TEST_CASE("create an embedded object", "[model][write]") {
     auto realm = realm::open<Business, ContactDetails>();
 
     auto business = Business();
-    business._id = 789012;
+    business._id = realm::object_id::generate();
     business.name = "MongoDB";
     business.contactDetails = ContactDetails { 
         .emailAddress = "email@example.com", 
@@ -216,8 +216,14 @@ TEST_CASE("create object with to-one relationship", "[model][write][relationship
     // :snippet-start: create-object-with-to-one-relationship
     auto realm = realm::open<ToOneRelationship_Dog, ToOneRelationship_FavoriteToy>();
 
-    auto favoriteToy = ToOneRelationship_FavoriteToy { .name = "Wubba" };
-    auto dog = ToOneRelationship_Dog { .name = "Lita", .age = 10 };
+    auto favoriteToy = ToOneRelationship_FavoriteToy { 
+        ._id = realm::uuid("68b696c9-320b-4402-a412-d9cee10fc6a5"), 
+        .name = "Wubba" };
+
+    auto dog = ToOneRelationship_Dog { 
+        ._id = realm::uuid("68b696d7-320b-4402-a412-d9cee10fc6a3"), 
+        .name = "Lita", 
+        .age = 10 };
     dog.favoriteToy = favoriteToy;
 
     realm.write([&realm, &dog] {
@@ -345,7 +351,11 @@ TEST_CASE("create object with to-many relationship", "[model][write][relationshi
 TEST_CASE("update an embedded object", "[model][update]") {
     auto realm = realm::open<Business, ContactDetails>();
 
-    auto business = Business { .name = "MongoDB" };
+    auto business = Business { 
+        ._id = realm::object_id::generate(), 
+        .name = "MongoDB" 
+    };
+    
     business.contactDetails = ContactDetails { 
         .emailAddress = "email@example.com", 
         .phoneNumber = "123-456-7890"

--- a/examples/cpp/examples.cpp
+++ b/examples/cpp/examples.cpp
@@ -35,7 +35,7 @@ struct Dog : realm::object<Dog> {
 // :snippet-end:
 
 struct Person : realm::object<Person> {
-    realm::persisted<int64_t> _id;
+    realm::persisted<std::string> _id;
     realm::persisted<std::string> name;
     realm::persisted<int64_t> age;
 

--- a/examples/cpp/supported-types.cpp
+++ b/examples/cpp/supported-types.cpp
@@ -64,6 +64,12 @@ struct AllTypesObject : realm::object<AllTypesObject> {
     // :snippet-start: optional-uuid
     realm::persisted<std::optional<realm::uuid>> optUuidName;
     // :snippet-end:
+    // :snippet-start: required-object-id
+    realm::persisted<realm::object_id> objectIdName;
+    // :snippet-end:
+    // :snippet-start: optional-object-id
+    realm::persisted<std::optional<realm::object_id>> optObjectIdName;
+    // :snippet-end:
     // :snippet-start: required-mixed-type
     realm::persisted<realm::mixed> mixedName;
     // :snippet-end:
@@ -104,7 +110,8 @@ TEST_CASE("required supported types", "[write]") {
             .enumName = AllTypesObject::Enum::one,
             // The below line causes this test to hang indefinitely running from the terminal, but works in Xcode
             // .binaryDataName = std::vector<uint8_t>{0,1,2},
-            .uuidName = realm::uuid()
+            .uuidName = realm::uuid(),
+            .objectIdName = realm::object_id::generate()
         };
 
         realm.write([&realm, &allRequiredTypesObject] {
@@ -142,7 +149,8 @@ TEST_CASE("optional supported types", "[write]") {
             .enumName = AllTypesObject::Enum::one,
             // The below line causes this test to hang indefinitely running from the terminal, but works in Xcode
             // .binaryDataName = std::vector<uint8_t>{0,1,2},
-            .uuidName = realm::uuid()
+            .uuidName = realm::uuid(),
+            .objectIdName = realm::object_id::generate()
         };
 
         realm.write([&realm, &allRequiredAndOptionalTypesObject] {
@@ -158,6 +166,7 @@ TEST_CASE("optional supported types", "[write]") {
             // Currently leaving this commented out due to issue reported in ln 53 above
             // allRequiredAndOptionalTypesObject.optBinaryDataName = std::vector<uint8_t>{3,4,5};
             allRequiredAndOptionalTypesObject.optUuidName = realm::uuid();
+            allRequiredAndOptionalTypesObject.optObjectIdName = realm::object_id::generate();
         });
 
        auto allTypeObjects = realm.objects<AllTypesObject>();

--- a/source/examples/generated/cpp/define-object-model.snippet.create-embedded-object.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.create-embedded-object.cpp
@@ -1,7 +1,6 @@
 auto realm = realm::open<Business, ContactDetails>();
 
 auto business = Business();
-business._id = realm::object_id::generate();
 business.name = "MongoDB";
 business.contactDetails = ContactDetails { 
     .emailAddress = "email@example.com", 

--- a/source/examples/generated/cpp/define-object-model.snippet.create-embedded-object.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.create-embedded-object.cpp
@@ -1,7 +1,7 @@
 auto realm = realm::open<Business, ContactDetails>();
 
 auto business = Business();
-business._id = 789012;
+business._id = realm::object_id::generate();
 business.name = "MongoDB";
 business.contactDetails = ContactDetails { 
     .emailAddress = "email@example.com", 

--- a/source/examples/generated/cpp/define-object-model.snippet.create-object-with-to-one-relationship.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.create-object-with-to-one-relationship.cpp
@@ -1,7 +1,13 @@
 auto realm = realm::open<Dog, FavoriteToy>();
 
-auto favoriteToy = FavoriteToy { .name = "Wubba" };
-auto dog = Dog { .name = "Lita", .age = 10 };
+auto favoriteToy = FavoriteToy { 
+    ._id = realm::uuid("68b696c9-320b-4402-a412-d9cee10fc6a5"), 
+    .name = "Wubba" };
+
+auto dog = Dog { 
+    ._id = realm::uuid("68b696d7-320b-4402-a412-d9cee10fc6a3"), 
+    .name = "Lita", 
+    .age = 10 };
 dog.favoriteToy = favoriteToy;
 
 realm.write([&realm, &dog] {

--- a/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp
@@ -11,7 +11,7 @@ struct ContactDetails : realm::embedded_object<ContactDetails> {
 };
 
 struct Business : realm::object<Business> {
-    realm::persisted<realm::object_id> _id;
+    realm::persisted<realm::object_id> _id{realm::object_id::generate()};
     realm::persisted<std::string> name;
     realm::persisted<std::optional<ContactDetails>> contactDetails; 
 

--- a/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.model-with-embedded-object.cpp
@@ -11,7 +11,7 @@ struct ContactDetails : realm::embedded_object<ContactDetails> {
 };
 
 struct Business : realm::object<Business> {
-    realm::persisted<int64_t> _id;
+    realm::persisted<realm::object_id> _id;
     realm::persisted<std::string> name;
     realm::persisted<std::optional<ContactDetails>> contactDetails; 
 

--- a/source/examples/generated/cpp/define-object-model.snippet.to-one-relationship.cpp
+++ b/source/examples/generated/cpp/define-object-model.snippet.to-one-relationship.cpp
@@ -1,5 +1,5 @@
 struct FavoriteToy : realm::object<FavoriteToy> {
-    realm::persisted<int64_t> _id;
+    realm::persisted<realm::uuid> _id;
     realm::persisted<std::string> name;
 
     static constexpr auto schema = realm::schema("FavoriteToy",
@@ -8,7 +8,7 @@ struct FavoriteToy : realm::object<FavoriteToy> {
 };
 
 struct Dog : realm::object<Dog> {
-    realm::persisted<int64_t> _id;
+    realm::persisted<realm::uuid> _id;
     realm::persisted<std::string> name;
     realm::persisted<int64_t> age;
     // To-one relationship objects must be optional

--- a/source/examples/generated/cpp/examples.snippet.define-models.cpp
+++ b/source/examples/generated/cpp/examples.snippet.define-models.cpp
@@ -8,7 +8,7 @@ struct Dog : realm::object<Dog> {
 };
 
 struct Person : realm::object<Person> {
-    realm::persisted<int64_t> _id;
+    realm::persisted<std::string> _id;
     realm::persisted<std::string> name;
     realm::persisted<int64_t> age;
 

--- a/source/examples/generated/cpp/supported-types.snippet.optional-object-id.cpp
+++ b/source/examples/generated/cpp/supported-types.snippet.optional-object-id.cpp
@@ -1,0 +1,1 @@
+realm::persisted<std::optional<realm::object_id>> optObjectIdName;

--- a/source/examples/generated/cpp/supported-types.snippet.required-object-id.cpp
+++ b/source/examples/generated/cpp/supported-types.snippet.required-object-id.cpp
@@ -1,0 +1,1 @@
+realm::persisted<realm::object_id> objectIdName;

--- a/source/sdk/cpp/model-data/object-models.txt
+++ b/source/sdk/cpp/model-data/object-models.txt
@@ -128,6 +128,13 @@ Primary keys are subject to the following limitations:
 If you are using :ref:`Device Sync <cpp-synced-realm>`, your models must 
 have a primary key named ``_id``.
 
+The Realm C++ SDK supports primary keys of the following types, required or optional:
+
+- ``realm::object_id``
+- ``realm::uuid``
+- ``realm::enum``
+- ``std::string``
+
 You set a property as a primary key by passing ``true`` to the second template parameter of the ``persisted`` template:
 
 .. literalinclude:: /examples/generated/cpp/examples.snippet.define-a-schema.cpp

--- a/source/sdk/cpp/model-data/supported-types.txt
+++ b/source/sdk/cpp/model-data/supported-types.txt
@@ -82,6 +82,13 @@ Property Cheat Sheet
      - .. literalinclude:: /examples/generated/cpp/supported-types.snippet.optional-uuid.cpp
           :language: cpp
           :copyable: false
+   * - Object ID
+     - .. literalinclude:: /examples/generated/cpp/supported-types.snippet.required-object-id.cpp
+          :language: cpp
+          :copyable: false
+     - .. literalinclude:: /examples/generated/cpp/supported-types.snippet.optional-object-id.cpp
+          :language: cpp
+          :copyable: false
    * - Mixed Data Type
      - .. literalinclude:: /examples/generated/cpp/supported-types.snippet.required-mixed-type.cpp
           :language: cpp


### PR DESCRIPTION
## Pull Request Info

### Jira

This PR initially just updated the code examples for the primary key fix in the C++ SDK PR # 42. There was no corresponding Jira ticket for that. However, since I'm now showing `object_id` primary keys in some of these code examples, I've added the Jira ticket for that work to this PR retroactively.

- https://jira.mongodb.org/browse/DOCSP-27497

### Staged Changes

- [Object Types & Schemas/Specify a Primary Key](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/primary-key-fix/sdk/cpp/model-data/object-models/#specify-a-primary-key): Add a list of supported primary key data types
- [Supported Types](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/primary-key-fix/sdk/cpp/model-data/supported-types/): Add `object_id` to supported types list
- [CRUD/Create](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/primary-key-fix/sdk/cpp/crud/create/): Update some of the create examples & related models to show creating objects with different types of primary keys

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
