### PR TITLE
(DOCSP-28641): Swift: Add Watch section to Query MongoDB page

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "14.2"
+          xcode-version: "14.3"
       - name: Build
         env:
           scheme: ${{ 'default' }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "14.3"
+          xcode-version: "14.2"
       - name: Build
         env:
           scheme: ${{ 'default' }}

--- a/examples/ios/Examples/EventLibrary.swift
+++ b/examples/ios/Examples/EventLibrary.swift
@@ -199,8 +199,7 @@ class EventLibrary: XCTestCase {
         }
     }
 
-    // TODO: realm.events is nil as of v 10.37.0. Temporarily skipping until this is addressed in the SDK.
-    func SKIP_testRecordReadAndWriteEvents() {
+    func testRecordReadAndWriteEvents() {
         let expectation = XCTestExpectation(description: "Populate a read and write event")
         app.login(credentials: Credentials.anonymous) { (result) in
             switch result {
@@ -223,7 +222,6 @@ class EventLibrary: XCTestCase {
             }
         }
 
-        // This test is currently failing with unexpectedly found nil in ln 228 - temporarily disabling
         func recordReadAndWriteEvents(_ realm: Realm) {
             let events = realm.events!
             let writeEventScope = events.beginScope(activity: "write object")
@@ -291,9 +289,7 @@ class EventLibrary: XCTestCase {
         wait(for: [expectation], timeout: 25)
     }
 
-    // TODO: realm.events is nil as of v 10.37.0. Temporarily skipping until this is addressed in the SDK.
-    // This test is currently failing with unexpectedly found nil in ln 313 - temporarily disabling
-    func SKIP_testRecordCustomEvents() {
+    func testRecordCustomEvents() {
         let expectation = XCTestExpectation(description: "Record a custom event")
         app.login(credentials: Credentials.anonymous) { (result) in
             switch result {
@@ -324,9 +320,7 @@ class EventLibrary: XCTestCase {
         wait(for: [expectation], timeout: 20)
     }
 
-    // TODO: realm.events is nil as of v 10.37.0. Temporarily skipping until this is addressed in the SDK.
-    // This test is currently failing with unexpectedly found nil in ln 360 - temporarily disabling
-    func SKIP_testEmbeddedObject() {
+    func testEmbeddedObject() {
         let expectation = XCTestExpectation(description: "Test Embedded Objects")
         app.login(credentials: Credentials.anonymous) { (result) in
             switch result {

--- a/examples/ios/Examples/MongoDBRemoteAccess.swift
+++ b/examples/ios/Examples/MongoDBRemoteAccess.swift
@@ -658,19 +658,17 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 let changeStream = collection.watch(delegate: delegate, queue: queue)
 
                 let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 42"]
-
                 delegate.waitForOpen() // :remove:
-                
                 sleep(5) // :remove:
-                
                 delegate.expectEvent() // :remove:
+                
                 collection.insertOne(drink) { result in
                     switch result {
                     case .failure(let error):
                         print("Call to MongoDB failed: \(error.localizedDescription)")
                         return
                     case .success(let objectId):
-                        XCTAssertNotNil(objectId)
+                        XCTAssertNotNil(objectId) // :remove:
                         print("Successfully inserted a document with id: \(objectId)")
                     }
                     sleep(5) // :remove:

--- a/examples/ios/Examples/MongoDBRemoteAccess.swift
+++ b/examples/ios/Examples/MongoDBRemoteAccess.swift
@@ -627,7 +627,6 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
             guard let changeEvent = changeEvent else { return }
             guard let document = changeEvent.documentValue else { return }
             print("Change event document received: \(document)")
-            
             changeExpectation?.fulfill() // :remove:
         }
     }

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1439,7 +1439,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.37.0;
+				minimumVersion = 10.37.2;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/source/examples/generated/code/start/CustomUserData.snippet.update-custom-user-data.m
+++ b/source/examples/generated/code/start/CustomUserData.snippet.update-custom-user-data.m
@@ -15,6 +15,6 @@ RLMApp *app = [RLMApp appWithId:YOUR_APP_ID];
             if (error != nil) {
                 NSLog(@"Failed to insert: %@", error);
             }
-            NSLog(@"Matched: %lu, modified: %lu", [updateResult matchedCount], [updateResult modifiedCount]); 
+            NSLog(@"Matched: %lu, modified: %lu", [updateResult matchedCount], [updateResult modifiedCount]);
     }];
 }];

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
@@ -1,0 +1,25 @@
+class MyChangeStreamDelegate: ChangeEventDelegate {
+    
+    func changeStreamDidOpen(_ changeStream: RealmSwift.ChangeStream) {
+        print("Change stream opened: \(changeStream)")
+    }
+    
+    func changeStreamDidClose(with error: Error?) {
+        if let anError = error {
+            print("Change stream closed with error: \(anError.localizedDescription)")
+        } else {
+            print("Change stream closed")
+        }
+    }
+    
+    func changeStreamDidReceive(error: Error) {
+        print("Received error: \(error.localizedDescription)")
+    }
+    
+    func changeStreamDidReceive(changeEvent: RealmSwift.AnyBSON?) {
+        guard let changeEvent = changeEvent else { return }
+        guard let document = changeEvent.documentValue else { return }
+        print("Change event document received: \(document)")
+        
+    }
+}

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
@@ -20,6 +20,5 @@ class MyChangeStreamDelegate: ChangeEventDelegate {
         guard let changeEvent = changeEvent else { return }
         guard let document = changeEvent.documentValue else { return }
         print("Change event document received: \(document)")
-        
     }
 }

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-async-sequence.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-async-sequence.swift
@@ -1,0 +1,27 @@
+let user = try await app.login(credentials: Credentials.anonymous)
+// Set up the client, database, and collection.
+let mongoClient = user.mongoClient("mongodb-atlas")
+let database = mongoClient.database(named: "ios")
+let collection = database.collection(withName: "CoffeeDrinks")
+
+// Set up a task you'll later await to keep the change stream open,
+// and you can cancel it when you're done watching for events.
+let task = Task {
+    // Open the change stream.
+    let changeEvents = collection.changeEvents(onOpen: {
+        print("Successfully opened change stream")
+    })
+    // Await events in the change stream.
+    for try await event in changeEvents {
+        let doc = event.documentValue!
+        print("Received event: \(event.documentValue!)")
+    }
+}
+
+// Updating a document in the collection triggers a change event.
+let queryFilter: Document = ["_id": AnyBSON(objectId) ]
+let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
+try await collection.updateOneDocument(filter: queryFilter, update: documentUpdate)
+// Cancel the task when you're done watching the stream.
+task.cancel()
+_ = await task.result

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-filter.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-filter.swift
@@ -1,0 +1,35 @@
+app.login(credentials: Credentials.anonymous) { (result) in
+    DispatchQueue.main.async {
+        switch result {
+        case .failure(let error):
+            print("Login failed: \(error)")
+        case .success(let user):
+            print("Login as \(user) succeeded!")
+            // Continue below
+        }
+        
+        let client = app.currentUser!.mongoClient("mongodb-atlas")
+
+        let database = client.database(named: "ios")
+
+        let collection = database.collection(withName: "CoffeeDrinks")
+        
+        let queue = DispatchQueue(label: "io.realm.watchQueue")
+        let delegate =  MyChangeStreamDelegate()
+        let changeStream = collection.watch(filterIds: [drinkObjectId], delegate: delegate, queue: queue)
+
+        let queryFilter: Document = ["_id": AnyBSON(drinkObjectId) ]
+        let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
+
+        collection.updateOneDocument(filter: queryFilter, update: documentUpdate) { result in
+            switch result {
+            case .failure(let error):
+                print("Call to MongoDB failed: \(error.localizedDescription)")
+                return
+            case .success(let updateResult):
+                print("Successfully updated the document")
+            }
+        }
+        changeStream.close()
+    }
+}

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-filter.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-filter.swift
@@ -8,16 +8,19 @@ app.login(credentials: Credentials.anonymous) { (result) in
             // Continue below
         }
         
+        // Set up the client, database, and collection.
         let client = app.currentUser!.mongoClient("mongodb-atlas")
-
         let database = client.database(named: "ios")
-
         let collection = database.collection(withName: "CoffeeDrinks")
         
+        // Watch the collection. In this example, we use a queue and delegate,
+        // both of which are optional arguments.
+        // `filterIds` is an array of specific document ObjectIds you want to watch.
         let queue = DispatchQueue(label: "io.realm.watchQueue")
         let delegate =  MyChangeStreamDelegate()
         let changeStream = collection.watch(filterIds: [drinkObjectId], delegate: delegate, queue: queue)
 
+        // An update to a relevant document triggers a change event.
         let queryFilter: Document = ["_id": AnyBSON(drinkObjectId) ]
         let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
 
@@ -30,6 +33,7 @@ app.login(credentials: Credentials.anonymous) { (result) in
                 print("Successfully updated the document")
             }
         }
+        // After you're done watching for events, close the change stream.
         changeStream.close()
     }
 }

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection.swift
@@ -19,8 +19,6 @@ app.login(credentials: Credentials.anonymous) { (result) in
         let changeStream = collection.watch(delegate: delegate, queue: queue)
 
         let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 42"]
-
-        
         
         collection.insertOne(drink) { result in
             switch result {
@@ -28,7 +26,6 @@ app.login(credentials: Credentials.anonymous) { (result) in
                 print("Call to MongoDB failed: \(error.localizedDescription)")
                 return
             case .success(let objectId):
-                XCTAssertNotNil(objectId)
                 print("Successfully inserted a document with id: \(objectId)")
             }
         }

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection.swift
@@ -1,0 +1,37 @@
+app.login(credentials: Credentials.anonymous) { (result) in
+    DispatchQueue.main.async {
+        switch result {
+        case .failure(let error):
+            print("Login failed: \(error)")
+        case .success(let user):
+            print("Login as \(user) succeeded!")
+            // Continue below
+        }
+        
+        let client = app.currentUser!.mongoClient("mongodb-atlas")
+
+        let database = client.database(named: "ios")
+
+        let collection = database.collection(withName: "CoffeeDrinks")
+        
+        let queue = DispatchQueue(label: "io.realm.watchQueue")
+        let delegate =  MyChangeStreamDelegate()
+        let changeStream = collection.watch(delegate: delegate, queue: queue)
+
+        let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 42"]
+
+        
+        
+        collection.insertOne(drink) { result in
+            switch result {
+            case .failure(let error):
+                print("Call to MongoDB failed: \(error.localizedDescription)")
+                return
+            case .success(let objectId):
+                XCTAssertNotNil(objectId)
+                print("Successfully inserted a document with id: \(objectId)")
+            }
+        }
+        changeStream.close()
+    }
+}

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -401,8 +401,8 @@ Watch for Changes in a Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can open a stream of changes made to a collection by calling 
-:swift-sdk:`collection.watch()
-<Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE5watch7Combine10PublishersOACE14WatchPublisherVyF`.
+:swift-sdk:`collection.watch() 
+<Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE5watch7Combine10PublishersOACE14WatchPublisherVyFz>`.
 This function creates a publisher that emits a AnyBSON change event when 
 the MongoDB collection changes. 
 

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -454,11 +454,26 @@ documents.
 The following snippet watches for changes to specific documents in the
 ``CoffeeDrinks`` collection:
 
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-filter.swift
+   :language: swift
+   :copyable: false
 
+It uses this delegate:
+
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
+   :language: swift
+   :copyable: false
 
 Running this snippet produces output resembling the following:
 
+.. code-block:: console
+   :copyable: false
 
+   Login as <RLMUser: 0x600003198780> succeeded!
+   Change stream opened: <RLMChangeStream: 0x600000418240>
+   Successfully updated the document
+   Change event document received: ["fullDocument": Optional(RealmSwift.AnyBSON.document(["_partition": Optional(RealmSwift.AnyBSON.string("Store 42")), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), "_id": Optional(RealmSwift.AnyBSON.objectId(6426121ec505cc40eb9f6de2)), "containsDairy": Optional(RealmSwift.AnyBSON.string("true"))])), "_id": Optional(RealmSwift.AnyBSON.document(["_data": Optional(RealmSwift.AnyBSON.string("826426122A000000102B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F696400646426121EC505CC40EB9F6DE20004"))])), "ns": Optional(RealmSwift.AnyBSON.document(["db": Optional(RealmSwift.AnyBSON.string("ios")), "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks"))])), "updateDescription": Optional(RealmSwift.AnyBSON.document(["removedFields": Optional(RealmSwift.AnyBSON.array([])), "updatedFields": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("true"))]))])), "operationType": Optional(RealmSwift.AnyBSON.string("update")), "documentKey": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(6426121ec505cc40eb9f6de2))])), "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-03-30 22:50:18 +0000))]
+   Change stream closed
 
 .. _swift-mongodb-watch-with-filter:
 

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -406,7 +406,6 @@ You can open a stream of changes made to a collection by calling
 This function creates a publisher that emits a AnyBSON change event when 
 the MongoDB collection changes. 
 
