### PR TITLE
(DOCSP-26730): C++: Add a React to Changes page

### DIFF
--- a/examples/cpp/examples.cpp
+++ b/examples/cpp/examples.cpp
@@ -272,7 +272,7 @@ TEST_CASE("object notification", "[notification]") {
     });
 
     //  Set up the listener & observe object notifications.
-    auto token = dog.observe([&](auto change) {
+    auto token = dog.observe([&](auto&& change) {
         try {
             // :snippet-start: notifications-property-changes
             if (change.error) {
@@ -299,8 +299,6 @@ TEST_CASE("object notification", "[notification]") {
     realm.write([&dog, &realm] {
         dog.name = "Wolfie";
     });
-    // Refresh the realm after the change to trigger the notification.
-    realm.refresh();
 
     // Deleting the object triggers a delete notification.
     realm.write([&dog, &realm] {

--- a/examples/cpp/examples.cpp
+++ b/examples/cpp/examples.cpp
@@ -260,30 +260,36 @@ TEST_CASE("custom user data", "[realm][sync]") {
     CHECK(deleteResult);
 }
 
-#if 0
-// Can't currently get this to work.
-TEST_CASE("live objects", "[test]") {
-    // Open the default realm.
+TEST_CASE("object notification", "[notification]") {
+    // :snippet-start: notifications-object
     auto realm = realm::open<Person, Dog>();
 
     auto dog = Dog { .name = "Max" };
 
-    // Create a dog in the realm.
+    // Create an object in the realm.
     realm.write([&realm, &dog] {
         realm.add(dog);
     });
 
     //  Set up the listener & observe object notifications.
-    auto token = dog.observe<Dog>([](auto&& change) {
+    auto token = dog.observe([&](auto change) {
         try {
+            // :snippet-start: notifications-property-changes
             if (change.error) {
                 rethrow_exception(change.error);
             }
             if (change.is_deleted) {
                 std::cout << "The object was deleted.\n";
             } else {
-                std::cout << "The object changed\n";
+                for (auto& propertyChange : change.property_changes) {
+                    std::cout << "The object's " << propertyChange.name << " property has changed.\n"; 
+                    CHECK(propertyChange.name == "name"); // :remove:
+                    auto newPropertyValue = std::get<std::string>(*propertyChange.new_value);
+                    std::cout << "The new value is " << newPropertyValue << "\n";
+                    CHECK(newPropertyValue == "Wolfie"); // :remove:
+                }
             }
+            // :snippet-end:
         } catch (std::exception const& e) {
             std::cerr << "Error: " << e.what() << "\n";
         }
@@ -293,5 +299,14 @@ TEST_CASE("live objects", "[test]") {
     realm.write([&dog, &realm] {
         dog.name = "Wolfie";
     });
+    // Refresh the realm after the change to trigger the notification.
+    realm.refresh();
+
+    // Deleting the object triggers a delete notification.
+    realm.write([&dog, &realm] {
+        realm.remove(dog);
+    });
+    // Refresh the realm after the change to trigger the notification.
+    realm.refresh();
+    // :snippet-end:
 }
-#endif

--- a/source/examples/generated/cpp/examples.snippet.notifications-object.cpp
+++ b/source/examples/generated/cpp/examples.snippet.notifications-object.cpp
@@ -1,0 +1,42 @@
+auto realm = realm::open<Person, Dog>();
+
+auto dog = Dog { .name = "Max" };
+
+// Create an object in the realm.
+realm.write([&realm, &dog] {
+    realm.add(dog);
+});
+
+//  Set up the listener & observe object notifications.
+auto token = dog.observe([&](auto change) {
+    try {
+        if (change.error) {
+            rethrow_exception(change.error);
+        }
+        if (change.is_deleted) {
+            std::cout << "The object was deleted.\n";
+        } else {
+            for (auto& propertyChange : change.property_changes) {
+                std::cout << "The object's " << propertyChange.name << " property has changed.\n"; 
+                auto newPropertyValue = std::get<std::string>(*propertyChange.new_value);
+                std::cout << "The new value is " << newPropertyValue << "\n";
+            }
+        }
+    } catch (std::exception const& e) {
+        std::cerr << "Error: " << e.what() << "\n";
+    }
+});
+
+// Update the dog's name to see the effect.
+realm.write([&dog, &realm] {
+    dog.name = "Wolfie";
+});
+// Refresh the realm after the change to trigger the notification.
+realm.refresh();
+
+// Deleting the object triggers a delete notification.
+realm.write([&dog, &realm] {
+    realm.remove(dog);
+});
+// Refresh the realm after the change to trigger the notification.
+realm.refresh();

--- a/source/examples/generated/cpp/examples.snippet.notifications-object.cpp
+++ b/source/examples/generated/cpp/examples.snippet.notifications-object.cpp
@@ -8,7 +8,7 @@ realm.write([&realm, &dog] {
 });
 
 //  Set up the listener & observe object notifications.
-auto token = dog.observe([&](auto change) {
+auto token = dog.observe([&](auto&& change) {
     try {
         if (change.error) {
             rethrow_exception(change.error);
@@ -31,8 +31,6 @@ auto token = dog.observe([&](auto change) {
 realm.write([&dog, &realm] {
     dog.name = "Wolfie";
 });
-// Refresh the realm after the change to trigger the notification.
-realm.refresh();
 
 // Deleting the object triggers a delete notification.
 realm.write([&dog, &realm] {

--- a/source/examples/generated/cpp/examples.snippet.notifications-property-changes.cpp
+++ b/source/examples/generated/cpp/examples.snippet.notifications-property-changes.cpp
@@ -1,0 +1,12 @@
+if (change.error) {
+    rethrow_exception(change.error);
+}
+if (change.is_deleted) {
+    std::cout << "The object was deleted.\n";
+} else {
+    for (auto& propertyChange : change.property_changes) {
+        std::cout << "The object's " << propertyChange.name << " property has changed.\n"; 
+        auto newPropertyValue = std::get<std::string>(*propertyChange.new_value);
+        std::cout << "The new value is " << newPropertyValue << "\n";
+    }
+}

--- a/source/sdk/cpp.txt
+++ b/source/sdk/cpp.txt
@@ -12,6 +12,7 @@ C++ SDK (Alpha)
    Model Data </sdk/cpp/model-data>
    Configure & Open a Realm </sdk/cpp/realm-files/configure-and-open-a-realm>
    CRUD </sdk/cpp/crud/>
+   React to Changes </sdk/cpp/react-to-changes>
    Connect to App Services </sdk/cpp/app-services/connect-to-app>
    Manage Users </sdk/cpp/manage-users>
    Manage Sync Subscriptions </sdk/cpp/sync/sync-subscriptions>

--- a/source/sdk/cpp/react-to-changes.txt
+++ b/source/sdk/cpp/react-to-changes.txt
@@ -1,0 +1,47 @@
+.. _cpp-react-to-changes:
+
+==================================
+React to Changes - C++ SDK (Alpha)
+==================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. _cpp-register-an-object-change-listener:
+
+Register an Object Change Listener
+----------------------------------
+
+You can register a notification handler on a specific object
+within a Realm. Realm Database notifies your handler:
+
+- When the object is deleted.
+- When any of the object's properties change.
+
+.. code-block:: cpp
+   :copyable: false
+   
+   auto token = object.observe([&](auto change) { ... }
+
+The handler receives an :cpp-sdk:`ObjectChange <structrealm_1_1ObjectChange.html>`
+object that contains information about the changes, such as whether the 
+object was deleted. It may include a list 
+of :cpp-sdk:`PropertyChange 
+<structrealm_1_1PropertyChange.html#a71dc45a7609e6a528e70b91d20ef8f94>` 
+objects that contain information about what fields changed, the new values
+of those fields (except on List properties), and potentially the old values 
+of the fields.
+
+.. literalinclude:: /examples/generated/cpp/examples.snippet.notifications-property-changes.cpp
+    :language: cpp
+
+When you make changes, :cpp-sdk:`refresh() <structrealm_1_1db.html>` the 
+realm to emit a notification.
+
+.. example::
+
+   .. literalinclude:: /examples/generated/cpp/examples.snippet.notifications-object.cpp
+      :language: cpp

--- a/source/sdk/cpp/react-to-changes.txt
+++ b/source/sdk/cpp/react-to-changes.txt
@@ -16,7 +16,7 @@ Register an Object Change Listener
 ----------------------------------
 
 You can register a notification handler on a specific object
-within a Realm. Realm Database notifies your handler:
+within a realm. Realm Database notifies your handler:
 
 - When the object is deleted.
 - When any of the object's properties change.
@@ -24,7 +24,7 @@ within a Realm. Realm Database notifies your handler:
 .. code-block:: cpp
    :copyable: false
    
-   auto token = object.observe([&](auto change) { ... }
+   auto token = object.observe([&](auto&& change) { ... }
 
 The handler receives an :cpp-sdk:`ObjectChange <structrealm_1_1ObjectChange.html>`
 object that contains information about the changes, such as whether the 


### PR DESCRIPTION
## Pull Request Info

Note for reviewer: Git shenanigans resulted in #2568 being closed when the feature branch it was working against got merged. This PR was approved in #2568 but had a couple of pieces of feedback, which I incorporated here. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-26730

### Staged Changes

- [React to Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26730/sdk/cpp/react-to-changes/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
