### PR TITLE
(DOCSP-27433): SwiftUI: Add sort example for ObservedResults

### DIFF
--- a/examples/ios/SwiftUICatalog/SwiftUICatalogApp.swift
+++ b/examples/ios/SwiftUICatalog/SwiftUICatalogApp.swift
@@ -46,6 +46,7 @@ struct SwiftUICatalogApp: SwiftUI.App {
         "SearchableDogsView": { AnyView(SearchableDogsView().environment(\.realm, SwiftUI_Dog.previewRealmJustDogs)) },
         "SectionedResultsList": { AnyView(SectionedDogsView().environment(\.realm, SwiftUI_Dog.previewRealmJustDogs))},
         "SectionedResultsListFiltered": { AnyView(SectionedDogsViewFiltered().environment(\.realm, SwiftUI_Dog.previewRealmJustDogs))},
+        "SortedDogsView": { AnyView(SortedDogsView().environment(\.realm, SwiftUI_Dog.previewRealmJustDogs))},
         "WriteToCollection": { AnyView(DogsListView().environment(\.realm, SwiftUI_Dog.previewRealmJustDogs)) }
     ]
     

--- a/examples/ios/SwiftUICatalog/Views/FilterData.swift
+++ b/examples/ios/SwiftUICatalog/Views/FilterData.swift
@@ -65,6 +65,23 @@ struct FilterDogsViewTypeSafeQuery: View {
 }
 // :snippet-end:
 
+// :snippet-start: sort-descriptor
+struct SortedDogsView: View {
+    @ObservedResults(SwiftUI_Dog.self,
+                     sortDescriptor: SortDescriptor(keyPath: "name",
+                        ascending: true)) var dogs
+    
+    var body: some View {
+        NavigationView {
+            // The list shows the dogs in the realm, sorted by name
+            List(dogs) { dog in
+                DogRow(dog: dog)
+            }
+        }
+    }
+}
+// :snippet-end:
+
 struct SectionedDogsViewFiltered: View {
     // :snippet-start: observed-filtered-sectioned-results
     @ObservedSectionedResults(SwiftUI_Dog.self,

--- a/examples/ios/SwiftUICatalogUITests/SwiftUICatalogUITests.swift
+++ b/examples/ios/SwiftUICatalogUITests/SwiftUICatalogUITests.swift
@@ -156,6 +156,16 @@ class SwiftUICatalogUITests: XCTestCase {
         XCTAssert(!app.staticTexts["Lita"].exists)
     }
     
+    func testSortedDogList() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["MyUITestsCustomView"] = "true"
+        app.launchEnvironment["MyCustomViewName"] = "SortedDogsView"
+        app.launch()
+        
+        // Test that the dog name in the first row - sorted by name - is Ben
+        XCTAssert(app.cells.firstMatch.staticTexts["Ben"].exists)
+    }
+    
     func testAppendToList() throws {
         let app = XCUIApplication()
         app.launchEnvironment["MyUITestsCustomView"] = "true"

--- a/source/examples/generated/swiftui/FilterData.snippet.sort-descriptor.swift
+++ b/source/examples/generated/swiftui/FilterData.snippet.sort-descriptor.swift
@@ -1,0 +1,14 @@
+struct SortedDogsView: View {
+    @ObservedResults(Dog.self,
+                     sortDescriptor: SortDescriptor(keyPath: "name",
+                        ascending: true)) var dogs
+    
+    var body: some View {
+        NavigationView {
+            // The list shows the dogs in the realm, sorted by name
+            List(dogs) { dog in
+                DogRow(dog: dog)
+            }
+        }
+    }
+}

--- a/source/sdk/swift/swiftui/react-to-changes.txt
+++ b/source/sdk/swift/swiftui/react-to-changes.txt
@@ -44,6 +44,16 @@ you can remove a dog from an observed list of dogs using ``onDelete``.
    supports, see: :ref:`Read - Swift SDK <swift-crud-read>` and :ref:`Filter 
    Data - Swift SDK <ios-filter-data>`.
 
+Sort Observed Results
+~~~~~~~~~~~~~~~~~~~~~
+
+The :swift-sdk:`@ObservedResults <Structs/ObservedResults.html>`
+property wrapper can take a :swift-sdk:`SortDescriptor 
+<Structs/SortDescriptor.html>` parameter to sort the query results.
+
+.. literalinclude:: /examples/generated/swiftui/FilterData.snippet.sort-descriptor.swift
+   :language: swift
+
 .. _swiftui-observe-sectioned-results:
 
 Observe Sectioned Results

--- a/source/sdk/swift/swiftui/react-to-changes.txt
+++ b/source/sdk/swift/swiftui/react-to-changes.txt
@@ -54,6 +54,10 @@ property wrapper can take a :swift-sdk:`SortDescriptor
 .. literalinclude:: /examples/generated/swiftui/FilterData.snippet.sort-descriptor.swift
    :language: swift
 
+.. tip::
+
+   You cannot use a computed property as a ``SortDescriptor`` for ``@ObservedResults``.
+
 .. _swiftui-observe-sectioned-results:
 
 Observe Sectioned Results


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-27433

### Staged Changes

- [React to Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27433/sdk/swift/swiftui/react-to-changes/): New "Sort Observed Results" subsection with example

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
