### PR TITLE
(DOCSP-27669) Get rid of 'Overview' heading in React Native SDK

### DIFF
--- a/source/sdk/react-native/bootstrap-with-expo.txt
+++ b/source/sdk/react-native/bootstrap-with-expo.txt
@@ -10,9 +10,6 @@ Bootstrap with Expo - React Native SDK
    :depth: 2
    :class: singlecol
 
-Overview
---------
-
 The :npm:`Realm Expo template <package/@realm/expo-template>`
 provides a fully working React Native application that you can use to bootstrap
 your app development project with Realm. This documentation covers how to

--- a/source/sdk/react-native/bootstrap-with-expo.txt
+++ b/source/sdk/react-native/bootstrap-with-expo.txt
@@ -10,6 +10,9 @@ Bootstrap with Expo - React Native SDK
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 The :npm:`Realm Expo template <package/@realm/expo-template>`
 provides a fully working React Native application that you can use to bootstrap
 your app development project with Realm. This documentation covers how to

--- a/source/sdk/react-native/install.txt
+++ b/source/sdk/react-native/install.txt
@@ -10,6 +10,9 @@ Install Realm for React Native
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 The Realm React Native SDK enables development of `React
 Native <https://facebook.github.io/react-native/>`__
 applications using the JavaScript and `TypeScript

--- a/source/sdk/react-native/install.txt
+++ b/source/sdk/react-native/install.txt
@@ -10,9 +10,6 @@ Install Realm for React Native
    :depth: 2
    :class: singlecol
 
-Overview
---------
-
 The Realm React Native SDK enables development of `React
 Native <https://facebook.github.io/react-native/>`__
 applications using the JavaScript and `TypeScript

--- a/source/sdk/react-native/integrations/mac-catalyst.txt
+++ b/source/sdk/react-native/integrations/mac-catalyst.txt
@@ -10,9 +10,6 @@ Build using Mac Catalyst
    :depth: 2
    :class: singlecol
 
-Overview
---------
-
 This page details steps required for building your Realm application when
 using `Mac Catalyst <https://developer.apple.com/mac-catalyst/>`_ with `React
 Native version 0.64 and below <https://reactnative.dev/versions>`_.

--- a/source/sdk/react-native/integrations/mac-catalyst.txt
+++ b/source/sdk/react-native/integrations/mac-catalyst.txt
@@ -10,6 +10,9 @@ Build using Mac Catalyst
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 This page details steps required for building your Realm application when
 using `Mac Catalyst <https://developer.apple.com/mac-catalyst/>`_ with `React
 Native version 0.64 and below <https://reactnative.dev/versions>`_.

--- a/source/sdk/react-native/migrate/index.txt
+++ b/source/sdk/react-native/migrate/index.txt
@@ -16,6 +16,8 @@ Upgrade from Stitch to Realm - React Native SDK
    :depth: 2
    :class: singlecol
 
+Overview
+--------
 If you have an existing app built with the Stitch SDK, you should migrate your
 app to use the new Realm SDK.  While much of the application logic and flow of
 information hasn't changed, there are a few changes to how it connects to the

--- a/source/sdk/react-native/migrate/index.txt
+++ b/source/sdk/react-native/migrate/index.txt
@@ -16,8 +16,6 @@ Upgrade from Stitch to Realm - React Native SDK
    :depth: 2
    :class: singlecol
 
-Overview
---------
 If you have an existing app built with the Stitch SDK, you should migrate your
 app to use the new Realm SDK.  While much of the application logic and flow of
 information hasn't changed, there are a few changes to how it connects to the

--- a/source/sdk/react-native/model-data/data-types/collections.txt
+++ b/source/sdk/react-native/model-data/data-types/collections.txt
@@ -10,9 +10,6 @@ Collections - React Native SDK
    :depth: 2
    :class: singlecol
 
-Overview
---------
-
 Realm has several types to represent groups of objects,
 which we call **collections**. A collection is an object that contains
 zero or more instances of one :ref:`Realm type

--- a/source/sdk/react-native/model-data/data-types/collections.txt
+++ b/source/sdk/react-native/model-data/data-types/collections.txt
@@ -10,6 +10,9 @@ Collections - React Native SDK
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 Realm has several types to represent groups of objects,
 which we call **collections**. A collection is an object that contains
 zero or more instances of one :ref:`Realm type

--- a/source/sdk/react-native/model-data/data-types/uuid.txt
+++ b/source/sdk/react-native/model-data/data-types/uuid.txt
@@ -11,6 +11,9 @@ UUID - React Native SDK
 
 .. versionadded:: ``realm@10.5.0``
 
+Overview
+--------
+
 ``UUID`` (Universal Unique Identifier) is a 16-byte :wikipedia:`unique value
 <Universally_unique_identifier>`. ``UUID`` is bundled with the Realm package as
 part of BSON (``Realm.BSON.UUID``).

