### PR TITLE
(DOCSP-26734): C++: Add a Sync Subscriptions page

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -20,6 +20,6 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2 cpprealm)
 
 # add_executable(examples testHelpers.hpp examples.cpp define-object-model.cpp authentication.cpp supported-types.cpp testHelpersTests.cpp)
-add_executable(examples examples.cpp define-object-model.cpp authentication.cpp supported-types.cpp)
+add_executable(examples examples.cpp define-object-model.cpp authentication.cpp supported-types.cpp flexible-sync.cpp)
 target_link_libraries(examples PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(examples PRIVATE cpprealm)

--- a/examples/cpp/flexible-sync.cpp
+++ b/examples/cpp/flexible-sync.cpp
@@ -1,0 +1,110 @@
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <thread>
+#include <future>
+#include <cpprealm/sdk.hpp>
+
+// :replace-start: {
+//   "terms": {
+//     "FlexibleSync_": ""
+//   }
+// }
+
+static std::string APP_ID = "cpp-tester-uliix";
+
+struct FlexibleSync_Dog : realm::object<FlexibleSync_Dog> {
+    realm::persisted<realm::object_id> _id{realm::object_id::generate()};
+    realm::persisted<std::string> name;
+    realm::persisted<int64_t> age;
+
+    static constexpr auto schema = realm::schema("FlexibleSync_Dog",
+        realm::property<&FlexibleSync_Dog::_id, true>("_id"),
+        realm::property<&FlexibleSync_Dog::name>("name"),
+        realm::property<&FlexibleSync_Dog::age>("age"));
+};
+
+TEST_CASE("subscribe to a all objects of a type", "[sync]") {
+    auto app = realm::App(APP_ID);
+    auto user = app.login(realm::App::credentials::anonymous()).get_future().get();
+    auto syncConfig = user.flexible_sync_configuration();
+    auto syncedRealmRef = realm::async_open<FlexibleSync_Dog>(syncConfig).get_future().get();
+    auto syncedRealm = syncedRealmRef.resolve();
+    auto clearInitialSubscriptions = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+        subs.clear();
+    }).get_future().get();
+    CHECK(clearInitialSubscriptions == true);
+    CHECK(syncedRealm.subscriptions().size() == 0);
+    // :snippet-start: subscribe-to-all-objects-of-a-type
+    auto updateSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+        subs.add<FlexibleSync_Dog>("dogs");
+    }).get_future().get();
+    // The .update() function returns a bool, which confirms whether or not the update succeeded
+    REQUIRE(updateSubscriptionSuccess == true);
+    // You can check the .size() of the subscription set, which tells you the 
+    // number of sync_subscription objects in the set
+    CHECK(syncedRealm.subscriptions().size() == 1);
+    // :snippet-end:
+    // :snippet-start: remove-subscription-by-name
+    auto removeSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+        subs.remove("dogs");
+    }).get_future().get();
+    REQUIRE(removeSubscriptionSuccess == true);
+    // :snippet-end:
+    CHECK(syncedRealm.subscriptions().size() == 0);
+    // :snippet-start: refresh-the-realm
+    syncedRealm.refresh();
+    // :snippet-end:
+}
+
+TEST_CASE("subscribe to a subset of objects", "[sync]") {
+    // :snippet-start: flexible-sync-prerequisites
+    // Initialize the App, authenticate a user, and open the realm
+    auto app = realm::App(APP_ID);
+    auto user = app.login(realm::App::credentials::anonymous()).get_future().get();
+    auto syncConfig = user.flexible_sync_configuration();
+    auto syncedRealmRef = realm::async_open<FlexibleSync_Dog>(syncConfig).get_future().get();
+    auto syncedRealm = syncedRealmRef.resolve();
+    // :snippet-end:
+    // :snippet-start: clear-all-subscriptions
+    // You can use .clear() inside a mutable_sync_subscription_set to clear all 
+    // sync_subscription objects from the set 
+    auto updateSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+        subs.clear();
+    }).get_future().get();
+    CHECK(updateSubscriptionSuccess == true);
+    CHECK(syncedRealm.subscriptions().size() == 0);
+    // :snippet-end:
+    // :snippet-start: subscribe-to-objects-matching-a-query
+    updateSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+        subs.add<FlexibleSync_Dog>("puppies", [](auto &obj) {
+            return obj.age < 3;
+        });
+    }).get_future().get();
+    REQUIRE(updateSubscriptionSuccess == true);
+    CHECK(syncedRealm.subscriptions().size() == 1);
+    // :snippet-end:
+    // :snippet-start: subscription-count-and-find-subscription
+    // Check the subscription count
+    CHECK(syncedRealm.subscriptions().size() == 1);
+
+    // Find a specific subscription by name
+    auto puppySubscription = *syncedRealm.subscriptions().find("puppies");
+    CHECK(puppySubscription.name == "puppies"); // :remove:
+
+    // Get information about the subscription
+    CHECK(puppySubscription.object_class_name == "FlexibleSync_Dog");
+    CHECK(puppySubscription.query_string == "age < 3");
+    // :snippet-end:
+    // :snippet-start: change-subscription-query
+    updateSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+        subs.update_subscription<FlexibleSync_Dog>("puppies", [](auto &obj) {
+            // Change the age filter from `age < 3` to `age < 2`
+            return obj.age < 2;
+        });
+    }).get_future().get();
+    REQUIRE(updateSubscriptionSuccess == true);
+    // :snippet-end:
+    auto updatedPuppySubscription = *syncedRealm.subscriptions().find("puppies");
+    CHECK(updatedPuppySubscription.query_string == "age < 2");
+}
+// :replace-end:

