### PR TITLE
(DOCSP-29641): Swift: Add new sorting API to Query MongoDB page

### DIFF
--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.find-and-sort.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.find-and-sort.swift
@@ -1,0 +1,15 @@
+let queryFilter: Document = ["name": "Americano"]
+let findOptions = FindOptions(0, nil, [["beanRegion": 1]])
+
+collection.find(filter: queryFilter, options: findOptions) { result in
+    switch result {
+    case .failure(let error):
+        print("Call to MongoDB failed: \(error.localizedDescription)")
+        return
+    case .success(let documents):
+        print("Results: ")
+        for document in documents {
+            print("Coffee drink: \(document)")
+        }
+    }
+}

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -229,9 +229,12 @@ with your preferred sort options. ``FindOptions`` has three parameters:
 :objc-sdk:`limit <Classes/RLMFindOptions.html#/c:objc(cs)RLMFindOptions(py)limit>`,
 :objc-sdk:`projection <Classes/RLMFindOptions.html#/c:objc(cs)RLMFindOptions(py)projection>`,
 and :objc-sdk:`sorting <Classes/RLMFindOptions.html#/c:objc(cs)RLMFindOptions(py)sorting>`.
-You can pass an array of key-value pairs where each key represents a field. 
-For each key, the value ``1`` sorts in descending order, or ``-1`` sorts 
-in ascending order.
+The ``sorting`` argument can be an array of key-value pairs where each key 
+represents a field. For each key, the value ``1`` sorts in descending order, 
+or ``-1`` sorts in ascending order.
+
+You then pass the ``FindOptions`` instance to the ``collection.find()`` method
+when running the query.
 
 This snippet finds all documents in a :ref:`collection of documents that 
 describe coffee drinks for sale in a group of stores <ios-mongodb-example-dataset>`, 

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -218,6 +218,47 @@ Running this snippet produces this output:
       "_id": Optional(RealmSwift.AnyBSON.objectId(6102...)), 
       "beanRegion": Optional(RealmSwift.AnyBSON.string("San Marcos, Guatemala"))]
 
+.. _ios-mongodb-findAndSort:
+
+Find and Sort Documents
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You can sort documents in a collection by initializing an instance of 
+:swift-sdk:`FindOptions <Typealiases.html#/s:10RealmSwift11FindOptionsa>`
+with your preferred sort options. ``FindOptions`` has three parameters:
+:objc-sdk:`limit <Classes/RLMFindOptions.html#/c:objc(cs)RLMFindOptions(py)limit>`,
+:objc-sdk:`projection <Classes/RLMFindOptions.html#/c:objc(cs)RLMFindOptions(py)projection>`,
+and :objc-sdk:`sorting <Classes/RLMFindOptions.html#/c:objc(cs)RLMFindOptions(py)sorting>`.
+You can pass an array of key-value pairs where each key represents a field. 
+For each key, the value ``1`` sorts in descending order, or ``-1`` sorts 
+in ascending order.
+
+This snippet finds all documents in a :ref:`collection of documents that 
+describe coffee drinks for sale in a group of stores <ios-mongodb-example-dataset>`, 
+where the document's ``name`` field contains the value "Americano", sorted 
+in descending order by the ``beanRegion`` field:
+
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.find-and-sort.swift
+   :language: swift
+
+Running this snippet produces this output:
+
+.. code-block:: text
+
+   Results: 
+   Coffee drink: [
+      "creamer": Optional(RealmSwift.AnyBSON.string("false")), 
+      "name": Optional(RealmSwift.AnyBSON.string("Americano")), 
+      "partition": Optional(RealmSwift.AnyBSON.string("Store 47")), 
+      "_id": Optional(RealmSwift.AnyBSON.objectId(6102...)), 
+      "beanRegion": Optional(RealmSwift.AnyBSON.string("San Marcos, Guatemala"))]
+   Coffee drink: [
+      "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), 
+      "creamer": Optional(RealmSwift.AnyBSON.string("false")), 
+      "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), 
+      "_id": Optional(RealmSwift.AnyBSON.objectId(6102...)), 
+      "name": Optional(RealmSwift.AnyBSON.string("Americano"))]
+
 .. _ios-mongodb-count:
 
 Count Documents in the Collection


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-29641

### Staged Changes

- [Query MongoDB](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29641/sdk/swift/app-services/mongodb-remote-access/#find-and-sort-documents): New "Find and Sort Documents" section with Bluehawked code example illustrating the `sorting` API

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
