### PR TITLE
(DOCSP-27632): C++: Add a Custom User Data page

### DIFF
--- a/examples/cpp/examples.cpp
+++ b/examples/cpp/examples.cpp
@@ -223,6 +223,43 @@ TEST_CASE("call a function", "[realm][sync]") {
     REQUIRE(resultString == "john.smith@companyemail.com");
 }
 
+TEST_CASE("custom user data", "[realm][sync]") {
+    auto app = realm::App(APP_ID);
+
+    // :snippet-start: create-custom-user-data
+    auto user = app.login(realm::App::credentials::anonymous()).get_future().get();
+
+    // Functions take an argument of BsonArray, so initialize the custom data as a BsonDocument
+    auto customDataBson = realm::bson::BsonDocument({{"userId", user.identifier()}, {"favoriteColor", "gold"}});
+
+    // Call an Atlas Function to insert custom data for the user
+    auto result = user.call_function("updateCustomUserData", { customDataBson }).get_future().get();
+    // :snippet-end:
+    CHECK(result);
+
+    // :snippet-start: read-custom-user-data
+    // Custom user data could be stale, so refresh it before reading it
+    user.refresh_custom_user_data().get_future().get();
+    CHECK((*user.custom_data())["favoriteColor"] == "gold");
+    // :snippet-end:
+
+    // :snippet-start: update-custom-user-data
+    // Functions take an argument of BsonArray, so initialize the custom data as a BsonDocument
+    auto updatedDataBson = realm::bson::BsonDocument({{"userId", user.identifier()}, { "favoriteColor", "black" }});
+
+    // Call an Atlas Function to update custom data for the user
+    auto updateResult = user.call_function("updateCustomUserData", { updatedDataBson }).get_future().get();
+
+    // Refresh the custom user data before reading it to verify it succeeded
+    user.refresh_custom_user_data().get_future().get();
+    CHECK((*user.custom_data())["favoriteColor"] == "black");
+    // :snippet-end:
+    // :snippet-start: delete-custom-user-data
+    auto deleteResult = user.call_function("deleteCustomUserData", {}).get_future().get();
+    // :snippet-end:
+    CHECK(deleteResult);
+}
+
 #if 0
 // Can't currently get this to work.
 TEST_CASE("live objects", "[test]") {

--- a/snooty.toml
+++ b/snooty.toml
@@ -14,6 +14,7 @@ toc_landing_pages = [
   # SDKs
   "/sdk",
   "/sdk/cpp",
+  "/sdk/cpp/manage-users",
   "/sdk/java",
   "/sdk/java/api",
   "/sdk/swift",

--- a/source/examples/generated/cpp/deleteCustomUserData.snippet.delete-custom-user-data.js
+++ b/source/examples/generated/cpp/deleteCustomUserData.snippet.delete-custom-user-data.js
@@ -1,0 +1,12 @@
+exports = async function deleteCustomUserData() {
+  const userId = context.user.id;
+  const customUserDataCollection = context.services
+    .get("mongodb-atlas")
+    .db("custom-user-data-database")
+    .collection("cpp-custom-user-data");
+
+  const filter = { userId };
+
+  const res = await customUserDataCollection.deleteOne(filter);
+  return res;
+};

--- a/source/examples/generated/cpp/examples.snippet.create-custom-user-data.cpp
+++ b/source/examples/generated/cpp/examples.snippet.create-custom-user-data.cpp
@@ -1,0 +1,7 @@
+auto user = app.login(realm::App::credentials::anonymous()).get_future().get();
+
+// Functions take an argument of BsonArray, so initialize the custom data as a BsonDocument
+auto customDataBson = realm::bson::BsonDocument({{"userId", user.identifier()}, {"favoriteColor", "gold"}});
+
+// Call an Atlas Function to insert custom data for the user
+auto result = user.call_function("updateCustomUserData", { customDataBson }).get_future().get();

--- a/source/examples/generated/cpp/examples.snippet.delete-custom-user-data.cpp
+++ b/source/examples/generated/cpp/examples.snippet.delete-custom-user-data.cpp
@@ -1,0 +1,1 @@
+auto deleteResult = user.call_function("deleteCustomUserData", {}).get_future().get();

--- a/source/examples/generated/cpp/examples.snippet.read-custom-user-data.cpp
+++ b/source/examples/generated/cpp/examples.snippet.read-custom-user-data.cpp
@@ -1,0 +1,3 @@
+// Custom user data could be stale, so refresh it before reading it
+user.refresh_custom_user_data().get_future().get();
+CHECK((*user.custom_data())["favoriteColor"] == "gold");

--- a/source/examples/generated/cpp/examples.snippet.update-custom-user-data.cpp
+++ b/source/examples/generated/cpp/examples.snippet.update-custom-user-data.cpp
@@ -1,0 +1,9 @@
+// Functions take an argument of BsonArray, so initialize the custom data as a BsonDocument
+auto updatedDataBson = realm::bson::BsonDocument({{"userId", user.identifier()}, { "favoriteColor", "black" }});
+
+// Call an Atlas Function to update custom data for the user
+auto updateResult = user.call_function("updateCustomUserData", { updatedDataBson }).get_future().get();
+
+// Refresh the custom user data before reading it to verify it succeeded
+user.refresh_custom_user_data().get_future().get();
+CHECK((*user.custom_data())["favoriteColor"] == "black");

--- a/source/examples/generated/cpp/updateCustomUserData.snippet.update-custom-user-data.js
+++ b/source/examples/generated/cpp/updateCustomUserData.snippet.update-custom-user-data.js
@@ -1,0 +1,16 @@
+exports = async function updateCustomUserData(newCustomUserData) {
+  const userId = context.user.id;
+  const customUserDataCollection = context.services
+    .get("mongodb-atlas")
+    .db("custom-user-data-database")
+    .collection("cpp-custom-user-data");
+
+  const filter = { userId };
+  // Replace the existing custom user data document with the new one.
+  const update = { $set: newCustomUserData };
+  // Insert document if it doesn't already exist
+  const options = { upsert: true };
+
+  const res = await customUserDataCollection.updateOne(filter, update, options);
+  return res;
+};

--- a/source/sdk/cpp.txt
+++ b/source/sdk/cpp.txt
@@ -13,7 +13,7 @@ C++ SDK (Alpha)
    Configure & Open a Realm </sdk/cpp/realm-files/configure-and-open-a-realm>
    CRUD </sdk/cpp/crud/>
    Connect to App Services </sdk/cpp/app-services/connect-to-app>
-   Manage Email/Password Users </sdk/cpp/users/manage-email-password-users>
+   Manage Users </sdk/cpp/manage-users>
    Manage Sync Subscriptions </sdk/cpp/sync/sync-subscriptions>
    Call an Atlas Function </sdk/cpp/app-services/call-a-function>
    GitHub <https://github.com/realm/realm-cpp>

--- a/source/sdk/cpp/manage-users.txt
+++ b/source/sdk/cpp/manage-users.txt
@@ -1,0 +1,96 @@
+.. _cpp-manage-users:
+
+==============================
+Manage Users - C++ SDK (Alpha)
+==============================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. toctree::
+   :titlesonly:
+
+   Authenticate Users </sdk/cpp/users/authenticate-users>
+   Manage Email/Password Users </sdk/cpp/users/manage-email-password-users>
+   Custom User Data </sdk/cpp/users/custom-user-data>
+
+Overview
+--------
+
+When you use Atlas App Services to back your client app, you get access to a
+:ref:`user object <user-objects>`. Use C++ SDK methods with this user 
+object to conveniently:
+
+- Create and delete users
+- Log users in and out
+- Create and update custom user data
+
+.. _cpp-creating-and-deleting-users:
+
+Create and Delete Users
+-----------------------
+
+For all authentication providers other than email/password authentication,
+App Services automatically creates a user object the first time a user 
+authenticates. With email/password authentication, your app must manually
+register a user.
+
+The C++ SDK Alpha does not yet have the ability to delete users through 
+the SDK. You can delete users from the server using the :ref:`App Services 
+Admin API <admin-api>` ``delete a user`` endpoints. You could optionally 
+create an :ref:`Atlas Function <functions>` that uses the Admin API to 
+delete a user, and :ref:`call the function from the SDK <cpp-call-a-function>`.
+
+.. _cpp-access-the-app-client:
+
+Log Users In and Out
+--------------------
+
+Use one or more :ref:`authentication providers <auth-providers>` to :ref:`log 
+users in and out <cpp-authenticate-users>` of your client app. You can: 
+
+- Log users in with an existing social account, such as Apple, Facebook,
+  or Google. 
+- Create new user accounts with App Services email/password management,
+  or your own custom function or custom JWT user management.
+- Enable anonymous users to let users access your App Services App without persisting
+  user data.
+
+When you have a logged-in user, SDK methods enable you to:
+
+- :ref:`Open a synced realm <cpp-open-synced-realm>` with the user's 
+  configuration object
+- :ref:`Run a backend function <cpp-call-a-function>` as the logged-in user
+- :ref:`Log the user out <cpp-logout>`
+
+On successful login, the C++ SDK caches credentials on the device. You 
+can bypass the login flow and access the cached user. Use this to open a 
+realm or call a function upon subsequent app opens. 
+
+User Sessions
+~~~~~~~~~~~~~
+
+App Services manages sessions with access tokens and refresh tokens.
+Client SDKs supply the logic to manage tokens, and provide them with requests.
+
+.. seealso:: 
+
+   :ref:`<user-sessions>`
+
+.. _cpp-app-work-with-custom-user-data:
+
+Read and Update Custom User Data
+--------------------------------
+
+You can :ref:`associate custom data <custom-user-data>` with a user object, 
+such as a preferred language or local timezone, and read it from your client 
+application. A user object has a ``customData`` property that you can use 
+to :ref:`access custom user data <cpp-read-a-users-custom-data>`. 
+
+To :ref:`create <cpp-create-a-users-custom-data-document>` and :ref:`update 
+<cpp-update-a-users-custom-data>` custom user data, you must access 
+your MongoDB data source directly. App Services does not offer a SDK 
+method to create or update this custom user data; it's a read-only property.

--- a/source/sdk/cpp/users/custom-user-data.txt
+++ b/source/sdk/cpp/users/custom-user-data.txt
@@ -1,0 +1,145 @@
+.. _cpp-custom-user-data:
+
+==================================
+Custom User Data - C++ SDK (Alpha)
+==================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. _cpp-read-a-users-custom-data:
+
+Read a User's Custom Data
+-------------------------
+
+You can read the :ref:`custom user data <custom-user-data>` of a
+currently logged-in user through that user's ``User`` object. You cannot
+edit custom user data through a ``User`` object. To edit custom user
+data, see :ref:`Update Custom User Data
+<cpp-update-a-users-custom-data>`. To read the data, access the
+``custom_data`` property on the ``User`` object of a logged-in user:
+
+.. literalinclude:: /examples/generated/cpp/examples.snippet.read-custom-user-data.cpp
+   :language: cpp
+
+
+.. warning:: Custom Data May Be Stale
+   
+   Atlas App Services does not dynamically update the value of the client-side
+   user custom data document immediately when underlying data changes.
+   Instead, App Services fetches the most recent version of custom user
+   data whenever a user refreshes their :ref:`access token
+   <user-sessions>`, which is used by most SDK operations that contact
+   the App Services backend. If the token is not refreshed before its default 
+   30 minute expiration time, the C++ SDK refreshes the token on the next 
+   call to the backend. Custom user data could be stale for up to 30 minutes 
+   plus the time until the next SDK call to the backend occurs.
+
+.. note::
+
+   If you require the most recent version of custom user data, use the
+   :cpp-sdk:`refresh_custom_user_data()
+   <structrealm_1_1User.html#a1da89a21c087001f5a67f5475474a192>`
+   function to request the latest version of a user's custom data.
+
+.. _cpp-create-a-users-custom-data-document:
+
+Create a User's Custom Data Document
+------------------------------------
+
+To create custom user data for a user, create a MongoDB document in the
+custom user data collection. The user ID field of the document should
+contain the the user's user ID.
+
+.. tip::
+   
+   In the App Services UI, check the :guilabel:`App Users` page under the
+   :guilabel:`Custom User Data` tab to find and configure custom user
+   data settings, including:
+
+   - The custom user data cluster, database, and collection
+   - The user ID field used to map custom user data documents to users
+
+One way you can create this document is by calling an :ref:`Atlas Function <functions>` 
+that inserts a custom data document into the custom user data collection.
+There is no single pattern for adding custom user data from an Atlas Function.
+You should write your Function or Functions to suit your application's use case.
+
+In this example, the Atlas Function takes an object passed by the client add adds
+it to the custom user data collection in Atlas. The Function creates
+the custom user data if it doesn't already exist and replaces all data in it
+if it does exist.
+
+.. literalinclude:: /examples/generated/cpp/updateCustomUserData.snippet.update-custom-user-data.js
+   :language: js
+   :caption: updateCustomUserData.js - Atlas Function running on server (JavaScript)
+
+The following example :ref:`calls a function <cpp-call-a-function>` to 
+insert a document containing the user ID of the currently logged in user 
+and a ``favoriteColor`` value into the custom user data collection:
+
+.. literalinclude:: /examples/generated/cpp/examples.snippet.create-custom-user-data.cpp
+   :language: cpp
+
+You can add any number of arbitrary fields and values to the custom user
+data document when you create it. The user ID field is the only
+requirement for the document to become available on the ``User`` object
+as custom user data.
+
+.. _cpp-update-a-users-custom-data:
+
+Update a User's Custom Data
+---------------------------
+
+You can update custom user data using :ref:`an Atlas Function
+<functions>`, :compass:`MongoDB Compass
+</>`, or the :atlas:`MongoDB Atlas Data
+Explorer </data-explorer/>`.
+
+To update a user's custom user data with an Atlas Function, edit the
+MongoDB document whose user ID field contains the user ID of the user.
+The following example calls the same function used to create the custom user 
+data document above. Here, we update the ``favoriteColor`` field of the 
+the document containing the user ID of the currently logged in user:
+
+.. literalinclude:: /examples/generated/cpp/examples.snippet.update-custom-user-data.cpp
+   :language: cpp
+
+.. tip::
+   
+   To determine a user's ID, access the ``user.identifier()`` property or find the
+   user in the App Services UI on the :guilabel:`App Users` page under the
+   :guilabel:`Users` tab.
+
+.. _cpp-delete-a-users-custom-data:
+
+Delete a User's Custom Data
+---------------------------
+
+Custom user data is stored in a document linked to the user object. 
+Deleting a user does not delete the custom user data. To fully delete user
+data to comply with, for example, :apple:`Apple's Account deletion guidance 
+<support/offering-account-deletion-in-your-app/>`, you must manually delete
+the user's custom data document.
+
+You can delete custom user data using :ref:`an Atlas Function
+<functions>`, :compass:`MongoDB Compass
+</>`, or the :atlas:`MongoDB Atlas Data
+Explorer </data-explorer/>`.
+
+In this example, the Atlas Function does not require any arguments. The 
+Function uses the function context to determine the caller's user ID, and 
+deletes the custom user data document matching the user's ID.
+
+.. literalinclude:: /examples/generated/cpp/deleteCustomUserData.snippet.delete-custom-user-data.js
+   :language: js
+   :caption: deleteCustomUserData.js - Atlas Function running on server (JavaScript)
+
+The code that calls this function requires only a logged-in user to call
+the function:
+
+.. literalinclude:: /examples/generated/cpp/examples.snippet.delete-custom-user-data.cpp
+   :language: cpp


### PR DESCRIPTION
## Pull Request Info

Now that we've got a few user-related pages, grouping them together in the ToC under a new "Manage Users" section. However, the directory structure for the pages hasn't changed so no redirects are needed.

### Jira

- https://jira.mongodb.org/browse/DOCSP-27632

### Staged Changes

- [Custom User Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27632/sdk/cpp/users/custom-user-data/): New page
- [Manage Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27632/sdk/cpp/manage-users/): New ToC entry + relevant content from the corresponding Swift SDK page, minus the stuff that isn't implemented yet in the C++ SDK

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
