### PR TITLE
Remove Serializer not needed

### DIFF
--- a/source/sdk/kotlin/realm-database/serialization.txt
+++ b/source/sdk/kotlin/realm-database/serialization.txt
@@ -37,8 +37,6 @@ KSerializer:
      - ``RealmInstantKSerializer::class``
    * - ``RealmList``
      - ``RealmListKSerializer::class``
-   * - ``ObjectId``
-     - ``ObjectIdKSerializer::class``
    * - ``RealmSet``
      - ``RealmSetKSerializer::class``
    * - ``RealmUUID``
@@ -90,7 +88,6 @@ a snippet containing all serializers to the top of a file:
       RealmInstantKSerializer::class,
       RealmListKSerializer::class,
       RealmSetKSerializer::class,
-      ObjectIdKSerializer::class,
       RealmUUIDKSerializer::class
    )
 


### PR DESCRIPTION
This PR updates the Kotlin Serializer section with updated information. The ObjectId serializer was needed in an earlier iteration of the API, but it turned out to not be needed for the final release.