### PR TITLE
(DOCSP-26538): Kotlin @PersistedName annotation documentation

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
@@ -98,8 +98,8 @@ class Post: RealmObject {
 class Horse : RealmObject {
     val _id: ObjectId = ObjectId()
     val name: String =""
-    @PersistedName("rider_name")
-    val riderName: Knight? = null
+    @PersistedName("rider_name") // Name persisted to realm
+    val riderName: Knight? = null // Kotlin name used in code
 }
 // :snippet-end:
 

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
@@ -1,30 +1,28 @@
 package com.mongodb.realm.realmkmmapp
 
-import io.realm.kotlin.Realm
-import io.realm.kotlin.RealmConfiguration
-import io.realm.kotlin.ext.realmListOf
-import io.realm.kotlin.internal.platform.runBlocking
-import io.realm.kotlin.mongodb.App
-import io.realm.kotlin.mongodb.Credentials
-import io.realm.kotlin.mongodb.sync.SyncConfiguration
-import io.realm.kotlin.types.*
-import io.realm.kotlin.types.annotations.Ignore
-import io.realm.kotlin.types.annotations.Index
-import io.realm.kotlin.types.annotations.PrimaryKey
-import kotlinx.datetime.Instant
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import io.realm.kotlin.ext.query
-import io.realm.kotlin.ext.backlinks
-import io.realm.kotlin.ext.realmListOf
-import io.realm.kotlin.ext.realmSetOf
-import io.realm.kotlin.log.RealmLogger
-import io.realm.kotlin.query.RealmResults
-import kotlinx.coroutines.*
 //import kotlinx.coroutines.Dispatchers
 //import kotlinx.coroutines.launch
 //import kotlinx.coroutines.runBlocking
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
+import io.realm.kotlin.ext.backlinks
+import io.realm.kotlin.ext.query
+import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.ext.realmSetOf
+import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.query.RealmResults
+import io.realm.kotlin.types.*
+import io.realm.kotlin.types.annotations.Ignore
+import io.realm.kotlin.types.annotations.Index
+import io.realm.kotlin.types.annotations.PersistedName
+import io.realm.kotlin.types.annotations.PrimaryKey
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Instant
 import org.mongodb.kbson.ObjectId
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 // :replace-start: {
 //    "terms": {
@@ -96,9 +94,14 @@ class Post: RealmObject {
 }
 // :snippet-end:
 
+// :snippet-start: persisted-name
 class Horse : RealmObject {
     val _id: ObjectId = ObjectId()
+    val name: String =""
+    @PersistedName("rider_name")
+    val riderName: Knight? = null
 }
+// :snippet-end:
 
 // :snippet-start: optional
 class Knight : RealmObject {
@@ -158,6 +161,9 @@ class Cat3 : RealmObject {
 
     @Ignore
     var tempId: Int = 0 // Ignored property
+
+    @PersistedName("latin_name") // Remapped property
+    var species: String? = null
 }
 // :snippet-end:
 
@@ -353,5 +359,6 @@ class SchemaTest: RealmTest() {
         }
 
     }
+
 }
 // :replace-end:

--- a/source/examples/generated/kotlin/SchemaTest.snippet.declare-properties.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.declare-properties.kt
@@ -11,4 +11,7 @@ class Cat : RealmObject {
 
     @Ignore
     var tempId: Int = 0 // Ignored property
+
+    @PersistedName("latin_name") // Remapped property
+    var species: String? = null
 }

--- a/source/examples/generated/kotlin/SchemaTest.snippet.persisted-name.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.persisted-name.kt
@@ -1,6 +1,6 @@
 class Horse : RealmObject {
     val _id: ObjectId = ObjectId()
     val name: String =""
-    @PersistedName("rider_name")
-    val riderName: Knight? = null
+    @PersistedName("rider_name") // Name persisted to realm
+    val riderName: Knight? = null // Kotlin name used in code
 }

--- a/source/examples/generated/kotlin/SchemaTest.snippet.persisted-name.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.persisted-name.kt
@@ -1,0 +1,6 @@
+class Horse : RealmObject {
+    val _id: ObjectId = ObjectId()
+    val name: String =""
+    @PersistedName("rider_name")
+    val riderName: Knight? = null
+}

--- a/source/sdk/kotlin/realm-database/define-realm-object-model.txt
+++ b/source/sdk/kotlin/realm-database/define-realm-object-model.txt
@@ -129,7 +129,7 @@ Map a Property to a Different Name
 
 To persist a field under a different property name, 
 use the ``@PersistedName`` annotation. 
-This is useful when open a Realm across different bindings
+This is useful when you open a Realm across different bindings
 where code style conventions can differ. 
 For more information, refer to :ref:`Remap a Property <kotlin-remap-a-property>`.
 

--- a/source/sdk/kotlin/realm-database/define-realm-object-model.txt
+++ b/source/sdk/kotlin/realm-database/define-realm-object-model.txt
@@ -127,7 +127,7 @@ For more information, refer to :ref:`Primary Keys <kotlin-primary-keys>`.
 Map a Property to a Different Name 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To indicate a property be persisted under a different name, 
+To persist a field under a different property name, 
 use the ``@PersistedName`` annotation. 
 This is useful when open a Realm across different bindings
 where code style conventions can differ. 

