### PR TITLE
(DOCSP-28143): C++: Add docs for unregistering a notification token

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        f5bdef8e958612143dea3615a0ba5d1b9eeddd36
+  GIT_TAG        98398af5c15c93d5e9137c878931ccdd88ffe55c
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/examples.cpp
+++ b/examples/cpp/examples.cpp
@@ -285,6 +285,11 @@ TEST_CASE("object notification", "[notification]") {
     });
     // Refresh the realm after the change to trigger the notification.
     realm.refresh();
+    
+    // :snippet-start: notifications-unregister
+    // Unregister the token when done observing.
+    token.unregister();
+    // :snippet-end:
     // :snippet-end:
 }
 
@@ -337,5 +342,12 @@ TEST_CASE("results notification", "[notification]") {
     
     // Refresh the realm after the change to trigger the notification.
     realm.refresh();
+    
+    // Unregister the token when done observing.
+    token.unregister();
     // :snippet-end:
+    // Clean up after the test
+    realm.write([&dog2, &realm] {
+        realm.remove(dog2);
+    });
 }

--- a/source/examples/generated/cpp/examples.snippet.notifications-object.cpp
+++ b/source/examples/generated/cpp/examples.snippet.notifications-object.cpp
@@ -38,3 +38,6 @@ realm.write([&dog, &realm] {
 });
 // Refresh the realm after the change to trigger the notification.
 realm.refresh();
+
+// Unregister the token when done observing.
+token.unregister();

--- a/source/examples/generated/cpp/examples.snippet.notifications-results.cpp
+++ b/source/examples/generated/cpp/examples.snippet.notifications-results.cpp
@@ -35,3 +35,6 @@ realm.write([&dog2, &realm] {
 
 // Refresh the realm after the change to trigger the notification.
 realm.refresh();
+
+// Unregister the token when done observing.
+token.unregister();

--- a/source/examples/generated/cpp/examples.snippet.notifications-unregister.cpp
+++ b/source/examples/generated/cpp/examples.snippet.notifications-unregister.cpp
@@ -1,0 +1,2 @@
+// Unregister the token when done observing.
+token.unregister();

--- a/source/sdk/cpp/react-to-changes.txt
+++ b/source/sdk/cpp/react-to-changes.txt
@@ -83,7 +83,7 @@ Stop Watching for Changes
 
 Observation stops when the token returned by an ``observe`` call becomes
 invalid. You can explicitly invalidate a token by calling its
-``unregister()`` method.
+``unregister()`` member function.
 
 .. important:: Retain Tokens as Long as You Want to Observe
 

--- a/source/sdk/cpp/react-to-changes.txt
+++ b/source/sdk/cpp/react-to-changes.txt
@@ -85,10 +85,12 @@ Observation stops when the token returned by an ``observe`` call becomes
 invalid. You can explicitly invalidate a token by calling its
 ``unregister()`` member function.
 
-.. important:: Retain Tokens as Long as You Want to Observe
-
-   Notifications stop if the token is in a local variable that goes out
-   of scope. 
-
 .. literalinclude:: /examples/generated/cpp/examples.snippet.notifications-unregister.cpp
    :language: cpp
+
+.. important:: Retain Tokens as Long as You Want to Observe
+
+   Notifications stop when the token's destructor is called. For example, 
+   if the token is in a local variable that goes out of scope. You can
+   use ``std::move`` to transfer the token to a variable in a different 
+   scope. 

--- a/source/sdk/cpp/react-to-changes.txt
+++ b/source/sdk/cpp/react-to-changes.txt
@@ -75,3 +75,20 @@ It can also notify you if the collection was deleted.
 
 .. literalinclude:: /examples/generated/cpp/examples.snippet.notifications-results.cpp
    :language: cpp
+
+.. _cpp-stop-watching-for-changes:
+
+Stop Watching for Changes
+-------------------------
+
+Observation stops when the token returned by an ``observe`` call becomes
+invalid. You can explicitly invalidate a token by calling its
+``unregister()`` method.
+
+.. important:: Retain Tokens as Long as You Want to Observe
+
+   Notifications stop if the token is in a local variable that goes out
+   of scope. 
+
+.. literalinclude:: /examples/generated/cpp/examples.snippet.notifications-unregister.cpp
+   :language: cpp


### PR DESCRIPTION
## Pull Request Info

DO NOT MERGE until PR 43 in realm-cpp is merged.

### Jira

- https://jira.mongodb.org/browse/DOCSP-28143

### Staged Changes

- [React to Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-28143/sdk/cpp/react-to-changes/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
