### PR TITLE
(DOCSP-30014) Update Flutter SDK versions, replace to-be-deprecated command

### DIFF
--- a/examples/dart/README.md
+++ b/examples/dart/README.md
@@ -11,20 +11,19 @@ make sure you have Flutter 2.8 and Dart 2.15 flutter --version Flutter 2.8.1 •
 Run these commands to setup the application:
 
 1. Disable Realm analytics. Set env variable `REALM_DISABLE_ANALYTICS=exists` either globally
-   (for example, in `.zshrc`) or locally to this terminal only. I suggest globally not to forget about it and
-   upload analytics unnecessarily.
-2. Get all packages for the example project:
+   (for example, in `.zshrc`) or locally to this terminal only. I suggest globally not to forget about it and upload analytics unnecessarily.
+1. Get all packages for the example project:
 
    ```sh
    dart pub get
    ```
-3. Install Realm Dart SDK:
+1. Install Realm Dart SDK:
 
    ```sh
    dart run realm_dart install
    ```
 
-4. Run the generator to generate the required Realm object definitions.
+1. Run the generator to generate the required Realm object definitions.
    (If asked "Found 4 declared outputs which already exist on disk.Delete these files?"
    use option 1. Delete):
 
@@ -32,7 +31,7 @@ Run these commands to setup the application:
    dart run realm_dart generate
    ```
 
-5. Run the project's tests **without concurrency**:
+1. Run the project's tests **without concurrency**:
 
    ```sh
    dart run test --concurrency=1

--- a/examples/dart/README.md
+++ b/examples/dart/README.md
@@ -13,13 +13,18 @@ Run these commands to setup the application:
 1. Disable Realm analytics. Set env variable `REALM_DISABLE_ANALYTICS=exists` either globally
    (for example, in `.zshrc`) or locally to this terminal only. I suggest globally not to forget about it and
    upload analytics unnecessarily.
-1. Get all packages for the example project:
+2. Get all packages for the example project:
 
    ```sh
    dart pub get
    ```
+3. Install Realm Dart SDK:
 
-1. Run the generator to generate the required Realm object definitions.
+   ```sh
+   dart run realm_dart install
+   ```
+
+4. Run the generator to generate the required Realm object definitions.
    (If asked "Found 4 declared outputs which already exist on disk.Delete these files?"
    use option 1. Delete):
 
@@ -27,7 +32,7 @@ Run these commands to setup the application:
    dart run realm_dart generate
    ```
 
-1. Run the project's tests **without concurrency**:
+5. Run the project's tests **without concurrency**:
 
    ```sh
    dart run test --concurrency=1

--- a/examples/dart/pubspec.lock
+++ b/examples/dart/pubspec.lock
@@ -730,4 +730,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=2.19.0 <3.0.0"

--- a/examples/dart/pubspec.lock
+++ b/examples/dart/pubspec.lock
@@ -493,26 +493,26 @@ packages:
     dependency: transitive
     description:
       name: realm_common
-      sha256: "94dccf30597b6ab48a18a12ac6f2414bef78f54b3e9221df51386699bb4dd8ab"
+      sha256: e31f72feddb77e7dcfb9a8a0d19c25c79d71ecf6d873de8801b9d58cc29b5a5e
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.0+rc"
+    version: "1.0.3"
   realm_dart:
     dependency: "direct main"
     description:
       name: realm_dart
-      sha256: "2345e802cb021dc23833a2443c7228122c7c97d15e318cbd4320abeba47e0baa"
+      sha256: "6d10aff68f6e78127ee19187cb37fe679c9e08567de04e2585fd7f19491049e5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.0+rc"
+    version: "1.0.3"
   realm_generator:
     dependency: transitive
     description:
       name: realm_generator
-      sha256: "0ec2186c9851433a95dae86f367a1c12821c4c93e9137fce7b80fc5c54e63f42"
+      sha256: "9af5252323e19ba4cd63e984b5aad20a3f809d79a6fee7779ef959456b2bb78e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.0+rc"
+    version: "1.0.3"
   rxdart:
     dependency: transitive
     description:

