### PR TITLE
(DOCSP-27109): Swift: Actor-Isolated Realm Concurrency Updates

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,14 +8,14 @@ on:
 jobs:
   build:
     name: Run iOS Example App Tests
-    runs-on: macOS-12
+    runs-on: macOS-13
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "14.2"
+          xcode-version: "14.3"
       - name: Build
         env:
           scheme: ${{ 'default' }}

--- a/examples/ios/Examples/RealmActor.swift
+++ b/examples/ios/Examples/RealmActor.swift
@@ -1,0 +1,358 @@
+// :replace-start: {
+//   "terms": {
+//     "RealmActor_": ""
+//   }
+// }
+import XCTest
+import RealmSwift
+
+// :snippet-start: model
+class RealmActor_Todo: Object {
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name: String
+    @Persisted var owner: String
+    @Persisted var status: String
+}
+//  :snippet-end:
+
+// :snippet-start: define-realm-actor
+actor RealmActor {
+    // An implicitly-unwrapped optional is used here to let us pass `self` to
+    // `Realm(actor:)` within `init`
+    var realm: Realm!
+    init() async throws {
+        realm = try await Realm(actor: self)
+    }
+
+    var count: Int {
+        realm.objects(RealmActor_Todo.self).count
+    }
+    
+    // :snippet-start: write-async
+    func createTodo(name: String, owner: String, status: String) async throws {
+        try await realm.asyncWrite {
+            realm.create(RealmActor_Todo.self, value: [
+                "_id": ObjectId.generate(),
+                "name": name,
+                "owner": owner,
+                "status": status
+            ])
+        }
+    }
+    // :snippet-end:
+    
+    // :snippet-start: update-async
+    func updateTodo(_id: ObjectId, name: String, owner: String, status: String) async throws {
+        try await realm.asyncWrite {
+            realm.create(RealmActor_Todo.self, value: [
+                "_id": _id,
+                "name": name,
+                "owner": owner,
+                "status": status
+            ], update: .modified)
+        }
+    }
+    // :snippet-end:
+    
+    // :snippet-start: delete-async
+    func deleteTodo(todo: RealmActor_Todo) async throws {
+        try await realm.asyncWrite {
+            realm.delete(todo)
+        }
+    }
+    // :snippet-end:
+    
+    func close() {
+        realm = nil
+    }
+    
+    // :remove-start:
+    func removeAll() async throws {
+        try await realm.asyncWrite {
+            let allTodos = realm.objects(RealmActor_Todo.self)
+            realm.delete(allTodos)
+        }
+    }
+    // :remove-end:
+}
+// :snippet-end:
+
+class RealmActorTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() async throws {
+        let actor = try await RealmActor()
+        try await actor.removeAll()
+        await actor.close()
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+#if swift(>=5.8)
+    func testActorIsolatedRealmAsync() async throws {
+        // :snippet-start: actor-isolated-realm-async
+        func createObject() async throws {
+            // Because this function is not isolated to this actor,
+            // you must await operations completed on the actor
+            try await actor.createTodo(name: "Write a new documentation page", owner: "Dachary", status: "In Progress")
+            let taskCount = await actor.count
+            print("The actor currently has \(taskCount) tasks")
+            XCTAssertEqual(taskCount, 1) // :remove:
+        }
+        
+        let actor = try await RealmActor()
+        
+        try await createObject()
+        // :snippet-end:
+        await actor.close()
+    }
+    
+    func testActorIsolatedRealmSynchronous() async throws {
+        // :snippet-start: actor-isolated-realm-synchronous
+        func createObject(in actor: isolated RealmActor) async throws {
+            // Because this function is isolated to this actor, you can use
+            // realm synchronously in this context without async/await keywords
+            try actor.realm.write {
+                actor.realm.create(RealmActor_Todo.self, value: [
+                    "name": "Write new code examples",
+                    "owner": "Dachary",
+                    "status": "In Progress"
+                ])
+            }
+            let taskCount = actor.count
+            print("The actor currently has \(taskCount) tasks")
+            XCTAssertEqual(taskCount, 1) // :remove:
+        }
+        
+        let actor = try await RealmActor()
+        
+        try await createObject(in: actor)
+        // :snippet-end:
+        await actor.close()
+    }
+    
+    func testActorIsolatedRealmUpdate() async throws {
+        func createObject(in actor: isolated RealmActor) async throws {
+            try actor.realm.write {
+                actor.realm.create(RealmActor_Todo.self, value: [
+                    "name": "Write an example of updating an object on a RealmActor",
+                    "owner": "Dachary",
+                    "status": "In Progress"
+                ])
+            }
+        }
+        // :snippet-start: update-object
+        // :snippet-start: read-objects
+        let actor = try await RealmActor()
+        
+        try await createObject(in: actor)
+        
+        let todo = await actor.realm.objects(RealmActor_Todo.self).where {
+            $0.name == "Write an example of updating an object on a RealmActor"
+        }.first!
+        // :snippet-end:
+        
+        XCTAssertNotNil(todo) // :remove:
+        
+        try await actor.updateTodo(_id: todo._id, name: todo.name, owner: todo.owner, status: "Completed")
+        // :snippet-end:
+        sleep(1)
+        XCTAssertEqual(todo.status, "Completed")
+        await actor.close()
+    }
+    
+    func testActorIsolatedRealmDelete() async throws {
+        func createObject(in actor: isolated RealmActor) async throws -> RealmActor_Todo {
+            return try actor.realm.write {
+                return actor.realm.create(RealmActor_Todo.self, value: [
+                    "name": "Write an example of deleting an object on a RealmActor",
+                    "owner": "Dachary",
+                    "status": "In Progress"
+                ])
+            }
+        }
+        // :snippet-start: delete-object
+        
+        let actor = try await RealmActor()
+        
+        let todo = try await createObject(in: actor)
+        XCTAssertNotNil(todo) // :remove:
+        print("Successfully created an object with id: \(todo._id)")
+        let todoCount = await actor.count
+        XCTAssertEqual(todoCount, 1) // :remove:
+        
+        try await actor.deleteTodo(todo: todo)
+        let updatedTodoCount = await actor.count
+        XCTAssertEqual(updatedTodoCount, 0) // :remove:
+        if updatedTodoCount == todoCount - 1 {
+            print("Successfully deleted the todo")
+        }
+        // :snippet-end:
+        await actor.close()
+    }
+    
+    func testOpenActorConfinedRealm() async throws {
+        try await mainThreadFunction()
+        // :snippet-start: await-main-actor-realm
+        @MainActor
+        func mainThreadFunction() async throws {
+            // These are identical: the async init produces a
+            // MainActor-confined Realm if no actor is supplied
+            let realm1 = try await Realm()
+            let realm2 = try await Realm(actor: MainActor.shared)
+            
+            try await useTheRealm(realm: realm1)
+        }
+        // :snippet-end:
+        @MainActor
+        func useTheRealm(realm: Realm) async throws {
+            let todoItems = realm.objects(RealmActor_Todo.self)
+            XCTAssertEqual(todoItems.count, 0) // :remove:
+            print("Todo item count is: \(todoItems.count)")
+            
+            try! realm.write {
+                realm.create(RealmActor_Todo.self, value: [
+                    "name": "Write async/await code examples",
+                    "owner": "Dachary",
+                    "status": "In Progress"
+                ])
+            }
+            await realm.asyncRefresh()
+            XCTAssertEqual(todoItems.count, 1) // :remove:
+            print("Todo item count is now: \(todoItems.count)")
+        }
+    }
+    
+    func testAwaitBackgroundActor() async throws {
+        try await mainThreadFunction()
+        
+        // :snippet-start: global-actor-example
+        // A simple example of a custom global actor
+        @globalActor actor BackgroundActor: GlobalActor {
+            static var shared = BackgroundActor()
+        }
+
+        @BackgroundActor
+        func backgroundThreadFunction() async throws {
+            // Explicitly specifying the actor is required for anything that is not MainActor
+            let realm = try await Realm(actor: BackgroundActor.shared)
+            try await realm.asyncWrite {
+                _ = realm.create(RealmActor_Todo.self, value: [
+                    "name": "Write async/await code examples",
+                    "owner": "Dachary",
+                    "status": "In Progress"
+                ])
+            }
+            // Thread-confined Realms would sometimes throw an exception here, as we
+            // may end up on a different thread after an `await`
+            let todoCount = realm.objects(RealmActor_Todo.self).count
+            print("The number of Realm objects is: \(todoCount)")
+            XCTAssertEqual(todoCount, 1) // :remove:
+        }
+        
+        @MainActor
+        func mainThreadFunction() async throws {
+            try await backgroundThreadFunction()
+        }
+        // :snippet-end:
+    }
+    
+    func testObserveCollectionOnActor() async throws {
+        let expectation = expectation(description: "A notification is triggered")
+        // :snippet-start: observe-collection-on-actor
+        let actor = try await RealmActor()
+        
+        // Add a todo to the realm so the collection has something to observe
+        try await actor.createTodo(name: "Write a code example for actor observability", owner: "Dachary", status: "In Progress")
+        let todoCount = await actor.count
+        print("The actor currently has \(todoCount) tasks")
+        XCTAssertEqual(todoCount, 1) // :remove:
+        
+        // Get a collection
+        let todos = await actor.realm.objects(RealmActor_Todo.self)
+        
+        // Register a notification token, providing the actor
+        let token = await todos.observe(on: actor, { actor, changes in
+            print("A change occurred on actor: \(actor)")
+            switch changes {
+            case .initial:
+                print("The initial value of the changed object was: \(changes)")
+            case .update(_, let deletions, let insertions, let modifications):
+                if !deletions.isEmpty {
+                    print("An object was deleted: \(changes)")
+                } else if !insertions.isEmpty {
+                    print("An object was inserted: \(changes)")
+                } else if !modifications.isEmpty {
+                    print("An object was modified: \(changes)")
+                    expectation.fulfill() // :remove:
+                }
+            case .error(let error):
+                print("An error occurred: \(error.localizedDescription)")
+            }
+        })
+        
+        // Make an update to an object to trigger the notification
+        await actor.realm.writeAsync {
+            todos.first!.status = "Completed"
+        }
+        
+        await fulfillment(of: [expectation], timeout: 2) // :remove:
+        // Invalidate the token when done observing
+        token.invalidate()
+        // :snippet-end:
+        await actor.close()
+    }
+    
+    func testObserveObjectOnActor() async throws {
+        let expectation = expectation(description: "A notification is triggered")
+        // :snippet-start: observe-object-on-actor
+        let actor = try await RealmActor()
+        
+        // Add a todo to the realm so we can observe it
+        try await actor.createTodo(name: "Write a code example for observing an object on an actor", owner: "Dachary", status: "In Progress")
+        let todoCount = await actor.count
+        print("The actor currently has \(todoCount) tasks")
+        XCTAssertEqual(todoCount, 1) // :remove:
+        
+        // Get an object
+        let todo = await actor.realm.objects(RealmActor_Todo.self).where {
+            $0.name == "Write a code example for observing an object on an actor"
+        }.first!
+        
+        // Register a notification token, providing the actor
+        let token = await todo.observe(on: actor, { actor, change in
+            print("A change occurred on actor: \(actor)")
+            switch change {
+            case .change(let object, let properties):
+                for property in properties {
+                    print("Property '\(property.name)' of object \(object) changed to '\(property.newValue!)'")
+                    expectation.fulfill() // :remove:
+                }
+            case .error(let error):
+                print("An error occurred: \(error)")
+            case .deleted:
+                print("The object was deleted.")
+            }
+        })
+        
+        // Make an update to an object to trigger the notification
+        await actor.realm.writeAsync {
+            todo.status = "Completed"
+        }
+        
+        await fulfillment(of: [expectation], timeout: 2) // :remove:
+        // Invalidate the token when done observing
+        token.invalidate()
+        // :snippet-end:
+        XCTAssertEqual(todo.status, "Completed")
+        await actor.close()
+    }
+#endif
+}
+// :replace-end:

--- a/examples/ios/Examples/RealmActor.swift
+++ b/examples/ios/Examples/RealmActor.swift
@@ -202,7 +202,7 @@ class RealmActorTests: XCTestCase {
         @MainActor
         func mainThreadFunction() async throws {
             // These are identical: the async init produces a
-            // MainActor-confined Realm if no actor is supplied
+            // MainActor-isolated Realm if no actor is supplied
             let realm1 = try await Realm()
             let realm2 = try await Realm(actor: MainActor.shared)
             
@@ -241,7 +241,7 @@ class RealmActorTests: XCTestCase {
             config.fileURL!.appendPathComponent(username)
             config.fileURL!.appendPathExtension("realm")
             
-            // Open an actor-confined realm with a specific configuration
+            // Open an actor-isolated realm with a specific configuration
             let realm = try await Realm(configuration: config, actor: MainActor.shared)
             
             try await useTheRealm(realm: realm)

--- a/examples/ios/Examples/RealmActor.swift
+++ b/examples/ios/Examples/RealmActor.swift
@@ -100,7 +100,7 @@ class RealmActorTests: XCTestCase {
         func createObject() async throws {
             // Because this function is not isolated to this actor,
             // you must await operations completed on the actor
-            try await actor.createTodo(name: "Write a new documentation page", owner: "Dachary", status: "In Progress")
+            try await actor.createTodo(name: "Take the ring to Mount Doom", owner: "Frodo", status: "In Progress")
             let taskCount = await actor.count
             print("The actor currently has \(taskCount) tasks")
             XCTAssertEqual(taskCount, 1) // :remove:
@@ -120,8 +120,8 @@ class RealmActorTests: XCTestCase {
             // realm synchronously in this context without async/await keywords
             try actor.realm.write {
                 actor.realm.create(RealmActor_Todo.self, value: [
-                    "name": "Write new code examples",
-                    "owner": "Dachary",
+                    "name": "Keep it secret",
+                    "owner": "Frodo",
                     "status": "In Progress"
                 ])
             }
@@ -141,8 +141,8 @@ class RealmActorTests: XCTestCase {
         func createObject(in actor: isolated RealmActor) async throws {
             try actor.realm.write {
                 actor.realm.create(RealmActor_Todo.self, value: [
-                    "name": "Write an example of updating an object on a RealmActor",
-                    "owner": "Dachary",
+                    "name": "Keep it safe",
+                    "owner": "Frodo",
                     "status": "In Progress"
                 ])
             }
@@ -154,7 +154,7 @@ class RealmActorTests: XCTestCase {
         try await createObject(in: actor)
         
         let todo = await actor.realm.objects(RealmActor_Todo.self).where {
-            $0.name == "Write an example of updating an object on a RealmActor"
+            $0.name == "Keep it safe"
         }.first!
         // :snippet-end:
         
@@ -171,14 +171,13 @@ class RealmActorTests: XCTestCase {
         func createObject(in actor: isolated RealmActor) async throws -> RealmActor_Todo {
             return try actor.realm.write {
                 return actor.realm.create(RealmActor_Todo.self, value: [
-                    "name": "Write an example of deleting an object on a RealmActor",
-                    "owner": "Dachary",
+                    "name": "Keep Mr. Frodo safe from that Gollum",
+                    "owner": "Sam",
                     "status": "In Progress"
                 ])
             }
         }
         // :snippet-start: delete-object
-        
         let actor = try await RealmActor()
         
         let todo = try await createObject(in: actor)
@@ -218,13 +217,13 @@ class RealmActorTests: XCTestCase {
             
             try! realm.write {
                 realm.create(RealmActor_Todo.self, value: [
-                    "name": "Write async/await code examples",
-                    "owner": "Dachary",
+                    "name": "Go to see the elves",
+                    "owner": "Sam",
                     "status": "In Progress"
                 ])
             }
             await realm.asyncRefresh()
-            XCTAssertEqual(todoItems.count, 1) // :remove:
+            XCTAssertEqual(todoItems.count, 1)
             print("Todo item count is now: \(todoItems.count)")
         }
     }
@@ -234,7 +233,7 @@ class RealmActorTests: XCTestCase {
         // :snippet-start: actor-confined-realm-with-config
         @MainActor
         func mainThreadFunction() async throws {
-            let username = "GordonCole"
+            let username = "Galadriel"
             
             // Customize the default realm config
             var config = Realm.Configuration.defaultConfiguration
@@ -251,19 +250,23 @@ class RealmActorTests: XCTestCase {
         @MainActor
         func useTheRealm(realm: Realm) async throws {
             let todoItems = realm.objects(RealmActor_Todo.self)
-            XCTAssertEqual(todoItems.count, 0) // :remove:
+            XCTAssertEqual(todoItems.count, 0)
             print("Todo item count is: \(todoItems.count)")
             
             try! realm.write {
                 realm.create(RealmActor_Todo.self, value: [
-                    "name": "Write code example showing a config",
-                    "owner": "Dachary",
+                    "name": "Diminish and go into the West",
+                    "owner": "Galadriel",
                     "status": "In Progress"
                 ])
             }
             await realm.asyncRefresh()
-            XCTAssertEqual(todoItems.count, 1) // :remove:
+            XCTAssertEqual(todoItems.count, 1)
             print("Todo item count is now: \(todoItems.count)")
+            try realm.write {
+                realm.deleteAll()
+            }
+            XCTAssertEqual(todoItems.count, 0)
         }
     }
     
@@ -289,13 +292,13 @@ class RealmActorTests: XCTestCase {
         @MainActor
         func useTheSyncedRealm(realm: Realm) async throws {
             let todoItems = realm.objects(RealmActor_Todo.self)
-            XCTAssertEqual(todoItems.count, 0) // :remove:
+            XCTAssertEqual(todoItems.count, 0)
             print("Todo item count at start of test is: \(todoItems.count)")
 
             try! realm.write {
                 realm.create(RealmActor_Todo.self, value: [
-                    "name": "Write synced realm code example",
-                    "owner": "Dachary",
+                    "name": "Keep the ring-bearer safe",
+                    "owner": "Aragorn",
                     "status": "In Progress"
                 ])
             }
@@ -327,8 +330,8 @@ class RealmActorTests: XCTestCase {
             let realm = try await Realm(actor: BackgroundActor.shared)
             try await realm.asyncWrite {
                 _ = realm.create(RealmActor_Todo.self, value: [
-                    "name": "Write async/await code examples",
-                    "owner": "Dachary",
+                    "name": "Pledge fealty and service to Gondor",
+                    "owner": "Pippin",
                     "status": "In Progress"
                 ])
             }
@@ -352,7 +355,7 @@ class RealmActorTests: XCTestCase {
         let actor = try await RealmActor()
         
         // Add a todo to the realm so the collection has something to observe
-        try await actor.createTodo(name: "Write a code example for actor observability", owner: "Dachary", status: "In Progress")
+        try await actor.createTodo(name: "Arrive safely in Bree", owner: "Merry", status: "In Progress")
         let todoCount = await actor.count
         print("The actor currently has \(todoCount) tasks")
         XCTAssertEqual(todoCount, 1) // :remove:
@@ -398,14 +401,14 @@ class RealmActorTests: XCTestCase {
         let actor = try await RealmActor()
         
         // Add a todo to the realm so we can observe it
-        try await actor.createTodo(name: "Write a code example for observing an object on an actor", owner: "Dachary", status: "In Progress")
+        try await actor.createTodo(name: "Scour the Shire", owner: "Merry", status: "In Progress")
         let todoCount = await actor.count
         print("The actor currently has \(todoCount) tasks")
         XCTAssertEqual(todoCount, 1) // :remove:
         
         // Get an object
         let todo = await actor.realm.objects(RealmActor_Todo.self).where {
-            $0.name == "Write a code example for observing an object on an actor"
+            $0.name == "Scour the Shire"
         }.first!
         
         // Register a notification token, providing the actor

--- a/examples/ios/Examples/RealmActor.swift
+++ b/examples/ios/Examples/RealmActor.swift
@@ -157,7 +157,6 @@ class RealmActorTests: XCTestCase {
             $0.name == "Keep it safe"
         }.first!
         // :snippet-end:
-        
         XCTAssertNotNil(todo) // :remove:
         
         try await actor.updateTodo(_id: todo._id, name: todo.name, owner: todo.owner, status: "Completed")

--- a/examples/ios/Examples/UpdateRealmObjects.swift
+++ b/examples/ios/Examples/UpdateRealmObjects.swift
@@ -90,6 +90,7 @@ class UpdateRealmObjects: XCTestCase {
         // :snippet-end:
     }
 
+    @MainActor
     func testAsyncWriteQueryOnLocalThread() {
         let expectation = expectation(description: "Objects append")
 

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		9175294C28467FB700F8CB03 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 9175294B28467FB700F8CB03 /* RealmSwift */; };
 		917529522846803200F8CB03 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 917529512846803200F8CB03 /* Realm */; };
 		917529542846803200F8CB03 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 917529532846803200F8CB03 /* RealmSwift */; };
+		91787E5429E594C100296021 /* RealmActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91787E5329E594C100296021 /* RealmActor.swift */; };
 		917CA79627ECADC200F9BDDC /* FacebookCore in Frameworks */ = {isa = PBXBuildFile; productRef = 917CA79527ECADC200F9BDDC /* FacebookCore */; };
 		917CA79827ECADC200F9BDDC /* FacebookLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 917CA79727ECADC200F9BDDC /* FacebookLogin */; };
 		917CA79B27ECB36700F9BDDC /* FacebookCore in Frameworks */ = {isa = PBXBuildFile; productRef = 917CA79A27ECB36700F9BDDC /* FacebookCore */; };
@@ -221,6 +222,7 @@
 		91713B3028AC41B700519F9D /* Authenticate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authenticate.swift; sourceTree = "<group>"; };
 		91713B3428AD2B0E00519F9D /* PassObjectsToView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassObjectsToView.swift; sourceTree = "<group>"; };
 		91713B3828AD2B3500519F9D /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
+		91787E5329E594C100296021 /* RealmActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmActor.swift; sourceTree = "<group>"; };
 		917D8C9E26167B69001B7A61 /* TestingAndDebugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestingAndDebugging.swift; sourceTree = "<group>"; };
 		917E73E526B8A9F80068242A /* MongoDBRemoteAccess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MongoDBRemoteAccess.swift; sourceTree = "<group>"; };
 		917E73E626B8A9F80068242A /* MongoDBRemoteAccessAggregate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MongoDBRemoteAccessAggregate.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 				914AC1BC28A3EAE00005E3C3 /* QuickStartFlexSync.swift */,
 				91AB03172899660A00A272E8 /* ReadRealmObjects.swift */,
 				4847120125891A3B004BD6EF /* ReadWriteData.m */,
+				91787E5329E594C100296021 /* RealmActor.swift */,
 				48BF34172511095C004139AF /* RealmApp.swift */,
 				9126A02E27ED00A1002006D2 /* RealmPlayground.playground */,
 				48944D9725C0BD520092B8AC /* Relationships.m */,
@@ -807,6 +810,7 @@
 				48944D9025C08D500092B8AC /* ObjectModels.m in Sources */,
 				48F38B5425278ECB00DDEB65 /* CustomUserData.m in Sources */,
 				48924B8C2514FEFC00CC9567 /* TestSetup.swift in Sources */,
+				91787E5429E594C100296021 /* RealmActor.swift in Sources */,
 				915C666A27B41B0900E7BDB4 /* BundleRealms.swift in Sources */,
 				4847120225891A3B004BD6EF /* ReadWriteData.m in Sources */,
 				48C072062511B6DB004B02BB /* ManageEmailPasswordUsers.m in Sources */,
@@ -1091,6 +1095,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = "";
 			};
 			name = Debug;
 		};
@@ -1147,6 +1152,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = "";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1095,6 +1095,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = "";
 			};
 			name = Debug;
@@ -1152,6 +1153,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = "";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/source/examples/generated/code/start/RealmActor.snippet.actor-confined-realm-with-config.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.actor-confined-realm-with-config.swift
@@ -1,6 +1,6 @@
 @MainActor
 func mainThreadFunction() async throws {
-    let username = "GordonCole"
+    let username = "Galadriel"
     
     // Customize the default realm config
     var config = Realm.Configuration.defaultConfiguration

--- a/source/examples/generated/code/start/RealmActor.snippet.actor-confined-realm-with-config.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.actor-confined-realm-with-config.swift
@@ -1,0 +1,15 @@
+@MainActor
+func mainThreadFunction() async throws {
+    let username = "GordonCole"
+    
+    // Customize the default realm config
+    var config = Realm.Configuration.defaultConfiguration
+    config.fileURL!.deleteLastPathComponent()
+    config.fileURL!.appendPathComponent(username)
+    config.fileURL!.appendPathExtension("realm")
+    
+    // Open an actor-confined realm with a specific configuration
+    let realm = try await Realm(configuration: config, actor: MainActor.shared)
+    
+    try await useTheRealm(realm: realm)
+}

--- a/source/examples/generated/code/start/RealmActor.snippet.actor-confined-realm-with-config.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.actor-confined-realm-with-config.swift
@@ -8,7 +8,7 @@ func mainThreadFunction() async throws {
     config.fileURL!.appendPathComponent(username)
     config.fileURL!.appendPathExtension("realm")
     
-    // Open an actor-confined realm with a specific configuration
+    // Open an actor-isolated realm with a specific configuration
     let realm = try await Realm(configuration: config, actor: MainActor.shared)
     
     try await useTheRealm(realm: realm)

--- a/source/examples/generated/code/start/RealmActor.snippet.actor-confined-synced-realm.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.actor-confined-synced-realm.swift
@@ -1,0 +1,15 @@
+@MainActor
+func mainThreadFunction() async throws {
+    // Initialize the app client and authenticate a user
+    let app = App(id: APPID)
+    let user = try await app.login(credentials: Credentials.anonymous)
+    
+    // Configure the synced realm
+    var flexSyncConfig = user.flexibleSyncConfiguration(initialSubscriptions: { subs in
+        subs.append(QuerySubscription<Todo>(name: "all_todos"))})
+    flexSyncConfig.objectTypes = [Todo.self]
+    
+    // Open and use the synced realm
+    let realm = try await Realm(configuration: flexSyncConfig, actor: MainActor.shared, downloadBeforeOpen: .always)
+    try await useTheSyncedRealm(realm: realm)
+}

--- a/source/examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-async.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-async.swift
@@ -1,7 +1,7 @@
 func createObject() async throws {
     // Because this function is not isolated to this actor,
     // you must await operations completed on the actor
-    try await actor.createTodo(name: "Write a new documentation page", owner: "Dachary", status: "In Progress")
+    try await actor.createTodo(name: "Take the ring to Mount Doom", owner: "Frodo", status: "In Progress")
     let taskCount = await actor.count
     print("The actor currently has \(taskCount) tasks")
 }

--- a/source/examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-async.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-async.swift
@@ -1,0 +1,11 @@
+func createObject() async throws {
+    // Because this function is not isolated to this actor,
+    // you must await operations completed on the actor
+    try await actor.createTodo(name: "Write a new documentation page", owner: "Dachary", status: "In Progress")
+    let taskCount = await actor.count
+    print("The actor currently has \(taskCount) tasks")
+}
+
+let actor = try await RealmActor()
+
+try await createObject()

--- a/source/examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-synchronous.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-synchronous.swift
@@ -3,8 +3,8 @@ func createObject(in actor: isolated RealmActor) async throws {
     // realm synchronously in this context without async/await keywords
     try actor.realm.write {
         actor.realm.create(Todo.self, value: [
-            "name": "Write new code examples",
-            "owner": "Dachary",
+            "name": "Keep it secret",
+            "owner": "Frodo",
             "status": "In Progress"
         ])
     }

--- a/source/examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-synchronous.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-synchronous.swift
@@ -1,0 +1,17 @@
+func createObject(in actor: isolated RealmActor) async throws {
+    // Because this function is isolated to this actor, you can use
+    // realm synchronously in this context without async/await keywords
+    try actor.realm.write {
+        actor.realm.create(Todo.self, value: [
+            "name": "Write new code examples",
+            "owner": "Dachary",
+            "status": "In Progress"
+        ])
+    }
+    let taskCount = actor.count
+    print("The actor currently has \(taskCount) tasks")
+}
+
+let actor = try await RealmActor()
+
+try await createObject(in: actor)

--- a/source/examples/generated/code/start/RealmActor.snippet.await-main-actor-realm.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.await-main-actor-realm.swift
@@ -1,0 +1,9 @@
+@MainActor
+func mainThreadFunction() async throws {
+    // These are identical: the async init produces a
+    // MainActor-confined Realm if no actor is supplied
+    let realm1 = try await Realm()
+    let realm2 = try await Realm(actor: MainActor.shared)
+    
+    try await useTheRealm(realm: realm1)
+}

--- a/source/examples/generated/code/start/RealmActor.snippet.await-main-actor-realm.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.await-main-actor-realm.swift
@@ -1,7 +1,7 @@
 @MainActor
 func mainThreadFunction() async throws {
     // These are identical: the async init produces a
-    // MainActor-confined Realm if no actor is supplied
+    // MainActor-isolated Realm if no actor is supplied
     let realm1 = try await Realm()
     let realm2 = try await Realm(actor: MainActor.shared)
     

--- a/source/examples/generated/code/start/RealmActor.snippet.define-realm-actor.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.define-realm-actor.swift
@@ -1,0 +1,45 @@
+actor RealmActor {
+    // An implicitly-unwrapped optional is used here to let us pass `self` to
+    // `Realm(actor:)` within `init`
+    var realm: Realm!
+    init() async throws {
+        realm = try await Realm(actor: self)
+    }
+
+    var count: Int {
+        realm.objects(Todo.self).count
+    }
+    
+    func createTodo(name: String, owner: String, status: String) async throws {
+        try await realm.asyncWrite {
+            realm.create(Todo.self, value: [
+                "_id": ObjectId.generate(),
+                "name": name,
+                "owner": owner,
+                "status": status
+            ])
+        }
+    }
+    
+    func updateTodo(_id: ObjectId, name: String, owner: String, status: String) async throws {
+        try await realm.asyncWrite {
+            realm.create(Todo.self, value: [
+                "_id": _id,
+                "name": name,
+                "owner": owner,
+                "status": status
+            ], update: .modified)
+        }
+    }
+    
+    func deleteTodo(todo: Todo) async throws {
+        try await realm.asyncWrite {
+            realm.delete(todo)
+        }
+    }
+    
+    func close() {
+        realm = nil
+    }
+    
+}

--- a/source/examples/generated/code/start/RealmActor.snippet.delete-async.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.delete-async.swift
@@ -1,0 +1,5 @@
+func deleteTodo(todo: Todo) async throws {
+    try await realm.asyncWrite {
+        realm.delete(todo)
+    }
+}

--- a/source/examples/generated/code/start/RealmActor.snippet.delete-object.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.delete-object.swift
@@ -1,0 +1,12 @@
+
+let actor = try await RealmActor()
+
+let todo = try await createObject(in: actor)
+print("Successfully created an object with id: \(todo._id)")
+let todoCount = await actor.count
+
+try await actor.deleteTodo(todo: todo)
+let updatedTodoCount = await actor.count
+if updatedTodoCount == todoCount - 1 {
+    print("Successfully deleted the todo")
+}

--- a/source/examples/generated/code/start/RealmActor.snippet.delete-object.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.delete-object.swift
@@ -1,4 +1,3 @@
-
 let actor = try await RealmActor()
 
 let todo = try await createObject(in: actor)

--- a/source/examples/generated/code/start/RealmActor.snippet.global-actor-example.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.global-actor-example.swift
@@ -9,8 +9,8 @@ func backgroundThreadFunction() async throws {
     let realm = try await Realm(actor: BackgroundActor.shared)
     try await realm.asyncWrite {
         _ = realm.create(Todo.self, value: [
-            "name": "Write async/await code examples",
-            "owner": "Dachary",
+            "name": "Pledge fealty and service to Gondor",
+            "owner": "Pippin",
             "status": "In Progress"
         ])
     }

--- a/source/examples/generated/code/start/RealmActor.snippet.global-actor-example.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.global-actor-example.swift
@@ -1,0 +1,26 @@
+// A simple example of a custom global actor
+@globalActor actor BackgroundActor: GlobalActor {
+    static var shared = BackgroundActor()
+}
+
+@BackgroundActor
+func backgroundThreadFunction() async throws {
+    // Explicitly specifying the actor is required for anything that is not MainActor
+    let realm = try await Realm(actor: BackgroundActor.shared)
+    try await realm.asyncWrite {
+        _ = realm.create(Todo.self, value: [
+            "name": "Write async/await code examples",
+            "owner": "Dachary",
+            "status": "In Progress"
+        ])
+    }
+    // Thread-confined Realms would sometimes throw an exception here, as we
+    // may end up on a different thread after an `await`
+    let todoCount = realm.objects(Todo.self).count
+    print("The number of Realm objects is: \(todoCount)")
+}
+
+@MainActor
+func mainThreadFunction() async throws {
+    try await backgroundThreadFunction()
+}

--- a/source/examples/generated/code/start/RealmActor.snippet.model.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.model.swift
@@ -1,0 +1,6 @@
+class Todo: Object {
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var name: String
+    @Persisted var owner: String
+    @Persisted var status: String
+}

--- a/source/examples/generated/code/start/RealmActor.snippet.observe-collection-on-actor.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.observe-collection-on-actor.swift
@@ -1,0 +1,36 @@
+let actor = try await RealmActor()
+
+// Add a todo to the realm so the collection has something to observe
+try await actor.createTodo(name: "Write a code example for actor observability", owner: "Dachary", status: "In Progress")
+let todoCount = await actor.count
+print("The actor currently has \(todoCount) tasks")
+
+// Get a collection
+let todos = await actor.realm.objects(Todo.self)
+
+// Register a notification token, providing the actor
+let token = await todos.observe(on: actor, { actor, changes in
+    print("A change occurred on actor: \(actor)")
+    switch changes {
+    case .initial:
+        print("The initial value of the changed object was: \(changes)")
+    case .update(_, let deletions, let insertions, let modifications):
+        if !deletions.isEmpty {
+            print("An object was deleted: \(changes)")
+        } else if !insertions.isEmpty {
+            print("An object was inserted: \(changes)")
+        } else if !modifications.isEmpty {
+            print("An object was modified: \(changes)")
+        }
+    case .error(let error):
+        print("An error occurred: \(error.localizedDescription)")
+    }
+})
+
+// Make an update to an object to trigger the notification
+await actor.realm.writeAsync {
+    todos.first!.status = "Completed"
+}
+
+// Invalidate the token when done observing
+token.invalidate()

--- a/source/examples/generated/code/start/RealmActor.snippet.observe-collection-on-actor.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.observe-collection-on-actor.swift
@@ -1,7 +1,7 @@
 let actor = try await RealmActor()
 
 // Add a todo to the realm so the collection has something to observe
-try await actor.createTodo(name: "Write a code example for actor observability", owner: "Dachary", status: "In Progress")
+try await actor.createTodo(name: "Arrive safely in Bree", owner: "Merry", status: "In Progress")
 let todoCount = await actor.count
 print("The actor currently has \(todoCount) tasks")
 

--- a/source/examples/generated/code/start/RealmActor.snippet.observe-object-on-actor.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.observe-object-on-actor.swift
@@ -1,0 +1,34 @@
+let actor = try await RealmActor()
+
+// Add a todo to the realm so we can observe it
+try await actor.createTodo(name: "Write a code example for observing an object on an actor", owner: "Dachary", status: "In Progress")
+let todoCount = await actor.count
+print("The actor currently has \(todoCount) tasks")
+
+// Get an object
+let todo = await actor.realm.objects(Todo.self).where {
+    $0.name == "Write a code example for observing an object on an actor"
+}.first!
+
+// Register a notification token, providing the actor
+let token = await todo.observe(on: actor, { actor, change in
+    print("A change occurred on actor: \(actor)")
+    switch change {
+    case .change(let object, let properties):
+        for property in properties {
+            print("Property '\(property.name)' of object \(object) changed to '\(property.newValue!)'")
+        }
+    case .error(let error):
+        print("An error occurred: \(error)")
+    case .deleted:
+        print("The object was deleted.")
+    }
+})
+
+// Make an update to an object to trigger the notification
+await actor.realm.writeAsync {
+    todo.status = "Completed"
+}
+
+// Invalidate the token when done observing
+token.invalidate()

--- a/source/examples/generated/code/start/RealmActor.snippet.observe-object-on-actor.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.observe-object-on-actor.swift
@@ -1,13 +1,13 @@
 let actor = try await RealmActor()
 
 // Add a todo to the realm so we can observe it
-try await actor.createTodo(name: "Write a code example for observing an object on an actor", owner: "Dachary", status: "In Progress")
+try await actor.createTodo(name: "Scour the Shire", owner: "Merry", status: "In Progress")
 let todoCount = await actor.count
 print("The actor currently has \(todoCount) tasks")
 
 // Get an object
 let todo = await actor.realm.objects(Todo.self).where {
-    $0.name == "Write a code example for observing an object on an actor"
+    $0.name == "Scour the Shire"
 }.first!
 
 // Register a notification token, providing the actor

--- a/source/examples/generated/code/start/RealmActor.snippet.read-objects.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.read-objects.swift
@@ -3,5 +3,5 @@ let actor = try await RealmActor()
 try await createObject(in: actor)
 
 let todo = await actor.realm.objects(Todo.self).where {
-    $0.name == "Write an example of updating an object on a RealmActor"
+    $0.name == "Keep it safe"
 }.first!

--- a/source/examples/generated/code/start/RealmActor.snippet.read-objects.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.read-objects.swift
@@ -1,0 +1,7 @@
+let actor = try await RealmActor()
+
+try await createObject(in: actor)
+
+let todo = await actor.realm.objects(Todo.self).where {
+    $0.name == "Write an example of updating an object on a RealmActor"
+}.first!

--- a/source/examples/generated/code/start/RealmActor.snippet.update-async.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.update-async.swift
@@ -1,0 +1,10 @@
+func updateTodo(_id: ObjectId, name: String, owner: String, status: String) async throws {
+    try await realm.asyncWrite {
+        realm.create(Todo.self, value: [
+            "_id": _id,
+            "name": name,
+            "owner": owner,
+            "status": status
+        ], update: .modified)
+    }
+}

--- a/source/examples/generated/code/start/RealmActor.snippet.update-object.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.update-object.swift
@@ -6,5 +6,4 @@ let todo = await actor.realm.objects(Todo.self).where {
     $0.name == "Keep it safe"
 }.first!
 
-
 try await actor.updateTodo(_id: todo._id, name: todo.name, owner: todo.owner, status: "Completed")

--- a/source/examples/generated/code/start/RealmActor.snippet.update-object.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.update-object.swift
@@ -3,7 +3,7 @@ let actor = try await RealmActor()
 try await createObject(in: actor)
 
 let todo = await actor.realm.objects(Todo.self).where {
-    $0.name == "Write an example of updating an object on a RealmActor"
+    $0.name == "Keep it safe"
 }.first!
 
 

--- a/source/examples/generated/code/start/RealmActor.snippet.update-object.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.update-object.swift
@@ -1,0 +1,10 @@
+let actor = try await RealmActor()
+
+try await createObject(in: actor)
+
+let todo = await actor.realm.objects(Todo.self).where {
+    $0.name == "Write an example of updating an object on a RealmActor"
+}.first!
+
+
+try await actor.updateTodo(_id: todo._id, name: todo.name, owner: todo.owner, status: "Completed")

--- a/source/examples/generated/code/start/RealmActor.snippet.write-async.swift
+++ b/source/examples/generated/code/start/RealmActor.snippet.write-async.swift
@@ -1,0 +1,10 @@
+func createTodo(name: String, owner: String, status: String) async throws {
+    try await realm.asyncWrite {
+        realm.create(Todo.self, value: [
+            "_id": ObjectId.generate(),
+            "name": name,
+            "owner": owner,
+            "status": status
+        ])
+    }
+}

--- a/source/sdk/swift.txt
+++ b/source/sdk/swift.txt
@@ -19,6 +19,7 @@ Realm Swift SDK
    CRUD </sdk/swift/crud>
    React to Changes </sdk/swift/react-to-changes>
    SwiftUI </sdk/swift/swiftui>
+   Actor-Isolated Realms </sdk/swift/actor-isolated-realm>
    Swift Concurrency </sdk/swift/swift-concurrency>
    Test and Debug </sdk/swift/test-and-debug>
    Application Services </sdk/swift/application-services>

--- a/source/sdk/swift/actor-isolated-realm.txt
+++ b/source/sdk/swift/actor-isolated-realm.txt
@@ -21,7 +21,7 @@ With an actor-isolated Realm, you can use Swift's async/await syntax to:
 - Listen for notifications
 
 For general information about Swift actors, refer to :apple:`Apple's Actor 
-documentation <swift/actor>`.
+documentation <documentation/swift/actor>`.
 
 Prerequisites
 ~~~~~~~~~~~~~

--- a/source/sdk/swift/actor-isolated-realm.txt
+++ b/source/sdk/swift/actor-isolated-realm.txt
@@ -159,7 +159,7 @@ a block to be called each time the object or collection changes.
 The SDK asynchronously calls the block on the given actor's executor.
 
 For write transactions performed on different threads or in different
-processes, the SDK calls the block when the managing realm is (auto)refreshed 
+processes, the SDK calls the block when the realm is (auto)refreshed 
 to a version including the changes. For local writes, the SDK calls the block
 at some point in the future after the write transaction is committed.
 

--- a/source/sdk/swift/actor-isolated-realm.txt
+++ b/source/sdk/swift/actor-isolated-realm.txt
@@ -10,7 +10,7 @@ Actor-Isolated Realms - Swift SDK
    :depth: 2
    :class: singlecol
 
-Starting with Realm Swift SDK version [VERSION], Realm supports actor-isolated
+Starting with Realm Swift SDK version 10.39.0, Realm supports actor-isolated
 realm instances. You can safely use an actor-isolated realm with Swift concurrency
 language features instead of managing threads or dispatch queues.
 
@@ -28,7 +28,7 @@ Prerequisites
 
 To use Realm in a Swift actor, your project must:
 
-- Use Realm Swift SDK version [VERSION] or later
+- Use Realm Swift SDK version 10.39.0 or later
 - Use Swift 5.8/Xcode 14.3
 
 In addition, we strongly recommend enabling these settings in your project:
@@ -47,12 +47,12 @@ The examples on this page use the following model:
 
 .. _swift-open-actor-confined-realm:
 
-Open an Actor-Confined Realm
+Open an Actor-Isolated Realm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use the Swift async/await syntax to await opening a realm.
 
-Initializing a realm with ``try await Realm()`` opens a MainActor-confined 
+Initializing a realm with ``try await Realm()`` opens a MainActor-isolated
 realm. Alternately, you can explicitly specify an actor when opening a 
 realm with the ``await`` syntax.
 
@@ -60,7 +60,7 @@ realm with the ``await`` syntax.
    :language: swift
 
 You can specify a default configuration or customize your configuration when 
-opening an actor-confined realm:
+opening an actor-isolated realm:
 
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-confined-realm-with-config.swift
    :language: swift
@@ -68,7 +68,7 @@ opening an actor-confined realm:
 For more general information about configuring a realm, refer to 
 :ref:`ios-configure-and-open-a-realm`.
 
-You can open a synced realm as an actor-confined realm:
+You can open a synced realm as an actor-isolated realm:
 
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-confined-synced-realm.swift
    :language: swift
@@ -117,7 +117,7 @@ with Swift's async/await syntax.
 
 .. _swift-write-to-actor-confined-realm:
 
-Write to an Actor-Confined Realm
+Write to an Actor-Isolated Realm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Actor-isolated realms can use Swift async/await syntax for asynchronous
@@ -127,7 +127,7 @@ the block. Realm writes the data to disk on a background thread and resumes
 the task when that completes. 
 
 This function from the example ``RealmActor`` defined above shows how you might
-write to an actor-confined realm:
+write to an actor-isolated realm:
 
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.write-async.swift
    :language: swift
@@ -147,10 +147,10 @@ Asynchronous writes are only supported for actor-isolated Realms or in
 
 .. _swift-observe-notifications-on-actor-confined-realm:
 
-Observe Notifications on an Actor-Confined Realm
+Observe Notifications on an Actor-Isolated Realm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can observe notifications on an actor-confined realm using Swift's 
+You can observe notifications on an actor-isolated realm using Swift's 
 async/await syntax.
 
 Calling ``await object.observe()`` or ``await collection.observe`` registers 

--- a/source/sdk/swift/actor-isolated-realm.txt
+++ b/source/sdk/swift/actor-isolated-realm.txt
@@ -59,6 +59,23 @@ realm with the ``await`` syntax.
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.await-main-actor-realm.swift
    :language: swift
 
+You can specify a default configuration or customize your configuration when 
+opening an actor-confined realm:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-confined-realm-with-config.swift
+   :language: swift
+
+For more general information about configuring a realm, refer to 
+:ref:`ios-configure-and-open-a-realm`.
+
+You can open a synced realm as an actor-confined realm:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-confined-synced-realm.swift
+   :language: swift
+
+For more general information about opening a synced realm, refer to 
+:ref:`ios-configure-and-open-a-synced-realm`.
+
 .. _swift-define-realm-actor:
 
 Define a Custom Realm Actor

--- a/source/sdk/swift/actor-isolated-realm.txt
+++ b/source/sdk/swift/actor-isolated-realm.txt
@@ -1,0 +1,216 @@
+.. _swift-actor-isolated-realm:
+
+=================================
+Actor-Isolated Realms - Swift SDK
+=================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Starting with Realm Swift SDK version [VERSION], Realm supports actor-isolated
+realm instances. You can safely use an actor-isolated realm with Swift concurrency
+language features as an alternative to managing threading or dispatch queues.
+
+With an actor-isolated Realm, you can use Swift's async/await syntax to:
+
+- Open a realm
+- Write to a realm
+- Listen for notifications
+
+For general information about Swift actors, refer to :apple:`Apple's Actor 
+documentation <swift/actor>`.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+To use Realm in a Swift actor, your project must:
+
+- Use Realm Swift SDK version [VERSION] or later
+- Use Swift 5.8/Xcode 14.3
+
+In addition, we strongly recommend enabling these settings in your project:
+
+- ``SWIFT_STRICT_CONCURRENCY=complete``: enables strict concurrency checking
+- ``OTHER_SWIFT_FLAGS=-Xfrontend-enable-actor-data-race-checks``: enables 
+  runtime actor data-race detection
+
+About the Examples On This Page
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The examples on this page use the following model:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.model.swift
+   :language: swift
+
+.. _swift-open-actor-confined-realm:
+
+Open an Actor-Confined Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use the Swift async/await syntax to await opening a realm.
+
+Initializing a realm with ``try await Realm()`` opens a MainActor-confined 
+realm. Alternately, you can explicitly specify an actor when opening a 
+realm with the ``await`` syntax.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.await-main-actor-realm.swift
+   :language: swift
+
+.. _swift-define-realm-actor:
+
+Define a Custom Realm Actor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can define a specific actor to manage Realm in asynchronous contexts.
+You can use this actor to manage realm access, perform write operations,
+and get notifications for changes.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.define-realm-actor.swift
+   :language: swift
+
+An actor-isolated realm may be used with either local or global actors.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.global-actor-example.swift
+   :language: swift
+
+.. _swift-actor-synchronous-isolated-function:
+
+Use a Realm Actor Synchronously in an Isolated Function
+````````````````````````````````````````````````````````
+
+When a function is confined to a specific actor, you can use the actor-isolated
+realm synchronously.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-synchronous.swift
+   :language: swift
+
+.. _swift-actor-async-nonisolated-function:
+
+Use a Realm Actor in Async Functions
+````````````````````````````````````
+
+When a function isn't confined to a specific actor, you can use your Realm actor
+with Swift's async/await syntax.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-async.swift
+   :language: swift
+
+.. _swift-write-to-actor-confined-realm:
+
+Write to an Actor-Confined Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Actor-isolated realms can use Swift async/await syntax for asynchronous
+writes. Using ``try await realm.writeAsync { ... }`` suspends the current task,
+acquires the write lock without blocking the current thread, and then invokes
+the block. Realm writes the data to disk on a background thread, and resumes 
+the task when that completes. 
+
+This function from the example ``RealmActor`` defined above shows how you might
+write to an actor-confined realm:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.write-async.swift
+   :language: swift
+
+And you might perform this write using Swift's async syntax:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-async.swift
+   :language: swift
+
+This does not block the calling thread while waiting to write. It does 
+not perform I/O on the calling thread. For small writes, this is safe to 
+use from ``@MainActor`` functions without blocking the UI. Sufficiently large 
+writes may still benefit from being done on a background thread. 
+
+Asynchronous writes are only supported for actor-isolated Realms or in
+``@MainActor`` functions.
+
+.. _swift-observe-notifications-on-actor-confined-realm:
+
+Observe Notifications on an Actor-Confined Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can observe notifications on an actor-confined realm using Swift's 
+async/await syntax.
+
+Calling ``await object.observe()`` or ``await collection.observe`` registers 
+a block to be called each time the object or collection changes.
+
+The SDK asynchronously calls the block on the given actor's executor.
+
+For write transactions performed on different threads or in different
+processes, the SDK calls the block when the managing realm is (auto)refreshed 
+to a version including the changes. For local write, the SDK calls the block
+at some point in the future after the write transaction is committed.
+
+Like :ref:`non-actor-confined notifications <ios-react-to-changes>`, you can 
+only observe objects or collections managed by a realm. You must retain the 
+returned token for as long as you want to watch for updates. 
+
+If you need to manually advance the state of an observed realm on the main 
+thread or an actor-isolated realm, call ``await realm.asyncRefresh()``. 
+This updates the realm and outstanding objects managed by the Realm to point to
+the most recent data and deliver any applicable notifications.
+
+.. warning:: 
+
+   You cannot call the ``observe`` method cannot during a write transaction, 
+   or when the containing realm is read-only.
+
+.. _swift-actor-collection-change-listener:
+
+Register a Collection Change Listener
+`````````````````````````````````````
+
+The SDK calls a collection notification block after each write transaction which:
+
+- Deletes an object from the collection.
+- Inserts an object into the collection.
+- Modifies any of the managed properties of an object in the collection. This 
+  includes self-assignments that set a property to its existing value. 
+
+.. important:: Order Matters
+   
+   In collection notification handlers, always apply changes
+   in the following order: deletions, insertions, then
+   modifications. Handling insertions before deletions may
+   result in unexpected behavior.
+
+These notifications provide information about the actor on which the change 
+occurred. Like non-actor-isolated :ref:`collection notifications 
+<ios-register-a-collection-change-listener>`, they also provide 
+a ``change`` parameter that reports which objects are deleted, added, or 
+modified during the write transaction. This
+:swift-sdk:`RealmCollectionChange <Enums/RealmCollectionChange.html>` 
+resolves to an array of index paths that you can pass to a ``UITableView``'s 
+batch update methods.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.observe-collection-on-actor.swift
+   :language: swift
+
+.. _swift-actor-object-change-listener:
+
+Register an Object Change Listener
+``````````````````````````````````
+
+The SDK calls an object notification block after each write transaction which:
+
+- Deletes the object.
+- Modifies any of the managed properties of the object. This includes 
+  self-assignments that set a property to its existing value. 
+
+The block is passed a copy of the object isolated to the requested actor,
+along with information about what changed. This object can be safely used
+on that actor.
+
+By default, only direct changes to the object's properties produce notifications.
+Changes to linked objects do not produce notifications. If a non-nil, non-empty 
+keypath array is passed in, only changes to the properties identified by those 
+keypaths produce change notifications. The keypaths may traverse link 
+properties to receive information about changes to linked objects.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.observe-object-on-actor.swift
+   :language: swift

--- a/source/sdk/swift/actor-isolated-realm.txt
+++ b/source/sdk/swift/actor-isolated-realm.txt
@@ -12,9 +12,9 @@ Actor-Isolated Realms - Swift SDK
 
 Starting with Realm Swift SDK version [VERSION], Realm supports actor-isolated
 realm instances. You can safely use an actor-isolated realm with Swift concurrency
-language features as an alternative to managing threading or dispatch queues.
+language features instead of managing threads or dispatch queues.
 
-With an actor-isolated Realm, you can use Swift's async/await syntax to:
+With an actor-isolated realm, you can use Swift's async/await syntax to:
 
 - Open a realm
 - Write to a realm
@@ -37,7 +37,7 @@ In addition, we strongly recommend enabling these settings in your project:
 - ``OTHER_SWIFT_FLAGS=-Xfrontend-enable-actor-data-race-checks``: enables 
   runtime actor data-race detection
 
-About the Examples On This Page
+About the Examples on This Page
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The examples on this page use the following model:
@@ -123,7 +123,7 @@ Write to an Actor-Confined Realm
 Actor-isolated realms can use Swift async/await syntax for asynchronous
 writes. Using ``try await realm.writeAsync { ... }`` suspends the current task,
 acquires the write lock without blocking the current thread, and then invokes
-the block. Realm writes the data to disk on a background thread, and resumes 
+the block. Realm writes the data to disk on a background thread and resumes 
 the task when that completes. 
 
 This function from the example ``RealmActor`` defined above shows how you might
@@ -160,7 +160,7 @@ The SDK asynchronously calls the block on the given actor's executor.
 
 For write transactions performed on different threads or in different
 processes, the SDK calls the block when the managing realm is (auto)refreshed 
-to a version including the changes. For local write, the SDK calls the block
+to a version including the changes. For local writes, the SDK calls the block
 at some point in the future after the write transaction is committed.
 
 Like :ref:`non-actor-confined notifications <ios-react-to-changes>`, you can 
@@ -174,7 +174,7 @@ the most recent data and deliver any applicable notifications.
 
 .. warning:: 
 
-   You cannot call the ``observe`` method cannot during a write transaction, 
+   You cannot call the ``observe`` method during a write transaction
    or when the containing realm is read-only.
 
 .. _swift-actor-collection-change-listener:

--- a/source/sdk/swift/app-services/connect-to-app-services-backend.txt
+++ b/source/sdk/swift/app-services/connect-to-app-services-backend.txt
@@ -24,7 +24,7 @@ provides access to the :ref:`authentication functionality
 Access the App Client
 ---------------------
 
-Pass the App ID for your App, which you can :ref:`find in the Realm UI
+Pass the App ID for your App, which you can :ref:`find in the App Services UI
 <find-your-app-id>`.
 
 .. literalinclude:: /examples/generated/code/start/RealmApp.snippet.init-realm-app-client.swift
@@ -35,7 +35,7 @@ Pass the App ID for your App, which you can :ref:`find in the Realm UI
 Configuration
 -------------
 
-You can pass a configuration object to ``RealmApp``:
+You can pass a configuration object to ``App``:
 
 .. literalinclude:: /examples/generated/code/start/RealmApp.snippet.realm-app-config.swift
    :language: swift

--- a/source/sdk/swift/crud/create.txt
+++ b/source/sdk/swift/crud/create.txt
@@ -242,11 +242,11 @@ Create an Object Asynchronously
 -------------------------------
 
 You can use Swift concurrency features to write asynchronously to an 
-actor-confined realm. 
+actor-isolated realm. 
 
 This function from the example ``RealmActor`` :ref:`defined on the 
 Actor-Isolated Realms page <swift-define-realm-actor>` shows how you might
-write to an actor-confined realm:
+write to an actor-isolated realm:
 
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.write-async.swift
    :language: swift

--- a/source/sdk/swift/crud/create.txt
+++ b/source/sdk/swift/crud/create.txt
@@ -236,6 +236,30 @@ you must check the type before you do anything with the value.
 .. literalinclude:: /examples/generated/code/start/CreateRealmObjects.snippet.mixed-data-type.swift
    :language: swift
 
+.. _swift-create-object-async:
+
+Create an Object Asynchronously
+-------------------------------
+
+You can use Swift concurrency features to write asynchronously to an 
+actor-confined realm. 
+
+This function from the example ``RealmActor`` :ref:`defined on the 
+Actor-Isolated Realms page <swift-define-realm-actor>` shows how you might
+write to an actor-confined realm:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.write-async.swift
+   :language: swift
+
+And you might perform this write using Swift's async syntax:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-isolated-realm-async.swift
+   :language: swift
+
+This operation does not block or perform I/O on the calling thread. For
+more information about writing to realm using Swift concurrency features, 
+refer to :ref:`swift-actor-isolated-realm`.
+
 .. _swift-create-asymmetric-object:
 
 Create an Asymmetric Object

--- a/source/sdk/swift/crud/delete.txt
+++ b/source/sdk/swift/crud/delete.txt
@@ -245,3 +245,27 @@ To delete the value of an AnyRealmValue, set it to ``.none``.
 
 .. literalinclude:: /examples/generated/code/start/DeleteRealmObjects.snippet.mixed-data-type.swift
    :language: swift
+
+.. _swift-delete-object-async:
+
+Delete an Object Asynchronously
+-------------------------------
+
+You can use Swift concurrency features to asynchronously delete objects 
+using an actor-confined realm. 
+
+This function from the example ``RealmActor`` :ref:`defined on the 
+Actor-Isolated Realms page <swift-define-realm-actor>` shows how you might
+delete an object in an actor-confined realm:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.delete-async.swift
+   :language: swift
+
+And you might perform this deletion using Swift's async syntax:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.delete-object.swift
+   :language: swift
+
+This operation does not block or perform I/O on the calling thread. For
+more information about writing to realm using Swift concurrency features, 
+refer to :ref:`swift-actor-isolated-realm`.

--- a/source/sdk/swift/crud/delete.txt
+++ b/source/sdk/swift/crud/delete.txt
@@ -15,8 +15,7 @@ Delete Realm Objects
 --------------------
 
 Deleting Realm Objects must occur within write transactions. For
-more information about write trasactions, see: :ref:`Key Concept: 
-Transactions <ios-write-transactions>`.
+more information about write trasactions, see: :ref:`Transactions <ios-write-transactions>`.
 
 If you want to delete the Realm file itself, see: :ref:`Delete a Realm 
 <swift-delete-a-realm>`.
@@ -252,11 +251,11 @@ Delete an Object Asynchronously
 -------------------------------
 
 You can use Swift concurrency features to asynchronously delete objects 
-using an actor-confined realm. 
+using an actor-isolated realm. 
 
 This function from the example ``RealmActor`` :ref:`defined on the 
 Actor-Isolated Realms page <swift-define-realm-actor>` shows how you might
-delete an object in an actor-confined realm:
+delete an object in an actor-isolated realm:
 
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.delete-async.swift
    :language: swift

--- a/source/sdk/swift/crud/read.txt
+++ b/source/sdk/swift/crud/read.txt
@@ -471,6 +471,25 @@ types during migration, and Realm converts the projected type to the persisted
 type. However, reading data during a migration gives the underlying persisted
 type.
 
+.. _swift-read-object-async:
+
+Read an Object Asynchronously
+-----------------------------
+
+When you use an actor-confined realm, you can use Swift concurrency features
+to asynchronously query objects.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.read-objects.swift
+   :language: swift
+
+If you need to manually advance the state of an observed realm on the main 
+thread or an actor-isolated realm, call ``await realm.asyncRefresh()``. 
+This updates the realm and outstanding objects managed by the Realm to point to
+the most recent data and deliver any applicable notifications.
+
+For more information about working with realm using Swift concurrency features, 
+refer to :ref:`swift-actor-isolated-realm`.
+
 .. _ios-sort-query-results:
 
 Sort Query Results

--- a/source/sdk/swift/crud/read.txt
+++ b/source/sdk/swift/crud/read.txt
@@ -476,7 +476,7 @@ type.
 Read an Object Asynchronously
 -----------------------------
 
-When you use an actor-confined realm, you can use Swift concurrency features
+When you use an actor-isolated realm, you can use Swift concurrency features
 to asynchronously query objects.
 
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.read-objects.swift

--- a/source/sdk/swift/crud/threading.txt
+++ b/source/sdk/swift/crud/threading.txt
@@ -42,7 +42,7 @@ Bypass Threading Concerns with Actor-Confined Realms
 
 This page describes how to manage realm files and objects across threads.
 You can bypass threading concerns by managing realm through a 
-:apple:`Swift actor <swift/actor>`. For an overview of how to manage realm 
+:apple:`Swift actor <documentation/swift/actor>`. For an overview of how to manage realm 
 access with actors, refer to :ref:`swift-actor-isolated-realm`.
 
 .. _ios-threading-three-rules:

--- a/source/sdk/swift/crud/threading.txt
+++ b/source/sdk/swift/crud/threading.txt
@@ -37,6 +37,14 @@ simplify this for you.
    <ios-thread-safe-reference>` or :ref:`frozen objects <ios-frozen-objects>` 
    across threads.
 
+Bypass Threading Concerns with Actor-Confined Realms
+----------------------------------------------------
+
+This page describes how to manage realm files and objects across threads.
+You can bypass threading concerns by managing realm through a 
+:apple:`Swift actor <swift/actor>`. For an overview of how to manage realm 
+access with actors, refer to :ref:`swift-actor-isolated-realm`.
+
 .. _ios-threading-three-rules:
 
 Three Rules to Follow

--- a/source/sdk/swift/crud/threading.txt
+++ b/source/sdk/swift/crud/threading.txt
@@ -37,7 +37,7 @@ simplify this for you.
    <ios-thread-safe-reference>` or :ref:`frozen objects <ios-frozen-objects>` 
    across threads.
 
-Actor-Confined Realms
+Actor-Isolated Realms
 ---------------------
 
 This page describes how to manually manage realm files and objects across threads.

--- a/source/sdk/swift/crud/threading.txt
+++ b/source/sdk/swift/crud/threading.txt
@@ -37,13 +37,13 @@ simplify this for you.
    <ios-thread-safe-reference>` or :ref:`frozen objects <ios-frozen-objects>` 
    across threads.
 
-Bypass Threading Concerns with Actor-Confined Realms
-----------------------------------------------------
+Actor-Confined Realms
+---------------------
 
-This page describes how to manage realm files and objects across threads.
-You can bypass threading concerns by managing realm through a 
-:apple:`Swift actor <documentation/swift/actor>`. For an overview of how to manage realm 
-access with actors, refer to :ref:`swift-actor-isolated-realm`.
+This page describes how to manually manage realm files and objects across threads.
+Realm also supports using a :apple:`Swift actor <documentation/swift/actor>`
+to manage realm access using Swift concurrency features. For an overview 
+of Realm's actor support, refer to :ref:`swift-actor-isolated-realm`.
 
 .. _ios-threading-three-rules:
 

--- a/source/sdk/swift/crud/update.txt
+++ b/source/sdk/swift/crud/update.txt
@@ -232,11 +232,11 @@ Update an Object Asynchronously
 -------------------------------
 
 You can use Swift concurrency features to asynchronously update objects 
-using an actor-confined realm. 
+using an actor-isolated realm. 
 
 This function from the example ``RealmActor`` :ref:`defined on the 
 Actor-Isolated Realms page <swift-define-realm-actor>` shows how you might
-update an object in an actor-confined realm:
+update an object in an actor-isolated realm:
 
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.update-async.swift
    :language: swift

--- a/source/sdk/swift/crud/update.txt
+++ b/source/sdk/swift/crud/update.txt
@@ -226,6 +226,30 @@ of a party to a new instance in a write transaction.
       .. literalinclude:: /examples/EmbeddedObjects/ReplaceEmbeddedObject.m
          :language: objectivec
 
+.. _swift-update-object-async:
+
+Update an Object Asynchronously
+-------------------------------
+
+You can use Swift concurrency features to asynchronously update objects 
+using an actor-confined realm. 
+
+This function from the example ``RealmActor`` :ref:`defined on the 
+Actor-Isolated Realms page <swift-define-realm-actor>` shows how you might
+update an object in an actor-confined realm:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.update-async.swift
+   :language: swift
+
+And you might perform this update using Swift's async syntax:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.update-object.swift
+   :language: swift
+
+This operation does not block or perform I/O on the calling thread. For
+more information about writing to realm using Swift concurrency features, 
+refer to :ref:`swift-actor-isolated-realm`.
+
 Update Properties through Class Projections
 -------------------------------------------
 

--- a/source/sdk/swift/react-to-changes.txt
+++ b/source/sdk/swift/react-to-changes.txt
@@ -325,10 +325,10 @@ does support this for code compatibility.
 
 .. _swift-react-to-changes-actor-confined-realm:
 
-React to Changes in an Actor-Confined Realm
+React to Changes in an Actor-Isolated Realm
 -------------------------------------------
 
-You can observe notifications on an actor-confined realm using Swift's 
+You can observe notifications on an actor-isolated realm using Swift's 
 async/await syntax. Calling ``await object.observe()`` or 
 ``await collection.observe`` registers a block to be called each time the 
 object or collection changes.
@@ -336,8 +336,8 @@ object or collection changes.
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.observe-collection-on-actor.swift
    :language: swift
 
-For more information about change notifications on actor-confined realms, refer to
-:ref:`swift-observe-notifications-on-actor-confined-realm`.
+For more information about change notifications on actor-isolated realms, 
+refer to :ref:`swift-observe-notifications-on-actor-confined-realm`.
 
 .. _ios-react-to-changes-to-a-class-projection:
 

--- a/source/sdk/swift/react-to-changes.txt
+++ b/source/sdk/swift/react-to-changes.txt
@@ -323,6 +323,22 @@ does support this for code compatibility.
    Objective-C<realm/realm-swift/tree/master/examples/ios/objc/RACTableView>`
    , and :github:`ReactKit from Swift<realm/realm-swift/tree/v2.3.0/examples/ios/swift-2.2/ReactKit>`.
 
+.. _swift-react-to-changes-actor-confined-realm:
+
+React to Changes in an Actor-Confined Realm
+-------------------------------------------
+
+You can observe notifications on an actor-confined realm using Swift's 
+async/await syntax. Calling ``await object.observe()`` or 
+``await collection.observe`` registers a block to be called each time the 
+object or collection changes.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.observe-collection-on-actor.swift
+   :language: swift
+
+For more information about change notifications on actor-confined realms, refer to
+:ref:`swift-observe-notifications-on-actor-confined-realm`.
+
 .. _ios-react-to-changes-to-a-class-projection:
 
 React to Changes to a Class Projection

--- a/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
@@ -130,6 +130,30 @@ closed.
    realm. To avoid this, hold onto a strong reference to any
    in-memory realms during your app's lifetime.
 
+.. _ios-open-actor-swift-concurrency:
+
+Open a Realm with Swift Concurrency Features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use Swift's async/await syntax to open a MainActor-confined realm,
+or specify an actor when opening a realm asynchronously:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.await-main-actor-realm.swift
+   :language: swift
+
+Or you can define a custom realm actor to manage all of your realm operations:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.define-realm-actor.swift
+   :language: swift
+
+An actor-isolated realm may be used with either local or global actors.
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.global-actor-example.swift
+   :language: swift
+
+For more information about working with actor-confined realms, refer to 
+:ref:`swift-actor-isolated-realm`.
+
 .. _ios-close-a-realm:
 
 Close a Realm

--- a/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
@@ -135,7 +135,7 @@ closed.
 Open a Realm with Swift Concurrency Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can use Swift's async/await syntax to open a MainActor-confined realm,
+You can use Swift's async/await syntax to open a MainActor-isolated realm,
 or specify an actor when opening a realm asynchronously:
 
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.await-main-actor-realm.swift
@@ -151,7 +151,7 @@ An actor-isolated realm may be used with either local or global actors.
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.global-actor-example.swift
    :language: swift
 
-For more information about working with actor-confined realms, refer to 
+For more information about working with actor-isolated realms, refer to 
 :ref:`swift-actor-isolated-realm`.
 
 .. _ios-close-a-realm:

--- a/source/sdk/swift/swift-concurrency.txt
+++ b/source/sdk/swift/swift-concurrency.txt
@@ -15,6 +15,19 @@ and parallel code in a structured way. For a detailed overview of the
 Swift concurrency system, refer to the `Swift Programming Language Concurrency
 topic <https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html>`__.
 
+While the considerations on this page broadly apply to using realm with 
+Swift concurrency features, Realm Swift SDK version [VERSION] adds support
+for actor-confined realms. Actor-confined realms support Swift concurrency 
+features including:
+
+- Opening an actor-confined realm
+- Reading and writing from an actor-confined realm
+- Getting notifications on actor-confined objects and collections
+
+This provides support for using realm in a MainActor and background actor
+context, and supersedes much of the advice on this page regarding concurrency
+considerations. For more information, refer to :ref:`swift-actor-isolated-realm`.
+
 Realm Concurrency Caveats
 -------------------------
 
@@ -132,6 +145,14 @@ networking activities like managing users.
 Actor Isolation
 ---------------
 
+.. seealso:: Actor-Isolated Realms
+
+   The information in this section is applicable to Realm SDK versions earlier
+   than [VERSION]. Starting in Realm Swift SDK version [VERSION] and newer, 
+   the SDK supports actor-confined realms and related async functionality.
+
+   For more information, refer to :ref:`swift-actor-isolated-realm`. 
+
 Actor isolation provides the perception of confining Realm access to a 
 dedicated actor, and therefore seems like a safe way to manage Realm 
 access in an asynchronous context.
@@ -167,20 +188,26 @@ thread-isolation issues described on this page.
 
 To avoid threading-related issues in code that uses Swift concurrency features:
 
+- Upgrade to a version of the Realm Swift SDK that supports actor-confined realms,
+  and use this to bypass threading-related issues. For more information, refer to
+  :ref:`swift-actor-isolated-realm`.
 - Do not change execution contexts when accessing a realm. If you open a realm 
   on the main thread to provide data for your UI, annotate subsequent functions
   where you access the realm asynchronously with ``@MainActor`` to ensure it
   always runs on the main thread. Remember that ``await`` marks a suspension 
   point that could change to a different thread.
-- Use the ``writeAsync`` API to :ref:`perform a background write 
-  <ios-async-write>`. This manages realm access in a thread-safe way without 
-  requiring you to write specialized code to do it yourself. This is a special
-  API that outsources aspects of the write process - where it is safe to do 
-  so - to run in an async context. You do not use this method with Swift's 
-  ``async/await`` syntax - use this method synchronously in your code.
-- If you want to explicitly write concurrency code where accessing a realm 
-  is done in a thread-safe way, you can explicitly :ref:`pass instances across 
-  threads <ios-thread-safe-reference>` or use :ref:`frozen objects 
-  <ios-frozen-objects>` where applicable to avoid threading-related crashes.
-  This does require a good understanding of Realm's threading model, as well
-  as being mindful of Swift concurrency threading behaviors.
+- Apps that do not use actor-confined realms can use the ``writeAsync`` API to 
+  :ref:`perform a background write <ios-async-write>`. This manages realm 
+  access in a thread-safe way without requiring you to write specialized code 
+  to do it yourself. This is a special API that outsources aspects of the 
+  write process - where it is safe to do so - to run in an async context. 
+  Unless you are writing to an actor-confined realm, you do not use this 
+  method with Swift's ``async/await`` syntax. Use this method synchronously 
+  in your code.
+- If you want to explicitly write concurrency code that is not actor-isolated 
+  where accessing a realm is done in a thread-safe way, you can explicitly 
+  :ref:`pass instances across threads <ios-thread-safe-reference>` or use 
+  :ref:`frozen objects <ios-frozen-objects>` where applicable to avoid 
+  threading-related crashes. This does require a good understanding of 
+  Realm's threading model, as well as being mindful of Swift concurrency 
+  threading behaviors.

--- a/source/sdk/swift/swift-concurrency.txt
+++ b/source/sdk/swift/swift-concurrency.txt
@@ -173,12 +173,6 @@ If you have code which uses ``await Realm()`` and works in 5.6, marking
 the function as ``@MainActor`` will make it work with Swift 5.7. It will 
 function how it did - unintentionally - in 5.6.
 
-The Swift SDK team is working on improving support for actor isolation.
-If you have specific feature requests related to actor isolation,
-check the status of similar feature requests or leave feedback through the 
-`MongoDB Feedback Engine for Realm 
-<https://feedback.mongodb.com/forums/923521-realm>`_.
-
 Errors Related to Concurrency Code
 ----------------------------------
 
@@ -189,8 +183,8 @@ thread-isolation issues described on this page.
 To avoid threading-related issues in code that uses Swift concurrency features:
 
 - Upgrade to a version of the Realm Swift SDK that supports actor-confined realms,
-  and use this to bypass threading-related issues. For more information, refer to
-  :ref:`swift-actor-isolated-realm`.
+  and use this as an alternative to manually managing threading. For more 
+  information, refer to :ref:`swift-actor-isolated-realm`.
 - Do not change execution contexts when accessing a realm. If you open a realm 
   on the main thread to provide data for your UI, annotate subsequent functions
   where you access the realm asynchronously with ``@MainActor`` to ensure it

--- a/source/sdk/swift/swift-concurrency.txt
+++ b/source/sdk/swift/swift-concurrency.txt
@@ -16,13 +16,13 @@ Swift concurrency system, refer to the `Swift Programming Language Concurrency
 topic <https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html>`__.
 
 While the considerations on this page broadly apply to using realm with 
-Swift concurrency features, Realm Swift SDK version [VERSION] adds support
-for actor-confined realms. Actor-confined realms support Swift concurrency 
+Swift concurrency features, Realm Swift SDK version 10.39.0 adds support
+for actor-isolated realms. Actor-isolated realms support Swift concurrency 
 features including:
 
-- Opening an actor-confined realm
-- Reading and writing from an actor-confined realm
-- Getting notifications on actor-confined objects and collections
+- Opening an actor-isolated realm
+- Reading and writing from an actor-isolated realm
+- Getting notifications on actor-isolated objects and collections
 
 This provides support for using realm in a MainActor and background actor
 context, and supersedes much of the advice on this page regarding concurrency
@@ -148,8 +148,8 @@ Actor Isolation
 .. seealso:: Actor-Isolated Realms
 
    The information in this section is applicable to Realm SDK versions earlier
-   than [VERSION]. Starting in Realm Swift SDK version [VERSION] and newer, 
-   the SDK supports actor-confined realms and related async functionality.
+   than 10.39.0. Starting in Realm Swift SDK version 10.39.0 and newer, 
+   the SDK supports actor-isolated realms and related async functionality.
 
    For more information, refer to :ref:`swift-actor-isolated-realm`. 
 
@@ -182,7 +182,7 @@ thread-isolation issues described on this page.
 
 To avoid threading-related issues in code that uses Swift concurrency features:
 
-- Upgrade to a version of the Realm Swift SDK that supports actor-confined realms,
+- Upgrade to a version of the Realm Swift SDK that supports actor-isolated realms,
   and use this as an alternative to manually managing threading. For more 
   information, refer to :ref:`swift-actor-isolated-realm`.
 - Do not change execution contexts when accessing a realm. If you open a realm 
@@ -190,12 +190,12 @@ To avoid threading-related issues in code that uses Swift concurrency features:
   where you access the realm asynchronously with ``@MainActor`` to ensure it
   always runs on the main thread. Remember that ``await`` marks a suspension 
   point that could change to a different thread.
-- Apps that do not use actor-confined realms can use the ``writeAsync`` API to 
+- Apps that do not use actor-isolated realms can use the ``writeAsync`` API to 
   :ref:`perform a background write <ios-async-write>`. This manages realm 
   access in a thread-safe way without requiring you to write specialized code 
   to do it yourself. This is a special API that outsources aspects of the 
   write process - where it is safe to do so - to run in an async context. 
-  Unless you are writing to an actor-confined realm, you do not use this 
+  Unless you are writing to an actor-isolated realm, you do not use this 
   method with Swift's ``async/await`` syntax. Use this method synchronously 
   in your code.
 - If you want to explicitly write concurrency code that is not actor-isolated 

--- a/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
@@ -275,13 +275,13 @@ the App Services backend.
 Open a Synced Realm with Swift Concurrency Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can open a synced realm as an actor-confined realm using Swift concurrency 
+You can open a synced realm as an actor-isolated realm using Swift concurrency 
 features:
 
 .. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-confined-synced-realm.swift
    :language: swift
 
-For more information about working with actor-confined realms, refer to 
+For more information about working with actor-isolated realms, refer to 
 :ref:`swift-actor-isolated-realm`.
 
 .. _ios-specify-download-behavior:

--- a/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
@@ -270,6 +270,20 @@ the App Services backend.
 .. literalinclude:: /examples/generated/code/start/ConvertSyncLocalRealms.snippet.convert-sync-to-local.swift
    :language: swift
 
+.. _ios-open-sync-realm-actor-swift-concurrency:
+
+Open a Synced Realm with Swift Concurrency Features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can open a synced realm as an actor-confined realm using Swift concurrency 
+features:
+
+.. literalinclude:: /examples/generated/code/start/RealmActor.snippet.actor-confined-synced-realm.swift
+   :language: swift
+
+For more information about working with actor-confined realms, refer to 
+:ref:`swift-actor-isolated-realm`.
+
 .. _ios-specify-download-behavior:
 
 Download Changes Before Open


### PR DESCRIPTION
## Pull Request Info

DO NOT MERGE until realm-swift PR #8197 is merged and released. At that point:

- [x] Add links to relevant autogenerated API reference docs for new async/actor APIs
- [x] Update `[VERSION]` references throughout docs with the appropriate release version
- [x] Check if GitHub has a macOS image that includes Xcode 14.3/Swift 5.8 so the tests can run in CI, and update it if so

### Jira

- https://jira.mongodb.org/browse/DOCSP-27109

### Staged Changes

- [Actor-Isolated Realms](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/actor-isolated-realm/): New page with details about all of the actor-related functionality
- [Configure & Open a Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/realm-files/configure-and-open-a-realm/#open-a-realm-with-swift-concurrency-features): New section "Open a Realm with Swift Concurrency Features"
- [CRUD/Create](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/crud/create/#create-an-object-asynchronously): New "Create an Object Asynchronously" section
- [CRUD/Read](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/crud/read/#read-an-object-asynchronously): New "Read an Object Asynchronously" section
- [CRUD/Update](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/crud/update/#update-an-object-asynchronously): New "Update an Object Asynchronously" section
- [CRUD/Delete](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/crud/delete/#delete-an-object-asynchronously): New "Delete an Object Asynchronously" section
- [Threading](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/crud/threading/#bypass-threading-concerns-with-actor-confined-realms): New "Bypass Threading Concerns with Actor-Confined Realms" section
- [React to Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/react-to-changes/#react-to-changes-in-an-actor-confined-realm): New "React to Changes in an Actor-Confined Realm" section
- [Swift Concurrency](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/swift-concurrency/): Updates throughout page, but this page may need additional updates - thoughts/suggestions are welcome
- [Configure & Open a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27109/sdk/swift/sync/configure-and-open-a-synced-realm/#open-a-synced-realm-with-swift-concurrency-features): New section "Open a Synced Realm with Swift Concurrency Features"

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