-
 You can optionally watch a filtered list of ``_ids`` in the collection with 
 :swift-sdk:`collection.watch(filterIds:) 
 <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE5watch9filterIds7Combine10PublishersOACE14WatchPublisherVSayAC8ObjectIdCG_tF>`,
@@ -423,7 +422,7 @@ The following snippet watches for changes to any documents in the
    :language: swift
    :copyable: false
 
-It uses this delegate:
+It uses this :swift-sdk:`ChangeEventDelegate <Protocols/ChangeEventDelegate.html>`:
 
 .. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
    :language: swift
@@ -458,7 +457,7 @@ The following snippet watches for changes to specific documents in the
    :language: swift
    :copyable: false
 
-It uses this delegate:
+It uses this :swift-sdk:`ChangeEventDelegate <Protocols/ChangeEventDelegate.html>`:
 
 .. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
    :language: swift
@@ -498,7 +497,7 @@ events corresponding to documents belonging to the partition named
    :language: swift
    :copyable: false
 
-It uses this delegate:
+It uses this :swift-sdk:`ChangeEventDelegate <Protocols/ChangeEventDelegate.html>`:
 
 .. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
    :language: swift
@@ -523,7 +522,34 @@ Watch a Collection as an Async Sequence
 
 .. versionadded:: 10.37.0
 