--- a/examples/dart/pubspec.yaml
+++ b/examples/dart/pubspec.yaml
@@ -4,10 +4,10 @@ description: A simple command-line application using Realm Dart SDK.
 publish_to: none
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.5 <4.0.0"
 
 dependencies:
-  realm_dart: 0.11.0+rc
+  realm_dart: ^1.0.3
   path: ^1.8.2
   dart_jsonwebtoken: ^2.4.2
   faker: ^2.0.0

--- a/examples/dart/test/task_project_models_test.g.dart
+++ b/examples/dart/test/task_project_models_test.g.dart
@@ -6,10 +6,10 @@ part of 'task_project_models_test.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Task extends _Task with RealmEntity, RealmObjectBase, RealmObject {
+class Item extends _Item with RealmEntity, RealmObjectBase, RealmObject {
   static var _defaultsSet = false;
 
-  Task(
+  Item(
     ObjectId id,
     String name, {
     bool isComplete = false,
@@ -18,7 +18,7 @@ class Task extends _Task with RealmEntity, RealmObjectBase, RealmObject {
     int progressMinutes = 0,
   }) {
     if (!_defaultsSet) {
-      _defaultsSet = RealmObjectBase.setDefaults<Task>({
+      _defaultsSet = RealmObjectBase.setDefaults<Item>({
         'isComplete': false,
         'priority': 0,
         'progressMinutes': 0,
@@ -32,7 +32,7 @@ class Task extends _Task with RealmEntity, RealmObjectBase, RealmObject {
     RealmObjectBase.set(this, 'progressMinutes', progressMinutes);
   }
 
-  Task._();
+  Item._();
 
   @override
   ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
@@ -68,17 +68,17 @@ class Task extends _Task with RealmEntity, RealmObjectBase, RealmObject {
       RealmObjectBase.set(this, 'progressMinutes', value);
 
   @override
-  Stream<RealmObjectChanges<Task>> get changes =>
-      RealmObjectBase.getChanges<Task>(this);
+  Stream<RealmObjectChanges<Item>> get changes =>
+      RealmObjectBase.getChanges<Item>(this);
 
   @override
-  Task freeze() => RealmObjectBase.freezeObject<Task>(this);
+  Item freeze() => RealmObjectBase.freezeObject<Item>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
-    RealmObjectBase.registerFactory(Task._);
-    return const SchemaObject(ObjectType.realmObject, Task, 'Task', [
+    RealmObjectBase.registerFactory(Item._);
+    return const SchemaObject(ObjectType.realmObject, Item, 'Item', [
       SchemaProperty('id', RealmPropertyType.objectid,
           mapTo: '_id', primaryKey: true),
       SchemaProperty('name', RealmPropertyType.string),
@@ -95,12 +95,12 @@ class Project extends _Project with RealmEntity, RealmObjectBase, RealmObject {
     ObjectId id,
     String name, {
     int? quota,
-    Iterable<Task> tasks = const [],
+    Iterable<Item> items = const [],
   }) {
     RealmObjectBase.set(this, '_id', id);
     RealmObjectBase.set(this, 'name', name);
     RealmObjectBase.set(this, 'quota', quota);
-    RealmObjectBase.set<RealmList<Task>>(this, 'tasks', RealmList<Task>(tasks));
+    RealmObjectBase.set<RealmList<Item>>(this, 'items', RealmList<Item>(items));
   }
 
   Project._();
@@ -116,10 +116,10 @@ class Project extends _Project with RealmEntity, RealmObjectBase, RealmObject {
   set name(String value) => RealmObjectBase.set(this, 'name', value);
 
   @override
-  RealmList<Task> get tasks =>
-      RealmObjectBase.get<Task>(this, 'tasks') as RealmList<Task>;
+  RealmList<Item> get items =>
+      RealmObjectBase.get<Item>(this, 'items') as RealmList<Item>;
   @override
-  set tasks(covariant RealmList<Task> value) =>
+  set items(covariant RealmList<Item> value) =>
       throw RealmUnsupportedSetError();
 
   @override
@@ -142,8 +142,8 @@ class Project extends _Project with RealmEntity, RealmObjectBase, RealmObject {
       SchemaProperty('id', RealmPropertyType.objectid,
           mapTo: '_id', primaryKey: true),
       SchemaProperty('name', RealmPropertyType.string),
-      SchemaProperty('tasks', RealmPropertyType.object,
-          linkTarget: 'Task', collectionType: RealmCollectionType.list),
+      SchemaProperty('items', RealmPropertyType.object,
+          linkTarget: 'Item', collectionType: RealmCollectionType.list),
       SchemaProperty('quota', RealmPropertyType.int, optional: true),
     ]);
   }

--- a/examples/dart/test_sdk_example/pubspec.yaml
+++ b/examples/dart/test_sdk_example/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.2 <3.0.0'
+  sdk: '>=2.17.5 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -36,7 +36,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  realm: ^0.9.0+rc
+  realm: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/source/sdk/flutter/install.txt
+++ b/source/sdk/flutter/install.txt
@@ -189,7 +189,7 @@ follow these steps.
 
          .. code-block::
 
-            flutter pub run realm generate
+            dart run realm generate
 
       These steps should make the updated SDK version work in your application.
       If issues persist, you can delete the application from your linked client and

--- a/source/sdk/flutter/quick-start.txt
+++ b/source/sdk/flutter/quick-start.txt
@@ -83,7 +83,7 @@ Now generate a RealmObject class ``Car`` from the data model class ``Car``:
 
       .. code-block::
 
-         flutter pub run realm generate
+         dart run realm generate
 
    .. tab:: Dart
       :tabid: dart
@@ -108,7 +108,7 @@ there's a change to ``_Car``, run:
 
       .. code-block::
 
-         flutter pub run realm generate --watch
+         dart run realm generate --watch
 
    .. tab:: Dart
       :tabid: dart

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -97,7 +97,7 @@ Create Model
 
             .. code-block::
 
-               flutter pub run realm generate
+               dart run realm generate
 
          .. tab:: Dart
             :tabid: dart
@@ -226,7 +226,7 @@ Run the following command to generate ``RealmObjects``:
 
       .. code-block::
 
-         flutter pub run realm generate
+         dart run realm generate
 
    .. tab:: Dart
       :tabid: dart
@@ -268,7 +268,7 @@ include the ``--watch`` flag in your command.
 
       .. code-block::
 
-         flutter pub run realm generate --watch
+         dart run realm generate --watch
 
    .. tab:: Dart
       :tabid: dart
@@ -287,7 +287,7 @@ Cleaning the generator cache can be useful when debugging.
 
       .. code-block::
 
-         flutter pub run realm generate --clean
+         dart run realm generate --clean
 
    .. tab:: Dart
       :tabid: dart

--- a/source/sdk/flutter/test-and-debug.txt
+++ b/source/sdk/flutter/test-and-debug.txt
@@ -26,7 +26,7 @@ the following command:
 
 .. code:: shell
 
-   flutter pub run realm install
+   dart run realm install
 
 This command installs native binaries needed to run tests for the
 Flutter app.


### PR DESCRIPTION
## Pull Request Info

Update Flutter SDK versions in the Flutter tests. Also, replace all instances of `flutter pub run` with `dart run`. The former is being deprecated.

Note: waiting for the next Flutter SDK release to merge.

### Jira

- https://jira.mongodb.org/browse/DOCSP-30014

### Staged Changes

Very small change on these pages: `flutter pub run` -> `dart run`.

- [Install](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-30014/sdk/flutter/install/)
- [Quickstart](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-30014/sdk/flutter/quick-start/)
- [Define a Realm Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-30014/sdk/flutter/realm-database/model-data/define-realm-object-schema/)
- [Test & Debug](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-30014/sdk/flutter/test-and-debug/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

![](https://english.cctv.com/20090814/images/1250217309998_1250217309998_r.jpg)
