### PR TITLE
(DOCSP-26866): Clarify supported writeCopy operations for to Flex Sync

### DIFF
--- a/source/includes/note-writecopy-local-to-sync.rst
+++ b/source/includes/note-writecopy-local-to-sync.rst
@@ -1,0 +1,5 @@
+.. note:: Partition-Based Sync Only
+
+   This method only supports converting between a non-sync realm and 
+   Partition-Based Sync. If your app uses Flexible Sync, you must manually 
+   iterate through the objects in one realm and copy them into the other realm.

--- a/source/includes/note-writecopy-pbs-only.rst
+++ b/source/includes/note-writecopy-pbs-only.rst
@@ -1,5 +1,0 @@
-.. note:: Partition-Based Sync Only
-
-   This method only supports Partition-Based Sync. If your app uses 
-   Flexible Sync, you must manually iterate through the objects in one 
-   realm and copy them into the other realm.

--- a/source/includes/note-writecopy-same-type-sync-only.rst
+++ b/source/includes/note-writecopy-same-type-sync-only.rst
@@ -1,0 +1,6 @@
+.. note:: Same-Type Sync Only
+
+   This method only supports copying a Partition-Based Sync configuration for 
+   another Partition-Based Sync user, or a Flexible Sync configuration for another
+   Flexible Sync user. You cannot use this method to convert between a 
+   Partition-Based Sync realm and a Flexible Sync realm or vice-versa.

--- a/source/sdk/dotnet/realm-files/bundle-a-realm.txt
+++ b/source/sdk/dotnet/realm-files/bundle-a-realm.txt
@@ -83,7 +83,7 @@ Create a Realm File for Bundling
          .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.snippet.copy_a_synced_realm.cs
             :language: csharp
 
-         .. include:: /includes/note-same-type-sync-only.rst
+         .. include:: /includes/note-writecopy-same-type-sync-only.rst
 
 Bundle a Realm File in Your Production Application
 --------------------------------------------------

--- a/source/sdk/dotnet/realm-files/bundle-a-realm.txt
+++ b/source/sdk/dotnet/realm-files/bundle-a-realm.txt
@@ -83,6 +83,8 @@ Create a Realm File for Bundling
          .. literalinclude:: /examples/generated/dotnet/BundleARealmExamples.snippet.copy_a_synced_realm.cs
             :language: csharp
 
+         .. include:: /includes/note-same-type-sync-only.rst
+
 Bundle a Realm File in Your Production Application
 --------------------------------------------------
 

--- a/source/sdk/dotnet/sync/convert-realm.txt
+++ b/source/sdk/dotnet/sync/convert-realm.txt
@@ -41,6 +41,7 @@ existing realm and open the new realm.
    :language: csharp
    :copyable: true
 
+.. include:: /includes/note-writecopy-local-to-sync.rst
 
 Convert a Synced Realm to a Non-Synced Realm
 --------------------------------------------
@@ -52,6 +53,8 @@ and
 :dotnet-sdk:`WaitForDownloadAsync <reference/Realms.Sync.Session.html#Realms_Sync_Session_WaitForDownloadAsync>`.
 Then we call ``WriteCopy()`` to copy the data to the non-synced realm. At this 
 point, we can delete the synced realm and start using the non-synced realm.
+
+.. include:: /includes/note-writecopy-local-to-sync.rst
 
 .. literalinclude:: /examples/generated/dotnet/Convert.snippet.sync-to-nosync.cs
    :language: csharp

