### PR TITLE
(DOCSP-29870b) Relocate Partition-Based Sync Content

### DIFF
--- a/source/sdk/node/realm-files/bundle.txt
+++ b/source/sdk/node/realm-files/bundle.txt
@@ -128,18 +128,15 @@ Bundle a Synchronized Realm
 
 .. include:: /includes/note-writecopy-same-type-sync-only.rst
 
-Generally, bundling a synchronized realm works the same as bundling a local-only realm. 
-However, there are some limitations to bundling realms that use Device Sync.
+Generally, bundling a synchronized realm works the same as bundling a local-only realm.
+However, you can only bundle fully synchronized realms. Make sure that the realm has fully synchronized
+with the server before bundling: 
 
-#. You can only bundle fully synchronized realms. Make sure that the realm has fully synchronized 
-   with the server before bundling: 
-
-   .. literalinclude:: /examples/generated/node/bundle-a-realm.snippet.fully-sync-before-copy.js
+.. literalinclude:: /examples/generated/node/bundle-a-realm.snippet.fully-sync-before-copy.js
       :language: javascript
 
-#. When opening a bundled synchronized realm that uses Partition-Based Sync, 
-   you must use the same partition key that was used in the original realm
-   configuration. If you use a different partition key, the SDK throws
-   an error when opening the bundled realm. 
+Further limitations exist when opening a bundled synchronized realm that uses the older
+Partition-Based Sync. For more information on using realms configured with Partition-Based Sync,
+refer to :ref:`Partition-Based Sync - Node.js SDK <node-partition-based-sync>`.
 
 .. include:: /includes/note-bundling-synced-realms.rst

--- a/source/sdk/node/realm-files/bundle.txt
+++ b/source/sdk/node/realm-files/bundle.txt
@@ -39,9 +39,9 @@ To create and bundle a realm file with your application:
 .. note:: Bundle Synchronized Realms
 
    SDK version 10.12.0 introduced the ability to bundle synchronized realms.
-   Before version 10.12.0, you could only bundle local realms. See the :ref:Bundle a
-   Synchronized Realm <node-bundle-synced-realm> section for details on considerations
-   and limitations when bundling a synchronized realm.`
+   Before version 10.12.0, you could only bundle local realms. See the :ref:`Bundle a
+   Synchronized Realm <node-bundle-synced-realm>` section for details on considerations
+   and limitations when bundling a synchronized realm.
 
 .. _node-create-a-realm-for-bundling:
 

--- a/source/sdk/node/realm-files/bundle.txt
+++ b/source/sdk/node/realm-files/bundle.txt
@@ -39,11 +39,9 @@ To create and bundle a realm file with your application:
 .. note:: Bundle Synchronized Realms
 
    SDK version 10.12.0 introduced the ability to bundle synchronized realms.
-   Before version 10.12.0, you could only bundle local realms.
-
-   :ref:`See the Bundle a Synchronized Realm section for details on considerations and limitations
-   when bundling a synchronized realm. <node-bundle-synced-realm>`
-   
+   Before version 10.12.0, you could only bundle local realms. See the :ref:Bundle a
+   Synchronized Realm <node-bundle-synced-realm> section for details on considerations
+   and limitations when bundling a synchronized realm.`
 
 .. _node-create-a-realm-for-bundling:
 
@@ -135,8 +133,8 @@ with the server before bundling:
 .. literalinclude:: /examples/generated/node/bundle-a-realm.snippet.fully-sync-before-copy.js
       :language: javascript
 
+.. include:: /includes/note-bundling-synced-realms.rst
+
 Further limitations exist when opening a bundled synchronized realm that uses the older
 Partition-Based Sync. For more information on using realms configured with Partition-Based Sync,
 refer to :ref:`Partition-Based Sync - Node.js SDK <node-partition-based-sync>`.
-
-.. include:: /includes/note-bundling-synced-realms.rst

--- a/source/sdk/node/realm-files/open-and-close-a-realm.txt
+++ b/source/sdk/node/realm-files/open-and-close-a-realm.txt
@@ -134,7 +134,7 @@ as an encrypted synced realm.
 .. seealso:: 
 
    - :ref:`Open a Flexible Synced Realm - Node.js SDK <node-flexible-sync-open-realm>`
-   - :ref:`Open a Partition-Based Synced Realm - Node.js SDK <node-partition-sync-open-realm>`
+   - :ref:`Open a Partition-Based Synced Realm - Node.js SDK <node-partition-based-sync>`
    - :ref:`Encrypt a Realm - Node.js SDK <node-partition-sync-open-realm>`
 
 .. _node-close-a-realm:

--- a/source/sdk/node/sync.txt
+++ b/source/sdk/node/sync.txt
@@ -12,6 +12,7 @@ Sync Data Between Devices - Node.js SDK
    Manual Client Reset Data Recovery </sdk/node/sync/client-reset-data-recovery>
    Set the Client Log Level </sdk/node/sync/log-level>
    Stream Data to Atlas </sdk/node/sync/stream-data-to-atlas>
+   Partition-Based Sync </sdk/node/sync/partition-based-sync>
 
 .. contents:: On this page
    :local:
@@ -26,15 +27,15 @@ an :ref:`Atlas App Services backend <realm-cloud>`. When a client
 device is online, Sync asynchronously synchronizes data in a 
 background thread between the device and your backend App. 
 
+Device Sync has two sync modes: Flexible Sync and the older Partition-Based
+Sync. We recommend using the Flexible Sync mode for new apps. For more 
+information on using Partition-Based Sync, refer to :ref:`Partition-Based Sync
+– Node.js SDK <node-partition-based-sync>`. 
+
 When you use Sync in your client application, your implementation must match 
-the Sync Mode you select in your backend App configuration. The Sync Mode
-options are:
-
-- Flexible Sync
-- Partition-Based Sync
-
-You can only use one Sync Mode for your application. You cannot mix 
-Partition-Based Sync and Flexible Sync within the same App.
+the Sync Mode you select in your backend App configuration. You can only use 
+one Sync Mode for your application. You cannot mix Partition-Based Sync 
+and Flexible Sync within the same App.
 
 .. seealso::
 

--- a/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
@@ -52,7 +52,7 @@ Open a Synced Realm
 
 The first step in implementing Device Sync is to open the synced Realm. The following
 information pertains to an app using Flexible Sync. If your existing app uses the
-older Partition-Based Sync, refer to :ref:Open a Partition-Based Synced Realm <node-partition-based-sync>.
+older Partition-Based Sync, refer to :ref:`Open a Partition-Based Synced Realm <node-partition-based-sync>`.
 If you have not yet decided or are unsure which to use, read the :ref:`Choose Your
 Sync Mode <sync-modes>` page.
 

--- a/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
@@ -47,18 +47,14 @@ Before you configure a realm with Flexible Sync in a Node.js application:
 #. :ref:`Initialize the App client <node-connect-to-mongodb-realm-backend-app>`.
 #. :ref:`Authenticate a user <node-authenticate-users>` in your client project.
 
-Open a Flexible Synced Realm
-----------------------------
+Open a Synced Realm
+-------------------
 
-You can open a Synced realm with Flexible Sync or the older Partition-Based 
-Sync. If you'd like to open a realm with Partition-Based Sync, refer to 
-:ref:`Open a Partition-Based Synced Realm <node-partition-based-sync>`. 
+The first step in implementing Device Sync is to open the synced Realm. The following
+information pertains to an app using Flexible Sync. If your existing app uses the
+older Partition-Based Sync, refer to :ref:Open a Partition-Based Synced Realm <node-partition-based-sync>.
 If you have not yet decided or are unsure which to use, read the :ref:`Choose Your
 Sync Mode <sync-modes>` page.
-
-By default, Realm syncs all data from the server before returning.
-If you want to sync data in the background, read the :ref:`Open a Synced Realm
-While Offline <node-open-synced-realm-offline>` section.
 
 .. _node-flexible-sync-open-realm:
 
@@ -70,6 +66,10 @@ In the SyncConfiguration, you must include include a ``user`` and ``flexible:tru
 
 .. literalinclude:: /examples/generated/node/flexible-sync.snippet.open-flexible-sync-realm.js
    :language: javascript
+
+By default, Realm syncs all data from the server before returning.
+If you want to sync data in the background, read the :ref:`Open a Synced Realm
+While Offline <node-sync-changes-in-the-background>` section.
 
 .. important:: Flexible Sync Requires a Subscription
 
@@ -129,10 +129,10 @@ to enable background synchronization.
 .. important:: Offline Login is Supported for Both Flexible and Partition-Based Sync Configurations
 
    You can open a realm immediately with background sync or after a timeout
-   elapses using Flexible Sync or the older Parition-Based Sync.
+   elapses using Flexible Sync or the older Partition-Based Sync.
    
-   :ref:`Partition-Based Sync is an outdated sync mode. See the Partition-Based Sync - Node.js SDK
-   page for details on using Parition-Based Sync for your application. <node-partition-based-sync>`
+   Partition-Based Sync is an outdated sync mode. See the :ref:`Partition-Based Sync - Node.js
+   SDK <node-partition-based-sync>` page for details on using Partition-Based Sync for your application.
 
 .. _node-open-immediately-with-background-sync:
 

