### PR TITLE
(DOCSP-29536): C++: update test suite to v0.1.1-alpha

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        74a363814de3bf28cd191306b9af65222fc18d0c 
+  GIT_TAG        v0.1.1-alpha 
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/quick-start.cpp
+++ b/examples/cpp/quick-start.cpp
@@ -101,6 +101,7 @@ TEST_CASE("local quick start", "[realm][write]") {
         realm.remove(todo);
     });
     // :snippet-end:
+    token.unregister();
 }
 
 TEST_CASE("sync quick start", "[realm][write][sync]") {

--- a/examples/cpp/sync-errors.cpp
+++ b/examples/cpp/sync-errors.cpp
@@ -35,7 +35,7 @@ TEST_CASE("set a sync error handler", "[error]") {
 
     // Setting an error handler on the sync_config gives you access to sync_session and sync_error
     dbConfig.sync_config().set_error_handler([](const realm::sync_session& session, const realm::sync_error& error) {
-        std::cerr << "A sync error occurred. Code: " << error.error_code() << " Message: " << error.message() << std::endl;
+        std::cerr << "A sync error occurred. Message: " << error.message() << std::endl;
     });
 
     auto syncRealmRef = realm::async_open<SyncError_Dog>(dbConfig).get_future().get();

--- a/examples/cpp/threading.cpp
+++ b/examples/cpp/threading.cpp
@@ -65,12 +65,6 @@ TEST_CASE("scheduler", "[write]") {
         
         void invoke(realm::Function<void()> &&task) override {
             // ... Add the task to the (lock-free) processor queue ...
-            // :remove-start:
-            // Had to implement some code in here in order to override invoke
-            // This is arbitrary code that isn't shown in the example just to
-            // get the tests to compile and run.
-            task.release(); 
-            // :remove-end:
         }
 
         [[nodiscard]] bool is_on_thread() const noexcept override {

--- a/examples/cpp/threading.cpp
+++ b/examples/cpp/threading.cpp
@@ -63,20 +63,29 @@ TEST_CASE("scheduler", "[write]") {
             // ... Call in the processor thread(s) and block until return ...
         }
         
-        void invoke(std::function<void()> &&task) override {
+        void invoke(realm::Function<void()> &&task) override {
             // ... Add the task to the (lock-free) processor queue ...
+            // :remove-start:
+            // Had to implement some code in here in order to override invoke
+            // This is arbitrary code that isn't shown in the example just to
+            // get the tests to compile and run.
+            task.release(); 
+            // :remove-end:
         }
 
         [[nodiscard]] bool is_on_thread() const noexcept override {
             // ... Return true if the caller is on the same thread as a processor thread ...
+            return false; // :remove:
         }
 
         bool is_same_as(const realm::scheduler *other) const noexcept override {
             // ... Compare scheduler instances ...
+            return false; // :remove:
         }
 
         [[nodiscard]] bool can_invoke() const noexcept override {
             // ... Return true if the scheduler can accept tasks ...
+            return false; // :remove:
         }
         // ...
     };

--- a/source/examples/generated/cpp/sync-errors.snippet.create-error-handler.cpp
+++ b/source/examples/generated/cpp/sync-errors.snippet.create-error-handler.cpp
@@ -4,7 +4,7 @@ auto dbConfig = user.flexible_sync_configuration();
 
 // Setting an error handler on the sync_config gives you access to sync_session and sync_error
 dbConfig.sync_config().set_error_handler([](const realm::sync_session& session, const realm::sync_error& error) {
-    std::cerr << "A sync error occurred. Code: " << error.error_code() << " Message: " << error.message() << std::endl;
+    std::cerr << "A sync error occurred. Message: " << error.message() << std::endl;
 });
 
 auto syncRealmRef = realm::async_open<Dog>(dbConfig).get_future().get();

--- a/source/examples/generated/cpp/threading.snippet.scheduler.cpp
+++ b/source/examples/generated/cpp/threading.snippet.scheduler.cpp
@@ -8,7 +8,7 @@ struct MyScheduler : realm::scheduler {
         // ... Call in the processor thread(s) and block until return ...
     }
     
-    void invoke(std::function<void()> &&task) override {
+    void invoke(realm::Function<void()> &&task) override {
         // ... Add the task to the (lock-free) processor queue ...
     }
 


### PR DESCRIPTION
## Pull Request Info

Updating the C++ test suite to use versioned releases!

A few minor code changes to fix build errors, but the only visible changes are listed in the Staged Changes section.

### Jira

- https://jira.mongodb.org/browse/DOCSP-29536

### Staged Changes

- [Handle Sync Errors](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29536/sdk/cpp/sync/handle-sync-errors/): Remove `error_code()` as it is no longer available 
- [Threading](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29536/sdk/cpp/crud/threading/#schedulers--run-loops-): Overriding `invoke` in a custom scheduler now requires `realm::Function` instead of `std::function`. I also added some minimal code to get past build errors, but that code is not reflected in the published code snippet.

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