--- a/source/sdk/java/examples/bundle-a-realm.txt
+++ b/source/sdk/java/examples/bundle-a-realm.txt
@@ -67,6 +67,8 @@ To create and bundle a realm file with your application:
    <java-open-a-realm-from-a-bundled-realm-file>`. For synced
    realms, you must supply the partition key.
 
+.. include:: /includes/note-writecopy-same-type-sync-only.rst
+
 .. _java-create-a-realm-for-bundling:
 
 Create a Realm File for Bundling

--- a/source/sdk/kotlin/realm-database/realm-files/open-and-close-a-realm.txt
+++ b/source/sdk/kotlin/realm-database/realm-files/open-and-close-a-realm.txt
@@ -104,10 +104,13 @@ You can copy data to a realm that uses different sync configurations:
 
 - Local realm to Partition-Based Sync realm 
 - Synced realm to local realm
+- Synced realm to a synced realm for a different user
 
 .. warning:: 
 
-  You *cannot* copy data from a local realm to a Flexible Sync realm.
+  You *cannot* copy data from a local realm to a Flexible Sync realm. You
+  cannot copy between different sync configuration types, for example
+  Partition-Based Sync to Flexible Sync.
 
 You can also combine changes to the configuration. For example, you can copy data from an 
 unencrypted, in-memory synced realm to an encrypted local realm.

--- a/source/sdk/node/advanced/bundle.txt
+++ b/source/sdk/node/advanced/bundle.txt
@@ -126,6 +126,8 @@ from your bundled realm in the realm you've just opened.
 Bundle a Synchronized Realm
 ---------------------------
 
+.. include:: /includes/note-writecopy-same-type-sync-only.rst
+
 Generally, bundling a synchronized realm works the same as bundling a local-only realm. 
 However, there are some limitations to bundling realms that use Device Sync.
 
@@ -135,8 +137,9 @@ However, there are some limitations to bundling realms that use Device Sync.
    .. literalinclude:: /examples/generated/node/bundle-a-realm.snippet.fully-sync-before-copy.js
       :language: javascript
 
-#. When opening a bundled synchronized realm, you must use the same partition key 
-   that was used in the original realm. If you use a different partition key, the SDK throws
+#. When opening a bundled synchronized realm that uses Partition-Based Sync, 
+   you must use the same partition key that was used in the original realm
+   configuration. If you use a different partition key, the SDK throws
    an error when opening the bundled realm. 
 
 .. warning:: Synchronized Realm Bundling and Client Maximum Offline Time

--- a/source/sdk/node/examples/open-and-close-a-realm.txt
+++ b/source/sdk/node/examples/open-and-close-a-realm.txt
@@ -129,8 +129,6 @@ To copy data from an existing realm to a new realm with different
 configuration options, pass the new configuration the
 :js-sdk:`Realm.writeCopyTo() <Realm.html#writeCopyTo>` method.
 
-.. include:: /includes/note-writecopy-pbs-only.rst
-
 In the new realm's configuration, you *must* specify the ``path``. 
 
 If you write the copied realm to a realm file that already exists, the data is written object by object.
@@ -144,6 +142,11 @@ The configuration change can include modifications to :js-sdk:`SyncConfiguration
 
 - Local realm to synced realm
 - Synced Realm to local realm
+- Synced Realm to a Synced Realm for a different user
+
+.. include:: /includes/note-writecopy-local-to-sync.rst
+
+.. include:: /includes/note-writecopy-same-type-sync-only.rst
 
 The configuration change can also include changes to ``encryptionKey`` 
 property of the ``Configuration``: 
@@ -170,7 +173,7 @@ as an encrypted synced realm.
 .. seealso:: 
 
    - :ref:`Open a Flexible Synced Realm - Node.js SDK <node-flexible-sync-open-realm>`
-   - :ref:`Open a Partition-Based Synced Realm - Node.js SDK <node-encrypt-a-realm>`
+   - :ref:`Open a Partition-Based Synced Realm - Node.js SDK <node-partition-sync-open-realm>`
    - :ref:`Encrypt a Realm - Node.js SDK <node-partition-sync-open-realm>`
 
 .. _node-close-a-realm:

--- a/source/sdk/react-native/realm-database/bundle.txt
+++ b/source/sdk/react-native/realm-database/bundle.txt
@@ -134,6 +134,7 @@ Follow these steps to create and bundle a realm file for your React Native appli
          :language: javascript
 
 .. TODO: bring back in refactored version in DOCSP-28176
+.. TODO: Add includes/note-writecopy-same-type-sync-only.rst
 .. .. _react-native-bundle-synced-realm:
 
 .. Bundle a Synchronized Realm

--- a/source/sdk/react-native/sync-data/partition-based-sync.txt
+++ b/source/sdk/react-native/sync-data/partition-based-sync.txt
@@ -48,7 +48,7 @@ To copy data from an existing realm to a new realm with different
 configuration options, pass the new configuration the
 :js-sdk:`Realm.writeCopyTo() <Realm.html#writeCopyTo>` method.
 
-.. include:: /includes/note-writecopy-pbs-only.rst
+.. include:: /includes/note-writecopy-same-type-sync-only.rst
 
 In the new realm's configuration, you *must* specify the ``path``. 
 

