### PR TITLE
(DOCSP-28151): Add Sync Session documentation for C++

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -16,6 +16,7 @@ toc_landing_pages = [
   "/sdk/cpp",
   "/sdk/cpp/application-services",
   "/sdk/cpp/manage-users",
+  "/sdk/cpp/sync",
   "/sdk/java",
   "/sdk/java/api",
   "/sdk/swift",

--- a/source/examples/generated/cpp/quick-start.snippet.sync-session.cpp
+++ b/source/examples/generated/cpp/quick-start.snippet.sync-session.cpp
@@ -1,0 +1,1 @@
+auto syncSession = realm.get_sync_session();

--- a/source/examples/generated/cpp/quick-start.snippet.sync-state.cpp
+++ b/source/examples/generated/cpp/quick-start.snippet.sync-state.cpp
@@ -1,0 +1,1 @@
+syncSession->state();

--- a/source/examples/generated/cpp/quick-start.snippet.wait-for-download.cpp
+++ b/source/examples/generated/cpp/quick-start.snippet.wait-for-download.cpp
@@ -1,0 +1,2 @@
+syncSession->wait_for_download_completion().get_future().get();
+realm.refresh();

--- a/source/examples/generated/cpp/quick-start.snippet.wait-for-upload.cpp
+++ b/source/examples/generated/cpp/quick-start.snippet.wait-for-upload.cpp
@@ -1,0 +1,1 @@
+syncSession->wait_for_upload_completion().get_future().get();

--- a/source/sdk/cpp.txt
+++ b/source/sdk/cpp.txt
@@ -20,8 +20,7 @@ C++ SDK (Alpha)
    React to Changes </sdk/cpp/react-to-changes>
    Application Services </sdk/cpp/application-services>
    Manage Users </sdk/cpp/manage-users>
-   Manage Sync Subscriptions </sdk/cpp/sync/sync-subscriptions>
-   Stream Data to Atlas </sdk/cpp/sync/stream-data-to-atlas>
+   Sync Data Between Devices </sdk/cpp/sync>
    SDK Telemetry </sdk/cpp/telemetry>
    GitHub <https://github.com/realm/realm-cpp>
    API Reference (Doxygen) <https://www.mongodb.com/docs/realm-sdks/cpp/latest/>

--- a/source/sdk/cpp.txt
+++ b/source/sdk/cpp.txt
@@ -20,7 +20,7 @@ C++ SDK (Alpha)
    React to Changes </sdk/cpp/react-to-changes>
    Application Services </sdk/cpp/application-services>
    Manage Users </sdk/cpp/manage-users>
-   Sync Data Between Devices </sdk/cpp/sync>
+   Sync Data </sdk/cpp/sync>
    SDK Telemetry </sdk/cpp/telemetry>
    GitHub <https://github.com/realm/realm-cpp>
    API Reference (Doxygen) <https://www.mongodb.com/docs/realm-sdks/cpp/latest/>

--- a/source/sdk/cpp/application-services.txt
+++ b/source/sdk/cpp/application-services.txt
@@ -38,7 +38,6 @@ which you can :ref:`find in the App Services UI <find-your-app-id>`.
    To learn how to initialize the App client, see
    :ref:`cpp-connect-to-backend`.
 
-
 Authentication & User Management
 --------------------------------
 
@@ -59,6 +58,19 @@ APIs, you can implement the following functionality:
 
    To learn how to provide custom user data, refer to :ref:`cpp-custom-user-data`.
 
+Device Sync
+-----------
+
+Device Sync adds data synchronization between an App Services backend and
+client devices on top of all of the functionality of Realm Database.
+When you use Realm Database with Sync, realms exist on device
+in the same way as a non-synced Realm Database. However, changes to
+the data stored in those realms synchronize between all client
+devices through a backend App Services instance. That backend also stores
+realm data in a cloud-based Atlas cluster running MongoDB.
+
+To get started with Sync, refer to :ref:`Device Sync <cpp-sync>`.
+
 Calling Functions
 -----------------
 
@@ -75,57 +87,3 @@ logic client-side.
 .. tip::
 
    To learn how to call Functions, see :ref:`Call a Function <cpp-call-a-function>`.
-
-.. _cpp-realm-sync:
-
-Sync Data
----------
-
-Atlas Device Sync automatically synchronizes data between client applications and 
-an :ref:`App Services backend <realm-cloud>`. When a client 
-device is online, Sync asynchronously synchronizes data in a 
-background thread between the device and your backend App. 
-
-When you use Sync in your client application, your implementation must match 
-the Sync Mode you select in your backend App configuration. The Realm C++ SDK
-only supports Flexible Sync.
-
-.. seealso::
-
-   :ref:`enable-realm-sync`
-
-.. _cpp-flexible-sync-fundamentals:
-
-Flexible Sync
-~~~~~~~~~~~~~
-
-When you select :ref:`Flexible Sync <flexible-sync>` for your backend App 
-configuration, your client implementation must include subscriptions to 
-queries on :ref:`queryable fields <queryable-fields>`. Flexible Sync works 
-by synchronizing data that matches query subscriptions you maintain in the 
-client application. 
-
-A subscription set contains a set of queries. Flexible Sync returns 
-documents matching those queries, where the user has the appropriate 
-:ref:`permissions <flexible-sync-rules-and-permissions>` to read and/or 
-read and write the documents. If documents match the query, but the client 
-does not have the permission to read or write them, they do not sync to 
-the client application.
-
-You can form queries using :ref:`Realm Query Language <realm-query-language>`.
-
-.. include:: /includes/note-unsupported-flex-sync-rql-operators.rst
-
-Subscription sets are based on a specific type of :ref:`Realm object 
-<cpp-object-model>`. You might have multiple subscriptions if you 
-have many types of Realm objects.
-
-To use Flexible Sync in your client application, open a synced realm 
-with a flexible sync configuration. Then, manage subscriptions
-to determine which documents to sync. For more information, refer to
-:ref:`cpp-manage-flexible-sync-subscriptions`.
-
-Group Updates for Improved Performance
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/sync-memory-performance.rst

--- a/source/sdk/cpp/sync.txt
+++ b/source/sdk/cpp/sync.txt
@@ -54,8 +54,8 @@ Subscription sets are based on a specific type of :ref:`Realm object
 <cpp-object-model>`. You might have multiple subscriptions if you 
 have many types of Realm objects.
 
-To use Flexible Sync in your client application, open a synced realm 
-with a flexible sync configuration. Then, manage subscriptions
+To use Device Sync in your client application, open a synced realm 
+with a Flexible Sync configuration. Then, manage subscriptions
 to determine which documents to sync. For more information, refer to
 :ref:`cpp-manage-flexible-sync-subscriptions`.
 

--- a/source/sdk/cpp/sync.txt
+++ b/source/sdk/cpp/sync.txt
@@ -1,0 +1,76 @@
+.. _cpp-sync:
+.. _cpp-realm-sync:
+
+===========================================
+Sync Data Between Devices - C++ SDK (Alpha)
+===========================================
+
+.. toctree::
+   :titlesonly:
+
+   Manage Sync Subscriptions </sdk/cpp/sync/sync-subscriptions>
+   Manage Sync Sessions </sdk/cpp/sync/manage-sync-session>
+   Stream Data to Atlas </sdk/cpp/sync/stream-data-to-atlas>
+
+Overview
+--------
+
+Atlas Device Sync automatically synchronizes data between client applications and 
+an :ref:`App Services backend <realm-cloud>`. When a client 
+device is online, Sync asynchronously synchronizes data in a 
+background thread between the device and your backend App. 
+
+When you use Sync in your client application, your implementation must match 
+the Sync Mode you select in your backend App configuration. The Realm C++ SDK
+only supports Flexible Sync.
+
+.. seealso::
+
+   :ref:`enable-realm-sync`
+
+.. _cpp-flexible-sync-fundamentals:
+
+Flexible Sync
+~~~~~~~~~~~~~
+
+When you select :ref:`Flexible Sync <flexible-sync>` for your backend App 
+configuration, your client implementation must include subscriptions to 
+queries on :ref:`queryable fields <queryable-fields>`. Flexible Sync works 
+by synchronizing data that matches query subscriptions you maintain in the 
+client application. 
+
+A subscription set contains a set of queries. Flexible Sync returns 
+documents matching those queries, where the user has the appropriate 
+:ref:`permissions <flexible-sync-rules-and-permissions>` to read and/or 
+read and write the documents. If documents match the query, but the client 
+does not have the permission to read or write them, they do not sync to 
+the client application.
+
+You can form queries using :ref:`Realm Query Language <realm-query-language>`.
+
+.. include:: /includes/note-unsupported-flex-sync-rql-operators.rst
+
+Subscription sets are based on a specific type of :ref:`Realm object 
+<cpp-object-model>`. You might have multiple subscriptions if you 
+have many types of Realm objects.
+
+To use Flexible Sync in your client application, open a synced realm 
+with a flexible sync configuration. Then, manage subscriptions
+to determine which documents to sync. For more information, refer to
+:ref:`cpp-manage-flexible-sync-subscriptions`.
+
+Group Updates for Improved Performance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/sync-memory-performance.rst
+
+Unidirectional Sync
+-------------------
+
+Device Sync supports the ability to **send** data to Atlas, 
+but not receive any updates.
+
+In this scenario, you can maximize sync performance by using 
+:ref:`Asymmetric Sync <cpp-stream-data-to-atlas>` to stream 
+data from the client application to a Flexible Sync-enabled Atlas App Services
+App.

--- a/source/sdk/cpp/sync/manage-sync-session.txt
+++ b/source/sdk/cpp/sync/manage-sync-session.txt
@@ -1,0 +1,74 @@
+.. _cpp-manage-sync-session:
+
+=======================================
+Manage a Sync Session - C++ SDK (Alpha)
+=======================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+When you use Atlas Device Sync, the Realm C++ SDK syncs data with Atlas
+in the background using a sync session. The sync session starts when
+you open a synced realm.
+
+The sync session manages the following:
+
+- Uploading and downloading changes to the realm
+- Monitoring sync state
+
+Prerequisites
+-------------
+
+Before you can manage a sync session state, you must:
+
+#. :ref:`Configure Flexible Sync on the Atlas App Services backend <enable-flexible-sync>`
+#. :ref:`Open a Synced Realm <cpp-open-synced-realm>`
+
+.. _cpp-get-sync-session:
+
+Get the Sync Session
+--------------------
+
+You can use the public member function :cpp-sdk:`get_sync_session() 
+<structrealm_1_1db.html#a79c5e6e92896703a54693be35720ae12>` to get a 
+:cpp-sdk:`sync_session 
+<structrealm_1_1internal_1_1bridge_1_1sync__session.html>` 
+object for any synced realm.
+
+.. literalinclude:: /examples/generated/cpp/quick-start.snippet.sync-session.cpp
+   :language: cpp
+
+.. _cpp-sync-wait-for-changes:
+
+Wait for Changes to Upload and Download
+---------------------------------------
+
+To wait for all changes to upload to Atlas from your synced realm,
+use the public member function ``.wait_for_upload_completion()``. 
+
+.. literalinclude:: /examples/generated/cpp/quick-start.snippet.wait-for-upload.cpp
+   :language: cpp
+
+To wait for all changes from Atlas
+to download to your synced realm, use the public member function 
+``wait_for_download_completion()``. Refresh the realm after downloading 
+any changes to be sure it reflects the most recent data.
+
+.. literalinclude:: /examples/generated/cpp/quick-start.snippet.wait-for-download.cpp
+   :language: cpp
+
+.. _cpp-check-sync-state:
+
+Check the Sync State
+--------------------
+
+You can use the :cpp-sdk:`sync_session 
+<structrealm_1_1internal_1_1bridge_1_1sync__session.html>`'s public 
+member function ``state()`` to check whether the sync session is active.
+This returns an enum whose value reflects possible Device Sync states.
+
+.. literalinclude:: /examples/generated/cpp/quick-start.snippet.sync-state.cpp
+   :language: cpp

--- a/source/sdk/cpp/sync/manage-sync-session.txt
+++ b/source/sdk/cpp/sync/manage-sync-session.txt
@@ -36,7 +36,8 @@ You can use the public member function :cpp-sdk:`get_sync_session()
 <structrealm_1_1db.html#a79c5e6e92896703a54693be35720ae12>` to get a 
 :cpp-sdk:`sync_session 
 <structrealm_1_1internal_1_1bridge_1_1sync__session.html>` 
-object for any synced realm.
+object for any synced realm. The SDK returns this object as an optional. 
+It is a lightweight handle that you can pass around by value.
 
 .. literalinclude:: /examples/generated/cpp/quick-start.snippet.sync-session.cpp
    :language: cpp

--- a/source/sdk/dotnet/sync.txt
+++ b/source/sdk/dotnet/sync.txt
@@ -81,7 +81,7 @@ Subscription sets are based on a specific type of :ref:`Realm object <dotnet-obj
 You can have multiple subscriptions if you have many types of Realm objects.
 
 To use Flexible Sync in your client application, open a synced realm 
-with a flexible sync configuration. Then, manage subscriptions
+with a Flexible Sync configuration. Then, manage subscriptions
 to determine which documents to sync.
 
 Group Updates for Improved Performance

--- a/source/sdk/flutter/sync.txt
+++ b/source/sdk/flutter/sync.txt
@@ -90,8 +90,8 @@ Subscription sets are based on a specific type of :ref:`Realm object
 <flutter-define-realm-object-schema>`.
 To sync data for many types of Realm objects, you must have multiple subscriptions.
 
-To use Flexible Sync in your client application, open a synced realm
-with a flexible sync configuration. Then, manage subscriptions
+To use Device Sync in your client application, open a synced realm
+with a Flexible Sync configuration. Then, manage subscriptions
 to determine which documents to sync.
 
 Enable Flexible Sync on the Backend

--- a/source/sdk/react-native/sync-data/overview.txt
+++ b/source/sdk/react-native/sync-data/overview.txt
@@ -58,7 +58,7 @@ Subscription sets are based on a specific type of :ref:`Realm object <react-nati
 You might have multiple subscriptions if you have many types of Realm objects.
 
 To use Flexible Sync in your client application, open a synced realm 
-with a flexible sync configuration. Then, manage subscriptions
+with a Flexible Sync configuration. Then, manage subscriptions
 to determine which documents to sync.
 
 .. seealso::

--- a/source/sdk/swift/application-services.txt
+++ b/source/sdk/swift/application-services.txt
@@ -166,7 +166,7 @@ Subscription sets are based on a specific type of :ref:`Realm object
 have many types of Realm objects.
 
 To use Flexible Sync in your client application, open a synced realm 
-with a flexible sync configuration. Then, manage subscriptions
+with a Flexible Sync configuration. Then, manage subscriptions
 to determine which documents to sync.
 
 Group Updates for Improved Performance


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-28151

### Staged Changes

- [Manage Sync Sessions](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-28151/sdk/cpp/sync/manage-sync-session/): New page
- [Sync Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-28151/sdk/cpp/sync/): New page containing existing content to serve as a container page for the Sync session, now that we have more than a couple of sync-related pages

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
