### PR TITLE
Fix ref for kotlin client reset page

### DIFF
--- a/source/sdk/kotlin/sync/handle-sync-errors.txt
+++ b/source/sdk/kotlin/sync/handle-sync-errors.txt
@@ -88,7 +88,7 @@ use a sync query compatible with your App configuration. This will most
 likely require the user to update to a new version of your app containing
 the fix.
 
-.. _kotlin-client-reset-strategies:
+.. _kotlin-client-reset:
 
 Handle Client Reset Errors
 --------------------------
@@ -105,6 +105,8 @@ discard that data during the client reset process.
 
 For more information about what can cause a client reset to occur, go to
 :ref:`Client Resets <client-resets>` in the App Services documentation.
+
+.. _kotlin-client-reset-strategies:
 
 Client Reset Strategies
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Related to https://jira.mongodb.org/browse/DOCSP-28993 and https://jira.mongodb.org/browse/DOCSP-25431

Fix ref to Kotlin Client Reset section on Sync Errors page 

### Staged Changes

- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/no-jira-reset-link/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
