### PR TITLE
(DOCSP-28642): Add missing ref target

### DIFF
--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -11,6 +11,8 @@ Handle Sync Errors - Swift SDK
    :depth: 2
    :class: singlecol
 
+.. _swift-sync-error-handler:
+
 Handle Sync Errors
 ------------------
 


### PR DESCRIPTION
Oops - I just merged #2662 but noticed I had forgotten to save the file that had a new ref target I'm using in that PR. Adding the ref target here to fix impending build errors.