### PR TITLE
DOCSP-27265): Fix failing RealmSet test

### DIFF
--- a/source/examples/generated/kotlin/SchemaTest.snippet.add-all-to-realm-set.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.add-all-to-realm-set.kt
@@ -1,4 +1,7 @@
 realm.write {
+    val myFrog: Frog = realm.query<Frog>("name = 'Kermit'").first().find()!!
+    val set = findLatest(myFrog)!!.favoriteSnacks
+
     val cricketsSnack = this.copyToRealm(Snack().apply {
         name = "crickets"
     })
@@ -10,4 +13,4 @@ realm.write {
     })
 
     set.addAll(setOf(cricketsSnack, earthWormsSnack, waxWormsSnack))
-}
+    }

--- a/source/examples/generated/kotlin/SchemaTest.snippet.add-item-to-realm-set.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.add-item-to-realm-set.kt
@@ -1,12 +1,12 @@
 realm.write {
-    // create a Frog object named 'Kermit' that will have a RealmSet of favorite snacks
+    // Create a Frog object named 'Kermit' that will have a RealmSet of favorite snacks
     val frog = this.copyToRealm(Frog().apply {
         name = "Kermit"
     })
-    // get the RealmSet of favorite snacks from the Frog object we just created
+    // Get the RealmSet of favorite snacks from the Frog object we just created
     val set = frog.favoriteSnacks
 
-    // create a Snack object for the Frog to add to Kermit's favorite snacks
+    // Create a Snack object for the Frog to add to Kermit's favorite snacks
     val fliesSnack = this.copyToRealm(Snack().apply {
         name = "flies"
     })

--- a/source/examples/generated/kotlin/SchemaTest.snippet.cancel-job.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.cancel-job.kt
@@ -1,1 +1,0 @@
-job.cancel()

--- a/source/examples/generated/kotlin/SchemaTest.snippet.remove-item-from-set.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.remove-item-from-set.kt
@@ -1,3 +1,3 @@
-realm.write {
-    set.remove(fliesSnack)
-}
+val fliesSnack = realm.query<Snack>("name = 'flies'").first().find()
+
+set.remove(fliesSnack)

--- a/source/examples/generated/kotlin/SchemaTest.snippet.remove-multiple-items-from-set.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.remove-multiple-items-from-set.kt
@@ -1,3 +1,1 @@
-realm.write {
-    set.removeAll(setOfFrogSnacks)
-}
+set.removeAll(set)

--- a/source/examples/generated/kotlin/SchemaTest.snippet.set-contains-multiple-items.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.set-contains-multiple-items.kt
@@ -1,3 +1,2 @@
-val setOfFrogSnacks = setOf(cricketsSnack, earthWormsSnack, waxWormsSnack)
-val containsAllSnacks = set.containsAll(setOfFrogSnacks)
-Log.v("Does Kermit eat crickets, earth worms, and wax worms?: $containsAllSnacks") // true
+val containsAllSnacks = set.containsAll(set)
+Log.v("Does Kermit eat crickets, earthworms, and wax worms?: $containsAllSnacks") // true

--- a/source/examples/generated/kotlin/SchemaTest.snippet.set-contains.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.set-contains.kt
@@ -1,1 +1,1 @@
-Log.v("Does Kermit eat earth worms?: ${set.contains(earthWormsSnack)}") // true
+Log.v("Does Kermit eat earthworms?: ${set.contains(earthWormsSnack)}") // true

--- a/source/sdk/kotlin/realm-database/schemas/realm-set.txt
+++ b/source/sdk/kotlin/realm-database/schemas/realm-set.txt
@@ -29,7 +29,12 @@ any ``RealmSet`` instances that contain the object.
 Define a RealmSet
 -----------------
 
-To define a property as a ``RealmSet``, specify its type within the schema.
+To define a property as a ``RealmSet<T>``, where T is any of the supported 
+:ref:`data types <kotlin-supported-types>` or a 
+`RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__. 
+Sets of ``RealmObject`` cannot have null elements. 
+All other types of ``RealmSet<T>`` can be nullable (``RealmSet<T?>``).
+
 Instantiate an unmanaged ``RealmSet`` by setting the field's default value
 using the `realmSetOf()
 <{+kotlin-local-prefix+}io.realm.kotlin.ext/realm-set-of.html>`__ method.
@@ -39,7 +44,6 @@ field that is a ``RealmSet`` of ``Snack`` objects.
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.define-a-realm-set.kt
    :language: kotlin
-   :copyable: false
 
 Add an Item to a RealmSet
 -------------------------
@@ -53,7 +57,6 @@ In the following example, we get the ``favoriteSnacks`` set, then add a new
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.add-item-to-realm-set.kt
    :language: kotlin
-   :copyable: false
 
 Add Many Items to a RealmSet
 ----------------------------
@@ -71,7 +74,6 @@ elements to the ``set.addAll()`` method to add them to our ``Frog`` object's fav
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.add-all-to-realm-set.kt
    :language: kotlin
-   :copyable: false
 
 Check if the RealmSet Contains an Item
 --------------------------------------
@@ -83,7 +85,6 @@ The method returns true if the set contains the element.
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.set-contains.kt
    :language: kotlin
-   :copyable: false
 
 Check if the RealmSet Contains Multiple Items
 ---------------------------------------------
@@ -100,7 +101,6 @@ the read-only set to ``set.containsAll()``.
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.set-contains-multiple-items.kt
    :language: kotlin
-   :copyable: false
 
 Remove an Item from a RealmSet
 ------------------------------
@@ -110,7 +110,6 @@ To remove an item from a ``RealmSet``, pass the element you wish to delete to `s
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.remove-item-from-set.kt
    :language: kotlin
-   :copyable: false
 
 Remove Multiple Items from a RealmSet
 -------------------------------------
@@ -122,7 +121,6 @@ In the following example, we delete the set of favorite snacks we created earlie
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.remove-multiple-items-from-set.kt
    :language: kotlin
-   :copyable: false
 
 Notifications
 -------------
@@ -142,12 +140,10 @@ In the following example, we react to changes on the ``favoriteSnacks`` set of o
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.react-to-changes-from-the-set.kt
    :language: kotlin
-   :copyable: false
 
 The ``Flow`` runs indefinitely until you `cancel the enclosing coroutine
 <https://kotlinlang.org/docs/cancellation-and-timeouts.html>`__ or until you
 delete the parent object.
 
-.. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.cancel-job.kt
+.. literalinclude:: /examples/generated/kotlin/QuickStartTest.snippet.quick-start-unsubscribe-to-changes.kt
    :language: kotlin
-   :copyable: false

--- a/source/sdk/kotlin/realm-database/schemas/realm-set.txt
+++ b/source/sdk/kotlin/realm-database/schemas/realm-set.txt
@@ -29,11 +29,10 @@ any ``RealmSet`` instances that contain the object.
 Define a RealmSet
 -----------------
 
-To define a property as a ``RealmSet<T>``, where T is any of the supported 
-:ref:`data types <kotlin-supported-types>` or a 
+To define a property as a ``RealmSet<T>``, specify its type within the schema, 
+where T is any of the supported :ref:`data types <kotlin-supported-types>` or a 
 `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__. 
-Sets of ``RealmObject`` cannot have null elements. 
-All other types of ``RealmSet<T>`` can be nullable (``RealmSet<T?>``).
+Note that T can be nullable (``RealmSet<T?>``) unless it is of type ``RealmObject``.
 
 Instantiate an unmanaged ``RealmSet`` by setting the field's default value
 using the `realmSetOf()


### PR DESCRIPTION
## Pull Request Info

Fix failing RealmSet test and generate corrected Bluehawk examples

### Jira

- https://jira.mongodb.org/browse/DOCSP-27265

### Staged Changes

- [RealmSet - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-27265-fix-realmset/sdk/kotlin/realm-database/schemas/realm-set/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any: https://jira.mongodb.org/browse/DOCSP-28334 will update Appx Data Model Mapping page
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