--- a/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
@@ -47,11 +47,13 @@ Before you configure a realm with Flexible Sync in a Node.js application:
 #. :ref:`Initialize the App client <node-connect-to-mongodb-realm-backend-app>`.
 #. :ref:`Authenticate a user <node-authenticate-users>` in your client project.
 
-Open a Synced Realm
--------------------
+Open a Flexible Synced Realm
+----------------------------
 
-You can open a Synced realm with a Flexible Sync or Partition-Based Sync. If
-you have not yet decided or are unsure which to use, read the :ref:`Choose Your
+You can open a Synced realm with Flexible Sync or the older Partition-Based 
+Sync. If you'd like to open a realm with Partition-Based Sync, refer to 
+:ref:`Open a Partition-Based Synced Realm <node-partition-based-sync>`. 
+If you have not yet decided or are unsure which to use, read the :ref:`Choose Your
 Sync Mode <sync-modes>` page.
 
 By default, Realm syncs all data from the server before returning.
@@ -59,9 +61,6 @@ If you want to sync data in the background, read the :ref:`Open a Synced Realm
 While Offline <node-open-synced-realm-offline>` section.
 
 .. _node-flexible-sync-open-realm:
-
-Open a Flexible Synced Realm
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To open a realm using Flexible Sync, call :js-sdk:`Realm.open() <Realm.html#.open>`. 
 Pass in a :js-sdk:`Configuration <Realm.html#~Configuration>`
@@ -108,27 +107,6 @@ on how you set :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`:
 - ``Realm.Configuration.path`` is an absolute path. Your Realm file is stored
   at ``Realm.Configuration.path``.
 
-.. _node-partition-sync-open-realm:
-
-Open a Partition-Based Synced Realm
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/node-open-a-synced-realm.rst
-
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: typescript
-
-      .. literalinclude:: /examples/generated/node/open-and-close-a-realm.snippet.open-partition-based.ts
-        :language: typescript
-
-   .. tab::
-      :tabid: javascript
-
-      .. literalinclude:: /examples/generated/node/open-and-close-a-realm.snippet.open-partition-based.js
-        :language: javascript
-
 .. _node-open-synced-realm-offline:
 
 Open a Synced Realm While Offline
@@ -151,7 +129,10 @@ to enable background synchronization.
 .. important:: Offline Login is Supported for Both Flexible and Partition-Based Sync Configurations
 
    You can open a realm immediately with background sync or after a timeout
-   elapses using either Flexible and Partition-Based Sync.
+   elapses using Flexible Sync or the older Parition-Based Sync.
+   
+   :ref:`Partition-Based Sync is an outdated sync mode. See the Partition-Based Sync - Node.js SDK
+   page for details on using Parition-Based Sync for your application. <node-partition-based-sync>`
 
 .. _node-open-immediately-with-background-sync:
 

--- a/source/sdk/node/sync/partition-based-sync.txt
+++ b/source/sdk/node/sync/partition-based-sync.txt
@@ -11,10 +11,9 @@ Partition-Based Sync - Node.js SDK
    :class: singlecol 
 
 Atlas Device Sync has two sync modes:  :ref:`Flexible Sync <flexible-sync>`
-and the older Partition-Based Sync. We recommend using Flexible Sync.
-The information on this page is for users who would still like to
-use Parition-Based Sync to build their Node.js app. For information
-about Partition-Based Sync, refer to :ref:`Partition-Based Sync <partition-based-sync>`.
+and Partition-Based Sync. We recommend using Flexible Sync.
+The information on this page is to support users who have existing apps that use
+:ref:`Partition-Based Sync <partition-based-sync>`.
 
 .. note:: Matching Sync Modes with Atlas Device Sync
 
@@ -22,11 +21,6 @@ about Partition-Based Sync, refer to :ref:`Partition-Based Sync <partition-based
   implementation must match the Sync Mode you select in your backend App configuration.
   You can only use one Sync mode for your application. You cannot mix Parition-Based
   Sync and Flexible Sync within the same app.
-
-You can open a Synced realm with a Flexible Sync or Partition-Based Sync. For information
-about opening a Flexible Synced realm, refer to :ref:`Configure & Open a Synced Realm -
-Node.js SDK <node-open-a-synced-realm>`. If you have not yet decided or are unsure which
-to use, refer to :ref:`Choose Your Sync Mode <sync-modes>`.
 
 .. _node-partition-sync-open-realm:
 

--- a/source/sdk/node/sync/partition-based-sync.txt
+++ b/source/sdk/node/sync/partition-based-sync.txt
@@ -53,11 +53,3 @@ Open a Bundled Partition-Based Synced Realm
 When opening a :ref:`bundled synchronized realm <node-bundle-a-realm>` that uses Partition-Based Sync,
 you must use the same partition key that was used in the original realm configuration. If you use a
 different partition key, the SDK throw an error when opening the bundled realm. 