--- a/source/sdk/kotlin/realm-database/define-realm-object-model.txt
+++ b/source/sdk/kotlin/realm-database/define-realm-object-model.txt
@@ -124,6 +124,19 @@ For more information, refer to :ref:`Primary Keys <kotlin-primary-keys>`.
   :language: kotlin
   :emphasize-lines: 2-3
 
+Map a Property to a Different Name 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To indicate a property be persisted under a different name, 
+use the ``@PersistedName`` annotation. 
+This is useful when open a Realm across different bindings
+where code style conventions can differ. 
+For more information, refer to :ref:`Remap a Property <kotlin-remap-a-property>`.
+
+.. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.declare-properties.kt
+  :language: kotlin
+  :emphasize-lines: 15-16
+
 Ignore Properties from Realm Schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/sdk/kotlin/realm-database/schemas.txt
+++ b/source/sdk/kotlin/realm-database/schemas.txt
@@ -13,10 +13,11 @@ Schemas - Kotlin SDK
    
    Supported Types </sdk/kotlin/realm-database/schemas/supported-types>
    Timestamps </sdk/kotlin/realm-database/schemas/timestamps>
+   Primary Keys </sdk/kotlin/realm-database/schemas/primary-key>
    Ignore a Field </sdk/kotlin/realm-database/schemas/ignore>
    Index a Field </sdk/kotlin/realm-database/schemas/index>
    Optional Fields </sdk/kotlin/realm-database/schemas/optional>
-   Primary Keys </sdk/kotlin/realm-database/schemas/primary-key>
+   Remap a Field </sdk/kotlin/realm-database/schemas/remap>
    Relationships </sdk/kotlin/realm-database/schemas/relationships>
    Embedded Objects </sdk/kotlin/realm-database/schemas/embedded-objects>
    RealmSet </sdk/kotlin/realm-database/schemas/realm-set>

--- a/source/sdk/kotlin/realm-database/schemas/remap.txt
+++ b/source/sdk/kotlin/realm-database/schemas/remap.txt
@@ -1,0 +1,30 @@
+.. _kotlin-remap-a-property:
+
+=============================
+Remap a Property - Kotlin SDK
+=============================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+By default, Realm Database uses the name defined in the model class
+to represent fields internally. 
+In some cases, you might want to change this behavior:
+
+- To make it easier to work across platforms where naming conventions differ.
+- To change a field name in Kotlin without forcing a :ref:`migration <kotlin-migrations>`.
+
+To map a different property name in your code than is stored in
+Realm Database, use the `@PersistedName <{+kotlin-local-prefix+}io.realm.kotlin.types.annotations/-persisted-name/index.html>`__
+annotation in the :ref:`object schema <kotlin-object-schema>`:
+
+.. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.persisted-name.kt
+   :language: kotlin
+
+Note that migrations must use the internal name when creating classes and 
+properties, and any schema errors reported will use the internal name. 
+
+You can query by both the internal name and the remapped name.

--- a/source/sdk/kotlin/realm-database/schemas/remap.txt
+++ b/source/sdk/kotlin/realm-database/schemas/remap.txt
@@ -14,7 +14,9 @@ By default, Realm Database uses the name defined in the model class
 to represent fields internally. 
 In some cases, you might want to change this behavior:
 
-- To make it easier to work across platforms where naming conventions differ.
+- To make it easier to work across platforms where naming conventions differ. 
+  For example, if your Device Sync schema property names use snake case, 
+  while your project uses camel case.
 - To change a field name in Kotlin without forcing a :ref:`migration <kotlin-migrations>`.
 
 To map a different property name in your code than is stored in

--- a/source/sdk/kotlin/realm-database/schemas/remap.txt
+++ b/source/sdk/kotlin/realm-database/schemas/remap.txt
@@ -21,12 +21,20 @@ In some cases, you might want to change this behavior:
 
 To map a different property name in your code than is stored in
 Realm Database, use the `@PersistedName <{+kotlin-local-prefix+}io.realm.kotlin.types.annotations/-persisted-name/index.html>`__
-annotation in the :ref:`object schema <kotlin-object-schema>`:
+annotation in the :ref:`object schema <kotlin-object-schema>` and specify the 
+property ``name`` that you want persisted to the realm. 
+If you write to a synced realm, the Sync schema sees the values stored using the
+persisted property name.
+
+In this example, ``riderName`` is the Kotlin property name used in the code 
+throughout the project to perform CRUD operations and ``rider_name`` is the 
+persisted name used to store values in Realm Database:
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.persisted-name.kt
    :language: kotlin
 
-Note that migrations must use the internal name when creating classes and 
-properties, and any schema errors reported will use the internal name. 
+Note that migrations must use the persisted property name when creating classes and 
+properties, and any schema errors reported will also use the persisted name. 
 
-You can query by both the internal name and the remapped name.
+You can query by both the Kotlin name used in the code
+and by the persisted name stored in Realm Database.


### PR DESCRIPTION
## Pull Request Info

Add documentation for `@PersistedName` annotation 

### Jira

- https://jira.mongodb.org/browse/DOCSP-26538

### Staged Changes

- new page: [Remap a Property - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-26538-persisted/sdk/kotlin/realm-database/schemas/remap/)
- updated page: [Define a Realm Object Model - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-26538-persisted/sdk/kotlin/realm-database/define-realm-object-model/#map-a-property-to-a-different-name)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
