### PR TITLE
(DOCSP-27552): Clarify Flex Sync RQL queries can't compare 2 lists

### DIFF
--- a/source/includes/flex-sync-limitations.rst
+++ b/source/includes/flex-sync-limitations.rst
@@ -56,6 +56,9 @@ contains a constant value:
 
       // Invalid Flexible Sync query. Do not do this!
       "{'comedy', 'horror', 'suspense'} IN genres"
+      
+      // Another invalid Flexible Sync query. Do not do this!
+      "ANY {'comedy', 'horror', 'suspense'} != ANY genres"
 
 Embedded or Linked Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/includes/flex-sync-limitations.rst
+++ b/source/includes/flex-sync-limitations.rst
@@ -47,6 +47,16 @@ contains a constant value:
    // Query an array-valued queryable field for a constant value
    "'comedy' IN genres"
 
+.. warning::
+
+   You **cannot** compare two lists with each other in a Flexible Sync query.
+   Note that this is valid Realm Query Language syntax outside of Flexible Sync queries.
+
+   .. code-block:: javascript
+
+      // Invalid Flexible Sync query. Do not do this!
+      "{'comedy', 'horror', 'suspense'} IN genres"
+
 Embedded or Linked Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/flex-sync-limitations.rst
+++ b/source/includes/flex-sync-limitations.rst
@@ -53,6 +53,7 @@ contains a constant value:
    Note that this is valid Realm Query Language syntax outside of Flexible Sync queries.
 
    .. code-block:: javascript
+      :copyable: false
 
       // Invalid Flexible Sync query. Do not do this!
       "{'comedy', 'horror', 'suspense'} IN genres"


### PR DESCRIPTION
## Pull Request Info

Clarify Flex Sync RQL queries can't compare 2 lists

### Jira

- https://jira.mongodb.org/browse/DOCSP-27552

### Staged Changes

- [Realm Query Language](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27552/realm-query-language/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
