### PR TITLE
(DOCSP-29868): Kotlin: Lint SyncTest code examples

### DIFF
--- a/source/examples/generated/kotlin/SyncTest.snippet.add-a-subscription.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.add-a-subscription.kt
@@ -1,3 +1,6 @@
 realm.subscriptions.update {
-    this.add(realm.query<Toad>("name == $0", "another name value"), "another subscription name")
+    this.add(
+        realm.query<Toad>("name == $0", "another name value"),
+        "another subscription name"
+    )
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.configure-a-synced-realm.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.configure-a-synced-realm.kt
@@ -1,11 +1,12 @@
 val app = App.create(YOUR_APP_ID)
 runBlocking {
     val user = app.login(Credentials.anonymous())
-    val config = SyncConfiguration.Builder(user, PARTITION, setOf(/*realm object models here*/))
-        .maxNumberOfActiveVersions(10)
-        .waitForInitialRemoteData()
-        .name("realm name")
-        .build()
+    val config =
+        SyncConfiguration.Builder(user, PARTITION, setOf(/*realm object models here*/))
+            .maxNumberOfActiveVersions(10)
+            .waitForInitialRemoteData()
+            .name("realm name")
+            .build()
     val realm = Realm.open(config)
     Log.v("Successfully opened realm: ${realm.configuration}")
     realm.close()

--- a/source/examples/generated/kotlin/SyncTest.snippet.define-custom-logger.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.define-custom-logger.kt
@@ -1,10 +1,12 @@
 class MyLogger() : RealmLogger {
     override val tag: String = "CUSTOM_LOG_ENTRY"
     override val level: LogLevel = LogLevel.DEBUG
-    override fun log(level: LogLevel,
-                     throwable: Throwable?,
-                     message: String?,
-                     vararg args: Any?) {
+    override fun log(
+        level: LogLevel,
+        throwable: Throwable?,
+        message: String?,
+        vararg args: Any?
+    ) {
         println(message) // Custom handling
     }
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.discard.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.discard.kt
@@ -8,7 +8,7 @@ val clientResetStrategy = object : DiscardUnsyncedChangesStrategy {
     override fun onAfterReset(before: TypedRealm, after: MutableRealm) {
         Log.i("Client reset: attempting to manually recover any unsynced changes")
         // ...Try to manually recover any unsynced data 
-        manuallyRecoverUnsyncedData(before, after) 
+        manuallyRecoverUnsyncedData(before, after)
     }
     // Executed after the client reset is complete.
     // Can be used to notify the user that the reset is done.

--- a/source/examples/generated/kotlin/SyncTest.snippet.fallback.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.fallback.kt
@@ -1,18 +1,18 @@
-        override fun onManualResetFallback(
-            session: SyncSession,
-            exception: ClientResetRequiredException
-        ) {
-            Log.i("Client reset: manual reset required")
+override fun onManualResetFallback(
+    session: SyncSession,
+    exception: ClientResetRequiredException
+) {
+    Log.i("Client reset: manual reset required")
 
-            // You *MUST* close any open Realm instance
-            closeAllRealmInstances();
+    // You *MUST* close any open Realm instance
+    closeAllRealmInstances();
 
-            // `executeClientReset()` creates a backup
-            exception.executeClientReset();
+    // `executeClientReset()` creates a backup
+    exception.executeClientReset();
 
-            // (Optional) Send backup for analysis
-            handleBackup(recoveryFilePath);
+    // (Optional) Send backup for analysis
+    handleBackup(recoveryFilePath);
 
-            // ... Restore the App state by reopening the realm 
-            // or restarting the app
-        }
+    // ... Restore the App state by reopening the realm 
+    // or restarting the app
+}

--- a/source/examples/generated/kotlin/SyncTest.snippet.open-a-synced-realm.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.open-a-synced-realm.kt
@@ -1,10 +1,11 @@
 val app = App.create(YOUR_APP_ID)
 runBlocking {
     val user = app.login(Credentials.anonymous())
-    val config = SyncConfiguration.Builder(user, PARTITION, setOf(/*realm object models here*/))
-        // specify name so realm doesn't just use the "default.realm" file for this user
-        .name(PARTITION)
-        .build()
+    val config =
+        SyncConfiguration.Builder(user, PARTITION, setOf(/*realm object models here*/))
+            // specify name so realm doesn't just use the "default.realm" file for this user
+            .name(PARTITION)
+            .build()
     val realm = Realm.open(config)
     Log.v("Successfully opened realm: ${realm.configuration.name}")
     realm.close()

--- a/source/examples/generated/kotlin/SyncTest.snippet.recover-discard.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.recover-discard.kt
@@ -13,7 +13,7 @@ val clientResetStrategy = object : RecoverOrDiscardUnsyncedChangesStrategy {
     override fun onAfterDiscard(before: TypedRealm, after: MutableRealm) {
         Log.i("Client reset: recovery unsuccessful, attempting to manually recover any changes")
         // ... Try to manually recover any unsynced data
-        manuallyRecoverUnsyncedData(before, after) 
+        manuallyRecoverUnsyncedData(before, after)
     }
     // Executed if the automatic recovery has failed,
     // but the discard unsynced changes fallback has completed successfully.

--- a/source/examples/generated/kotlin/SyncTest.snippet.set-custom-logger-deprecated.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.set-custom-logger-deprecated.kt
@@ -14,7 +14,7 @@ val config = SyncConfiguration.Builder(user, setOf(Toad::class))
     .log(LogLevel.ALL, customLoggers = listOf(customLogger))
 
     .initialSubscriptions { realm ->
-        add(realm.query<Toad>(),  "sync subscription")
+        add(realm.query<Toad>(), "sync subscription")
     }
     .build()
 

--- a/source/examples/generated/kotlin/SyncTest.snippet.set-log-level-deprecated.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.set-log-level-deprecated.kt
@@ -10,7 +10,7 @@ val config = SyncConfiguration.Builder(user, setOf(Toad::class))
     .log(LogLevel.DEBUG)
 
     .initialSubscriptions { realm ->
-        add(realm.query<Toad>(),  "sync subscription")
+        add(realm.query<Toad>(), "sync subscription")
     }
     .build()
 

--- a/source/examples/generated/kotlin/SyncTest.snippet.set-log-level-realmlog.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.set-log-level-realmlog.kt
@@ -6,7 +6,7 @@ val app: App = App.create(YOUR_APP_ID) // Replace this with your App ID
 val user = app.login(Credentials.emailPassword(email, password))
 val config = SyncConfiguration.Builder(user, setOf(Toad::class))
     .initialSubscriptions { realm ->
-        add(realm.query<Toad>("name == $0", "name value"),  "sync subscription")
+        add(realm.query<Toad>("name == $0", "name value"), "sync subscription")
     }
     .build()
 val realm = Realm.open(config)

--- a/source/examples/generated/kotlin/SyncTest.snippet.sync-error-handler.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.sync-error-handler.kt
@@ -1,5 +1,5 @@
-val syncErrorHandler = SyncSession.ErrorHandler {
-        session, error -> Log.e("Error message" + error.message.toString())
+val syncErrorHandler = SyncSession.ErrorHandler { session, error ->
+    Log.e("Error message" + error.message.toString())
 }
 runBlocking {
     val user = app.login(credentials)

--- a/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-query.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-query.kt
@@ -1,6 +1,7 @@
 val subscription =
     realm.subscriptions.findByQuery(
-        realm.query<Toad>("name == $0", "name value"))
+        realm.query<Toad>("name == $0", "name value")
+    )
 if (subscription != null) {
     realm.subscriptions.update {
         this.remove(subscription)

--- a/source/examples/generated/kotlin/SyncTest.snippet.wait-for-subscription-changes.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.wait-for-subscription-changes.kt
@@ -1,6 +1,9 @@
 // make an update to the list of subscriptions
 realm.subscriptions.update {
-    this.add(realm.query<Toad>("name == $0", "another name value"), "another subscription name")
+    this.add(
+        realm.query<Toad>("name == $0", "another name value"),
+        "another subscription name"
+    )
 }
 // wait for subscription to fully synchronize changes
 realm.subscriptions.waitForSynchronization(Duration.parse("10s"))


### PR DESCRIPTION
## Pull Request Info

Just regenerating a handful of Bluehawked code examples that Android Studio has linted. No code changes.

### Jira

- https://jira.mongodb.org/browse/DOCSP-29868

### Staged Changes

- [Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29868/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