--- a/source/examples/generated/cpp/flexible-sync.snippet.change-subscription-query.cpp
+++ b/source/examples/generated/cpp/flexible-sync.snippet.change-subscription-query.cpp
@@ -1,0 +1,7 @@
+updateSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+    subs.update_subscription<Dog>("puppies", [](auto &obj) {
+        // Change the age filter from `age < 3` to `age < 2`
+        return obj.age < 2;
+    });
+}).get_future().get();
+REQUIRE(updateSubscriptionSuccess == true);

--- a/source/examples/generated/cpp/flexible-sync.snippet.clear-all-subscriptions.cpp
+++ b/source/examples/generated/cpp/flexible-sync.snippet.clear-all-subscriptions.cpp
@@ -1,0 +1,7 @@
+// You can use .clear() inside a mutable_sync_subscription_set to clear all 
+// sync_subscription objects from the set 
+auto updateSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+    subs.clear();
+}).get_future().get();
+CHECK(updateSubscriptionSuccess == true);
+CHECK(syncedRealm.subscriptions().size() == 0);

--- a/source/examples/generated/cpp/flexible-sync.snippet.flexible-sync-prerequisites.cpp
+++ b/source/examples/generated/cpp/flexible-sync.snippet.flexible-sync-prerequisites.cpp
@@ -1,0 +1,6 @@
+// Initialize the App, authenticate a user, and open the realm
+auto app = realm::App(APP_ID);
+auto user = app.login(realm::App::credentials::anonymous()).get_future().get();
+auto syncConfig = user.flexible_sync_configuration();
+auto syncedRealmRef = realm::async_open<Dog>(syncConfig).get_future().get();
+auto syncedRealm = syncedRealmRef.resolve();

--- a/source/examples/generated/cpp/flexible-sync.snippet.refresh-the-realm.cpp
+++ b/source/examples/generated/cpp/flexible-sync.snippet.refresh-the-realm.cpp
@@ -1,0 +1,1 @@
+syncedRealm.refresh();

--- a/source/examples/generated/cpp/flexible-sync.snippet.remove-subscription-by-name.cpp
+++ b/source/examples/generated/cpp/flexible-sync.snippet.remove-subscription-by-name.cpp
@@ -1,0 +1,4 @@
+auto removeSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+    subs.remove("dogs");
+}).get_future().get();
+REQUIRE(removeSubscriptionSuccess == true);

--- a/source/examples/generated/cpp/flexible-sync.snippet.subscribe-to-all-objects-of-a-type.cpp
+++ b/source/examples/generated/cpp/flexible-sync.snippet.subscribe-to-all-objects-of-a-type.cpp
@@ -1,0 +1,8 @@
+auto updateSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+    subs.add<Dog>("dogs");
+}).get_future().get();
+// The .update() function returns a bool, which confirms whether or not the update succeeded
+REQUIRE(updateSubscriptionSuccess == true);
+// You can check the .size() of the subscription set, which tells you the 
+// number of sync_subscription objects in the set
+CHECK(syncedRealm.subscriptions().size() == 1);

