### PR TITLE
(DOCSP-26714): Swift: Add reference table of sendable, non-sendable & thread-confined types

### DIFF
--- a/source/includes/swift-api-sendable-thread-confined-reference.rst
+++ b/source/includes/swift-api-sendable-thread-confined-reference.rst
@@ -1,0 +1,127 @@
+The Realm Swift SDK public API contains types that fall into three broad
+categories:
+
+- Sendable
+- Not Sendable and not thread-confined
+- Thread-confined
+
+Types that are not Sendable and not thread confined can be shared between
+threads, but require external synchronization.
+
+Thread-confined types, unless frozen, are confined to an isolation context
+and cannot be passed between these contexts even with synchronization.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Sendable
+     - Non-Sendable
+     - Thread-Confined
+   * - AnyBSON
+     - RLMAppConfiguration
+     - AnyRealmCollection
+   * - AsyncOpen
+     - RLMFindOneAndModifyOptions
+     - AnyRealmValue
+   * - AsyncOpenSubscription
+     - RLMFindOptions
+     - List
+   * - RLMAPIKeyAuth
+     - RLMNetworkTransport
+     - Map
+   * - RLMApp
+     - RLMRequest
+     - MutableSet
+   * - RLMAsyncOpenTask
+     - RLMResponse
+     - Projection
+   * - RLMChangeStream
+     - RLMSyncConfiguration
+     - RLMArray
+   * - RLMCompensatingWriteInfo
+     - RLMSyncTimeoutOptions
+     - RLMChangeStream
+   * - RLMCredentials
+     - 
+     - RLMDictionary
+   * - RLMDecimal128
+     - 
+     - RLMDictionaryChange
+   * - RLMEmailPasswordAuth
+     -
+     - RLMEmbeddedObject
+   * - RLMMaxKey
+     - 
+     - RLMLinkingObjects
+   * - RLMMinKey
+     - 
+     - RLMObject
+   * - RLMMongoClient
+     -
+     - RLMPropertyChange
+   * - RLMMongoCollection
+     - 
+     - RLMRealm
+   * - RLMMongoDatabase
+     - 
+     - RLMResults
+   * - RLMObjectId
+     -
+     - RLMSection
+   * - RLMObjectSchema
+     -
+     - RLMSectionedResults
+   * - RLMProgressNotification
+     -
+     - RLMSectionedResultsChangeset
+   * - RLMProgressNotificationToken
+     -
+     - RLMSet
+   * - RLMProperty
+     -
+     - RLMSyncSubscription
+   * - RLMPropertyDescriptor
+     -
+     - RLMSyncSubscriptionSet
+   * - RLMProviderClient
+     -
+     - RealmOptional
+   * - RLMPushClient
+     -
+     - RealmProperty
+   * - RLMSchema
+     -
+     -
+   * - RLMSortDescriptor
+     -
+     -
+   * - RLMSyncErrorActionToken
+     -
+     -
+   * - RLMSyncManager
+     -
+     -
+   * - RLMSyncSession
+     -
+     -
+   * - RLMThreadSafeReference
+     -
+     -
+   * - RLMUpdateResult
+     -
+     -
+   * - RLMUser
+     -
+     -
+   * - RLMUserAPIKey
+     -
+     -
+   * - RLMUserIdentity
+     -
+     -
+   * - RLMUserProfile
+     -
+     -
+   * - ThreadSafe
+     -
+     -

--- a/source/includes/swift-api-sendable-thread-confined-reference.rst
+++ b/source/includes/swift-api-sendable-thread-confined-reference.rst
@@ -2,14 +2,14 @@ The Realm Swift SDK public API contains types that fall into three broad
 categories:
 
 - Sendable
-- Not Sendable and not thread-confined
+- Not Sendable and not thread confined
 - Thread-confined
 
-Types that are not Sendable and not thread confined can be shared between
-threads, but require external synchronization.
+You can share types that are not Sendable and not thread confined between
+threads, but you must synchronize them.
 
-Thread-confined types, unless frozen, are confined to an isolation context
-and cannot be passed between these contexts even with synchronization.
+Thread-confined types, unless frozen, are confined to an isolation context.
+You cannot pass them between these contexts even with synchronization.
 
 .. list-table::
    :header-rows: 1

--- a/source/sdk/swift/crud/threading.txt
+++ b/source/sdk/swift/crud/threading.txt
@@ -596,3 +596,10 @@ Summary
   only one true latest version for each realm.
 
 - Realm Database commits in two stages to guarantee isolation and durability.
+
+.. _threading-page-sendable-thread-confined-reference:
+
+Sendable, Non-Sendable and Thread-Confined Types
+------------------------------------------------
+
+.. include:: /includes/swift-api-sendable-thread-confined-reference.rst

--- a/source/sdk/swift/swift-concurrency.txt
+++ b/source/sdk/swift/swift-concurrency.txt
@@ -205,3 +205,10 @@ To avoid threading-related issues in code that uses Swift concurrency features:
   threading-related crashes. This does require a good understanding of 
   Realm's threading model, as well as being mindful of Swift concurrency 
   threading behaviors.
+
+.. _concurrency-page-sendable-thread-confined-reference:
+
+Sendable, Non-Sendable and Thread-Confined Types
+------------------------------------------------
+
+.. include:: /includes/swift-api-sendable-thread-confined-reference.rst


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-26714

### Staged Changes

This PR adds a new shared include at the bottom of these two pages:

- [Threading](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26714/sdk/swift/crud/threading/#sendable--non-sendable-and-thread-confined-types)
- [Swift Concurrency](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-26714/sdk/swift/swift-concurrency/#sendable--non-sendable-and-thread-confined-types)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