+You can open an async sequence to watch for changes to a collection. In an 
+async context, call :swift-sdk:`changeEvents() 
+<Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE12changeEvents7Combine22AsyncThrowingPublisherVyAE10PublishersOACE05WatchJ0VGvp>` 
+on a collection to open a change stream. This provides an async sequence of 
+AnyBSON values containing information about each change to the MongoDB 
+collection.
 
+You can optionally provide an :swift-sdk:`changeEvents(onOpen: ) 
+<Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE12changeEvents6onOpen7Combine22AsyncThrowingPublisherVyAF10PublishersOACE05WatchL0VGyyYbc_tF>`
+callback which is invoked when the watch stream has initialized on the server.
+
+The ``changeEvents()`` API can take ``filterIds`` or a ``matchFilter``
+to watch a subset of documents in a collection, similar to the examples above.
+
+The following snippet watches for changes to any documents in the
+``CoffeeDrinks`` collection as an async sequence:
+
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-async-sequence.swift
+   :language: swift
+   :copyable: false
+
+Running this snippet produces this output:
+
+.. code-block:: console
+   :copyable: false
+
+   Successfully opened change stream
+   Received event: ["_id": Optional(RealmSwift.AnyBSON.document(["_data": Optional(RealmSwift.AnyBSON.string("82642722F9000000052B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F69640064642722F800B264566E25B5CC0004"))])), "updateDescription": Optional(RealmSwift.AnyBSON.document(["updatedFields": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("true"))])), "removedFields": Optional(RealmSwift.AnyBSON.array([]))])), "ns": Optional(RealmSwift.AnyBSON.document(["db": Optional(RealmSwift.AnyBSON.string("ios")), "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks"))])), "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-03-31 18:14:17 +0000)), "fullDocument": Optional(RealmSwift.AnyBSON.document(["beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "_id": Optional(RealmSwift.AnyBSON.objectId(642722f800b264566e25b5cc)), "containsDairy": Optional(RealmSwift.AnyBSON.string("true")), "_partition": Optional(RealmSwift.AnyBSON.string("Store 43"))])), "documentKey": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(642722f800b264566e25b5cc))])), "operationType": Optional(RealmSwift.AnyBSON.string("update"))]
 
 .. _ios-mongodb-aggregation-pipelines:
 

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -384,6 +384,115 @@ Running this snippet produces this output:
 
    Successfully deleted 3 documents.
 