--- a/source/examples/generated/cpp/flexible-sync.snippet.subscribe-to-objects-matching-a-query.cpp
+++ b/source/examples/generated/cpp/flexible-sync.snippet.subscribe-to-objects-matching-a-query.cpp
@@ -1,0 +1,7 @@
+updateSubscriptionSuccess = syncedRealm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+    subs.add<Dog>("puppies", [](auto &obj) {
+        return obj.age < 3;
+    });
+}).get_future().get();
+REQUIRE(updateSubscriptionSuccess == true);
+CHECK(syncedRealm.subscriptions().size() == 1);

--- a/source/examples/generated/cpp/flexible-sync.snippet.subscription-count-and-find-subscription.cpp
+++ b/source/examples/generated/cpp/flexible-sync.snippet.subscription-count-and-find-subscription.cpp
@@ -1,0 +1,9 @@
+// Check the subscription count
+CHECK(syncedRealm.subscriptions().size() == 1);
+
+// Find a specific subscription by name
+auto puppySubscription = *syncedRealm.subscriptions().find("puppies");
+
+// Get information about the subscription
+CHECK(puppySubscription.object_class_name == "Dog");
+CHECK(puppySubscription.query_string == "age < 3");

--- a/source/sdk/cpp.txt
+++ b/source/sdk/cpp.txt
@@ -14,6 +14,7 @@ C++ SDK (Alpha)
    CRUD </sdk/cpp/crud/>
    Connect to App Services </sdk/cpp/app-services/connect-to-app>
    Manage Email/Password Users </sdk/cpp/users/manage-email-password-users>
+   Manage Sync Subscriptions </sdk/cpp/sync/sync-subscriptions>
    GitHub <https://github.com/realm/realm-cpp>
    API Reference (Doxygen) <https://www.mongodb.com/docs/realm-sdks/cpp/latest/>
 

