### PR TITLE
(DOCSP-26501): Flutter set sync client log level

### DIFF
--- a/examples/dart/test/sync_log_level_test.dart
+++ b/examples/dart/test/sync_log_level_test.dart
@@ -1,9 +1,9 @@
 import 'package:test/test.dart';
-// :replace-start:
+// :replace-start: {
 //   "terms": {
-//     "realm_dart": "realm",
+//     "realm_dart": "realm"
 //   }
-// :replace-end:
+// }
 // :snippet-start: log-level
 import 'package:realm_dart/realm.dart';
 import 'package:logging/logging.dart';
@@ -19,4 +19,5 @@ main() {
   });
   // :remove-end:
 }
-  // :snippet-end:
+// :snippet-end:
+// :replace-end:

--- a/examples/dart/test/sync_log_level_test.dart
+++ b/examples/dart/test/sync_log_level_test.dart
@@ -1,22 +1,24 @@
 import 'package:test/test.dart';
-// :replace-start: {
-//   "terms": {
-//     "realm_dart": "realm"
-//   }
-// }
-// :snippet-start: log-level
 import 'package:realm_dart/realm.dart';
-import 'package:logging/logging.dart';
+import './schemas.dart';
+import 'utils.dart';
 
-main() {
-  Realm.logger = Logger('Realm Error Logger')..level = RealmLogLevel.error;
-
-  // ...rest of app
-  // :remove-start:
+const APP_ID = "flutter-flexible-luccm";
+final SCHEMA_OBJECTS = [SyncSchema.schema];
+main() async {
   test("Add custom sync logger", () async {
-    expect(Realm.logger.name, 'Realm Error Logger');
+    // :snippet-start: log-level
+    // Must set log level before opening synced realm.
+    Realm.logger.level = RealmLogLevel.error;
+
+    // Initialize app and user before can open synced realm.
+    final app = App(AppConfiguration(APP_ID));
+    final user = await app.logIn(Credentials.anonymous());
+
+    // Synced realm writes logs according to log level set above.
+    final realm = Realm(Configuration.flexibleSync(user, SCHEMA_OBJECTS));
+    // :snippet-end:
+    expect(Realm.logger.level, RealmLogLevel.error);
+    cleanUpRealm(realm, app);
   });
-  // :remove-end:
 }
-// :snippet-end:
-// :replace-end:

--- a/examples/dart/test/sync_log_level_test.dart
+++ b/examples/dart/test/sync_log_level_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+// :replace-start:
+//   "terms": {
+//     "realm_dart": "realm",
+//   }
+// :replace-end:
+// :snippet-start: log-level
+import 'package:realm_dart/realm.dart';
+import 'package:logging/logging.dart';
+
+main() {
+  Realm.logger = Logger('Realm Error Logger')..level = RealmLogLevel.error;
+
+  // ...rest of app
+
+  // :remove-start:
+  test("Add custom sync logger", () async {
+    expect(Realm.logger.name, 'Realm Error Logger');
+  });
+  // :remove-end:
+}
+  // :snippet-end:

--- a/examples/dart/test/sync_log_level_test.dart
+++ b/examples/dart/test/sync_log_level_test.dart
@@ -12,7 +12,6 @@ main() {
   Realm.logger = Logger('Realm Error Logger')..level = RealmLogLevel.error;
 
   // ...rest of app
-
   // :remove-start:
   test("Add custom sync logger", () async {
     expect(Realm.logger.name, 'Realm Error Logger');

--- a/source/examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
+++ b/source/examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
@@ -1,8 +1,9 @@
-import 'package:realm/realm.dart';
-import 'package:logging/logging.dart';
+// Must set log level before opening synced realm.
+Realm.logger.level = RealmLogLevel.error;
 
-main() {
-  Realm.logger = Logger('Realm Error Logger')..level = RealmLogLevel.error;
+// Initialize app and user before can open synced realm.
+final app = App(AppConfiguration(APP_ID));
+final user = await app.logIn(Credentials.anonymous());
 
-  // ...rest of app
-}
+// Synced realm writes logs according to log level set above.
+final realm = Realm(Configuration.flexibleSync(user, SCHEMA_OBJECTS));

--- a/source/examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
+++ b/source/examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
@@ -1,0 +1,9 @@
+import 'package:realm/realm.dart';
+import 'package:logging/logging.dart';
+
+main() {
+  Realm.logger = Logger('Realm Error Logger')..level = RealmLogLevel.error;
+
+  // ...rest of app
+
+}

--- a/source/examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
+++ b/source/examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
@@ -5,5 +5,4 @@ main() {
   Realm.logger = Logger('Realm Error Logger')..level = RealmLogLevel.error;
 
   // ...rest of app
-
 }

--- a/source/sdk/flutter/sync.txt
+++ b/source/sdk/flutter/sync.txt
@@ -14,6 +14,7 @@ Device Sync - Flutter SDK
    Manage Sync Session </sdk/flutter/sync/manage-sync-session>
    Sync Multiple Processes </sdk/flutter/sync/sync-multiple-processes>
    Handle Sync Errors </sdk/flutter/sync/handle-sync-errors>
+   Set Sync Log Level </sdk/flutter/sync/log-level>
 
 .. contents:: On this page
    :local:

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -20,11 +20,15 @@ To diagnose and troubleshoot errors while developing your application,
 set the log level to ``debug`` or ``trace``. For production deployments,
 decrease the log level for improved performance.
 
-To configure the log level, set the static property :flutter-sdk:`Realm.logger <realm/Realm/logger.html>`
-to a `Logger <https://pub.dev/documentation/logger/latest/logger/Logger-class.html>`__
-with its ``level`` property set to one of the ``Logger`` levels provided by
-``RealmLogLevel``. You must also import ``Logger`` from the `logging <https://pub.dev/packages/logger>`__
-package, which is installed when you add the Realm package to your app.
+To configure the log level, perform the following:
+
+#. Import the ``realm`` package and the ``Logger`` class from the
+   `logging <https://pub.dev/packages/logger>`__ package,
+   which is installed when you add the Realm package to your app.
+#. Set the static property :flutter-sdk:`Realm.logger <realm/Realm/logger.html>`
+   to a `Logger <https://pub.dev/documentation/logger/latest/logger/Logger-class.html>`__
+   with its ``level`` property set to one of the ``Logger`` levels provided by
+   ``RealmLogLevel``.
 
 .. literalinclude:: /examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
    :language: dart

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -1,0 +1,32 @@
+.. _flutter-client-log-level:
+
+======================================
+Set the Client Log Level - Flutter SDK
+======================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 3
+   :class: singlecol
+
+You can set the realm sync client log level. You might want to do this
+to log different amounts of data depending on where you app is running.
+
+For a full reference of available logging levels, refer to the
+:flutter-sdk:`RealmLogLevel reference documentation <realm/RealmLogLevel-class.html>`.
+
+To diagnose and troubleshoot errors while developing your application,
+set the log level to ``debug`` or ``trace``. For production deployments,
+decrease the log level for improved performance.
+
+To configure the log level, set the static property :flutter-sdk:`Realm.logger <realm/Realm/logger.html>`
+to a `Logger <https://pub.dev/documentation/logger/latest/logger/Logger-class.html>__`
+with it's ``level`` property set to one of the ``Logger`` levels provided by
+``RealmLogLevel``. You must also import ``Logger`` from the `logging <https://pub.dev/packages/logger>`__
+package, which is also installed when you add the Realm package to your app.
+
+Set the log level for realms using Device Sync:
+
+.. literalinclude:: TODO
+   :language: dart

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -23,10 +23,10 @@ decrease the log level for improved performance.
 To configure the log level, perform the following:
 
 #. Import the ``realm`` package and the ``Logger`` class from the
-   `logging <https://pub.dev/packages/logger>`__ package,
+   `logging <https://pub.dev/packages/logging>`__ package,
    which is installed when you add the Realm package to your app.
 #. Set the static property :flutter-sdk:`Realm.logger <realm/Realm/logger.html>`
-   to a `Logger <https://pub.dev/documentation/logger/latest/logger/Logger-class.html>`__
+   to a `Logger <https://pub.dev/documentation/logging/latest/logging/Logger-class.html>`__
    with its ``level`` property set to one of the ``Logger`` levels provided by
    ``RealmLogLevel``.
 

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -21,7 +21,7 @@ set the log level to ``debug`` or ``trace``. For production deployments,
 decrease the log level for improved performance.
 
 To configure the log level, set the static property :flutter-sdk:`Realm.logger <realm/Realm/logger.html>`
-to a `Logger <https://pub.dev/documentation/logger/latest/logger/Logger-class.html>__`
+to a `Logger <https://pub.dev/documentation/logger/latest/logger/Logger-class.html>`__
 with it's ``level`` property set to one of the ``Logger`` levels provided by
 ``RealmLogLevel``. You must also import ``Logger`` from the `logging <https://pub.dev/packages/logger>`__
 package, which is also installed when you add the Realm package to your app.

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -16,19 +16,14 @@ to log different amounts of data depending on the app's environment.
 To learn more about all available logging levels, refer to the
 :flutter-sdk:`RealmLogLevel documentation <realm/RealmLogLevel-class.html>`.
 
-To diagnose and troubleshoot errors while developing your application,
-set the log level to ``debug`` or ``trace``. For production deployments,
+Set the log level to ``debug`` or ``trace`` to diagnose and troubleshoot errors
+while developing your application. For production deployments,
 decrease the log level for improved performance.
 
-To configure the log level, perform the following:
+To configure the log level, set the static property :flutter-sdk:`Realm.logger.level <realm/Realm/logger.html>`
+to one of the ``Logger`` levels provided by ``RealmLogLevel``.
 
-#. Import the ``realm`` package and the ``Logger`` class from the
-   `logging <https://pub.dev/packages/logging>`__ package,
-   which is installed when you add the Realm package to your app.
-#. Set the static property :flutter-sdk:`Realm.logger <realm/Realm/logger.html>`
-   to a `Logger <https://pub.dev/documentation/logging/latest/logging/Logger-class.html>`__
-   with its ``level`` property set to one of the ``Logger`` levels provided by
-   ``RealmLogLevel``.
+You must set the log level **before** you open a synced realm.
 
 .. literalinclude:: /examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
    :language: dart

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -24,7 +24,7 @@ To configure the log level, set the static property :flutter-sdk:`Realm.logger <
 to a `Logger <https://pub.dev/documentation/logger/latest/logger/Logger-class.html>`__
 with it's ``level`` property set to one of the ``Logger`` levels provided by
 ``RealmLogLevel``. You must also import ``Logger`` from the `logging <https://pub.dev/packages/logger>`__
-package, which is also installed when you add the Realm package to your app.
+package, which is installed when you add the Realm package to your app.
 
 Set the log level for realms using Device Sync:
 

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -11,7 +11,7 @@ Set the Client Log Level - Flutter SDK
    :class: singlecol
 
 You can set the realm sync client log level. You might want to do this
-to log different amounts of data depending on where you app is running.
+to log different amounts of data depending on the app's environment.
 
 To learn more about all available logging levels, refer to the
 :flutter-sdk:`RealmLogLevel documentation <realm/RealmLogLevel-class.html>`.
@@ -25,8 +25,6 @@ to a `Logger <https://pub.dev/documentation/logger/latest/logger/Logger-class.ht
 with it's ``level`` property set to one of the ``Logger`` levels provided by
 ``RealmLogLevel``. You must also import ``Logger`` from the `logging <https://pub.dev/packages/logger>`__
 package, which is installed when you add the Realm package to your app.
-
-Set the log level for realms using Device Sync:
 
 .. literalinclude:: /examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
    :language: dart

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -28,5 +28,5 @@ package, which is also installed when you add the Realm package to your app.
 
 Set the log level for realms using Device Sync:
 
-.. literalinclude:: TODO
+.. literalinclude:: /examples/generated/flutter/sync_log_level_test.snippet.log-level.dart
    :language: dart

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -22,7 +22,7 @@ decrease the log level for improved performance.
 
 To configure the log level, set the static property :flutter-sdk:`Realm.logger <realm/Realm/logger.html>`
 to a `Logger <https://pub.dev/documentation/logger/latest/logger/Logger-class.html>`__
-with it's ``level`` property set to one of the ``Logger`` levels provided by
+with its ``level`` property set to one of the ``Logger`` levels provided by
 ``RealmLogLevel``. You must also import ``Logger`` from the `logging <https://pub.dev/packages/logger>`__
 package, which is installed when you add the Realm package to your app.
 

--- a/source/sdk/flutter/sync/log-level.txt
+++ b/source/sdk/flutter/sync/log-level.txt
@@ -13,8 +13,8 @@ Set the Client Log Level - Flutter SDK
 You can set the realm sync client log level. You might want to do this
 to log different amounts of data depending on where you app is running.
 
-For a full reference of available logging levels, refer to the
-:flutter-sdk:`RealmLogLevel reference documentation <realm/RealmLogLevel-class.html>`.
+To learn more about all available logging levels, refer to the
+:flutter-sdk:`RealmLogLevel documentation <realm/RealmLogLevel-class.html>`.
 
 To diagnose and troubleshoot errors while developing your application,
 set the log level to ``debug`` or ``trace``. For production deployments,


### PR DESCRIPTION
## Pull Request Info

Flutter set sync client log level

### Jira

- https://jira.mongodb.org/browse/DOCSP-26501

### Staged Changes

- [Set Sync Client Log Level (Flutter)](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26501/sdk/flutter/sync/log-level/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
