### PR TITLE
(DOCSP-28190) Refactor to avoid calling model constructor

### DIFF
--- a/examples/react-native/__tests__/js/CRUD/create-test.jsx
+++ b/examples/react-native/__tests__/js/CRUD/create-test.jsx
@@ -40,7 +40,7 @@ describe('Create Data Tests', () => {
 
       const handleAddDog = () => {
         realm.write(() => {
-          new Dog(realm, {name: dogName, age: 1});
+          realm.create('Dog', {name: dogName, age: 1})
         });
       };
 

--- a/examples/react-native/__tests__/js/CRUD/delete-test.jsx
+++ b/examples/react-native/__tests__/js/CRUD/delete-test.jsx
@@ -24,12 +24,12 @@ describe('Delete Data Tests', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects('Dog'));
 
-      new Dog(assertionRealm, {name: 'Blaise', age: 7});
-      new Dog(assertionRealm, {name: 'Bronson', age: 2});
-      new Dog(assertionRealm, {name: 'Bowie', age: 1});
+      assertionRealm.create('Dog', {name: 'Blaise', age: 7});
+      assertionRealm.create('Dog', {name: 'Bronson', age: 2});
+      assertionRealm.create('Dog', {name: 'Bowie', age: 1});
 
-      new Person(assertionRealm, {name: 'John Smith', age: 18});
-      new Person(assertionRealm, {name: 'Jane Doe', age: 20});
+      assertionRealm.create('Person', {name: 'John Smith', age: 18});
+      assertionRealm.create('Person', {name: 'Jane Doe', age: 20});
     });
   });
   it('should delete an object', async () => {
@@ -76,9 +76,11 @@ describe('Delete Data Tests', () => {
     // Test that a Dog Realm.Object is deleted and there is one less Dog in the UI when the "Delete Dog" button is pressed
     expect(assertionRealm.objects('Dog').length).toBe(3);
     expect(getAllByTestId('deleteDog').length).toBe(3); // we can't use the value of deleteDogButtons because the variable doesn't update when a deleteDog testID is removed from the UI, so we need to call getAllByTestId() again
-    await act(async () => {
-      fireEvent.press(firstDeleteDogButton);
-    });
+    
+    fireEvent.press(firstDeleteDogButton);
+
+    await waitFor(() => {expect(getAllByTestId('deleteDog').length).toBe(2)});
+    
     expect(assertionRealm.objects('Dog').length).toBe(2);
     expect(getAllByTestId('deleteDog').length).toBe(2);
   });

--- a/examples/react-native/__tests__/js/CRUD/read-test.jsx
+++ b/examples/react-native/__tests__/js/CRUD/read-test.jsx
@@ -25,10 +25,10 @@ describe('Read Data Tests', () => {
       assertionRealm.delete(assertionRealm.objects('Person'));
       assertionRealm.delete(assertionRealm.objects('Task'));
 
-      const annieObj = new Person(assertionRealm, {name: 'Annie', age: 54});
-      const bobObj = new Person(assertionRealm, {name: 'Bob', age: 29});
+      const annieObj = assertionRealm.create('Person', {name: 'Annie', age: 54});
+      const bobObj = assertionRealm.create('Person', {name: 'Bob', age: 29});
 
-      new Task(assertionRealm, {
+      assertionRealm.create('Task', {
         _id: 142339,
         name: 'Wash the dishes',
         priority: 3,
@@ -37,7 +37,7 @@ describe('Read Data Tests', () => {
       });
 
       // high priority, high progress
-      new Task(assertionRealm, {
+      assertionRealm.create('Task', {
         _id: 204191,
         name: 'Do the laundry',
         priority: 4,
@@ -46,7 +46,7 @@ describe('Read Data Tests', () => {
       });
 
       // low priority, low progress
-      new Task(assertionRealm, {
+      assertionRealm.create('Task', {
         _id: 214810,
         name: 'Gym Workout',
         priority: 3,

--- a/examples/react-native/__tests__/js/CRUD/update-test.jsx
+++ b/examples/react-native/__tests__/js/CRUD/update-test.jsx
@@ -25,19 +25,21 @@ describe('Update Data Tests', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects('Task'));
 
-      new Task(assertionRealm, {
+      assertionRealm.create('Task', {
         _id: 92140,
         priority: 4,
         progressMinutes: 0,
         name: 'Paint the walls',
       });
-      new Task(assertionRealm, {
+
+      assertionRealm.create('Task', {
         _id: 87432,
         priority: 2,
         progressMinutes: 0,
         name: 'Complete math homework',
       });
-      new Task(assertionRealm, {
+
+      assertionRealm.create('Task', {
         _id: 93479,
         priority: 2,
         progressMinutes: 30,
@@ -97,12 +99,10 @@ describe('Update Data Tests', () => {
     const {getByTestId} = render(<App />);
 
     const handleIncrementBtn = await waitFor(
-      () => getByTestId('handleIncrementBtn'),
-      {timeout: 5000},
+      () => getByTestId('handleIncrementBtn')
     );
     const progressMinutesText = await waitFor(
-      () => getByTestId('progressMinutes'),
-      {timeout: 5000},
+      () => getByTestId('progressMinutes')
     );
 
     const paintTask = assertionRealm.objectForPrimaryKey(Task, 92140);
@@ -111,9 +111,9 @@ describe('Update Data Tests', () => {
     expect(paintTask.progressMinutes).toBe(0);
     expect(progressMinutesText.children.toString()).toBe('0');
 
-    await act(async () => {
-      fireEvent.press(handleIncrementBtn);
-    });
+    fireEvent.press(handleIncrementBtn);
+
+    await waitFor(() => {expect(progressMinutesText.children.toString()).toBe('1')});
 
     // Test that the  progress value in the realm and in the UI after incrementing is 1 minutes
     expect(paintTask.progressMinutes).toBe(1);

--- a/examples/react-native/__tests__/js/realm-database/schemas/dictionary-test.jsx
+++ b/examples/react-native/__tests__/js/realm-database/schemas/dictionary-test.jsx
@@ -22,19 +22,22 @@ describe('Dictionary Tests', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(HomeOwner));
 
-      new HomeOwner(assertionRealm, {
+      assertionRealm.create('HomeOwner', {
         name: 'Martin Doe',
         home: {address: 'Summerhill St.', color: 'pink'},
       });
-      new HomeOwner(assertionRealm, {
+
+      assertionRealm.create('HomeOwner', {
         name: 'Tony Henry',
         home: {address: '200 lake street', price: 123000},
       });
-      new HomeOwner(assertionRealm, {
+
+      assertionRealm.create('HomeOwner', {
         name: 'Rob Johnson',
         home: {address: '1 washington street', color: 'red'},
       });
-      new HomeOwner(assertionRealm, {
+
+      assertionRealm.create('HomeOwner', {
         name: 'Anna Smith',
         home: {address: '2 jefferson lane', yearRenovated: 1994, color: 'blue'},
       });
@@ -51,7 +54,7 @@ describe('Dictionary Tests', () => {
       const submitHomeOwner = () => {
         // Create a HomeOwner within a Write Transaction
         realm.write(() => {
-          new HomeOwner(realm, {
+          realm.create('HomeOwner', {
             name: homeOwnerName,
             // For the dictionary field, 'home', set the value to a regular javascript object
             home: {

--- a/examples/react-native/__tests__/js/realm-database/schemas/embedded-objects-test.jsx
+++ b/examples/react-native/__tests__/js/realm-database/schemas/embedded-objects-test.jsx
@@ -25,7 +25,7 @@ describe('embedded objects tests', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(Contact));
 
-      new Contact(assertionRealm, {
+      assertionRealm.create('Contact', {
         name: 'John Smith',
         _id: new Realm.BSON.ObjectID(),
         address: {
@@ -36,7 +36,7 @@ describe('embedded objects tests', () => {
         },
       });
 
-      new Contact(assertionRealm, {
+      assertionRealm.create('Contact', {
         name: 'Jane Doe',
         _id: new Realm.BSON.ObjectID(),
         address: {
@@ -84,7 +84,8 @@ describe('embedded objects tests', () => {
             country,
             postalCode,
           };
-          new Contact(realm, {
+          
+          realm.create('Contact', {
             _id: new Realm.BSON.ObjectID(),
             name,
             address, // Embed the address in the Contact object

--- a/examples/react-native/__tests__/js/realm-database/schemas/mixed-test.jsx
+++ b/examples/react-native/__tests__/js/realm-database/schemas/mixed-test.jsx
@@ -25,7 +25,7 @@ describe('Mixed Tests', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(Cat));
 
-      new Cat(assertionRealm, {
+      assertionRealm.create('Cat', {
         name: 'Clover',
         birthDate: new Date('January 21, 2016'),
       });
@@ -50,21 +50,22 @@ describe('Mixed Tests', () => {
         // Add data to the Realm when the component mounts
         realm.write(() => {
           // create a Cat with a birthDate value of type string
-          new Cat(realm, {
+          realm.create('Cat', {
             name: 'Euler',
             birthDate: 'December 25th, 2017',
           });
+
           // create a Cat with a birthDate value of type date
-          new Cat(realm, {
+          realm.create('Cat', {
             name: 'Blaise',
             birthDate: new Date('August 17, 2020'),
           });
 
           // create a Cat with a birthDate value of type int
-          new Cat(realm, {name: 'Euclid', birthDate: 10152021});
+          realm.create('Cat', {name: 'Euclid', birthDate: 10152021});
 
           // create a Cat with a birthDate value of type null
-          new Cat(realm, {name: 'Pythagoras', birthDate: null});
+          realm.create('Cat', {name: 'Pythagoras', birthDate: null});
         });
       }, []);
 

--- a/examples/react-native/__tests__/js/realm-database/schemas/sets-test.jsx
+++ b/examples/react-native/__tests__/js/realm-database/schemas/sets-test.jsx
@@ -24,14 +24,14 @@ describe('Set schema', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(Character));
 
-      new Character(assertionRealm, {
+      assertionRealm.create('Character', {
         _id: new Realm.BSON.ObjectId(),
         name: 'PlayerZero',
         levelsCompleted: [1, 2, 3],
         inventory: ['sword', 'shield', 'potion'],
       });
 
-      new Character(assertionRealm, {
+      assertionRealm.create('Character', {
         _id: new Realm.BSON.ObjectID(),
         name: 'PlayerOne',
         inventory: [],
@@ -55,7 +55,7 @@ describe('Set schema', () => {
       const realm = useRealm();
       useEffect(() => {
         realm.write(() => {
-          new Character(realm, {
+          realm.create('Character', {
             _id: new Realm.BSON.ObjectId(),
             name: 'AdventurousPlayer',
             inventory: ['elixir', 'compass', 'glowing shield'],
@@ -63,7 +63,7 @@ describe('Set schema', () => {
           });
         });
         realm.write(() => {
-          new Character(realm, {
+          realm.create('Character', {
             _id: new Realm.BSON.ObjectId(),
             name: 'HealerPlayer',
             inventory: ['estus flask', 'gloves', 'rune'],

--- a/examples/react-native/__tests__/js/realm-database/schemas/uuid.test.jsx
+++ b/examples/react-native/__tests__/js/realm-database/schemas/uuid.test.jsx
@@ -24,7 +24,7 @@ describe('uuid schema', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(Profile));
 
-      new Profile(assertionRealm, {
+      assertionRealm.create('Profile', {
         name: 'Tony Stark',
         _id: new Realm.BSON.UUID(),
       });
@@ -45,7 +45,7 @@ describe('uuid schema', () => {
       // createProfile creates a new 'Profile' Realm Object with a new UUID based on user input
       const createProfile = () => {
         realm.write(() => {
-          new Profile(realm, {
+          realm.create('Profile', {
             name,
             _id: new Realm.BSON.UUID(),
           });

--- a/examples/react-native/__tests__/ts/CRUD/create-test.tsx
+++ b/examples/react-native/__tests__/ts/CRUD/create-test.tsx
@@ -40,7 +40,7 @@ describe('Create Data Tests', () => {
 
       const handleAddDog = () => {
         realm.write(() => {
-          new Dog(realm, {name: dogName, age: 1});
+          realm.create('Dog', {name: dogName, age: 1});
         });
       };
 

--- a/examples/react-native/__tests__/ts/CRUD/delete-test.tsx
+++ b/examples/react-native/__tests__/ts/CRUD/delete-test.tsx
@@ -24,12 +24,12 @@ describe('Delete Data Tests', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects('Dog'));
 
-      new Dog(assertionRealm, {name: 'Blaise', age: 7});
-      new Dog(assertionRealm, {name: 'Bronson', age: 2});
-      new Dog(assertionRealm, {name: 'Bowie', age: 1});
+      assertionRealm.create('Dog', {name: 'Blaise', age: 7});
+      assertionRealm.create('Dog', {name: 'Bronson', age: 2});
+      assertionRealm.create('Dog', {name: 'Bowie', age: 1});
 
-      new Person(assertionRealm, {name: 'John Smith', age: 18});
-      new Person(assertionRealm, {name: 'Jane Doe', age: 20});
+      assertionRealm.create('Person', {name: 'John Smith', age: 18});
+      assertionRealm.create('Person', {name: 'Jane Doe', age: 20});
     });
   });
   it('should delete an object', async () => {
@@ -76,9 +76,11 @@ describe('Delete Data Tests', () => {
     // Test that a Dog Realm.Object is deleted and there is one less Dog in the UI when the "Delete Dog" button is pressed
     expect(assertionRealm.objects('Dog').length).toBe(3);
     expect(getAllByTestId('deleteDog').length).toBe(3); // we can't use the value of deleteDogButtons because the variable doesn't update when a deleteDog testID is removed from the UI, so we need to call getAllByTestId() again
-    await act(async () => {
-      fireEvent.press(firstDeleteDogButton);
-    });
+
+    fireEvent.press(firstDeleteDogButton);
+
+    await waitFor(() => {expect(getAllByTestId('deleteDog').length).toBe(2)});
+
     expect(assertionRealm.objects('Dog').length).toBe(2);
     expect(getAllByTestId('deleteDog').length).toBe(2);
   });

--- a/examples/react-native/__tests__/ts/CRUD/read-test.tsx
+++ b/examples/react-native/__tests__/ts/CRUD/read-test.tsx
@@ -25,10 +25,10 @@ describe('Read Data Tests', () => {
       assertionRealm.delete(assertionRealm.objects('Person'));
       assertionRealm.delete(assertionRealm.objects('Task'));
 
-      const annieObj = new Person(assertionRealm, {name: 'Annie', age: 54});
-      const bobObj = new Person(assertionRealm, {name: 'Bob', age: 29});
+      const annieObj = assertionRealm.create('Person', {name: 'Annie', age: 54});
+      const bobObj = assertionRealm.create('Person', {name: 'Bob', age: 29});
 
-      new Task(assertionRealm, {
+      assertionRealm.create('Task', {
         _id: 142339,
         name: 'Wash the dishes',
         priority: 3,
@@ -37,7 +37,7 @@ describe('Read Data Tests', () => {
       });
 
       // high priority, high progress
-      new Task(assertionRealm, {
+      assertionRealm.create('Task', {
         _id: 204191,
         name: 'Do the laundry',
         priority: 4,
@@ -46,7 +46,7 @@ describe('Read Data Tests', () => {
       });
 
       // low priority, low progress
-      new Task(assertionRealm, {
+      assertionRealm.create('Task', {
         _id: 214810,
         name: 'Gym Workout',
         priority: 3,

--- a/examples/react-native/__tests__/ts/CRUD/update-test.tsx
+++ b/examples/react-native/__tests__/ts/CRUD/update-test.tsx
@@ -24,19 +24,21 @@ describe('Update Data Tests', () => {
     // delete every object in the realmConfig in the Realm to make test idempotent
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects('Task'));
-      new Task(assertionRealm, {
+      assertionRealm.create('Task', {
         _id: 92140,
         priority: 4,
         progressMinutes: 0,
         name: 'Paint the walls',
       });
-      new Task(assertionRealm, {
+
+      assertionRealm.create('Task', {
         _id: 87432,
         priority: 2,
         progressMinutes: 0,
         name: 'Complete math homework',
       });
-      new Task(assertionRealm, {
+
+      assertionRealm.create('Task', {
         _id: 93479,
         priority: 2,
         progressMinutes: 30,
@@ -63,7 +65,7 @@ describe('Update Data Tests', () => {
       const incrementTaskProgress = () => {
         if (myTask) {
           realm.write(() => {
-            myTask.progressMinutes += 1;
+            myTask.progressMinutes! += 1;
           });
         }
       };
@@ -96,26 +98,24 @@ describe('Update Data Tests', () => {
     const {getByTestId} = render(<App />);
 
     const handleIncrementBtn = await waitFor(
-      () => getByTestId('handleIncrementBtn'),
-      {timeout: 5000},
+      () => getByTestId('handleIncrementBtn')
     );
     const progressMinutesText = await waitFor(
-      () => getByTestId('progressMinutes'),
-      {timeout: 5000},
+      () => getByTestId('progressMinutes')
     );
 
     const paintTask = assertionRealm.objectForPrimaryKey(Task, 92140);
 
     // Test that the initial progress value in the realm and in the UI is 0 minutes
-    expect(paintTask.progressMinutes).toBe(0);
+    expect(paintTask!.progressMinutes).toBe(0);
     expect(progressMinutesText.children.toString()).toBe('0');
 
-    await act(async () => {
-      fireEvent.press(handleIncrementBtn);
-    });
+    fireEvent.press(handleIncrementBtn);
+
+    await waitFor(() => {expect(progressMinutesText.children.toString()).toBe('1')});
 
     // Test that the  progress value in the realm and in the UI after incrementing is 1 minutes
-    expect(paintTask.progressMinutes).toBe(1);
+    expect(paintTask!.progressMinutes).toBe(1);
     expect(progressMinutesText.children.toString()).toBe('1');
   });
 

--- a/examples/react-native/__tests__/ts/realm-database/schemas/dictionary-test.tsx
+++ b/examples/react-native/__tests__/ts/realm-database/schemas/dictionary-test.tsx
@@ -22,19 +22,22 @@ describe('Dictionary Tests', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(HomeOwner));
 
-      new HomeOwner(assertionRealm, {
+      assertionRealm.create('HomeOwner', {
         name: 'Martin Doe',
         home: {address: 'Summerhill St.', color: 'pink'},
       });
-      new HomeOwner(assertionRealm, {
+
+      assertionRealm.create('HomeOwner', {
         name: 'Tony Henry',
         home: {address: '200 lake street', price: 123000},
       });
-      new HomeOwner(assertionRealm, {
+
+      assertionRealm.create('HomeOwner', {
         name: 'Rob Johnson',
         home: {address: '1 washington street', color: 'red'},
       });
-      new HomeOwner(assertionRealm, {
+
+      assertionRealm.create('HomeOwner', {
         name: 'Anna Smith',
         home: {address: '2 jefferson lane', yearRenovated: 1994, color: 'blue'},
       });
@@ -50,7 +53,7 @@ describe('Dictionary Tests', () => {
       const submitHomeOwner = () => {
         // Create a HomeOwner within a Write Transaction
         realm.write(() => {
-          new HomeOwner(realm, {
+          realm.create('HomeOwner', {
             name: homeOwnerName,
             // For the dictionary field, 'home', set the value
             // to a regular JavaScript object

--- a/examples/react-native/__tests__/ts/realm-database/schemas/embedded-objects-test.tsx
+++ b/examples/react-native/__tests__/ts/realm-database/schemas/embedded-objects-test.tsx
@@ -25,7 +25,7 @@ describe('embedded objects tests', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(Contact));
 
-      new Contact(assertionRealm, {
+      assertionRealm.create('Contact', {
         name: 'John Smith',
         _id: new Realm.BSON.ObjectID(),
         address: {
@@ -36,7 +36,7 @@ describe('embedded objects tests', () => {
         },
       });
 
-      new Contact(assertionRealm, {
+      assertionRealm.create('Contact', {
         name: 'Jane Doe',
         _id: new Realm.BSON.ObjectID(),
         address: {
@@ -83,7 +83,8 @@ describe('embedded objects tests', () => {
             country,
             postalCode,
           };
-          new Contact(realm, {
+
+          realm.create('Contact', {
             _id: new Realm.BSON.ObjectID(),
             name,
             address, // Embed the address in the Contact object

--- a/examples/react-native/__tests__/ts/realm-database/schemas/mixed-test.tsx
+++ b/examples/react-native/__tests__/ts/realm-database/schemas/mixed-test.tsx
@@ -25,7 +25,7 @@ describe('Mixed Tests', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(Cat));
 
-      new Cat(assertionRealm, {
+      assertionRealm.create('Cat', {
         name: 'Clover',
         birthDate: new Date('January 21, 2016'),
       });
@@ -50,21 +50,22 @@ describe('Mixed Tests', () => {
         // Add data to the Realm when the component mounts
         realm.write(() => {
           // create a Cat with a birthDate value of type string
-          new Cat(realm, {
+          realm.create('Cat', {
             name: 'Euler',
             birthDate: 'December 25th, 2017',
           });
+
           // create a Cat with a birthDate value of type date
-          new Cat(realm, {
+          realm.create('Cat', {
             name: 'Blaise',
             birthDate: new Date('August 17, 2020'),
           });
 
           // create a Cat with a birthDate value of type int
-          new Cat(realm, {name: 'Euclid', birthDate: 10152021});
+          realm.create('Cat', {name: 'Euclid', birthDate: 10152021});
 
           // create a Cat with a birthDate value of type null
-          new Cat(realm, {name: 'Pythagoras', birthDate: null});
+          realm.create('Cat', {name: 'Pythagoras', birthDate: null});
         });
       }, []);
 

--- a/examples/react-native/__tests__/ts/realm-database/schemas/sets-test.tsx
+++ b/examples/react-native/__tests__/ts/realm-database/schemas/sets-test.tsx
@@ -24,14 +24,14 @@ describe('Set schema', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(Character));
 
-      new Character(assertionRealm, {
+      assertionRealm.create('Character', {
         _id: new Realm.BSON.ObjectId(),
         name: 'PlayerZero',
         levelsCompleted: [1, 2, 3],
         inventory: ['sword', 'shield', 'potion'],
       });
 
-      new Character(assertionRealm, {
+      assertionRealm.create('Character', {
         _id: new Realm.BSON.ObjectID(),
         name: 'PlayerOne',
         inventory: [],
@@ -55,15 +55,16 @@ describe('Set schema', () => {
       const realm = useRealm();
       useEffect(() => {
         realm.write(() => {
-          new Character(realm, {
+          realm.create('Character', {
             _id: new Realm.BSON.ObjectId(),
             name: 'AdventurousPlayer',
             inventory: ['elixir', 'compass', 'glowing shield'],
             levelsCompleted: [4, 9],
           });
         });
+
         realm.write(() => {
-          new Character(realm, {
+          realm.create('Character', {
             _id: new Realm.BSON.ObjectId(),
             name: 'HealerPlayer',
             inventory: ['estus flask', 'gloves', 'rune'],

--- a/examples/react-native/__tests__/ts/realm-database/schemas/uuid.test.tsx
+++ b/examples/react-native/__tests__/ts/realm-database/schemas/uuid.test.tsx
@@ -24,7 +24,7 @@ describe('uuid schema', () => {
     assertionRealm.write(() => {
       assertionRealm.delete(assertionRealm.objects(Profile));
 
-      new Profile(assertionRealm, {
+      assertionRealm.create('Profile', {
         name: 'Tony Stark',
         _id: new Realm.BSON.UUID(),
       });
@@ -45,7 +45,7 @@ describe('uuid schema', () => {
       // createProfile creates a new 'Profile' Realm Object with a new UUID based on user input
       const createProfile = () => {
         realm.write(() => {
-          new Profile(realm, {
+          realm.create('Profile', {
             name,
             _id: new Realm.BSON.UUID(),
           });

--- a/source/examples/generated/react-native/js/create-test.snippet.crud-create-object.jsx
+++ b/source/examples/generated/react-native/js/create-test.snippet.crud-create-object.jsx
@@ -5,7 +5,7 @@ const CreateDogInput = () => {
 
   const handleAddDog = () => {
     realm.write(() => {
-      new Dog(realm, {name: dogName, age: 1});
+      realm.create('Dog', {name: dogName, age: 1})
     });
   };
 

--- a/source/examples/generated/react-native/js/dictionary-test.snippet.create-object-with-dictionary-value.jsx
+++ b/source/examples/generated/react-native/js/dictionary-test.snippet.create-object-with-dictionary-value.jsx
@@ -7,7 +7,7 @@ const CreateHomeOwner = () => {
   const submitHomeOwner = () => {
     // Create a HomeOwner within a Write Transaction
     realm.write(() => {
-      new HomeOwner(realm, {
+      realm.create('HomeOwner', {
         name: homeOwnerName,
         // For the dictionary field, 'home', set the value to a regular javascript object
         home: {

--- a/source/examples/generated/react-native/js/embedded-objects-test.snippet.create-embedded-object.jsx
+++ b/source/examples/generated/react-native/js/embedded-objects-test.snippet.create-embedded-object.jsx
@@ -17,7 +17,8 @@ const CreateContact = () => {
         country,
         postalCode,
       };
-      new Contact(realm, {
+      
+      realm.create('Contact', {
         _id: new Realm.BSON.ObjectID(),
         name,
         address, // Embed the address in the Contact object

--- a/source/examples/generated/react-native/js/mixed-test.snippet.create-mixed-object.jsx
+++ b/source/examples/generated/react-native/js/mixed-test.snippet.create-mixed-object.jsx
@@ -5,21 +5,22 @@ const CreateCatsInput = () => {
     // Add data to the Realm when the component mounts
     realm.write(() => {
       // create a Cat with a birthDate value of type string
-      new Cat(realm, {
+      realm.create('Cat', {
         name: 'Euler',
         birthDate: 'December 25th, 2017',
       });
+
       // create a Cat with a birthDate value of type date
-      new Cat(realm, {
+      realm.create('Cat', {
         name: 'Blaise',
         birthDate: new Date('August 17, 2020'),
       });
 
       // create a Cat with a birthDate value of type int
-      new Cat(realm, {name: 'Euclid', birthDate: 10152021});
+      realm.create('Cat', {name: 'Euclid', birthDate: 10152021});
 
       // create a Cat with a birthDate value of type null
-      new Cat(realm, {name: 'Pythagoras', birthDate: null});
+      realm.create('Cat', {name: 'Pythagoras', birthDate: null});
     });
   }, []);
 

--- a/source/examples/generated/react-native/js/sets-test.snippet.create-set-object.jsx
+++ b/source/examples/generated/react-native/js/sets-test.snippet.create-set-object.jsx
@@ -2,7 +2,7 @@ const CreateInitialCharacters = () => {
   const realm = useRealm();
   useEffect(() => {
     realm.write(() => {
-      new Character(realm, {
+      realm.create('Character', {
         _id: new Realm.BSON.ObjectId(),
         name: 'AdventurousPlayer',
         inventory: ['elixir', 'compass', 'glowing shield'],
@@ -10,7 +10,7 @@ const CreateInitialCharacters = () => {
       });
     });
     realm.write(() => {
-      new Character(realm, {
+      realm.create('Character', {
         _id: new Realm.BSON.ObjectId(),
         name: 'HealerPlayer',
         inventory: ['estus flask', 'gloves', 'rune'],

--- a/source/examples/generated/react-native/js/uuid.test.snippet.create-uuid-object.jsx
+++ b/source/examples/generated/react-native/js/uuid.test.snippet.create-uuid-object.jsx
@@ -5,7 +5,7 @@ const CreateProfileInput = () => {
   // createProfile creates a new 'Profile' Realm Object with a new UUID based on user input
   const createProfile = () => {
     realm.write(() => {
-      new Profile(realm, {
+      realm.create('Profile', {
         name,
         _id: new Realm.BSON.UUID(),
       });

--- a/source/examples/generated/react-native/ts/create-test.snippet.crud-create-object.tsx
+++ b/source/examples/generated/react-native/ts/create-test.snippet.crud-create-object.tsx
@@ -5,7 +5,7 @@ const CreateDogInput = () => {
 
   const handleAddDog = () => {
     realm.write(() => {
-      new Dog(realm, {name: dogName, age: 1});
+      realm.create('Dog', {name: dogName, age: 1});
     });
   };
 

--- a/source/examples/generated/react-native/ts/mixed-test.snippet.create-mixed-object.tsx
+++ b/source/examples/generated/react-native/ts/mixed-test.snippet.create-mixed-object.tsx
@@ -5,21 +5,22 @@ const CreateCatsInput = () => {
     // Add data to the Realm when the component mounts
     realm.write(() => {
       // create a Cat with a birthDate value of type string
-      new Cat(realm, {
+      realm.create('Cat', {
         name: 'Euler',
         birthDate: 'December 25th, 2017',
       });
+
       // create a Cat with a birthDate value of type date
-      new Cat(realm, {
+      realm.create('Cat', {
         name: 'Blaise',
         birthDate: new Date('August 17, 2020'),
       });
 
       // create a Cat with a birthDate value of type int
-      new Cat(realm, {name: 'Euclid', birthDate: 10152021});
+      realm.create('Cat', {name: 'Euclid', birthDate: 10152021});
 
       // create a Cat with a birthDate value of type null
-      new Cat(realm, {name: 'Pythagoras', birthDate: null});
+      realm.create('Cat', {name: 'Pythagoras', birthDate: null});
     });
   }, []);
 

--- a/source/examples/generated/react-native/ts/sets-test.snippet.create-set-object.tsx
+++ b/source/examples/generated/react-native/ts/sets-test.snippet.create-set-object.tsx
@@ -2,15 +2,16 @@ const CreateInitialCharacters = () => {
   const realm = useRealm();
   useEffect(() => {
     realm.write(() => {
-      new Character(realm, {
+      realm.create('Character', {
         _id: new Realm.BSON.ObjectId(),
         name: 'AdventurousPlayer',
         inventory: ['elixir', 'compass', 'glowing shield'],
         levelsCompleted: [4, 9],
       });
     });
+
     realm.write(() => {
-      new Character(realm, {
+      realm.create('Character', {
         _id: new Realm.BSON.ObjectId(),
         name: 'HealerPlayer',
         inventory: ['estus flask', 'gloves', 'rune'],

--- a/source/examples/generated/react-native/ts/update-test.snippet.crud-update-object.tsx
+++ b/source/examples/generated/react-native/ts/update-test.snippet.crud-update-object.tsx
@@ -5,7 +5,7 @@ const TaskItem = ({_id}: {_id: number}) => {
   const incrementTaskProgress = () => {
     if (myTask) {
       realm.write(() => {
-        myTask.progressMinutes += 1;
+        myTask.progressMinutes! += 1;
       });
     }
   };

--- a/source/examples/generated/react-native/ts/uuid.test.snippet.create-uuid-object.tsx
+++ b/source/examples/generated/react-native/ts/uuid.test.snippet.create-uuid-object.tsx
@@ -5,7 +5,7 @@ const CreateProfileInput = () => {
   // createProfile creates a new 'Profile' Realm Object with a new UUID based on user input
   const createProfile = () => {
     realm.write(() => {
-      new Profile(realm, {
+      realm.create('Profile', {
         name,
         _id: new Realm.BSON.UUID(),
       });

--- a/source/sdk/react-native/realm-database/crud/create.txt
+++ b/source/sdk/react-native/realm-database/crud/create.txt
@@ -34,12 +34,10 @@ The example on this page uses the following schema:
 Create a New Object
 -------------------
 
-To add an object to a realm instance, instantiate the :js-sdk:`Realm Object
-<Realm.Object.html>` as you would any other object by using the :mdn:`new
-<Web/JavaScript/Reference/Operators/new>` operator to create a new Realm object
-inside of a write transaction. If the :ref:`schema <react-native-realm-schema>`
-includes the object type and the object conforms to the schema, then Realm
-Database stores the object.
+To add a new Realm object to a realm instance, use :js-sdk:`realm.create()
+<Realm.html#create>` inside of a write transaction. If the
+:ref:`schema <react-native-realm-schema>` includes the object type and the
+object conforms to the schema, then Realm Database stores the object.
 
 In the following example of a ``CreateDogInput`` component, we:
 


### PR DESCRIPTION
## Pull Request Info

Instead of creating realm objects with the class constructor (`new Cat( realm, {...}`), we should use `realm.create()`.

I've re-factored all the instances of using `new` for object creation that could find. Also fixed a couple tests with async issues.

### Jira

- https://jira.mongodb.org/browse/DOCSP-28190

### Staged Changes

- [Throughout the RN SDK docs](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-28190-avoid-using-constructor/sdk/react-native/realm-database/crud/create/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal in a Hat

<img src="http://2.bp.blogspot.com/-YdnvIk1-_Po/Us7fl8gO57I/AAAAAAAAAog/3wxrUyE2qws/s1600/march2014.jpg" width=400>