--- a/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
@@ -106,6 +106,30 @@ With cached credentials, you can:
 - Open a synced realm after downloading changes from your App. 
   This requires the user to have an active internet connection.
 
+.. _ios-flexible-sync-open-realm:
+
+Open a Synced Realm for Flexible Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 10.22.0
+
+When you use Flexible Sync, use the ``flexibleSyncConfiguration()``
+to open a synced realm. 
+
+.. include:: /includes/swift-concurrency-mainactor.rst
+
+.. literalinclude:: /examples/generated/code/start/FlexibleSync.snippet.flex-sync-open-realm.swift
+   :language: swift
+
+.. important:: Flexible Sync Requires a Subscription
+
+   If your app uses bidirectional, standard Device Sync, you can't use a 
+   Flexible Sync realm until you add at least one subscription. To learn 
+   how to add subscriptions, see: :ref:`<ios-sync-add-subscription>`.
+
+   This does not apply to :ref:`Asymmetric Sync <optimize-asymmetric-sync>`.
+   You cannot create a subscription for an ``AsymmetricObject``.
+
 .. _ios-partition-based-sync-open-realm:
 
 Open a Synced Realm for Partition-Based Sync
@@ -160,30 +184,6 @@ This enables you to specify a partition value whose data should sync to the real
       .. literalinclude:: /examples/generated/code/start/Sync.snippet.init-synced-realm.m
          :language: swift
 
-.. _ios-flexible-sync-open-realm:
-
-Open a Synced Realm for Flexible Sync
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 10.22.0
-
-When you use Flexible Sync, use the ``flexibleSyncConfiguration()``
-to open a synced realm. 
-
-.. include:: /includes/swift-concurrency-mainactor.rst
-
-.. literalinclude:: /examples/generated/code/start/FlexibleSync.snippet.flex-sync-open-realm.swift
-   :language: swift
-
-.. important:: Flexible Sync Requires a Subscription
-
-   If your app uses bidirectional, standard Device Sync, you can't use a 
-   Flexible Sync realm until you add at least one subscription. To learn 
-   how to add subscriptions, see: :ref:`<ios-sync-add-subscription>`.
-
-   This does not apply to :ref:`Asymmetric Sync <optimize-asymmetric-sync>`.
-   You cannot create a subscription for an ``AsymmetricObject``.
-
 .. _ios-open-synced-realm-as-different-sync-user:
 
 Open a Synced Realm as a Different Sync User
@@ -202,7 +202,7 @@ configuration.
 After you copy the realm for the new Sync user's configuration, you can 
 open the copy as a synced realm for that user. 
 
-.. include:: /includes/note-writecopy-pbs-only.rst
+.. include:: /includes/note-writecopy-same-type-sync-only.rst
 
 .. include:: /includes/swift-concurrency-mainactor.rst
 
@@ -228,7 +228,7 @@ synced realm. Any changes you make to the synced realm will reflect
 in the synced realm file, and they will also propogate to other devices and
 the App Services backend.
 
-.. include:: /includes/note-writecopy-pbs-only.rst
+.. include:: /includes/note-writecopy-local-to-sync.rst
 
 .. include:: /includes/swift-concurrency-mainactor.rst
 
@@ -262,6 +262,8 @@ After you copy the realm for use without Sync, you can open the copy as a
 non-synced realm. Any changes you make to the non-synced realm reflect 
 only in the local realm file. No changes propogate to other devices or
 the App Services backend.
+
+.. include:: /includes/note-writecopy-local-to-sync.rst
 
 .. include:: /includes/swift-concurrency-mainactor.rst
 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-26866

### Staged Changes

- [.NET - Bundle a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26866/sdk/dotnet/realm-files/bundle-a-realm/)
- [.NET - Convert Between Non-Synced and Synced Realms](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26866/sdk/dotnet/sync/convert-realm/)
- [Java - Bundle a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26866/sdk/java/examples/bundle-a-realm/)
- [Kotlin - Open & Close a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26866/sdk/kotlin/realm-database/realm-files/open-and-close-a-realm/)
- [Node.js - Open & Close a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26866/sdk/node/examples/open-and-close-a-realm/)
- [Node.js - Bundle a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26866/sdk/node/advanced/bundle/)
- [React Native - Partition-Based Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26866/sdk/react-native/sync-data/partition-based-sync/)
- [Swift - Configure & Open a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26866/sdk/swift/sync/configure-and-open-a-synced-realm/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