+.. _swift-mongodb-watch:
+
+Watch for Changes
+-----------------
+
+You can :manual:`watch </reference/method/db.collection.watch/>` a collection 
+for change notifications that MongoDB emits whenever a document in the 
+collection is added, modified, or deleted. Each notification specifies a 
+document that changed, how it changed, and the full document after the 
+operation that caused the event.
+
+.. include:: /includes/serverless-watch-note.rst
+
+Watch for Changes in a Collection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can open a stream of changes made to a collection by calling 
+:swift-sdk:`collection.watch()
+<Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE5watch7Combine10PublishersOACE14WatchPublisherVyF`.
+This function creates a publisher that emits a AnyBSON change event when 
+the MongoDB collection changes. 
+
+
+You can optionally watch a filtered list of ``_ids`` in the collection with 
+:swift-sdk:`collection.watch(filterIds:) 
+<Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE5watch9filterIds7Combine10PublishersOACE14WatchPublisherVSayAC8ObjectIdCG_tF>`,
+or apply a ``$match`` filter to incoming change events with :swift-sdk:`collection.watch(matchFilter:) 
+<Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE5watch11matchFilter7Combine10PublishersOACE14WatchPublisherVSDySSAC7AnyBSONOSgG_tF>`.
+
+The ``.watch()`` method can take a :swift-sdk:`ChangeEventDelegate 
+<Protocols/ChangeEventDelegate.html>` to subscribe to changes on a stream.
+
+The following snippet watches for changes to any documents in the
+``CoffeeDrinks`` collection:
+
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection.swift
+   :language: swift
+   :copyable: false
+
+It uses this delegate:
+
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
+   :language: swift
+   :copyable: false
+
+Running this snippet produces output resembling the following:
+
+.. code-block:: console
+   :copyable: false
+
+   Login as <RLMUser: 0x600003908880> succeeded!
+   Change stream opened: <RLMChangeStream: 0x600000c9a1c0>
+   Change event document received: ["clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-03-30 21:42:44 +0000)), "documentKey": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(642602546207d8b9ce866ec4))])), "_id": Optional(RealmSwift.AnyBSON.document(["_data": Optional(RealmSwift.AnyBSON.string("8264260254000000012B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F69640064642602546207D8B9CE866EC40004"))])), "operationType": Optional(RealmSwift.AnyBSON.string("insert")), "fullDocument": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("false")), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "_id": Optional(RealmSwift.AnyBSON.objectId(642602546207d8b9ce866ec4)), "_partition": Optional(RealmSwift.AnyBSON.string("Store 42")), "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia"))])), "ns": Optional(RealmSwift.AnyBSON.document(["coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks")), "db": Optional(RealmSwift.AnyBSON.string("ios"))]))]
+   Successfully inserted a document with id: objectId(642602546207d8b9ce866ec4)
+   Change stream closed
+
+.. _swift-mongodb-watch-with-list-of-ids:
+
+Watch for Changes in a Collection to Specific IDs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can watch for changes in a collection to a specific list of objects by
+passing in their ``_id``. Call :swift-sdk:`collection.watch(filterIds: ) 
+<Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE5watch9filterIds7Combine10PublishersOACE14WatchPublisherVSayAC8ObjectIdCG_tF>`
+with an array of ObjectIds to receive only change events that apply to those
+documents.
+
+The following snippet watches for changes to specific documents in the
+``CoffeeDrinks`` collection:
+
+
+
+Running this snippet produces output resembling the following:
+
+
+
+.. _swift-mongodb-watch-with-filter:
+
+Watch for Changes in a Collection with a Filter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can open a stream of changes made to documents in a collection that
+fulfill certain criteria by calling :swift-sdk:`collection.watch(matchFilter: )
+<Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE5watch11matchFilter7Combine10PublishersOACE14WatchPublisherVSDySSAC7AnyBSONOSgG_tF>`.
+This method accepts a ``Document`` parameter that is
+used as the query of a :manual:`$match operator
+</reference/operator/aggregation/match/>` to process each
+:ref:`database event <database-events>` that occurs while watching the
+collection.
+
+The following snippet watches for changes to documents in the
+``CoffeeDrink`` collection, but only triggers the provided callback for
+events corresponding to documents belonging to the partition named
+"Store 42":
+
+
+
+Running this snippet produces output resembling the following:
+
+
+.. _swift-mongodb-watch-async-sequence:
+
+Watch a Collection as an Async Sequence
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 10.37.0
+
+
+
 .. _ios-mongodb-aggregation-pipelines:
 
 Aggregate Documents

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -391,7 +391,7 @@ Watch for Changes
 
 You can :manual:`watch </reference/method/db.collection.watch/>` a collection 
 for change notifications that MongoDB emits whenever a document in the 
-collection is added, modified, or deleted. Each notification specifies a 
+collection is created, modified, or deleted. Each notification specifies a 
 document that changed, how it changed, and the full document after the 
 operation that caused the event.
 

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -429,7 +429,7 @@ It uses this delegate:
    :language: swift
    :copyable: false
 
-Running this snippet produces output resembling the following:
+Running this snippet produces this output:
 
 .. code-block:: console
    :copyable: false
@@ -464,7 +464,7 @@ It uses this delegate:
    :language: swift
    :copyable: false
 
-Running this snippet produces output resembling the following:
+Running this snippet produces this output:
 
 .. code-block:: console
    :copyable: false
@@ -494,9 +494,26 @@ The following snippet watches for changes to documents in the
 events corresponding to documents belonging to the partition named
 "Store 42":
 
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-match.swift
+   :language: swift
+   :copyable: false
 
+It uses this delegate:
 
-Running this snippet produces output resembling the following:
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
+   :language: swift
+   :copyable: false
+
+Running this snippet produces this output:
+
+.. code-block:: console
+   :copyable: false
+
+   Login as <RLMUser: 0x60000183d7e0> succeeded!
+   Change stream opened: <RLMChangeStream: 0x600002d580c0>
+   Change event document received: ["fullDocument": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(6426e0feedf76ba4a8969b34)), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "_partition": Optional(RealmSwift.AnyBSON.string("Store 42")), "containsDairy": Optional(RealmSwift.AnyBSON.string("true")), "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia"))])), "documentKey": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(6426e0feedf76ba4a8969b34))])), "updateDescription": Optional(RealmSwift.AnyBSON.document(["updatedFields": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("true"))])), "removedFields": Optional(RealmSwift.AnyBSON.array([]))])), "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-03-31 13:33:03 +0000)), "operationType": Optional(RealmSwift.AnyBSON.string("update")), "ns": Optional(RealmSwift.AnyBSON.document(["db": Optional(RealmSwift.AnyBSON.string("ios")), "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks"))])), "_id": Optional(RealmSwift.AnyBSON.document(["_data": Optional(RealmSwift.AnyBSON.string("826426E10F0000000F2B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F696400646426E0FEEDF76BA4A8969B340004"))]))]
+   Successfully updated the document
+   Change stream closed
 
 
 .. _swift-mongodb-watch-async-sequence:

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -529,7 +529,7 @@ on a collection to open a change stream. This provides an async sequence of
 AnyBSON values containing information about each change to the MongoDB 
 collection.
 
