### PR TITLE
(DOCSP-28798) Expose App.Configuration.baseFilePath

### DIFF
--- a/examples/node/Examples/open-and-close-a-realm.js
+++ b/examples/node/Examples/open-and-close-a-realm.js
@@ -1,7 +1,7 @@
 import Realm from "realm";
 import nock from "nock";
 
-describe.skip("Open and Close a Realm", () => {
+describe("Open and Close a Realm", () => {
   test("should open and close a local realm", async () => {
     // :snippet-start: open-local-realm-with-car-schema
     const Car = {
@@ -89,7 +89,7 @@ describe.skip("Open and Close a Realm", () => {
     }
   });
 
-  test.skip("should open an in memory realm", async () => {
+  test("should open an in memory realm", async () => {
     const Car = {
       name: "Car",
       properties: {
@@ -108,7 +108,7 @@ describe.skip("Open and Close a Realm", () => {
     realm.close();
   });
 
-  test.skip("should open and close a synced realm with internet", async () => {
+  test("should open and close a synced realm with internet", async () => {
     const Car = {
       name: "Car",
       properties: {
@@ -146,7 +146,7 @@ describe.skip("Open and Close a Realm", () => {
     // :snippet-end:xw
   });
 
-  test.skip("should open and close a sycned realm without internet", async () => {
+  test("should open and close a sycned realm without internet", async () => {
     const Car = {
       name: "Car",
       properties: {
@@ -208,7 +208,7 @@ describe.skip("Open and Close a Realm", () => {
     nock.enableNetConnect();
   });
 
-  test.skip("Should open and close a realm with background sync", async () => {
+  test("Should open and close a realm with background sync", async () => {
     const Car = {
       name: "Car",
       properties: {
@@ -288,7 +288,7 @@ describe.skip("Open and Close a Realm", () => {
   });
 });
 
-describe.skip("Convert Realm using writeCopyTo()", () => {
+describe("Convert Realm using writeCopyTo()", () => {
   const Car = {
     name: "SportsCar22",
     properties: {

--- a/examples/node/Examples/open-and-close-a-realm.js
+++ b/examples/node/Examples/open-and-close-a-realm.js
@@ -1,8 +1,5 @@
 import Realm from "realm";
 import nock from "nock";
-import { existsSync, rmSync } from "node:fs";
-
-const APP_ID = "js-flexible-oseso";
 
 describe.skip("Open and Close a Realm", () => {
   test("should open and close a local realm", async () => {
@@ -443,94 +440,5 @@ describe.skip("Convert Realm using writeCopyTo()", () => {
     localUnencryptedRealm.close();
     Realm.deleteFile(localUnencryptedConfig);
     Realm.deleteFile(syncedEncryptedConfig);
-  });
-});
-
-describe("Open realm at different paths", () => {
-  const Car = {
-    name: "Car",
-    properties: {
-      _id: "objectId",
-      make: "string",
-      model: "string",
-      miles: "int",
-    },
-    primaryKey: "_id",
-  };
-
-  test("should open a realm at an absolute path", async () => {
-    const absolutePath = `${__dirname}/testFiles/${new Realm.BSON.UUID().toHexString()}`;
-
-    console.debug(`
-    ${absolutePath}
-    `);
-
-    // Check to make sure the path for the realm doesn't already exist.
-    expect(existsSync(absolutePath)).toBe(false);
-
-    const app = new Realm.App({ id: APP_ID, baseFilePath: absolutePath });
-    const user = await app.logIn(Realm.Credentials.anonymous());
-
-    const realm = await Realm.open({
-      schema: [Car],
-      sync: {
-        flexible: true,
-        user,
-      },
-    });
-
-    console.debug(`
-    ${realm.path}
-    `);
-
-    // Check that realm exists at absolute path.
-    expect(existsSync(absolutePath)).toBe(true);
-    // Check that the realm's path starts with the absolute path.
-    expect(realm.path.startsWith(absolutePath));
-
-    await app.currentUser.logOut();
-
-    realm.close();
-
-    // Remove realm files that are generated for this test.
-    rmSync(absolutePath, { recursive: true });
-  });
-
-  test("should open a realm at a relative path", async () => {
-    const relativePath = `testFiles/${new Realm.BSON.UUID().toHexString()}`;
-
-    console.debug(`
-    ${relativePath}
-    `);
-
-    // Check to make sure the path for the realm doesn't already exist.
-    expect(existsSync(relativePath)).toBe(false);
-
-    const app = new Realm.App({ id: APP_ID, baseFilePath: relativePath });
-    const user = await app.logIn(Realm.Credentials.anonymous());
-
-    const realm = await Realm.open({
-      schema: [Car],
-      sync: {
-        flexible: true,
-        user,
-      },
-    });
-
-    console.debug(`
-    ${realm.path}
-    `);
-
-    // Check that realm exists at relative path.
-    expect(existsSync(relativePath)).toBe(true);
-    // Check that the realm's path starts with the relative path.
-    expect(realm.path.startsWith(relativePath));
-
-    await app.currentUser?.logOut();
-
-    realm.close();
-
-    // Remove realm files that are generated for this test.
-    rmSync(relativePath, { recursive: true });
   });
 });

--- a/examples/node/Examples/open-and-close-a-realm.ts
+++ b/examples/node/Examples/open-and-close-a-realm.ts
@@ -16,13 +16,13 @@ describe("Open realm at different paths", () => {
   };
 
   test("should open a realm at an absolute path", async () => {
-    const absolutePath = `${__dirname}/testFiles/${new Realm.BSON.UUID().toHexString()}`;
+    const customPath = `${__dirname}/testFiles/${new Realm.BSON.UUID().toHexString()}`;
 
     // Check to make sure the path for the realm doesn't already exist.
-    expect(existsSync(absolutePath)).toBe(false);
+    expect(existsSync(customPath)).toBe(false);
 
     // :snippet-start: set-absolute-path
-    const app = new Realm.App({ id: APP_ID, baseFilePath: absolutePath });
+    const app = new Realm.App({ id: APP_ID, baseFilePath: customPath });
     const user = await app.logIn(Realm.Credentials.anonymous());
 
     const realm = await Realm.open({
@@ -35,16 +35,49 @@ describe("Open realm at different paths", () => {
     // :snippet-end:
 
     // Check that realm exists at absolute path.
-    expect(existsSync(absolutePath)).toBe(true);
+    expect(existsSync(customPath)).toBe(true);
 
     // Check that the realm's path starts with the absolute path.
-    expect(realm.path.startsWith(absolutePath));
+    expect(realm.path.startsWith(customPath));
 
     await app.currentUser?.logOut();
 
     realm.close();
 
     // Remove realm files that are generated for this test.
-    rmSync(absolutePath, { recursive: true });
+    rmSync(customPath, { recursive: true });
+  });
+
+  test("should open a realm at a relative path", async () => {
+    const customPath = `testFiles`;
+
+    // Check to make sure the path for the realm doesn't already exist.
+    expect(existsSync(customPath)).toBe(false);
+
+    // :snippet-start: set-absolute-path
+    const app = new Realm.App({ id: APP_ID, baseFilePath: customPath });
+    const user = await app.logIn(Realm.Credentials.anonymous());
+
+    const realm = await Realm.open({
+      schema: [Car],
+      sync: {
+        flexible: true,
+        user,
+      },
+    });
+    // :snippet-end:
+
+    // Check that realm exists at absolute path.
+    expect(existsSync(customPath)).toBe(true);
+
+    // Check that the realm's path starts with the absolute path.
+    expect(realm.path.startsWith(customPath));
+
+    await app.currentUser?.logOut();
+
+    realm.close();
+
+    // Remove realm files that are generated for this test.
+    rmSync(customPath, { recursive: true });
   });
 });

--- a/examples/node/Examples/open-and-close-a-realm.ts
+++ b/examples/node/Examples/open-and-close-a-realm.ts
@@ -1,0 +1,50 @@
+import Realm from "realm";
+import { existsSync, rmSync } from "node:fs";
+
+const APP_ID = "js-flexible-oseso";
+
+describe("Open realm at different paths", () => {
+  const Car = {
+    name: "Car",
+    properties: {
+      _id: "objectId",
+      make: "string",
+      model: "string",
+      miles: "int",
+    },
+    primaryKey: "_id",
+  };
+
+  test("should open a realm at an absolute path", async () => {
+    const absolutePath = `${__dirname}/testFiles/${new Realm.BSON.UUID().toHexString()}`;
+
+    // Check to make sure the path for the realm doesn't already exist.
+    expect(existsSync(absolutePath)).toBe(false);
+
+    // :snippet-start: set-absolute-path
+    const app = new Realm.App({ id: APP_ID, baseFilePath: absolutePath });
+    const user = await app.logIn(Realm.Credentials.anonymous());
+
+    const realm = await Realm.open({
+      schema: [Car],
+      sync: {
+        flexible: true,
+        user,
+      },
+    });
+    // :snippet-end:
+
+    // Check that realm exists at absolute path.
+    expect(existsSync(absolutePath)).toBe(true);
+
+    // Check that the realm's path starts with the absolute path.
+    expect(realm.path.startsWith(absolutePath));
+
+    await app.currentUser?.logOut();
+
+    realm.close();
+
+    // Remove realm files that are generated for this test.
+    rmSync(absolutePath, { recursive: true });
+  });
+});

--- a/examples/node/Examples/open-and-close-a-realm.ts
+++ b/examples/node/Examples/open-and-close-a-realm.ts
@@ -47,39 +47,4 @@ describe("Open realm at different paths", () => {
     // Remove realm files that are generated for this test.
     rmSync(customPath, { recursive: true });
   });
-
-  test("should open a realm at a relative path", async () => {
-    const customBaseFilePath = "customBasePath";
-    const customRealmPath = "customRealmPath";
-
-    // Check to make sure the path for the realm doesn't already exist.
-    expect(existsSync(customBaseFilePath)).toBe(false);
-
-    // :snippet-start: set-relative-path
-    const app = new Realm.App({ id: APP_ID, baseFilePath: customBaseFilePath });
-    const user = await app.logIn(Realm.Credentials.anonymous());
-
-    const realm = await Realm.open({
-      path: customRealmPath,
-      schema: [Car],
-      sync: {
-        flexible: true,
-        user,
-      },
-    });
-    // :snippet-end:
-
-    // Check that realm exists at relative path.
-    expect(existsSync(customBaseFilePath)).toBe(true);
-
-    // Check that the realm's path matches defined paths.
-    expect(realm.path).toEqual(`${customBaseFilePath}/${customRealmPath}`);
-
-    await app.currentUser?.logOut();
-
-    realm.close();
-
-    // Remove realm files that are generated for this test.
-    rmSync(customBaseFilePath, { recursive: true });
-  });
 });

--- a/examples/node/Examples/open-and-close-a-realm.ts
+++ b/examples/node/Examples/open-and-close-a-realm.ts
@@ -49,16 +49,18 @@ describe("Open realm at different paths", () => {
   });
 
   test("should open a realm at a relative path", async () => {
-    const customPath = `testFiles`;
+    const customBaseFilePath = "customBasePath";
+    const customRealmPath = "customRealmPath";
 
     // Check to make sure the path for the realm doesn't already exist.
-    expect(existsSync(customPath)).toBe(false);
+    expect(existsSync(customBaseFilePath)).toBe(false);
 
     // :snippet-start: set-relative-path
-    const app = new Realm.App({ id: APP_ID, baseFilePath: customPath });
+    const app = new Realm.App({ id: APP_ID, baseFilePath: customBaseFilePath });
     const user = await app.logIn(Realm.Credentials.anonymous());
 
     const realm = await Realm.open({
+      path: customRealmPath,
       schema: [Car],
       sync: {
         flexible: true,
@@ -68,16 +70,16 @@ describe("Open realm at different paths", () => {
     // :snippet-end:
 
     // Check that realm exists at relative path.
-    expect(existsSync(customPath)).toBe(true);
+    expect(existsSync(customBaseFilePath)).toBe(true);
 
-    // Check that the realm's path starts with the relative path.
-    expect(realm.path.startsWith(customPath));
+    // Check that the realm's path matches defined paths.
+    expect(realm.path).toEqual(`${customBaseFilePath}/${customRealmPath}`);
 
     await app.currentUser?.logOut();
 
     realm.close();
 
     // Remove realm files that are generated for this test.
-    rmSync(customPath, { recursive: true });
+    rmSync(customBaseFilePath, { recursive: true });
   });
 });

--- a/examples/node/Examples/open-and-close-a-realm.ts
+++ b/examples/node/Examples/open-and-close-a-realm.ts
@@ -54,7 +54,7 @@ describe("Open realm at different paths", () => {
     // Check to make sure the path for the realm doesn't already exist.
     expect(existsSync(customPath)).toBe(false);
 
-    // :snippet-start: set-absolute-path
+    // :snippet-start: set-relative-path
     const app = new Realm.App({ id: APP_ID, baseFilePath: customPath });
     const user = await app.logIn(Realm.Credentials.anonymous());
 
@@ -67,10 +67,10 @@ describe("Open realm at different paths", () => {
     });
     // :snippet-end:
 
-    // Check that realm exists at absolute path.
+    // Check that realm exists at relative path.
     expect(existsSync(customPath)).toBe(true);
 
-    // Check that the realm's path starts with the absolute path.
+    // Check that the realm's path starts with the relative path.
     expect(realm.path.startsWith(customPath));
 
     await app.currentUser?.logOut();

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -4,7 +4,7 @@
   "description": "Source for generated js/typescript code samples in the Realm Node.js client guide",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --runInBand --detectOpenHandles --forceExit",
     "test:js": "jest --selectProjects JavaScript --runInBand --detectOpenHandles --forceExit",
     "test:ts": "jest --selectProjects TypeScript --runInBand --detectOpenHandles --forceExit",
     "lint": "eslint Examples/*",

--- a/examples/react-native/.gitignore
+++ b/examples/react-native/.gitignore
@@ -75,3 +75,4 @@ mongodb-realm/
 /*.management/
 /*.lock
 default.realm.lock
+/customBasePath

--- a/examples/react-native/__tests__/js/realm-database/configure-realm-path.test.jsx
+++ b/examples/react-native/__tests__/js/realm-database/configure-realm-path.test.jsx
@@ -1,0 +1,81 @@
+// :snippet-start: configure-realm-path
+import React from 'react';
+import {AppProvider, createRealmContext, UserProvider} from '@realm/react';
+// :remove-start:
+import {useEffect} from 'react';
+import Realm from 'realm';
+import {render, waitFor} from '@testing-library/react-native';
+import {useApp} from '@realm/react';
+import {Text} from 'react-native';
+
+const APP_ID = 'js-flexible-oseso';
+const customBaseFilePath = 'customBasePath';
+const customRealmPath = 'customRealmPath';
+let higherScopeRealmPath;
+
+class Profile extends Realm.Object {
+  static schema = {
+    name: 'Profile',
+    primaryKey: '_id',
+    properties: {
+      _id: 'uuid',
+      name: 'string',
+    },
+  };
+}
+// :remove-end:
+
+const realmContext = createRealmContext({
+  path: customRealmPath,
+  schema: [Profile],
+});
+const {RealmProvider} = realmContext;
+
+function AppWrapperSync({customBaseFilePath}) {
+  return (
+    <AppProvider id={APP_ID} baseFilePath={customBaseFilePath}>
+      <UserProvider fallback={LogIn}>
+        <RealmProvider
+          sync={{
+            flexible: true,
+          }}>
+          <RestOfApp />
+        </RealmProvider>
+      </UserProvider>
+    </AppProvider>
+  );
+}
+// :snippet-end:
+
+function LogIn() {
+  const app = useApp();
+
+  useEffect(() => {
+    app.logIn(Realm.Credentials.anonymous());
+  }, []);
+
+  return <></>;
+}
+
+function RestOfApp() {
+  const {useRealm} = realmContext;
+  const realm = useRealm();
+
+  higherScopeRealmPath = realm.path;
+
+  return (
+    <>
+      <Text testID='text-container'>Rest of the app!</Text>
+    </>
+  );
+}
+
+test('Instantiate AppWrapperSync and test sync', async () => {
+  render(<AppWrapperSync customBaseFilePath={customBaseFilePath} />);
+
+  await waitFor(() => {
+    expect(higherScopeRealmPath).toEqual(
+      `${customBaseFilePath}/${customRealmPath}`,
+    );
+  });
+});

--- a/examples/react-native/__tests__/ts/realm-database/configure-realm-path.test.tsx
+++ b/examples/react-native/__tests__/ts/realm-database/configure-realm-path.test.tsx
@@ -1,0 +1,88 @@
+// :snippet-start: configure-realm-path
+import React from 'react';
+import {AppProvider, createRealmContext, UserProvider} from '@realm/react';
+// :remove-start:
+import {useEffect} from 'react';
+import Realm from 'realm';
+import {render, waitFor} from '@testing-library/react-native';
+import {useApp} from '@realm/react';
+import {Text} from 'react-native';
+
+const APP_ID = 'js-flexible-oseso';
+const customBaseFilePath = 'customBasePath';
+const customRealmPath = 'customRealmPath';
+let higherScopeRealmPath: string;
+
+class Profile extends Realm.Object<Profile> {
+  _id!: Realm.BSON.UUID;
+  name!: string;
+
+  static schema = {
+    name: 'Profile',
+    primaryKey: '_id',
+    properties: {
+      _id: 'uuid',
+      name: 'string',
+    },
+  };
+}
+// :remove-end:
+
+const realmContext = createRealmContext({
+  path: customRealmPath,
+  schema: [Profile],
+});
+const {RealmProvider} = realmContext;
+
+type AppWrapperSyncProps = {
+  customBaseFilePath: string;
+};
+
+function AppWrapperSync({customBaseFilePath}: AppWrapperSyncProps) {
+  return (
+    <AppProvider id={APP_ID} baseFilePath={customBaseFilePath}>
+      <UserProvider fallback={LogIn}>
+        <RealmProvider
+          sync={{
+            flexible: true,
+          }}>
+          <RestOfApp />
+        </RealmProvider>
+      </UserProvider>
+    </AppProvider>
+  );
+}
+// :snippet-end:
+
+function LogIn() {
+  const app = useApp();
+
+  useEffect(() => {
+    app.logIn(Realm.Credentials.anonymous());
+  }, []);
+
+  return <></>;
+}
+
+function RestOfApp() {
+  const {useRealm} = realmContext;
+  const realm = useRealm();
+
+  higherScopeRealmPath = realm.path;
+
+  return (
+    <>
+      <Text testID='text-container'>Rest of the app!</Text>
+    </>
+  );
+}
+
+test('Instantiate AppWrapperSync and test sync', async () => {
+  render(<AppWrapperSync customBaseFilePath={customBaseFilePath} />);
+
+  await waitFor(() => {
+    expect(higherScopeRealmPath).toEqual(
+      `${customBaseFilePath}/${customRealmPath}`,
+    );
+  });
+});

--- a/examples/react-native/package-lock.json
+++ b/examples/react-native/package-lock.json
@@ -13,7 +13,7 @@
         "react": "18.1.0",
         "react-native": "0.70.6",
         "react-native-polyfill-globals": "^3.1.0",
-        "realm": "^11.5.2",
+        "realm": "^11.8.0",
         "text-encoding": "^0.7.0"
       },
       "devDependencies": {
@@ -17860,9 +17860,9 @@
       "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
     },
     "node_modules/realm": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-11.5.2.tgz",
-      "integrity": "sha512-E5Ia4B2zsLge1o0jJ3NmlBKN8vtgQTt7CRvYHNNvWRoIEraZhOJtuyNMm/Yg8b9MvaLZPeDmVo8KO05lSoni6Q==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-11.8.0.tgz",
+      "integrity": "sha512-c4NLKJs85CLY7wo4csIGcQRIjcAYI4FlVnxGkuzQR+uwwkGE1nPWKFBh+wPFPsPJXtZ1BBG4e3tt275ja/7SoA==",
       "hasInstallScript": true,
       "dependencies": {
         "@realm/common": "^0.1.4",
@@ -34002,9 +34002,9 @@
       "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
     },
     "realm": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-11.5.2.tgz",
-      "integrity": "sha512-E5Ia4B2zsLge1o0jJ3NmlBKN8vtgQTt7CRvYHNNvWRoIEraZhOJtuyNMm/Yg8b9MvaLZPeDmVo8KO05lSoni6Q==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-11.8.0.tgz",
+      "integrity": "sha512-c4NLKJs85CLY7wo4csIGcQRIjcAYI4FlVnxGkuzQR+uwwkGE1nPWKFBh+wPFPsPJXtZ1BBG4e3tt275ja/7SoA==",
       "requires": {
         "@realm/common": "^0.1.4",
         "@realm/network-transport": "^0.7.2",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -17,7 +17,7 @@
     "react": "18.1.0",
     "react-native": "0.70.6",
     "react-native-polyfill-globals": "^3.1.0",
-    "realm": "^11.5.2",
+    "realm": "^11.8.0",
     "text-encoding": "^0.7.0"
   },
   "devDependencies": {

--- a/source/examples/generated/node/open-and-close-a-realm.snippet.set-absolute-path.ts
+++ b/source/examples/generated/node/open-and-close-a-realm.snippet.set-absolute-path.ts
@@ -1,4 +1,4 @@
-const app = new Realm.App({ id: APP_ID, baseFilePath: absolutePath });
+const app = new Realm.App({ id: APP_ID, baseFilePath: customPath });
 const user = await app.logIn(Realm.Credentials.anonymous());
 
 const realm = await Realm.open({

--- a/source/examples/generated/node/open-and-close-a-realm.snippet.set-absolute-path.ts
+++ b/source/examples/generated/node/open-and-close-a-realm.snippet.set-absolute-path.ts
@@ -1,0 +1,10 @@
+const app = new Realm.App({ id: APP_ID, baseFilePath: absolutePath });
+const user = await app.logIn(Realm.Credentials.anonymous());
+
+const realm = await Realm.open({
+  schema: [Car],
+  sync: {
+    flexible: true,
+    user,
+  },
+});

--- a/source/examples/generated/react-native/js/configure-realm-path.test.snippet.configure-realm-path.jsx
+++ b/source/examples/generated/react-native/js/configure-realm-path.test.snippet.configure-realm-path.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {AppProvider, createRealmContext, UserProvider} from '@realm/react';
+
+const realmContext = createRealmContext({
+  path: customRealmPath,
+  schema: [Profile],
+});
+const {RealmProvider} = realmContext;
+
+function AppWrapperSync({customBaseFilePath}) {
+  return (
+    <AppProvider id={APP_ID} baseFilePath={customBaseFilePath}>
+      <UserProvider fallback={LogIn}>
+        <RealmProvider
+          sync={{
+            flexible: true,
+          }}>
+          <RestOfApp />
+        </RealmProvider>
+      </UserProvider>
+    </AppProvider>
+  );
+}

--- a/source/examples/generated/react-native/ts/configure-realm-path.test.snippet.configure-realm-path.tsx
+++ b/source/examples/generated/react-native/ts/configure-realm-path.test.snippet.configure-realm-path.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {AppProvider, createRealmContext, UserProvider} from '@realm/react';
+
+const realmContext = createRealmContext({
+  path: customRealmPath,
+  schema: [Profile],
+});
+const {RealmProvider} = realmContext;
+
+type AppWrapperSyncProps = {
+  customBaseFilePath: string;
+};
+
+function AppWrapperSync({customBaseFilePath}: AppWrapperSyncProps) {
+  return (
+    <AppProvider id={APP_ID} baseFilePath={customBaseFilePath}>
+      <UserProvider fallback={LogIn}>
+        <RealmProvider
+          sync={{
+            flexible: true,
+          }}>
+          <RestOfApp />
+        </RealmProvider>
+      </UserProvider>
+    </AppProvider>
+  );
+}

--- a/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
@@ -80,8 +80,27 @@ In the SyncConfiguration, you must include include a ``user`` and ``flexible:tru
 Write Synced Realm to Specific Path
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. TODO: finish adding content and example.
-.. Should mention it's for sync only, including realm and metadata.
+.. versionadded:: ``realm@11.6.0``
+
+Using :js-sdk:`AppConfiguration.baseFilePath <Realm.App.html#~AppConfiguration>`,
+you can write a synced realm and its metadata to a specific device path.
+
+.. literalinclude:: /examples/generated/node/open-and-close-a-realm.snippet.set-absolute-path.ts
+   :language: typescript
+
+If ``baseFilePath`` is not set, the current work directory is used. Where,
+exactly, your Realm file and metadata file are stored can vary depending on how
+you set :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`:
+
+- If ``Realm.Configuration.path`` is not set, your Realm file and metadata are
+  stored in a location following this pattern: 
+  ``<currentWorkingDirectory>/<baseFilePath>/mongodb-realm/``.
+- If ``Realm.Configuation.path`` is set to a relative path, the Realm file is
+  stored relative to ``baseFilePath``. Metadata is stored in 
+  ``<baseFilePath>/mongodb-realm``.
+- If ``Realm.Configuration.path`` is an absolute path, your Realm file is stored
+  at ``Realm.Configuration.path``. Metadata is stored in 
+  ``<baseFilePath>/mongodb-realm``.
 
 .. _node-partition-sync-open-realm:
 

--- a/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
@@ -98,7 +98,7 @@ If ``baseFilePath`` is set, metadata is always stored in
 ``<baseFilePath>/mongodb-realm/``. If ``baseFilePath`` isn't sßet, then metadata
 is stored in ``<Realm.defaultPath>/mongodb-realm``.
 
-Where, exactly, your Realm file is stored can vary depending
+Where exactly your Realm file is stored can vary depending
 on how you set :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`:
 
 - ``Realm.Configuration.path`` is not set and ``baseFilePath`` is set. Your

--- a/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
@@ -77,30 +77,36 @@ In the SyncConfiguration, you must include include a ``user`` and ``flexible:tru
    You can't use a Flexible Sync realm until you add at least one subscription.
    To learn how to add subscriptions, see: :ref:`<node-sync-add-subscription>`.
 
-Write Synced Realm to Specific Path
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Open Synced Realm at Specific Path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: ``realm@11.6.0``
 
 Using :js-sdk:`AppConfiguration.baseFilePath <Realm.App.html#~AppConfiguration>`,
-you can write a synced realm and its metadata to a specific device path.
+and :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`, you can
+control where Realm and metadata files are stored on client devices.
+
+To do so, set ``<AppProvider>.baseFilePath``. If ``baseFilePath`` is not set, the
+current work directory is used. You can also set ``<RealmProvider>.sync.path``
+for more control.
 
 .. literalinclude:: /examples/generated/node/open-and-close-a-realm.snippet.set-absolute-path.ts
    :language: typescript
+   :emphasize-lines: 1
 
-If ``baseFilePath`` is not set, the current work directory is used. Where,
-exactly, your Realm file and metadata file are stored can vary depending on how
-you set :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`:
+If ``baseFilePath`` is set, metadata is always stored in
+``<baseFilePath>/mongodb-realm/``. If ``baseFilePath`` isn't sßet, then metadata
+is stored in ``<Realm.defaultPath>/mongodb-realm``.
 
-- If ``Realm.Configuration.path`` is not set, your Realm file and metadata are
-  stored in a location following this pattern: 
-  ``<currentWorkingDirectory>/<baseFilePath>/mongodb-realm/``.
-- If ``Realm.Configuation.path`` is set to a relative path, the Realm file is
-  stored relative to ``baseFilePath``. Metadata is stored in 
-  ``<baseFilePath>/mongodb-realm``.
-- If ``Realm.Configuration.path`` is an absolute path, your Realm file is stored
-  at ``Realm.Configuration.path``. Metadata is stored in 
-  ``<baseFilePath>/mongodb-realm``.
+Where, exactly, your Realm file is stored can vary depending
+on how you set :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`:
+
+- ``Realm.Configuration.path`` is not set and ``baseFilePath`` is set. Your
+  Realm file is stored at ``baseFilePath``.
+- ``Realm.Configuation.path`` is set to a relative path. Your Realm file is
+  stored relative to ``baseFilePath``.
+- ``Realm.Configuration.path`` is an absolute path. Your Realm file is stored
+  at ``Realm.Configuration.path``.
 
 .. _node-partition-sync-open-realm:
 

--- a/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
@@ -77,6 +77,12 @@ In the SyncConfiguration, you must include include a ``user`` and ``flexible:tru
    You can't use a Flexible Sync realm until you add at least one subscription.
    To learn how to add subscriptions, see: :ref:`<node-sync-add-subscription>`.
 
+Write Synced Realm to Specific Path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. TODO: finish adding content and example.
+.. Should mention it's for sync only, including realm and metadata.
+
 .. _node-partition-sync-open-realm:
 
 Open a Partition-Based Synced Realm

--- a/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
+++ b/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
@@ -87,6 +87,30 @@ to ``<RealmProvider>``.
    You can't use a Flexible Sync realm until you add at least one subscription.
    To learn how to add subscriptions, refer to :ref:`<react-native-sync-add-subscription>`.
 
+Write Synced Realm to Specific Path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: ``realm@11.6.0``
+
+Using :js-sdk:`AppConfiguration.baseFilePath <Realm.App.html#~AppConfiguration>`,
+you can write a synced realm and its metadata to a specific device path.
+
+.. TODO: Work with this info
+
+If not set, current work directory is used.
+
+If Realm.Configuration.path is not set, the file is determined as before BUT 
+files are created in `baseFilePath` - including the directory `mongodb-realm`.
+
+If Realm.Configuation.path is a relative path, the Realm file is created
+relative to `baseFilePath` and metadata (`mongodb-realm`) in `baseFilePath`
+
+If Realm.Configuration.path is an absolute path, `path` is used for the Realm
+file and `baseFilePath` is used for metadata
+
+.. TODO: finish adding content and example.
+.. Should mention it's for sync only, including realm and metadata.
+
 .. _react-native-open-synced-realm-offline:
 
 Access a Synced Realm While Offline

--- a/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
+++ b/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
@@ -97,7 +97,7 @@ you can write a synced realm and its metadata to a specific device path.
 
 .. TODO: Work with this info
 
-If not set, current work directory is used.
+If not set, c\urrent work directory is used.
 
 If Realm.Configuration.path is not set, the file is determined as before BUT 
 files are created in `baseFilePath` - including the directory `mongodb-realm`.

--- a/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
+++ b/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
@@ -100,9 +100,21 @@ To do so, set ``<AppProvider>.baseFilePath``. If ``baseFilePath`` is not set, th
 current work directory is used. You can also set ``<RealmProvider>.sync.path``
 for more control.
 
-.. literalinclude:: /examples/generated/react-native/ts/configure-realm-path.test.snippet.configure-realm-path.tsx
-   :language: typescript
-   :emphasize-lines: 16
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: typescript
+
+      .. literalinclude:: /examples/generated/react-native/ts/configure-realm-path.test.snippet.configure-realm-path.tsx
+         :language: typescript
+         :emphasize-lines: 5, 16
+
+   .. tab::
+      :tabid: javascript
+
+      .. literalinclude:: /examples/generated/react-native/js/configure-realm-path.test.snippet.configure-realm-path.jsx
+         :language: typescript
+         :emphasize-lines: 5, 12
 
 If ``baseFilePath`` is set, metadata is always stored in
 ``<baseFilePath>/mongodb-realm/``. If ``baseFilePath`` isn't sßet, then metadata

--- a/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
+++ b/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
@@ -87,31 +87,36 @@ to ``<RealmProvider>``.
    You can't use a Flexible Sync realm until you add at least one subscription.
    To learn how to add subscriptions, refer to :ref:`<react-native-sync-add-subscription>`.
 
-Write Synced Realm to Specific Path
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Open Synced Realm at Specific Path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: ``realm@11.6.0``
 
 Using :js-sdk:`AppConfiguration.baseFilePath <Realm.App.html#~AppConfiguration>`,
-you can write a synced realm and its metadata to a specific device path. To do so,
-set ``baseFilePath`` on ``<AppProvider>``.
+and :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`, you can
+control where Realm and metadata files are stored on client devices.
+
+To do so, set ``<AppProvider>.baseFilePath``. If ``baseFilePath`` is not set, the
+current work directory is used. You can also set ``<RealmProvider>.sync.path``
+for more control.
 
 .. literalinclude:: /examples/generated/react-native/ts/configure-realm-path.test.snippet.configure-realm-path.tsx
    :language: typescript
+   :emphasize-lines: 16
 
-If ``baseFilePath`` is not set, the current work directory is used. Where,
-exactly, your Realm file and metadata file are stored can vary depending on how
-you set :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`:
+If ``baseFilePath`` is set, metadata is always stored in
+``<baseFilePath>/mongodb-realm/``. If ``baseFilePath`` isn't sßet, then metadata
+is stored in ``<Realm.defaultPath>/mongodb-realm``.
 
-- If ``Realm.Configuration.path`` is not set, your Realm file and metadata are
-  stored in a location following this pattern: 
-  ``<currentWorkingDirectory>/<baseFilePath>/mongodb-realm/``.
-- If ``Realm.Configuation.path`` is set to a relative path, the Realm file is
-  stored relative to ``baseFilePath``. Metadata is stored in 
-  ``<baseFilePath>/mongodb-realm``.
-- If ``Realm.Configuration.path`` is an absolute path, your Realm file is stored
-  at ``Realm.Configuration.path``. Metadata is stored in 
-  ``<baseFilePath>/mongodb-realm``.
+Where, exactly, your Realm file is stored can vary depending
+on how you set :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`:
+
+- ``Realm.Configuration.path`` is not set and ``baseFilePath`` is set. Your
+  Realm file is stored at ``baseFilePath``.
+- ``Realm.Configuation.path`` is set to a relative path. Your Realm file is
+  stored relative to ``baseFilePath``.
+- ``Realm.Configuration.path`` is an absolute path. Your Realm file is stored
+  at ``Realm.Configuration.path``.
 
 .. _react-native-open-synced-realm-offline:
 

--- a/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
+++ b/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
@@ -93,23 +93,25 @@ Write Synced Realm to Specific Path
 .. versionadded:: ``realm@11.6.0``
 
 Using :js-sdk:`AppConfiguration.baseFilePath <Realm.App.html#~AppConfiguration>`,
-you can write a synced realm and its metadata to a specific device path.
+you can write a synced realm and its metadata to a specific device path. To do so,
+set ``baseFilePath`` on ``<AppProvider>``.
 
-.. TODO: Work with this info
+.. literalinclude:: /examples/generated/react-native/ts/configure-realm-path.test.snippet.configure-realm-path.tsx
+   :language: typescript
 
-If not set, c\urrent work directory is used.
+If ``baseFilePath`` is not set, the current work directory is used. Where,
+exactly, your Realm file and metadata file are stored can vary depending on how
+you set :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`:
 
-If Realm.Configuration.path is not set, the file is determined as before BUT 
-files are created in `baseFilePath` - including the directory `mongodb-realm`.
-
-If Realm.Configuation.path is a relative path, the Realm file is created
-relative to `baseFilePath` and metadata (`mongodb-realm`) in `baseFilePath`
-
-If Realm.Configuration.path is an absolute path, `path` is used for the Realm
-file and `baseFilePath` is used for metadata
-
-.. TODO: finish adding content and example.
-.. Should mention it's for sync only, including realm and metadata.
+- If ``Realm.Configuration.path`` is not set, your Realm file and metadata are
+  stored in a location following this pattern: 
+  ``<currentWorkingDirectory>/<baseFilePath>/mongodb-realm/``.
+- If ``Realm.Configuation.path`` is set to a relative path, the Realm file is
+  stored relative to ``baseFilePath``. Metadata is stored in 
+  ``<baseFilePath>/mongodb-realm``.
+- If ``Realm.Configuration.path`` is an absolute path, your Realm file is stored
+  at ``Realm.Configuration.path``. Metadata is stored in 
+  ``<baseFilePath>/mongodb-realm``.
 
 .. _react-native-open-synced-realm-offline:
 


### PR DESCRIPTION
## Pull Request Info

Note about the tests: currently, the React Native test is only for relative paths. The Node.js test is only for absolute paths. I tried to standardize, but ran into issues and figured it was better to get this content up than toil on the samples for too much longer.

They serve the same purpose: testing that setting an absolute path works.

### Jira

- https://jira.mongodb.org/browse/DOCSP-28798

### Staged Changes

- [Node.js - Configure a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-28798/sdk/node/sync/configure-and-open-a-synced-realm/#open-synced-realm-at-specific-path)
- [React Native - Configure a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-28798/sdk/react-native/sync-data/configure-a-synced-realm/#open-synced-realm-at-specific-path)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

<img src="https://i.redd.it/xh9dhe69bf061.jpg" width=400 />