--- a/source/sdk/cpp/sync/sync-subscriptions.txt
+++ b/source/sdk/cpp/sync/sync-subscriptions.txt
@@ -202,8 +202,8 @@ Refresh the Realm After Updating Subscriptions
 ----------------------------------------------
 
 After you update subscriptions, call ``refresh()`` on the :cpp-sdk:`realm 
-<structrealm_1_1db.html>`. This updates the Realm and outstanding objects 
-managed by the Realm to point to the most recent data.
+<structrealm_1_1db.html>`. This updates the realm and outstanding objects 
+managed by the realm to point to the most recent data.
 
 .. literalinclude:: /examples/generated/cpp/flexible-sync.snippet.refresh-the-realm.cpp
    :language: cpp

--- a/source/sdk/cpp/sync/sync-subscriptions.txt
+++ b/source/sdk/cpp/sync/sync-subscriptions.txt
@@ -1,0 +1,209 @@
+.. _cpp-manage-flexible-sync-subscriptions:
+.. _cpp-flexible-sync:
+
+===========================================
+Manage Sync Subscriptions - C++ SDK (Alpha)
+===========================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 3
+   :class: singlecol
+
+Overview
+--------
+
+Flexible Sync uses subscriptions and permissions to determine which
+data to sync between your Atlas App Services App and your client device.
+In the client, query subscriptions manage and filter the object types that
+can sync to the realm.
+
+Before You Begin
+----------------
+
+To use Flexible Sync in your app, you must:
+
+- :ref:`Configure Flexible Sync on the backend <enable-flexible-sync>`
+- :ref:`Initialize the app <cpp-connect-to-backend>`
+- :ref:`Authenticate a user <cpp-authenticate-users>`
+- :ref:`Open the synced Realm with a Flexible Sync configuration <cpp-open-synced-realm>`
+
+The setup code for the examples on this page handles these prerequisites:
+
+.. literalinclude:: /examples/generated/cpp/flexible-sync.snippet.flexible-sync-prerequisites.cpp
+   :language: cpp
+
+.. _cpp-align-subscription-with-app:
+
+Align Subscriptions with Backend App
+------------------------------------
+
+Your client-side subscription queries must align with the Device Sync configuration
+in your backend App Services App.
+
+You subscription queries can either:
+
+- **Query all objects of a type.**
+- **Query object of a type that match backend App's queryable fields.**
+
+To learn more about configuring queryable fields, refer to :ref:`Queryable 
+Fields <queryable-fields>` in the App Services documentation.
+
+A synced realm must have one or more subscriptions in order
+to be able to read and write data to the realm. You can only write data to
+the realm that matches one or more subscriptions, *and* matches the 
+user's permissions. If you attempt to write objects to a realm that do 
+not match a subscription, or for which the user does not have permission
+to perform the write, you get a compensating write from the server and 
+the write reverts.
+
+.. _cpp-manage-subscriptions:
+
+Manage Your Subscriptions
+-------------------------
+
+When configuring Flexible Sync on the backend, you specify which fields your
+client application can query. In the client application, the
+:cpp-sdk:`sync_subscription_set <structrealm_1_1SyncSubscriptionSet.html>` 
+is a list of zero or more :cpp-sdk:`sync_subscriptions 
+<structrealm_1_1SyncSubscription.html>` that determine what objects the 
+realm can store. 
+
+The Realm C++ SDK also has a :cpp-sdk:`mutable_sync_subscription_set 
+<structrealm_1_1MutableSyncSubscriptionSet.html>` that enables you to
+add, change, and remove subscriptions.
+
+You can do the following with your ``sync_subscription_set``:
+
+- Get the number of subscriptions
+- Find a specific subscription
+
+With a ``mutable_subscription_set`` you can:
+
+- Add a new subscription
+- Find a specific subscription
+- Update a specific subscription
+- Remove a specific subscription
+- Clear all subscriptions
+
+When you access a specific ``sync_subscription``, you can read or update its 
+attributes:
+
+- Reference the subscription by string ``name``
+- Find out when it was created (``created_at``) or updated (``updated_at``)
+- Check its string ``object_class_name`` and check or modify its ``query_string``
+
+.. _cpp-verify-subscription-size-find-subscription:
+
+Verify Number of Subscriptions or Find a Specific Subscription
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When your app first opens a synced realm, you may want to verify that it 
+has the expected number of subscriptions or has a specific subscription.
+
+You can get this information by accessing the ``subscriptions()`` public
+member function of a :cpp-sdk:`realm <structrealm_1_1db.html>`. This 
+provides the :cpp-sdk:`sync_subscription_set 
+<structrealm_1_1SyncSubscriptionSet.html>` where you can use the 
+``size()`` or ``find()`` public member functions.
+
+.. literalinclude:: /examples/generated/cpp/flexible-sync.snippet.subscription-count-and-find-subscription.cpp
+   :language: cpp
+
+.. _cpp-add-subscriptions:
+
+Add Sync Subscriptions
+~~~~~~~~~~~~~~~~~~~~~~
+
+To update a subscription set, use the ``subscription().updates()`` function.
+This gives you access to a :cpp-sdk:`mutable_sync_subscription_set 
+<structrealm_1_1MutableSyncSubscriptionSet.html>` where you can use the
+use the ``add()`` function to add a new Sync subscription.
+
+This template requires the object type of the object you want to sync, and 
+a string name for the subscription.
+
+Subscribe to All Objects of a Type
+``````````````````````````````````
+
+You can subscribe to all objects of a type. This enables the synced realm to 
+read and write any objects of the type where the user's permissions match 
+the server-side permissions.
+
+.. literalinclude:: /examples/generated/cpp/flexible-sync.snippet.subscribe-to-all-objects-of-a-type.cpp
+   :language: cpp
+
+Subscribe to Objects that Match a Query
+```````````````````````````````````````
+
+If you only want to subscribe to a subset of objects, provide a query to 
+filter the subscription.
+
+.. literalinclude:: /examples/generated/cpp/flexible-sync.snippet.subscribe-to-objects-matching-a-query.cpp
+   :language: cpp
+
+When you filter a subscription, you cannot write objects that do not match 
+the filter. In this example, the query matches ``Dog`` objects whose ``age`` is 
+less than ``3``. The realm does not sync any dogs who are 3 or older. This 
+filter also applies to writes. If you try to write a ``Dog`` object where 
+the ``age`` is ``4``, you get a compensating write error and the write 
+reverts.
+
+.. _cpp-update-subscriptions:
+
+Update Sync Subscriptions
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To update a subscription set, use the ``subscription().updates()`` function.
+This gives you access to a :cpp-sdk:`mutable_sync_subscription_set 
+<structrealm_1_1MutableSyncSubscriptionSet.html>` where you can use the
+``update_subscription()`` function to update a specific :cpp-sdk:`sync_subscription 
+<structrealm_1_1SyncSubscription.html>`.
+
+You can change a ``sync_subscription``'s query in an update. You can add, remove,
+or update the query string for a given ``sync_subscription``.
+
+.. literalinclude:: /examples/generated/cpp/flexible-sync.snippet.change-subscription-query.cpp
+   :language: cpp
+
+.. _cpp-remove-subscriptions:
+
+Remove Sync Subscriptions
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To update a subscription set, use the ``subscription().updates()`` function.
+This gives you access to a :cpp-sdk:`mutable_sync_subscription_set 
+<structrealm_1_1MutableSyncSubscriptionSet.html>` where you can use the
+``remove()`` or ``clear()`` functions to remove subscriptions.
+
+Remove a Specific Subscription
+``````````````````````````````
+
+You can remove a specific subscription by name using the ``remove()`` function.
+Removing a subscription by name throws an error if the subscription does
+not exist, so you should check for a subscription before removing it.
+
+.. literalinclude:: /examples/generated/cpp/flexible-sync.snippet.remove-subscription-by-name.cpp
+   :language: cpp
+
+Remove All Subscriptions
+````````````````````````
+
+You can remove all subscriptions in a subscription set using the ``clear()`` 
+function.
+
+.. literalinclude:: /examples/generated/cpp/flexible-sync.snippet.clear-all-subscriptions.cpp
+   :language: cpp
+
+.. _cpp-refresh-realm:
+
+Refresh the Realm After Updating Subscriptions
+----------------------------------------------
+
+After you update subscriptions, call ``refresh()`` on the :cpp-sdk:`realm 
+<structrealm_1_1db.html>`. This updates the Realm and outstanding objects 
+managed by the Realm to point to the most recent data.
+
+.. literalinclude:: /examples/generated/cpp/flexible-sync.snippet.refresh-the-realm.cpp
+   :language: cpp