-
-Data Ingest
-~~~~~~~~~~~
-
-You cannot query an asymmetric object or write it to a local realm, so asymmetric objects are incompatible 
-with bi-directional Partition-Based Sync, as well as with Flexible Sync and local Realm use.
-
-

--- a/source/sdk/node/sync/partition-based-sync.txt
+++ b/source/sdk/node/sync/partition-based-sync.txt
@@ -1,0 +1,69 @@
+.. _node-partition-based-sync:
+
+==================================
+Partition-Based Sync - Node.js SDK
+==================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 3
+   :class: singlecol 
+
+Atlas Device Sync has two sync modes:  :ref:`Flexible Sync <flexible-sync>`
+and the older Partition-Based Sync. We recommend using Flexible Sync.
+The information on this page is for users who would still like to
+use Parition-Based Sync to build their Node.js app. For information
+about Partition-Based Sync, refer to :ref:`Partition-Based Sync <partition-based-sync>`.
+
+.. note:: Matching Sync Modes with Atlas Device Sync
+
+  When you use :ref:`Atlas Device Sync <sync>` in your client application, your
+  implementation must match the Sync Mode you select in your backend App configuration.
+  You can only use one Sync mode for your application. You cannot mix Parition-Based
+  Sync and Flexible Sync within the same app.
+
+You can open a Synced realm with a Flexible Sync or Partition-Based Sync. For information
+about opening a Flexible Synced realm, refer to :ref:`Configure & Open a Synced Realm -
+Node.js SDK <node-open-a-synced-realm>`. If you have not yet decided or are unsure which
+to use, refer to :ref:`Choose Your Sync Mode <sync-modes>`.
+
+.. _node-partition-sync-open-realm:
+
+Open a Partition-Based Synced Realm
+-----------------------------------
+
+.. include:: /includes/node-open-a-synced-realm.rst
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: typescript
+
+      .. literalinclude:: /examples/generated/node/open-and-close-a-realm.snippet.open-partition-based.ts
+        :language: typescript
+
+   .. tab::
+      :tabid: javascript
+
+      .. literalinclude:: /examples/generated/node/open-and-close-a-realm.snippet.open-partition-based.js
+        :language: javascript
+
+.. important:: Offline Login is Supported for Partition-Based Sync Configurations
+    You can open a realm immediately with background sync or after a timeout elapses using
+    Partition-Based Sync. 
+
+Open a Bundled Partition-Based Synced Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When opening a :ref:`bundled synchronized realm <node-bundle-a-realm>` that uses Partition-Based Sync,
+you must use the same partition key that was used in the original realm configuration. If you use a
+different partition key, the SDK throw an error when opening the bundled realm. 
+
+Data Ingest
+~~~~~~~~~~~
+
+You cannot query an asymmetric object or write it to a local realm, so asymmetric objects are incompatible 
+with bi-directional Partition-Based Sync, as well as with Flexible Sync and local Realm use.
+
+

--- a/source/sdk/node/sync/partition-based-sync.txt
+++ b/source/sdk/node/sync/partition-based-sync.txt
@@ -19,7 +19,7 @@ The information on this page is to support users who have existing apps that use
 
   When you use :ref:`Atlas Device Sync <sync>` in your client application, your
   implementation must match the Sync Mode you select in your backend App configuration.
-  You can only use one Sync mode for your application. You cannot mix Parition-Based
+  You can only use one Sync mode for your application. You cannot mix Partition-Based
   Sync and Flexible Sync within the same app.
 
 .. _node-partition-sync-open-realm:


### PR DESCRIPTION
## Pull Request Info

The Node.js docs have references to Partition-Based Sync sprinkled throughout. We should shift this content to a single page dedicated to Partition-Based Sync. That way, the rest of the docs default to Flexible Sync.

This should be similar in nature to the App Services page for PBS: https://www.mongodb.com/docs/atlas/app-services/reference/partition-based-sync/#overview

This involves:

- Finding PBS content in the Node.js SDK and moving it to a new dedicated PBS page
- May need to write new Flexible Sync test
- Ensure internal links go to new locations

### Jira

- https://jira.mongodb.org/browse/DOCSP-29870

### Staged Changes

- [Partition-Based Sync - Node.js SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29870b/sdk/node/sync/partition-based-sync/)
- [Sync Data – Node.js SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29870b/sdk/node/sync/)
- [Bundle a Realm File – Node.js SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29870b/sdk/node/realm-files/bundle/)
- [Configure, Open, and Close a Realm – Node.js SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29870b/sdk/node/realm-files/open-and-close-a-realm/)
- [Configure & Open a Synced Realm – Node.js SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29870b/sdk/node/sync/configure-and-open-a-synced-realm/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
