### PR TITLE
(DOCSP-29572): Kotlin: Authentication change listener as a flow

### DIFF
--- a/source/examples/generated/kotlin/AuthenticationTest.snippet.auth-change-listener.kt
+++ b/source/examples/generated/kotlin/AuthenticationTest.snippet.auth-change-listener.kt
@@ -1,0 +1,27 @@
+val app: App = App.create(YOUR_APP_ID) // Replace this with your App ID
+runBlocking { // use runBlocking sparingly -- it can delay UI interactions
+    val authChanges = mutableSetOf<AuthenticationChange>()
+    // flow.collect() is blocking -- for this example we run it in a background context
+    val job = CoroutineScope(Dispatchers.Default).launch {
+        // Create a Flow of AuthenticationChange objects
+        app.authenticationChangeAsFlow().collect() { change: AuthenticationChange ->
+            when (change) {
+                is LoggedIn -> authChanges.add(change)
+                is LoggedOut -> authChanges.add(change)
+                is Removed -> authChanges.add(change)
+            }
+        }
+    }
+    // After logging in, you should see AuthenticationChange is LoggedIn
+    val user = app.login(Credentials.emailPassword(email, password))
+    if (authChanges.first() is LoggedIn) {
+        Log.v("User ${authChanges.first().user} is logged in")
+    }
+    authChanges.clear()
+    // After logging out, observe the AuthenticationChange
+    user.logOut()
+    if (authChanges.first() is LoggedOut) {
+        Log.v("User ${authChanges.first().user} is logged out")
+    }
+    job.cancel()
+}

--- a/source/examples/generated/kotlin/AuthenticationTest.snippet.auth-change-listener.kt
+++ b/source/examples/generated/kotlin/AuthenticationTest.snippet.auth-change-listener.kt
@@ -1,27 +1,8 @@
-val app: App = App.create(YOUR_APP_ID) // Replace this with your App ID
-runBlocking { // use runBlocking sparingly -- it can delay UI interactions
-    val authChanges = mutableSetOf<AuthenticationChange>()
-    // flow.collect() is blocking -- for this example we run it in a background context
-    val job = CoroutineScope(Dispatchers.Default).launch {
-        // Create a Flow of AuthenticationChange objects
-        app.authenticationChangeAsFlow().collect() { change: AuthenticationChange ->
-            when (change) {
-                is LoggedIn -> authChanges.add(change)
-                is LoggedOut -> authChanges.add(change)
-                is Removed -> authChanges.add(change)
-            }
-        }
+// Create a Flow of AuthenticationChange objects
+app.authenticationChangeAsFlow().collect() { change: AuthenticationChange ->
+    when (change) {
+        is LoggedIn -> proceedToAppActivity(change.user)
+        is LoggedOut -> proceedToLoginActivity(change.user)
+        is Removed -> proceedToRemovedUserActivity(change.user)
     }
-    // After logging in, you should see AuthenticationChange is LoggedIn
-    val user = app.login(Credentials.emailPassword(email, password))
-    if (authChanges.first() is LoggedIn) {
-        Log.v("User ${authChanges.first().user} is logged in")
-    }
-    authChanges.clear()
-    // After logging out, observe the AuthenticationChange
-    user.logOut()
-    if (authChanges.first() is LoggedOut) {
-        Log.v("User ${authChanges.first().user} is logged out")
-    }
-    job.cancel()
 }

--- a/source/sdk/kotlin/realm-database/react-to-changes.txt
+++ b/source/sdk/kotlin/realm-database/react-to-changes.txt
@@ -30,6 +30,9 @@ You can subscribe to changes on the following events:
 - :ref:`Realm object <kotlin-realm-object-change-listener>`
 - :ref:`Realm collections (e.g. list) <kotlin-realm-list-change-listener>`
 
+You can also react to changes in user authentication state. For more information,
+refer to :ref:`kotlin-authentication-change-listener`.
+
 .. example:: About the Examples on This Page
 
    The examples in this page use two Realm object types, ``Character`` and

--- a/source/sdk/kotlin/users/authenticate-users.txt
+++ b/source/sdk/kotlin/users/authenticate-users.txt
@@ -313,3 +313,26 @@ the app shuts down after the initial authentication, you do not need to call
 
 .. literalinclude:: /examples/generated/kotlin/AuthenticationTest.snippet.retrieve-current-user.kt
    :language: kotlin
+
+.. _kotlin-authentication-change-listener:
+
+Authentication Changes as a Flow
+--------------------------------
+
+.. versionadded:: 10.8.0
+
+You can observe a flow of authentication change events by calling 
+`App.authenticationChangeAsFlow() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app/authentication-change-as-flow.html>`__ .
+This flow emits 
+`AuthenticationChange <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-authentication-change/index.html>`__ 
+events of three possible states, represented as subclasses:
+
+- ``LoggedIn``: A user logs into the app.
+- ``LoggedOut``: A a user logs out of the app.
+- ``Removed``: A user is removed from the app, which also logs them out.
+
+These events contain a ``user`` property that provides a reference to the 
+``User`` object that has logged in, logged out, or been removed.
+
+.. literalinclude:: /examples/generated/kotlin/AuthenticationTest.snippet.auth-change-listener.kt
+   :language: kotlin


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-29572

### Staged Changes

- [Authenticate Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29572/sdk/kotlin/users/authenticate-users/#authentication-changes-as-a-flow): New section w/tested example
- [React to Changes](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29572/sdk/kotlin/realm-database/react-to-changes/): Mention auth change listener, link to section on Authenticate Users page

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