--- a/source/sdk/cpp/sync/sync-subscriptions.txt
+++ b/source/sdk/cpp/sync/sync-subscriptions.txt
@@ -66,33 +66,13 @@ Manage Your Subscriptions
 When configuring Flexible Sync on the backend, you specify which fields your
 client application can query. In the client application, the
 :cpp-sdk:`sync_subscription_set <structrealm_1_1SyncSubscriptionSet.html>` 
-is a list of zero or more :cpp-sdk:`sync_subscriptions 
-<structrealm_1_1SyncSubscription.html>` that determine what objects the 
+is a list of zero or more :cpp-sdk:`sync_subscription 
+<structrealm_1_1SyncSubscription.html>` objects that determine what objects the 
 realm can store. 
 
 The Realm C++ SDK also has a :cpp-sdk:`mutable_sync_subscription_set 
 <structrealm_1_1MutableSyncSubscriptionSet.html>` that enables you to
-add, change, and remove subscriptions.
-
-You can do the following with your ``sync_subscription_set``:
-
-- Get the number of subscriptions
-- Find a specific subscription
-
-With a ``mutable_subscription_set`` you can:
-
-- Add a new subscription
-- Find a specific subscription
-- Update a specific subscription
-- Remove a specific subscription
-- Clear all subscriptions
-
-When you access a specific ``sync_subscription``, you can read or update its 
-attributes:
-
-- Reference the subscription by string ``name``
-- Find out when it was created (``created_at``) or updated (``updated_at``)
-- Check its string ``object_class_name`` and check or modify its ``query_string``
+add, change, and remove ``sync_subscription`` objects.
 
 .. _cpp-verify-subscription-size-find-subscription:
 


### PR DESCRIPTION
## Pull Request Info

Note for reviewer: I expect a Snooty build error for the ref `cpp-authenticate-users`. That ref is introduced in PR #2531 which will also be merging into this feature branch before merging to master.

### Jira

- https://jira.mongodb.org/browse/DOCSP-26734

### Staged Changes

- [Sync Subscriptions](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26734/sdk/cpp/sync/sync-subscriptions/): New page

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