-You can optionally provide an :swift-sdk:`changeEvents(onOpen: ) 
+You can optionally provide a :swift-sdk:`changeEvents(onOpen: ) 
 <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE12changeEvents6onOpen7Combine22AsyncThrowingPublisherVyAF10PublishersOACE05WatchL0VGyyYbc_tF>`
 callback which is invoked when the watch stream has initialized on the server.
 


### PR DESCRIPTION
## Pull Request Info

This PR also adds back the formerly failing Event Library tests, as SDK version 10.37.2 fixes the issue that was causing the failure.

The new async sequence test requires Xcode 14.3, which is not yet available in the GitHub action that runs our iOS CI. So that test won't actually run in CI. Here is the output of running it locally:

```console
Delete all users result: document(["$undefined": Optional(RealmSwift.AnyBSON.bool(true))])
Removing all users...
Test Suite 'Selected tests' started at 2023-03-31 14:23:34.674
Test Suite 'RealmExamples.xctest' started at 2023-03-31 14:23:34.675
Test Suite 'MongoDBRemoteAccessTestCase' started at 2023-03-31 14:23:34.675
Test Case '-[RealmExamples.MongoDBRemoteAccessTestCase testAsyncStreamWatchForChangesInMDBCollection]' started.
Successfully inserted a document with id: objectId(64272527edf76ba4a8f3716f)
Successfully opened change stream
Received event: ["operationType": Optional(RealmSwift.AnyBSON.string("update")), "_id": Optional(RealmSwift.AnyBSON.document(["_data": Optional(RealmSwift.AnyBSON.string("8264272527000000082B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F6964006464272527EDF76BA4A8F3716F0004"))])), "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-03-31 18:23:35 +0000)), "fullDocument": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("true")), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "_partition": Optional(RealmSwift.AnyBSON.string("Store 43")), "_id": Optional(RealmSwift.AnyBSON.objectId(64272527edf76ba4a8f3716f)), "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia"))])), "ns": Optional(RealmSwift.AnyBSON.document(["coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks")), "db": Optional(RealmSwift.AnyBSON.string("ios"))])), "updateDescription": Optional(RealmSwift.AnyBSON.document(["updatedFields": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("true"))])), "removedFields": Optional(RealmSwift.AnyBSON.array([]))])), "documentKey": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(64272527edf76ba4a8f3716f))]))]
Test Case '-[RealmExamples.MongoDBRemoteAccessTestCase testAsyncStreamWatchForChangesInMDBCollection]' passed (2.757 seconds).
Test Suite 'MongoDBRemoteAccessTestCase' passed at 2023-03-31 14:23:37.434.
	 Executed 1 test, with 0 failures (0 unexpected) in 2.757 (2.758) seconds
Test Suite 'RealmExamples.xctest' passed at 2023-03-31 14:23:37.434.
	 Executed 1 test, with 0 failures (0 unexpected) in 2.757 (2.759) seconds
Test Suite 'Selected tests' passed at 2023-03-31 14:23:37.435.
	 Executed 1 test, with 0 failures (0 unexpected) in 2.757 (2.761) seconds
```

### Jira

- https://jira.mongodb.org/browse/DOCSP-28641

### Staged Changes

- [Query MongoDB](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-28641/sdk/swift/app-services/mongodb-remote-access/#watch-for-changes)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
