### PR TITLE
(DOCSP-27907): C++: Fix Sync-related naming

### DIFF
--- a/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
@@ -23,7 +23,7 @@ specifies details about how to configure the realm file. This can include:
 
 - The models that the realm file should manage
 - An optional path where the realm is stored on device
-- A ``SyncConfig`` if you want to use the realm with Device Sync
+- A ``sync_config`` if you want to use the realm with Device Sync
 
 .. _cpp-realm-file:
 
@@ -49,7 +49,7 @@ Key Concept: Synced Realms
 
 You can configure a realm to automatically synchronize data between many 
 devices that each have their own local copy of the data. Synced realms 
-need a ``SyncConfig`` and require an Atlas App Services backend to handle 
+need a ``sync_config`` and require an Atlas App Services backend to handle 
 the synchronization process. 
 
 Applications can always create, modify, and delete synced realm objects locally,


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-27500

### Staged Changes

- [Configure & Open a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27907/sdk/cpp/realm-files/configure-and-open-a-realm/): Updated the old `SyncConfig` naming to new `sync_config`, confirmed that path and `async_open` details are correct

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-app-services update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