--- a/source/sdk/react-native/model-data/data-types/uuid.txt
+++ b/source/sdk/react-native/model-data/data-types/uuid.txt
@@ -11,9 +11,6 @@ UUID - React Native SDK
 
 .. versionadded:: ``realm@10.5.0``
 
-Overview
---------
-
 ``UUID`` (Universal Unique Identifier) is a 16-byte :wikipedia:`unique value
 <Universally_unique_identifier>`. ``UUID`` is bundled with the Realm package as
 part of BSON (``Realm.BSON.UUID``).

--- a/source/sdk/react-native/realm-files/encrypt.txt
+++ b/source/sdk/react-native/realm-files/encrypt.txt
@@ -10,9 +10,6 @@ Encrypt a Realm - React Native SDK
    :depth: 2
    :class: singlecol
 
-Overview
---------
-
 You can encrypt the realm database file on disk with AES-256 +
 SHA-2 by supplying a 64-byte encryption key when opening a realm.
 

--- a/source/sdk/react-native/realm-files/encrypt.txt
+++ b/source/sdk/react-native/realm-files/encrypt.txt
@@ -10,6 +10,9 @@ Encrypt a Realm - React Native SDK
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 You can encrypt the realm database file on disk with AES-256 +
 SHA-2 by supplying a 64-byte encryption key when opening a realm.
 

--- a/source/sdk/react-native/sync-data/log-level.txt
+++ b/source/sdk/react-native/sync-data/log-level.txt
@@ -10,9 +10,6 @@ Set the Client Log Level - React Native SDK
    :depth: 3
    :class: singlecol
 
-Overview
---------
-
 You can set the realm Sync client :js-sdk:`log level
 <Realm.App.Sync.html#~LogLevel>` by calling
 :js-sdk:`Realm.App.Sync.setLogLevel() <Realm.App.Sync.html#.setLogLevel>` with

--- a/source/sdk/react-native/sync-data/log-level.txt
+++ b/source/sdk/react-native/sync-data/log-level.txt
@@ -10,6 +10,9 @@ Set the Client Log Level - React Native SDK
    :depth: 3
    :class: singlecol
 
+Overview
+--------
+
 You can set the realm Sync client :js-sdk:`log level
 <Realm.App.Sync.html#~LogLevel>` by calling
 :js-sdk:`Realm.App.Sync.setLogLevel() <Realm.App.Sync.html#.setLogLevel>` with

--- a/source/sdk/react-native/test-and-debug/debugging-with-flipper.txt
+++ b/source/sdk/react-native/test-and-debug/debugging-with-flipper.txt
@@ -10,9 +10,6 @@ Debugging with Flipper - React Native SDK
    :depth: 2
    :class: singlecol
 
-Overview
---------
-
 To debug Realm apps built with React Native, use the Flipper Debugger. Flipper provides a way to visualize, inspect, and control your apps from a simple desktop interface. In addition to Flipper's intuitive interface, the :github:`Realm Flipper Plugin <realm/realm-flipper-plugin>` provides additional ways to inspect your Realm Database through:
 
 - Live Objects: See objects in real-time.

--- a/source/sdk/react-native/test-and-debug/debugging-with-flipper.txt
+++ b/source/sdk/react-native/test-and-debug/debugging-with-flipper.txt
@@ -10,6 +10,9 @@ Debugging with Flipper - React Native SDK
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 To debug Realm apps built with React Native, use the Flipper Debugger. Flipper provides a way to visualize, inspect, and control your apps from a simple desktop interface. In addition to Flipper's intuitive interface, the :github:`Realm Flipper Plugin <realm/realm-flipper-plugin>` provides additional ways to inspect your Realm Database through:
 
 - Live Objects: See objects in real-time.

--- a/source/sdk/react-native/test-and-debug/testing.txt
+++ b/source/sdk/react-native/test-and-debug/testing.txt
@@ -11,9 +11,6 @@ Testing - React Native SDK
    :depth: 2
    :class: singlecol
 
-Overview
---------
-
 You can test the Realm React Native SDK with popular React Native testing libraries
 like `Jest <https://jestjs.io/>`__, `Jasmine <https://jasmine.github.io/>`__,
 and `Mocha <https://mochajs.org/>`__.

--- a/source/sdk/react-native/test-and-debug/testing.txt
+++ b/source/sdk/react-native/test-and-debug/testing.txt
@@ -11,6 +11,9 @@ Testing - React Native SDK
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 You can test the Realm React Native SDK with popular React Native testing libraries
 like `Jest <https://jestjs.io/>`__, `Jasmine <https://jasmine.github.io/>`__,
 and `Mocha <https://mochajs.org/>`__.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-27669

### Staged Changes

- [Bootstrap with Expo](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-27669/sdk/react-native/bootstrap-with-expo/)
- Removed on other pages throughout.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

<img src="https://i.pinimg.com/564x/c6/04/00/c60400aa302b25becc47466ecc2cbcc7.jpg" widht=400>
