### PR TITLE
(DOCSP-30328): Swift MutableSet: Add missing supported types

### DIFF
--- a/source/sdk/swift/model-data/supported-types.txt
+++ b/source/sdk/swift/model-data/supported-types.txt
@@ -647,19 +647,21 @@ collection represents a :ref:`to-many relationship <ios-to-many-relationship>`
 containing distinct values. A ``MutableSet`` supports the following types 
 (and their optional versions): 
 
-- Bool, 
-- Int, 
-- Int8, 
-- Int16, 
-- Int32, 
-- Int64, 
-- Float, 
-- Double, 
-- String, 
-- Data, 
-- Date, 
-- Decimal128, 
+- Bool
+- Data
+- Date
+- Decimal128
+- Double
+- Float
+- Int
+- Int8
+- Int16
+- Int32
+- Int64
+- Object
 - ObjectId
+- String
+- UUID
 
 Like Swift's :apple:`Set <documentation/swift/set>`, ``MutableSet`` is a 
 generic type that is parameterized on the type it stores. Unlike 


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-30328

### Staged Changes

- [Supported Types/MutableSet](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-30328/sdk/swift/model-data/supported-types/#mutable-set)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
