### PR TITLE
(DOCSP-27197): Rename 'task' to 'item' in RQL examples

### DIFF
--- a/examples/dart/test/task_project_models_test.dart
+++ b/examples/dart/test/task_project_models_test.dart
@@ -8,7 +8,7 @@ part 'task_project_models_test.g.dart'; // :remove:
 // :uncomment-end:
 
 @RealmModel()
-class _Task {
+class _Item {
   @MapTo("_id")
   @PrimaryKey()
   late ObjectId id;
@@ -27,7 +27,7 @@ class _Project {
   late ObjectId id;
 
   late String name;
-  late List<_Task> tasks;
+  late List<_Item> items;
   int? quota;
 }
 // :snippet-end:

--- a/examples/dotnet/Examples/RqlSchemaExamples.cs
+++ b/examples/dotnet/Examples/RqlSchemaExamples.cs
@@ -10,7 +10,8 @@ namespace Examples.RqlSchemaExamples
     //  "terms": {
     //   "RqlTask": "Item",
     //   "RqlProject": "Project",
-    //   "RqlTasks": "Items"}
+    //   "RqlTasks": "Items",
+    //   "RqlItems": "Items"}
     // }
     public class RqlTask : RealmObject
     {

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/RQLTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/RQLTest.kt
@@ -1,13 +1,13 @@
 package com.mongodb.realm.realmkmmapp
 
 import io.realm.kotlin.types.RealmList
-import org.mongodb.kbson.ObjectId
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.PrimaryKey
+import org.mongodb.kbson.ObjectId
 
 class RQLTest: RealmTest() {
     // :snippet-start: rql-schema-example
-    class Task(): RealmObject {
+    class Item(): RealmObject {
         @PrimaryKey
         var _id: ObjectId = ObjectId()
         lateinit var name: String
@@ -21,7 +21,7 @@ class RQLTest: RealmTest() {
         @PrimaryKey
         var _id: ObjectId = ObjectId()
         lateinit var name: String
-        lateinit var tasks: RealmList<Task>
+        lateinit var items: RealmList<Item>
         var quota: Int? = null
     }
     // :snippet-end:

--- a/examples/node/Examples/realm-query-language.js
+++ b/examples/node/Examples/realm-query-language.js
@@ -1,11 +1,11 @@
 import Realm, { BSON } from "realm";
-import { TaskModel, ProjectModel } from "./schemas/rql-data-models";
+import { ItemModel, ProjectModel } from "./schemas/rql-data-models";
 
 describe("Realm Query Language Reference", () => {
   let realm;
   beforeEach(async () => {
     realm = await Realm.open({
-      schema: [ProjectModel, TaskModel],
+      schema: [ProjectModel, ItemModel],
       deleteRealmIfMigrationNeeded: true,
     });
 
@@ -14,7 +14,7 @@ describe("Realm Query Language Reference", () => {
       realm.create("Project", {
         id: new Realm.BSON.ObjectId(),
         name: "New Project",
-        tasks: [
+        items: [
           {
             id: new Realm.BSON.ObjectId(),
             name: "Write tests",
@@ -45,7 +45,7 @@ describe("Realm Query Language Reference", () => {
         id: new Realm.BSON.ObjectId(),
         name: "Project with High Quota",
         quota: 12,
-        tasks: [
+        items: [
           {
             id: new Realm.BSON.ObjectId(),
             name: "Create a ticket",
@@ -76,10 +76,10 @@ describe("Realm Query Language Reference", () => {
       const proj2 = realm.create("Project", {
         id: new Realm.BSON.ObjectId(),
         name: "Another project",
-        tasks: [proj1.tasks[2]],
+        items: [proj1.items[2]],
       });
 
-      realm.create("Task", {
+      realm.create("Item", {
         id: new Realm.BSON.ObjectId(),
         name: "Assign me to a project",
         isComplete: false,
@@ -90,7 +90,7 @@ describe("Realm Query Language Reference", () => {
     });
 
     expect(realm.objects("Project")[0].name).toBe("New Project");
-    expect(realm.objects("Task")[0].name).toBe("Write tests");
+    expect(realm.objects("Item")[0].name).toBe("Write tests");
   });
 
   afterEach(() => {
@@ -105,39 +105,39 @@ describe("Realm Query Language Reference", () => {
 
   test("simple query example", () => {
     // :snippet-start: simple-query
-    const tasks = realm.objects("Task");
-    // Gets all tasks where the 'priority' property is 7 or more.
-    const importantTasks = tasks.filtered("priority >= 7");
+    const items = realm.objects("Item");
+    // Gets all items where the 'priority' property is 7 or more.
+    const importantItems = items.filtered("priority >= 7");
     // :snippet-end:
-    expect(importantTasks.length).toBeGreaterThan(0);
+    expect(importantItems.length).toBeGreaterThan(0);
   });
   test("comparison queries", () => {
-    const tasks = realm.objects("Task");
+    const items = realm.objects("Item");
 
-    const highPriorityTasks = tasks.filtered(
+    const highPriorityItems = items.filtered(
       // :snippet-start: comparison-operators
       "priority > 5"
       // :remove-start:
     );
-    expect(highPriorityTasks.length).toBe(4);
+    expect(highPriorityItems.length).toBe(4);
 
-    const longRunningTasks = tasks.filtered(
+    const longRunningItems = items.filtered(
       // :remove-end:
 
       "progressMinutes > 120"
       // :remove-start:
     );
-    expect(longRunningTasks.length).toBe(1);
+    expect(longRunningItems.length).toBe(1);
 
-    const unassignedTasks = tasks.filtered(
+    const unassignedItems = items.filtered(
       // :remove-end:
 
       "assignee == nil"
       // :remove-start:
     );
-    expect(unassignedTasks.length).toBe(1);
+    expect(unassignedItems.length).toBe(1);
 
-    const progressMinutesRange = tasks.filtered(
+    const progressMinutesRange = items.filtered(
       // :remove-end:
 
       "progressMinutes BETWEEN { 30,60 }"
@@ -145,7 +145,7 @@ describe("Realm Query Language Reference", () => {
     );
     expect(progressMinutesRange.length).toBe(1);
 
-    const progressMinutesIn = tasks.filtered(
+    const progressMinutesIn = items.filtered(
       // :remove-end:
 
       "progressMinutes IN { 10, 20, 30, 40, 50, 60 }"
@@ -155,10 +155,10 @@ describe("Realm Query Language Reference", () => {
   });
 
   test("logic queries", () => {
-    const tasks = realm.objects("Task");
+    const items = realm.objects("Item");
     const projects = realm.objects("Project");
 
-    const aliComplete = tasks.filtered(
+    const aliComplete = items.filtered(
       // :snippet-start: logical-operators
       "assignee == 'Ali' AND isComplete == true"
       // :snippet-end:
@@ -185,41 +185,41 @@ describe("Realm Query Language Reference", () => {
 
   test("aggregate queries", () => {
     const projects = realm.objects("Project");
-    const averageTaskPriorityAbove5 = projects.filtered(
+    const averageItemPriorityAbove5 = projects.filtered(
       // :snippet-start: aggregate-operators
-      "tasks.@avg.priority > 5"
+      "items.@avg.priority > 5"
       // :remove-start:
     );
-    expect(averageTaskPriorityAbove5.length).toBe(3);
+    expect(averageItemPriorityAbove5.length).toBe(3);
 
-    const allTasksLowerPriority = projects.filtered(
+    const allItemsLowerPriority = projects.filtered(
       // :remove-end:
 
-      "tasks.@max.priority < 5"
+      "items.@max.priority < 5"
       // :remove-start:
     );
-    expect(allTasksLowerPriority.length).toBe(0);
+    expect(allItemsLowerPriority.length).toBe(0);
 
-    const allTasksHighPriority = projects.filtered(
+    const allItemsHighPriority = projects.filtered(
       // :remove-end:
 
-      "tasks.@min.priority > 5"
+      "items.@min.priority > 5"
       // :remove-start:
     );
-    expect(allTasksHighPriority.length).toBe(1);
+    expect(allItemsHighPriority.length).toBe(1);
 
-    const moreThan5Tasks = projects.filtered(
+    const moreThan5Items = projects.filtered(
       // :remove-end:
 
-      "tasks.@count > 5"
+      "items.@count > 5"
       // :remove-start:
     );
-    expect(moreThan5Tasks.length).toBe(0);
+    expect(moreThan5Items.length).toBe(0);
 
     const longRunningProjects = projects.filtered(
       // :remove-end:
 
-      "tasks.@sum.progressMinutes > 100"
+      "items.@sum.progressMinutes > 100"
       // :snippet-end:
     );
     expect(longRunningProjects.length).toBe(1);
@@ -227,57 +227,57 @@ describe("Realm Query Language Reference", () => {
 
   test("collection queries", () => {
     const projects = realm.objects("Project");
-    const noCompleteTasks = projects.filtered(
+    const noCompleteItems = projects.filtered(
       // :snippet-start: set-operators
-      // Projects with no complete tasks.
-      "NONE tasks.isComplete == true"
+      // Projects with no complete items.
+      "NONE items.isComplete == true"
       // :remove-start:
     );
 
-    const anyTopPriorityTasks = projects.filtered(
+    const anyTopPriorityItems = projects.filtered(
       // :remove-end:
 
-      // Projects that contain a task with priority 10
-      "ANY tasks.priority == 10"
+      // Projects that contain a item with priority 10
+      "ANY items.priority == 10"
       // :remove-start:
     );
-    const allTasksCompleted = projects.filtered(
+    const allItemsCompleted = projects.filtered(
       // :remove-end:
 
-      // Projects that only contain completed tasks
-      "ALL tasks.isComplete == true"
+      // Projects that only contain completed items
+      "ALL items.isComplete == true"
       // :remove-start:
     );
     const assignedToAlexOrAli = projects.filtered(
       // :remove-end:
 
-      // Projects with at least one task assigned to either Alex or Ali
-      "ANY tasks.assignee IN { 'Alex', 'Ali' }"
+      // Projects with at least one item assigned to either Alex or Ali
+      "ANY items.assignee IN { 'Alex', 'Ali' }"
       // :remove-start:
     );
     const notAssignedToAlexOrAli = projects.filtered(
       // :remove-end:
 
-      // Projects with no tasks assigned to either Alex or Ali
-      "NONE tasks.assignee IN { 'Alex', 'Ali' }"
+      // Projects with no items assigned to either Alex or Ali
+      "NONE items.assignee IN { 'Alex', 'Ali' }"
       // :snippet-end:
     );
-    expect(noCompleteTasks.length).toBe(2);
-    expect(anyTopPriorityTasks.length).toBe(1);
-    expect(allTasksCompleted.length).toBe(0);
+    expect(noCompleteItems.length).toBe(2);
+    expect(anyTopPriorityItems.length).toBe(1);
+    expect(allItemsCompleted.length).toBe(0);
     expect(assignedToAlexOrAli.length).toBe(1);
     expect(notAssignedToAlexOrAli.length).toBe(2);
   });
 
   test("sort, distinct and limit queries", () => {
-    const tasks = realm.objects("Task");
+    const items = realm.objects("Item");
 
-    const sortedUniqueAliTasks = tasks.filtered(
+    const sortedUniqueAliItems = items.filtered(
       // :snippet-start: sort-distinct-limit
       "assignee == 'Ali' SORT(priority DESC) DISTINCT(name) LIMIT(5)"
       // :snippet-end:
     );
-    expect(sortedUniqueAliTasks.length).toBe(1);
+    expect(sortedUniqueAliItems.length).toBe(1);
   });
 
   test("list comparisons", () => {
@@ -285,7 +285,7 @@ describe("Realm Query Language Reference", () => {
       realm.create("Project", {
         id: new Realm.BSON.ObjectId(),
         name: "List Query Project",
-        tasks: [
+        items: [
           {
             id: new BSON.ObjectId("631a072f75120729dc9223d9"),
             name: "Do the dishes",
@@ -314,14 +314,14 @@ describe("Realm Query Language Reference", () => {
       });
     });
     const projects = realm.objects("Project");
-    const tasks = realm.objects("Task");
+    const items = realm.objects("Item");
 
     const collectionQuery = projects.filtered(
       // :snippet-start: list-comparisons-collection
-      "oid(631a072f75120729dc9223d9) IN tasks.id"
+      "oid(631a072f75120729dc9223d9) IN items.id"
       // :snippet-end:
     );
-    const staticQuery = tasks.filtered(
+    const staticQuery = items.filtered(
       // :snippet-start: list-comparisons-static
       "priority IN {0, 1, 2}"
       // :snippet-end:
@@ -332,7 +332,7 @@ describe("Realm Query Language Reference", () => {
       new BSON.ObjectId("631a0737c98f89f5b81cd24d"),
       new BSON.ObjectId("631a073c833a34ade21db2b2"),
     ];
-    const parameterizedQuery = realm.objects("Task").filtered("id IN $0", ids);
+    const parameterizedQuery = realm.objects("Item").filtered("id IN $0", ids);
     // :snippet-end:
 
     expect(collectionQuery.length).toBe(1);
@@ -342,18 +342,18 @@ describe("Realm Query Language Reference", () => {
 
   describe("Backlink queries", () => {
     test("dot-notation", () => {
-      const atLinksResult = realm.objects("Task").filtered(
+      const atLinksResult = realm.objects("Item").filtered(
         // :snippet-start: backlinks-atLinks
-        // Find tasks that belong to a project with a quota greater than 10 (@links)
-        "@links.Project.tasks.quota > 10"
+        // Find items that belong to a project with a quota greater than 10 (@links)
+        "@links.Project.items.quota > 10"
         // :snippet-end:
       );
       expect(atLinksResult.length).toBe(3);
       expect(atLinksResult[0].name).toBe("Create a ticket");
 
-      const linkingObjectsResult = realm.objects("Task").filtered(
+      const linkingObjectsResult = realm.objects("Item").filtered(
         // :snippet-start: backlinks-linkingObjects
-        // Find tasks that belong to a project with a quota greater than 10 (LinkingObjects)
+        // Find items that belong to a project with a quota greater than 10 (LinkingObjects)
         "projects.quota > 10"
         // :snippet-end:
       );
@@ -362,19 +362,19 @@ describe("Realm Query Language Reference", () => {
     });
 
     test("collection operators", () => {
-      const anyResult = realm.objects("Task").filtered(
+      const anyResult = realm.objects("Item").filtered(
         // :snippet-start: backlinks-collection-operators
-        // Find tasks where any project that references the task has a quota greater than 0
-        "ANY @links.Project.tasks.quota > 0"
+        // Find items where any project that references the item has a quota greater than 0
+        "ANY @links.Project.items.quota > 0"
         // :remove-start:
       );
       expect(anyResult.length).toBe(3);
       expect(anyResult[0].name).toBe("Create a ticket");
 
-      const allResult = realm.objects("Task").filtered(
+      const allResult = realm.objects("Item").filtered(
         // :remove-end:
-        // Find tasks where all projects that reference the task have a quota greater than 0
-        "ALL @links.Project.tasks.quota > 0"
+        // Find items where all projects that reference the item have a quota greater than 0
+        "ALL @links.Project.items.quota > 0"
         // :snippet-end:
       );
       expect(allResult.length).toBe(3);
@@ -382,29 +382,29 @@ describe("Realm Query Language Reference", () => {
     });
 
     test("aggregate operators", () => {
-      const shallowResultLinkingObjects = realm.objects("Task").filtered(
+      const shallowResultLinkingObjects = realm.objects("Item").filtered(
         // :snippet-start: backlinks-aggregate-operators
-        // Find tasks that are referenced by multiple projects
+        // Find items that are referenced by multiple projects
         "projects.@count > 1"
         // :remove-start:
       );
       expect(shallowResultLinkingObjects.length).toBe(1);
       expect(shallowResultLinkingObjects[0].name).toBe("Get coffee");
       
-      const shallowResultAtLinks = realm.objects("Task").filtered(
+      const shallowResultAtLinks = realm.objects("Item").filtered(
         // :remove-end:
-        // Find tasks that are not referenced by any project
-        "@links.Project.tasks.@count == 0"
+        // Find items that are not referenced by any project
+        "@links.Project.items.@count == 0"
         // :remove-start:
       );
       expect(shallowResultAtLinks.length).toBe(1);
       expect(shallowResultAtLinks[0].name).toBe("Assign me to a project");
 
-      const deepResultAtLinks = realm.objects("Task").filtered(
+      const deepResultAtLinks = realm.objects("Item").filtered(
         // :remove-end:
-        // Find tasks that belong to a project where the average task has
+        // Find items that belong to a project where the average item has
         // been worked on for at least 5 minutes
-        "@links.Project.tasks.tasks.@avg.progressMinutes > 10"
+        "@links.Project.items.items.@avg.progressMinutes > 10"
         // :snippet-end:
       );
       expect(deepResultAtLinks.length).toBe(3);
@@ -412,9 +412,9 @@ describe("Realm Query Language Reference", () => {
     });
 
     test("count all backlinks (@links.@count)", () => {
-      const result = realm.objects("Task").filtered(
+      const result = realm.objects("Item").filtered(
         // :snippet-start: backlinks-atCount
-        // Find tasks that are not referenced by another object of any type
+        // Find items that are not referenced by another object of any type
         "@links.@count == 0"
         // :snippet-end:
       );
@@ -429,7 +429,7 @@ describe("Realm Query Language Reference", () => {
         id: new Realm.BSON.ObjectId(),
         name: "Project with Quota",
         quota: 2,
-        tasks: [
+        items: [
           {
             id: new Realm.BSON.ObjectId(),
             name: "Write tests",
@@ -460,9 +460,9 @@ describe("Realm Query Language Reference", () => {
     const projects = realm.objects("Project");
     const subquery = projects.filtered(
       // :snippet-start: subquery
-      // Returns projects with tasks that have not been completed
+      // Returns projects with items that have not been completed
       // by a user named Alex.
-      "SUBQUERY(tasks, $task, $task.isComplete == false AND $task.assignee == 'Alex').@count > 0"
+      "SUBQUERY(items, $item, $item.isComplete == false AND $item.assignee == 'Alex').@count > 0"
       // :remove-start:
     );
     expect(subquery.length).toBe(1);
@@ -471,9 +471,9 @@ describe("Realm Query Language Reference", () => {
     const subquery2 = projects.filtered(
       // :remove-end:
 
-      // Returns the projects where the number of completed tasks is
+      // Returns the projects where the number of completed items is
       // greater than or equal to the value of a project's `quota` property.
-      "SUBQUERY(tasks, $task, $task.isComplete == true).@count >= quota"
+      "SUBQUERY(items, $item, $item.isComplete == true).@count >= quota"
       // :snippet-end:
     );
     expect(subquery2.length).toBe(1);
@@ -481,10 +481,10 @@ describe("Realm Query Language Reference", () => {
   });
 
   test("predicate substitution", () => {
-    const tasks = realm.objects("Task");
+    const items = realm.objects("Item");
 
     // prettier-ignore
-    const substitution = tasks.filtered(
+    const substitution = items.filtered(
       // :snippet-start: predicate
       "progressMinutes > 1 AND assignee == $0", "Ali"
       // :snippet-end:
@@ -493,10 +493,10 @@ describe("Realm Query Language Reference", () => {
   });
 
   test("multiple predicate substitution", () => {
-    const tasks = realm.objects("Task");
+    const items = realm.objects("Item");
 
     // prettier-ignore
-    const substitution = tasks.filtered(
+    const substitution = items.filtered(
       // :snippet-start: multiple-predicate
       "progressMinutes > $0 AND assignee == $1", 1, "Alex"
       // :snippet-end:
@@ -504,13 +504,13 @@ describe("Realm Query Language Reference", () => {
     expect(substitution.length).toBe(1);
   });
   test("Basic arithmetic", () => {
-    const tasks = realm.objects("Task");
-    const basicMath = tasks.filtered(
+    const items = realm.objects("Item");
+    const basicMath = items.filtered(
       // :snippet-start: basic-arithmetic
       "2 * priority > 6"
       // :remove-start:
     );
-    const lessBasicMath = tasks.filtered(
+    const lessBasicMath = items.filtered(
       // :remove-end:
       // Is equivalent to
       "priority >= 2 * (2 - 1) + 2"
@@ -521,8 +521,8 @@ describe("Realm Query Language Reference", () => {
     expect(lessBasicMath.length).toBe(5);
   });
   test("Arithmetic with object properties", () => {
-    const tasks = realm.objects("Task");
-    const mathWithObjProps = tasks.filtered(
+    const items = realm.objects("Item");
+    const mathWithObjProps = items.filtered(
       // :snippet-start: arithmetic-obj-properties
       "progressMinutes * priority == 90"
       // :snippet-end:
@@ -644,16 +644,16 @@ describe("Realm Query Language Reference", () => {
       progressMinutes: 12,
     };
     realm.write(() => {
-      realm.create("Task", takeANap);
+      realm.create("Item", takeANap);
     });
-    const res = realm.objects("Task").filtered(
+    const res = realm.objects("Item").filtered(
       // :snippet-start: nil-type
       "assignee == nil"
       // :snippet-end:
     );
 
     // prettier-ignore
-    const res2 = realm.objects("Task").filtered(
+    const res2 = realm.objects("Item").filtered(
       // :snippet-start: nil-type-parameterized-query
       // comparison to language null pointer
       "assignee == $0", null

--- a/examples/node/Examples/rql-data-models.js
+++ b/examples/node/Examples/rql-data-models.js
@@ -1,10 +1,10 @@
 import Realm from "realm";
-import { TaskModel, ProjectModel } from "./schemas/rql-data-models";
+import { ItemModel, ProjectModel } from "./schemas/rql-data-models";
 
 describe("test models", () => {
   let realm;
   const config = {
-    schema: [TaskModel, ProjectModel],
+    schema: [ItemModel, ProjectModel],
     path: "testing.realm",
   };
   beforeEach(async () => {
@@ -23,33 +23,33 @@ describe("test models", () => {
   test("open realm with config", async () => {
     expect(realm.isClosed).toBe(false);
   });
-  test("Can create object of Task type", () => {
+  test("Can create object of Item type", () => {
     realm.write(() => {
-      realm.create("Task", {
+      realm.create("Item", {
         id: new Realm.BSON.ObjectId(),
         name: "get coffee",
       });
     });
-    const coffeeTask = realm.objects("Task")[0];
-    expect(coffeeTask.id instanceof Realm.BSON.ObjectId).toBe(true);
-    expect(coffeeTask.name).toBe("get coffee");
-    expect(coffeeTask.isComplete).toBe(false);
+    const coffeeItem = realm.objects("Item")[0];
+    expect(coffeeItem.id instanceof Realm.BSON.ObjectId).toBe(true);
+    expect(coffeeItem.name).toBe("get coffee");
+    expect(coffeeItem.isComplete).toBe(false);
   });
   test("Can create object of Project type", () => {
     realm.write(() => {
-      const teaTask = realm.create("Task", {
+      const teaItem = realm.create("Item", {
         id: new Realm.BSON.ObjectId(),
         name: "get tea",
       });
       realm.create("Project", {
         id: new Realm.BSON.ObjectId(),
         name: "beverages",
-        tasks: [teaTask],
+        items: [teaItem],
       });
     });
     const bevProject = realm.objects("Project")[0];
     expect(bevProject.id instanceof Realm.BSON.ObjectId).toBe(true);
     expect(bevProject.name).toBe("beverages");
-    expect(bevProject.tasks[0].name).toBe("get tea");
+    expect(bevProject.items[0].name).toBe("get tea");
   });
 });

--- a/examples/node/Examples/schemas/rql-data-models.js
+++ b/examples/node/Examples/schemas/rql-data-models.js
@@ -1,6 +1,6 @@
 // :snippet-start: rql-data-models
-const TaskModel = {
-  name: "Task",
+const ItemModel = {
+  name: "Item",
   properties: {
     id: "objectId",
     name: "string",
@@ -17,7 +17,7 @@ const TaskModel = {
     projects: {
       type: "linkingObjects",
       objectType: "Project",
-      property: "tasks",
+      property: "items",
     },
   },
   primaryKey: "id",
@@ -28,11 +28,11 @@ const ProjectModel = {
   properties: {
     id: "objectId",
     name: "string",
-    tasks: "Task[]",
+    items: "Item[]",
     quota: "int?",
   },
   primaryKey: "id",
 };
 // :snippet-end:
 
-export { TaskModel, ProjectModel };
+export { ItemModel, ProjectModel };

--- a/source/examples/generated/dotnet/RqlSchemaExamples.snippet.rql-schema-examples.cs
+++ b/source/examples/generated/dotnet/RqlSchemaExamples.snippet.rql-schema-examples.cs
@@ -21,7 +21,7 @@ public class Item : RealmObject
     public int ProgressMinutes { get; set; } = 0;
 
     [MapTo("projects")]
-    [Backlink(nameof(Project.RqlItems))]
+    [Backlink(nameof(Project.Items))]
     public IQueryable<Project> Projects { get; }
 }
 
@@ -36,7 +36,7 @@ public class Project : RealmObject
     public string Name { get; set; }
 
     [MapTo("items")]
-    public IList<Item> RqlItems { get; }
+    public IList<Item> Items { get; }
 
     [MapTo("quota")]
     public int Quota { get; set; }

--- a/source/examples/generated/flutter/task_project_models_test.snippet.task-project-models.dart
+++ b/source/examples/generated/flutter/task_project_models_test.snippet.task-project-models.dart
@@ -2,7 +2,7 @@
 part 'models.g.dart';
 
 @RealmModel()
-class _Task {
+class _Item {
   @MapTo("_id")
   @PrimaryKey()
   late ObjectId id;
@@ -21,6 +21,6 @@ class _Project {
   late ObjectId id;
 
   late String name;
-  late List<_Task> tasks;
+  late List<_Item> items;
   int? quota;
 }

--- a/source/examples/generated/kotlin/RQLTest.snippet.rql-schema-example.kt
+++ b/source/examples/generated/kotlin/RQLTest.snippet.rql-schema-example.kt
@@ -1,4 +1,4 @@
-class Task(): RealmObject {
+class Item(): RealmObject {
     @PrimaryKey
     var _id: ObjectId = ObjectId()
     lateinit var name: String
@@ -12,6 +12,6 @@ class Project(): RealmObject {
     @PrimaryKey
     var _id: ObjectId = ObjectId()
     lateinit var name: String
-    lateinit var tasks: RealmList<Task>
+    lateinit var items: RealmList<Item>
     var quota: Int? = null
 }

--- a/source/examples/generated/node/rql-data-models.snippet.rql-data-models.js
+++ b/source/examples/generated/node/rql-data-models.snippet.rql-data-models.js
@@ -1,5 +1,5 @@
-const TaskModel = {
-  name: "Task",
+const ItemModel = {
+  name: "Item",
   properties: {
     id: "objectId",
     name: "string",
@@ -16,7 +16,7 @@ const TaskModel = {
     projects: {
       type: "linkingObjects",
       objectType: "Project",
-      property: "tasks",
+      property: "items",
     },
   },
   primaryKey: "id",
@@ -27,7 +27,7 @@ const ProjectModel = {
   properties: {
     id: "objectId",
     name: "string",
-    tasks: "Task[]",
+    items: "Item[]",
     quota: "int?",
   },
   primaryKey: "id",

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.aggregate-operators.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.aggregate-operators.js
@@ -1,9 +1,9 @@
-  "tasks.@avg.priority > 5"
+  "items.@avg.priority > 5"
 
-  "tasks.@max.priority < 5"
+  "items.@max.priority < 5"
 
-  "tasks.@min.priority > 5"
+  "items.@min.priority > 5"
 
-  "tasks.@count > 5"
+  "items.@count > 5"
 
-  "tasks.@sum.progressMinutes > 100"
+  "items.@sum.progressMinutes > 100"

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-aggregate-operators.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-aggregate-operators.js
@@ -1,7 +1,7 @@
-  // Find tasks that are referenced by multiple projects
+  // Find items that are referenced by multiple projects
   "projects.@count > 1"
-  // Find tasks that are not referenced by any project
-  "@links.Project.tasks.@count == 0"
-  // Find tasks that belong to a project where the average task has
+  // Find items that are not referenced by any project
+  "@links.Project.items.@count == 0"
+  // Find items that belong to a project where the average item has
   // been worked on for at least 5 minutes
-  "@links.Project.tasks.tasks.@avg.progressMinutes > 10"
+  "@links.Project.items.items.@avg.progressMinutes > 10"

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-atCount.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-atCount.js
@@ -1,2 +1,2 @@
-// Find tasks that are not referenced by another object of any type
+// Find items that are not referenced by another object of any type
 "@links.@count == 0"

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-atLinks.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-atLinks.js
@@ -1,2 +1,2 @@
-// Find tasks that belong to a project with a quota greater than 10 (@links)
-"@links.Project.tasks.quota > 10"
+// Find items that belong to a project with a quota greater than 10 (@links)
+"@links.Project.items.quota > 10"

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-collection-operators.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-collection-operators.js
@@ -1,4 +1,4 @@
-  // Find tasks where any project that references the task has a quota greater than 0
-  "ANY @links.Project.tasks.quota > 0"
-  // Find tasks where all projects that reference the task have a quota greater than 0
-  "ALL @links.Project.tasks.quota > 0"
+  // Find items where any project that references the item has a quota greater than 0
+  "ANY @links.Project.items.quota > 0"
+  // Find items where all projects that reference the item have a quota greater than 0
+  "ALL @links.Project.items.quota > 0"

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-linkingObjects.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.backlinks-linkingObjects.js
@@ -1,2 +1,2 @@
-// Find tasks that belong to a project with a quota greater than 10 (LinkingObjects)
+// Find items that belong to a project with a quota greater than 10 (LinkingObjects)
 "projects.quota > 10"

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.list-comparisons-collection.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.list-comparisons-collection.js
@@ -1,1 +1,1 @@
-"oid(631a072f75120729dc9223d9) IN tasks.id"
+"oid(631a072f75120729dc9223d9) IN items.id"

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.list-comparisons-parameterized.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.list-comparisons-parameterized.js
@@ -3,4 +3,4 @@ const ids = [
   new BSON.ObjectId("631a0737c98f89f5b81cd24d"),
   new BSON.ObjectId("631a073c833a34ade21db2b2"),
 ];
-const parameterizedQuery = realm.objects("Task").filtered("id IN $0", ids);
+const parameterizedQuery = realm.objects("Item").filtered("id IN $0", ids);

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.set-operators.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.set-operators.js
@@ -1,14 +1,14 @@
-  // Projects with no complete tasks.
-  "NONE tasks.isComplete == true"
+  // Projects with no complete items.
+  "NONE items.isComplete == true"
 
-  // Projects that contain a task with priority 10
-  "ANY tasks.priority == 10"
+  // Projects that contain a item with priority 10
+  "ANY items.priority == 10"
 
-  // Projects that only contain completed tasks
-  "ALL tasks.isComplete == true"
+  // Projects that only contain completed items
+  "ALL items.isComplete == true"
 
-  // Projects with at least one task assigned to either Alex or Ali
-  "ANY tasks.assignee IN { 'Alex', 'Ali' }"
+  // Projects with at least one item assigned to either Alex or Ali
+  "ANY items.assignee IN { 'Alex', 'Ali' }"
 
-  // Projects with no tasks assigned to either Alex or Ali
-  "NONE tasks.assignee IN { 'Alex', 'Ali' }"
+  // Projects with no items assigned to either Alex or Ali
+  "NONE items.assignee IN { 'Alex', 'Ali' }"

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.simple-query.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.simple-query.js
@@ -1,3 +1,3 @@
-const tasks = realm.objects("Task");
-// Gets all tasks where the 'priority' property is 7 or more.
-const importantTasks = tasks.filtered("priority >= 7");
+const items = realm.objects("Item");
+// Gets all items where the 'priority' property is 7 or more.
+const importantItems = items.filtered("priority >= 7");

--- a/source/examples/generated/realm-query-language/realm-query-language.snippet.subquery.js
+++ b/source/examples/generated/realm-query-language/realm-query-language.snippet.subquery.js
@@ -1,7 +1,7 @@
-  // Returns projects with tasks that have not been completed
+  // Returns projects with items that have not been completed
   // by a user named Alex.
-  "SUBQUERY(tasks, $task, $task.isComplete == false AND $task.assignee == 'Alex').@count > 0"
+  "SUBQUERY(items, $item, $item.isComplete == false AND $item.assignee == 'Alex').@count > 0"
 
-  // Returns the projects where the number of completed tasks is
+  // Returns the projects where the number of completed items is
   // greater than or equal to the value of a project's `quota` property.
-  "SUBQUERY(tasks, $task, $task.isComplete == true).@count >= quota"
+  "SUBQUERY(items, $item, $item.isComplete == true).@count >= quota"

--- a/source/realm-query-language.txt
+++ b/source/realm-query-language.txt
@@ -28,10 +28,15 @@ Some SDKs also support idiomatic APIs for querying realms in their language.
 Query with Realm SDKs
 ---------------------
 
-For further reading on SDK-specific methods for querying realms, select the tab
-below for your SDK.
+For further reading on SDK-specific methods for querying realms, see the documentation
+for your SDK: 
 
 .. tabs::
+
+   .. tab:: Flutter SDK
+      :tabid: flutter
+
+      - :ref:`Filter & Sort Results - Flutter SDK <flutter-filter-results>`
 
    .. tab:: Java SDK
       :tabid: java
@@ -39,15 +44,10 @@ below for your SDK.
       - :ref:`Query Engine - Java SDK <java-client-query-engine>`
       - :ref:`Query with Realm Query Language - Java SDK <java-filter-with-realm-query-language>`
 
-   .. tab:: Swift SDK
-      :tabid: swift
+   .. tab:: Kotlin SDK
+      :tabid: kotlin
 
-      - :ref:`Filter Data - Swift SDK <ios-client-query-engine>`
-
-      .. note:: Swift SDK does not support Realm Query Language
-
-         The Swift SDK does not support querying with Realm Query Language.
-         You can instead use NSPredicate to query Realm.
+      - :ref:`Filter Data - Kotlin SDK <kotlin-filter-data>`
 
    .. tab:: .NET SDK
       :tabid: dotnet
@@ -66,16 +66,11 @@ below for your SDK.
       - :ref:`Query Engine - React Native SDK <react-native-client-query-engine>`
       - :ref:`Filter Queries - React Native SDK <react-native-filter-queries>`
 
-   .. tab:: Kotlin SDK
-      :tabid: kotlin
+.. note:: Swift SDK does not support Realm Query Language
 
-      - :ref:`Filter Data - Kotlin SDK <kotlin-filter-data>`
-
-   .. tab:: Flutter SDK
-      :tabid: flutter
-
-      - :ref:`Filter & Sort Results - Flutter SDK <flutter-filter-results>`
-
+   The Swift SDK does not support querying with Realm Query Language.
+   You can instead use NSPredicate to query Realm. Refer to 
+   :ref:`Filter Data - Swift SDK <ios-client-query-engine>.
 
 You can also use Realm Query Language to browse for data in
 :ref:`Realm Studio <realm-studio>`. Realm Studio is a visual tool
@@ -84,16 +79,16 @@ to view, edit, and design Realm Database files.
 Examples on This Page
 ---------------------
 
-Many of the examples in this page use a simple data set for a task list app.
-The two Realm object types are ``Project`` and ``Task``.
+Many of the examples in this page use a simple data set for a to-do list app.
+The two Realm object types are ``Project`` and ``Item``.
 
-- A ``Task`` has a name, assignee's name, and completed flag.
+- An ``Item`` has a name, assignee's name, and completed flag.
   There is also an arbitrary number for priority (higher is more important)
   and a count of minutes spent working on it.
-- A ``Project`` has zero or more ``Tasks`` and an optional quota
-  for minimum number of tasks expected to be completed.
+- A ``Project`` has zero or more ``Items`` and an optional quota
+  for minimum number of to-do items expected to be completed.
 
-See the schema for these two classes, ``Project`` and ``Task``, below:
+See the schema for these two classes, ``Project`` and ``Item``, below:
 
 .. tabs::
 
@@ -107,20 +102,20 @@ See the schema for these two classes, ``Project`` and ``Task``, below:
 
              .. code-block:: java
 
-               public class Task extends RealmObject {
+               public class Item extends RealmObject {
                  ObjectId id = new ObjectId();
                  String name;
                  Boolean isComplete = false;
                  String assignee;
                  Integer priority = 0;
                  Integer progressMinutes = 0;
-                 @LinkingObjects("tasks")
+                 @LinkingObjects("items")
                  final RealmResults<Project> projects = null;
                } 
                public class Project extends RealmObject {
                  ObjectId id = new ObjectId();
                  String name;
-                 RealmList<Task> tasks;
+                 RealmList<Item> items;
                  Integer quota = null;
                }
 
@@ -129,7 +124,7 @@ See the schema for these two classes, ``Project`` and ``Task``, below:
 
             .. code-block:: kotlin
 
-               open class Task(): RealmObject() {
+               open class Item(): RealmObject() {
                  var id: ObjectId = new ObjectId()
                  lateinit var name: String
                  var isComplete: Boolean = false
@@ -141,7 +136,7 @@ See the schema for these two classes, ``Project`` and ``Task``, below:
                open class Project(): RealmObject() {
                  var id: ObjectId = new ObjectId()
                  lateinit var name: String
-                 lateinit var tasks: RealmList<Task>
+                 lateinit var items: RealmList<Item>
                  var quota: Int? = null
                }
 
@@ -150,20 +145,20 @@ See the schema for these two classes, ``Project`` and ``Task``, below:
 
       .. code-block:: swift
 
-         class Task {
+         class Item {
              @Persisted(primaryKey: true) var id: ObjectId
              @Persisted var name: string
              @Persisted var isComplete: bool
              @Persisted var assignee: string?
              @Persisted var priority: int
              @Persisted var progressMinutes: int
-             @Persisted(originProperty: "tasks") var projects: LinkingObjects<Project>
+             @Persisted(originProperty: "items") var projects: LinkingObjects<Project>
          }
 
          class Project {
              @Persisted(primaryKey: true) var id: ObjectId
              @Persisted var name: string
-             @Persisted var tasks: List<Task>
+             @Persisted var items: List<Item>
              @Persisted var quota: int?
          }
 
@@ -342,13 +337,13 @@ values.
 
    The following example uses Realm Query Language's comparison operators to:
 
-   - Find high priority tasks by comparing the value of the ``priority``
+   - Find high priority to-do items by comparing the value of the ``priority``
      property value with a threshold number, above which priority can be considered high.
-   - Find long-running tasks by seeing if the ``progressMinutes`` property
+   - Find long-running to-do items by seeing if the ``progressMinutes`` property
      is at or above a certain value.
-   - Find unassigned tasks by finding tasks where the ``assignee`` property
+   - Find unassigned to-do items by finding items where the ``assignee`` property
      is equal to ``null``.
-   - Find tasks within a certain time range by finding tasks where the
+   - Find to-do items within a certain time range by finding items where the
      ``progressMinutes`` property is between two numbers.
 
    .. literalinclude:: /examples/generated/realm-query-language/realm-query-language.snippet.comparison-operators.js
@@ -383,7 +378,7 @@ Make compound predicates using logical operators.
 .. example::
 
    We can use the query language's logical operators to find
-   all of Ali's completed tasks. That is, we find all tasks
+   all of Ali's completed to-do items. That is, we find all items
    where the ``assignee`` property value is equal to 'Ali' AND
    the ``isComplete`` property value is ``true``:
 
@@ -674,14 +669,14 @@ single value.
 
 .. example::
 
-   These examples all query for projects containing tasks that meet
+   These examples all query for projects containing to-do items that meet
    this criteria:
 
-   - Projects with average task priority above 5.
-   - Projects with a task whose priority is less than 5.
-   - Projects with a task whose priority is greater than 5.
-   - Projects with more than 5 tasks.
-   - Projects with long-running tasks.
+   - Projects with average item priority above 5.
+   - Projects with an item whose priority is less than 5.
+   - Projects with an item whose priority is greater than 5.
+   - Projects with more than 5 items.
+   - Projects with long-running items.
 
    .. literalinclude:: /examples/generated/realm-query-language/realm-query-language.snippet.aggregate-operators.js
       :language: javascript
@@ -717,7 +712,7 @@ If the predicate returns true, the object is included in the output collection.
 
 .. example::
 
-   This example uses collection operators to find projects that contain tasks
+   This example uses collection operators to find projects that contain to-do items
    matching certain criteria:
 
    .. literalinclude:: /examples/generated/realm-query-language/realm-query-language.snippet.set-operators.js
@@ -946,12 +941,12 @@ Sort and limit the results collection of your query using additional operators.
 
 .. example::
 
-   Use the query engine's sort, distinct, and limit operators to find tasks
+   Use the query engine's sort, distinct, and limit operators to find to-do items
    where the assignee is Ali:
 
    - Sorted by priority in descending order
    - Enforcing uniqueness by name
-   - Limiting the results to 5 tasks
+   - Limiting the results to 5 items
 
    .. literalinclude:: /examples/generated/realm-query-language/realm-query-language.snippet.sort-distinct-limit.js
       :language: javascript

--- a/source/realm-query-language.txt
+++ b/source/realm-query-language.txt
@@ -140,28 +140,6 @@ See the schema for these two classes, ``Project`` and ``Item``, below:
                  var quota: Int? = null
                }
 
-   .. tab:: Swift SDK
-      :tabid: swift
-
-      .. code-block:: swift
-
-         class Item {
-             @Persisted(primaryKey: true) var id: ObjectId
-             @Persisted var name: string
-             @Persisted var isComplete: bool
-             @Persisted var assignee: string?
-             @Persisted var priority: int
-             @Persisted var progressMinutes: int
-             @Persisted(originProperty: "items") var projects: LinkingObjects<Project>
-         }
-
-         class Project {
-             @Persisted(primaryKey: true) var id: ObjectId
-             @Persisted var name: string
-             @Persisted var items: List<Item>
-             @Persisted var quota: int?
-         }
-
    .. tab:: .NET SDK
       :tabid: dotnet
 

--- a/source/realm-query-language.txt
+++ b/source/realm-query-language.txt
@@ -70,7 +70,7 @@ for your SDK:
 
    The Swift SDK does not support querying with Realm Query Language.
    You can instead use NSPredicate to query Realm. Refer to 
-   :ref:`Filter Data - Swift SDK <ios-client-query-engine>.
+   :ref:`Filter Data - Swift SDK <ios-client-query-engine>`.
 
 You can also use Realm Query Language to browse for data in
 :ref:`Realm Studio <realm-studio>`. Realm Studio is a visual tool


### PR DESCRIPTION
## Pull Request Info

Rename `task` to `item` in RQL examples and generated code samples

### Jira

- https://jira.mongodb.org/browse/DOCSP-27197

### Staged Changes

- [Realm Query Language](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-27197-rename-task-rql/realm-query-language/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
