### PR TITLE
Swift: Fix incorrect API reference link

### DIFF
--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -36,7 +36,7 @@ API calls.
       
       .. note::
    
-         Realm's :swift-sdk:`SyncError <Structs/Realm/Configuration.html#/s:10RealmSwift0A0V13ConfigurationV07defaultC0AEvpZ>` conforms to :apple:`Swift's Error protocol <documentation/swift/error>`
+         Realm's :swift-sdk:`SyncError <Typealiases.html#/s:10RealmSwift9SyncErrora>` conforms to :apple:`Swift's Error protocol <documentation/swift/error>`
 
       .. literalinclude:: /examples/generated/code/start/Errors.snippet.create-error-handler.swift
          :language: swift


### PR DESCRIPTION
## Pull Request Info

### Jira

No Jira ticket - this is a quickie fix based on some docs feedback.

### Staged Changes

- [Handle Sync Errors](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fix-wrong-api-reference-link/sdk/swift/sync/handle-sync-errors/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
