### PR TITLE
Update Expo Template References

### DIFF
--- a/source/sdk/react-native/bootstrap-with-expo.txt
+++ b/source/sdk/react-native/bootstrap-with-expo.txt
@@ -13,7 +13,7 @@ Bootstrap with Expo - React Native SDK
 Overview
 --------
 
-The :npm:`Realm Expo template <package/@realm/expo-template-ts>`
+The :npm:`Realm Expo template <package/@realm/expo-template>`
 provides a fully working React Native application that you can use to bootstrap
 your app development project with Realm. This documentation covers how to
 initialize and work with the Realm Expo template.
@@ -42,31 +42,14 @@ Initialize the Template
 -----------------------
 To initialize a React Native application using the Realm Expo template use the Expo CLI.
 
-.. tabs-realm-languages::
+Use ``expo init``  with the flag ``--template @realm/expo-template`` to initialize a
+React Native application using the Realm Expo Template. 
 
-   .. tab::
-      :tabid: javascript
+Run the following command in your terminal: 
 
-      Use ``expo init``  with the flag ``--template @realm/expo-template-js`` to initialize a
-      React Native application using the Realm Expo template with JavaScript. 
+.. code-block:: shell
 
-      Run the following command in your terminal: 
-
-      .. code-block:: shell
-      
-         expo init MyAwesomeRealmAppJS --template @realm/expo-template-js
-
-   .. tab::
-      :tabid: typescript
-
-      Use ``expo init``  with the flag ``--template @realm/expo-template-ts`` to initialize a
-      React Native application using the Realm Expo template with TypeScript. 
-
-      Run the following command in your terminal: 
-
-      .. code-block:: shell
-
-         expo init MyAwesomeRealmApp --template @realm/expo-template-ts
+   expo init MyAwesomeRealmApp --template @realm/expo-template
 
 Explore The File Structure
 --------------------------


### PR DESCRIPTION
We are going TS only now for the templates.  In that light, we have created `@realm/expo-template` to be a typescript template and will not be updating `expo-template-js` or `expo-template-ts` anymore.

## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-NNNNN

### Staged Changes

- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/BRANCH_NAME/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-app-services update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
