### PR TITLE
Quick fix: React Native migration sample line emphasis

### DIFF
--- a/source/examples/Migrations/LocalMigration/LocalMigration-modify-property-type.js
+++ b/source/examples/Migrations/LocalMigration/LocalMigration-modify-property-type.js
@@ -1,7 +1,7 @@
 const realm = await Realm.open({
     schema: [Dog],
     schemaVersion: 2,
-    migration: (oldRealm, newRealm) => {
+    onMigration: (oldRealm, newRealm) => {
         if(oldRealm.schemaVersion < 2){
             const oldObjects = oldRealm.objects('Dog');
             const newObjects = newRealm.objects('Dog');

--- a/source/examples/Migrations/LocalMigration/LocalMigration.js
+++ b/source/examples/Migrations/LocalMigration/LocalMigration.js
@@ -1,7 +1,7 @@
 Realm.open({
   schema: [Person],
   schemaVersion: 2,
-  migration: (oldRealm, newRealm) => {
+  onMigration: (oldRealm, newRealm) => {
     // only apply this change if upgrading to schemaVersion 2
     if (oldRealm.schemaVersion < 2) {
       const oldObjects = oldRealm.objects('Person');

--- a/source/sdk/react-native/model-data/change-an-object-model.txt
+++ b/source/sdk/react-native/model-data/change-an-object-model.txt
@@ -188,14 +188,14 @@ property, and then delete the old property.
  
          .. literalinclude:: /examples/generated/react-native/ts/change-an-object-model-test.snippet.rename-a-property-of-a-schema.tsx
            :language: typescript
-           :emphasize-lines: 3, 11, 20, 30
+           :emphasize-lines: 3, 12, 20-21, 28-29, 38, 50
 
      .. tab::
          :tabid: javascript
  
          .. literalinclude:: /examples/generated/react-native/js/change-an-object-model-test.snippet.rename-a-property-of-a-schema.jsx
            :language: javascript
-           :emphasize-lines: 7, 16, 26
+           :emphasize-lines: 8, 18, 30
 
 .. important:: Synced Realms
 
@@ -244,11 +244,11 @@ callback function of the :js-sdk:`Configuration
  
          .. literalinclude:: /examples/generated/react-native/ts/change-an-object-model-test.snippet.modify-a-property-type.tsx
            :language: typescript
-           :emphasize-lines: 2, 11, 22, 32
+           :emphasize-lines: 2, 11, 19, 27, 38, 49
 
      .. tab::
          :tabid: javascript
  
          .. literalinclude:: /examples/generated/react-native/js/change-an-object-model-test.snippet.modify-a-property-type.jsx
            :language: javascript
-           :emphasize-lines: 6, 17, 27
+           :emphasize-lines: 6, 17, 28


### PR DESCRIPTION
## Pull Request Info

Also, update erroneous Node samples. These Node samples aren't unit tested. I have a ticket in the Node.js Docs Upgrade epic to convert them to tests. For now, they should at least have the correct syntax.

### Staged Changes

- [React Native: Change an Object Model](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fix-rn-migration-emphasis/sdk/react-native/model-data/change-an-object-model/#rename-a-property). Rename a property and modify a property type examples.
- [Node: Change an Object Model](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/fix-rn-migration-emphasis/sdk/node/model-data/modify-an-object-schema/#rename-a-property). Rename a property and modify a property type examples.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcThXLPJNbJZIiE3JSQvyEdLjfy6WSgTzbwP8w&usqp=CAU)

