### PR TITLE
(DOCSP-30433): Add RealmDictionary to list of supported data types

### DIFF
--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -36,6 +36,7 @@ Realm supports the following field data types:
 - ``Decimal128``
 - ``ObjectId`` 
 - ``RealmInstant``
+- ``RealmUUID``
 - Any ``RealmObject`` subclass
 - ``RealmList<T>``, where T is any of the supported data types or a   
   `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
@@ -45,7 +46,11 @@ Realm supports the following field data types:
   `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
   Sets of ``RealmObject`` cannot have null elements. 
   All other types of ``RealmSet<T>`` can be nullable (``RealmSet<T?>``).
-- ``RealmUUID``
+- ``RealmDictionary<T>``, where T is any type of Realm primitive nullable or 
+  non-nullable value (``RealmDictionary<T?>``), a
+  `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__,
+  or an `EmbeddedRealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
+  Dictionaries of ``RealmObject`` and ``EmbeddedRealmObject`` must be declared nullable. 
 - ``BacklinksDelegate<T>``, a `backlinks <{+kotlin-local-prefix+}io.realm.kotlin.ext/backlinks.html>`__
   delegate used to define an inverse relationship between 
   `RealmObjects <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__. 


### PR DESCRIPTION
## Pull Request Info

Add `RealmDictionary` to supported data types list. 
> NOTE: This page (and list) will be revisited and revamped as part of upcoming Kotlin Gap Analysis epic work.

### Jira

- https://jira.mongodb.org/browse/DOCSP-30433

### Staged Changes

- [Data Types - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-30433-realmDictionary/sdk/kotlin/realm-database/schemas/supported-types/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
