### PR TITLE
(DOCSP-31233): Add info to docs around map key limitations

### DIFF
--- a/examples/ios/Examples/CreateRealmObjects.swift
+++ b/examples/ios/Examples/CreateRealmObjects.swift
@@ -3,6 +3,7 @@
 //     "CreateExamples_": ""
 //   }
 // }
+import Foundation
 import XCTest
 import RealmSwift
 
@@ -201,6 +202,34 @@ class CreateRealmObjects: XCTestCase {
             dog.favoriteParksByCity.setValue("Bush Park", forKey: "Ottawa")
         }
         // :snippet-end:
+    }
+    
+    func testCreateObjectWithMapKeysPercentEncodedForbiddenCharacters() {
+        // :snippet-start: percent-encode-disallowed-map-keys
+        // Percent encode . or $ characters to use them in map keys
+        let mapKey = "New York.Brooklyn"
+        let encodedMapKey = "New York%2EBrooklyn"
+        // :snippet-end:
+        
+        let realm = try! Realm()
+        let dog = CreateExamples_Dog()
+        dog.name = "Wishbone"
+        dog.currentCity = "New York"
+        // Set map values
+        dog.favoriteParksByCity[encodedMapKey] = "Domino Park"
+
+        // Round-trip adding a dog with a percent-encoded map key, querying it, and decoding it
+        try! realm.write {
+            realm.add(dog)
+        }
+        let savedWishbone = realm.objects(CreateExamples_Dog.self).where {
+            $0.name == "Wishbone"
+        }.first!
+        let savedWishboneMapKey = savedWishbone.favoriteParksByCity.keys[0]
+        XCTAssert(savedWishboneMapKey == "New York%2EBrooklyn")
+        let decodedMapKey = savedWishboneMapKey.removingPercentEncoding
+        let unwrappedDecodedMapKey = decodedMapKey
+        XCTAssert(mapKey == unwrappedDecodedMapKey)
     }
 
     func testCreateMutableSet() {

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1451,7 +1451,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.39.0;
+				minimumVersion = 10.41.0;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/CreateTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/CreateTest.kt
@@ -62,6 +62,50 @@ class CreateTest: RealmTest() {
             realm.close()
         }
     }
+
+    @Test
+    fun createRealmDictionaryPercentEncodedDisallowedCharacter() {
+        runBlocking {
+            val config = RealmConfiguration.Builder(
+                schema = setOf(CreateTest_Frog::class) // Pass the defined class as the object schema
+            )
+                .directory("/tmp/") // default location for jvm is... in the project root
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.name}")
+
+            // Delete frogs to make this test successful on consecutive reruns
+            realm.write {
+                // fetch all frogs from the realm
+                val frogs: RealmResults<CreateTest_Frog> = this.query<CreateTest_Frog>().find()
+                // call delete on the results of a query to delete those objects permanently
+                delete(frogs)
+                assertEquals(0, frogs.size)
+            }
+
+            // :snippet-start: percent-encode-disallowed-characters
+            // Percent encode . or $ characters to use them in map keys
+            val mapKey = "Hundred Acre Wood.Northeast"
+            val encodedMapKey = "Hundred Acre Wood%2ENortheast"
+            // :snippet-end:
+
+            // Round-trip an object with a percent-encoded map key just to confirm it works
+            // Not testing encoding/decoding here because (Dachary) could not figure out how to add java.net as a dependency
+            // This functionality seems to be provided by java.net.URLEncoder/URLDecoder
+            realm.write {
+                this.copyToRealm(CreateTest_Frog().apply {
+                    name = "Kermit"
+                    favoritePondsByForest = realmDictionaryOf(encodedMapKey to "Picnic Pond")
+                })
+            }
+
+            val frogs: RealmResults<CreateTest_Frog> = realm.query<CreateTest_Frog>().find()
+            val thisFrog = frogs.first()
+            val savedEncodedMapKey = thisFrog.favoritePondsByForest.keys.first()
+            assertEquals(encodedMapKey, savedEncodedMapKey)
+            realm.close()
+        }
+    }
 }
 
 // :replace-end:

--- a/examples/node/legacy/Examples/data-types.js
+++ b/examples/node/legacy/Examples/data-types.js
@@ -622,20 +622,21 @@ describe("Node.js Data Types", () => {
       janeSmith = realm.create("Person", {
         name: "Jane Smith",
         home: {
-          "kitchen%2Ewindows" : 5,
+          [encodedMapKey] : 5,
         },
       });
     });
 
     const persons = realm.objects("Person");
-    const jane = persons.first;
-    expect();
+    const jane = persons[0];
+    const janesHome = jane.home;
+    const encodedKeyValue = janesHome["kitchen%2Ewindows"];
 
-//    expect(jane.home["kitchen%2Ewindows"]);
+    expect(encodedKeyValue).toBe(5);
 
-    // realm.write(() => {
-    //   realm.delete(janeSmith);
-    // });
+    realm.write(() => {
+      realm.delete(janeSmith);
+    });
 
     realm.close();
   });

--- a/examples/node/legacy/Examples/data-types.js
+++ b/examples/node/legacy/Examples/data-types.js
@@ -595,4 +595,48 @@ describe("Node.js Data Types", () => {
     realm.close();
     // :snippet-end:
   });
+
+  test("should create a dictionary with a percent-encoded key", async () => {
+    const PersonSchema = {
+      name: "Person",
+      properties: {
+        name: "string",
+        home: "{}",
+      },
+    };
+
+    realm = await Realm.open({
+      path: "realm-files/data-type.realm",
+      schema: [PersonSchema],
+    });
+
+    // :snippet-start: percent-encode-disallowed-characters
+    // Percent encode . or $ characters to use them in map keys
+    const mapKey = "kitchen.windows";
+    const encodedMapKey = mapKey.replace(".", "%2E");
+    // :snippet-end:
+    expect(encodedMapKey).toBe("kitchen%2Ewindows");
+
+    let janeSmith;
+    realm.write(() => {
+      janeSmith = realm.create("Person", {
+        name: "Jane Smith",
+        home: {
+          "kitchen%2Ewindows" : 5,
+        },
+      });
+    });
+
+    const persons = realm.objects("Person");
+    const jane = persons.first;
+    expect();
+
+//    expect(jane.home["kitchen%2Ewindows"]);
+
+    // realm.write(() => {
+    //   realm.delete(janeSmith);
+    // });
+
+    realm.close();
+  });
 });

--- a/source/examples/generated/code/start/CreateRealmObjects.snippet.percent-encode-disallowed-map-keys.swift
+++ b/source/examples/generated/code/start/CreateRealmObjects.snippet.percent-encode-disallowed-map-keys.swift
@@ -1,0 +1,3 @@
+// Percent encode . or $ characters to use them in map keys
+let mapKey = "New York.Brooklyn"
+let encodedMapKey = "New York%2EBrooklyn"

--- a/source/examples/generated/cpp/crud.snippet.percent-encode-disallowed-characters.cpp
+++ b/source/examples/generated/cpp/crud.snippet.percent-encode-disallowed-characters.cpp
@@ -1,0 +1,3 @@
+// Percent encode . or $ characters to use them in map keys
+auto mapKey = "Monday.Morning";
+auto encodedMapKey = "Monday%2EMorning";

--- a/source/examples/generated/kotlin/CreateTest.snippet.percent-encode-disallowed-characters.kt
+++ b/source/examples/generated/kotlin/CreateTest.snippet.percent-encode-disallowed-characters.kt
@@ -1,0 +1,3 @@
+// Percent encode . or $ characters to use them in map keys
+val mapKey = "Hundred Acre Wood.Northeast"
+val encodedMapKey = "Hundred Acre Wood%2ENortheast"

--- a/source/examples/generated/node/data-types.snippet.percent-encode-disallowed-characters.js
+++ b/source/examples/generated/node/data-types.snippet.percent-encode-disallowed-characters.js
@@ -1,0 +1,3 @@
+    // Percent encode . or $ characters to use them in map keys
+    const mapKey = "kitchen.windows";
+    const encodedMapKey = mapKey.replace(".", "%2E");

--- a/source/includes/map-key-string-limitations.rst
+++ b/source/includes/map-key-string-limitations.rst
@@ -1,0 +1,3 @@
+Realm disallows the use of ``.`` or ``$`` characters in map keys.
+You can use percent encoding and decoding to store a map key that contains
+one of these disallowed characters.

--- a/source/sdk/cpp/crud/create.txt
+++ b/source/sdk/cpp/crud/create.txt
@@ -411,6 +411,11 @@ keys in a few ways:
 
       .. include:: /includes/tip-cpp-beta-experimental-features.rst
 
+.. include:: /includes/map-key-string-limitations.rst
+
+.. literalinclude:: /examples/generated/cpp/crud.snippet.percent-encode-disallowed-characters.cpp
+   :language: cpp
+
 Model
 `````
 

--- a/source/sdk/cpp/model-data/supported-types.txt
+++ b/source/sdk/cpp/model-data/supported-types.txt
@@ -275,3 +275,8 @@ String is the only supported type for a map key, but map values can be:
 - Required versions of any of the SDK's supported data types
 - Optional user-defined object links
 - Optional embedded objects
+
+.. include:: /includes/map-key-string-limitations.rst
+
+.. literalinclude:: /examples/generated/cpp/crud.snippet.percent-encode-disallowed-characters.cpp
+   :language: cpp

--- a/source/sdk/dotnet/model-data/data-types/dictionaries.txt
+++ b/source/sdk/dotnet/model-data/data-types/dictionaries.txt
@@ -36,6 +36,8 @@ or you do not have nullability enabled, use the
 :ref:`[Required]<dotnet-required-optional-property>` attribute if the dictionary  
 contains nullable reference types, such as ``string`` or ``byte[]``.
 
+.. include:: /includes/map-key-string-limitations.rst
+
 .. important:: Nullable Values Not Supported with Sync
 
    Local-only realms support collections of nullable (optional) values, 

--- a/source/sdk/kotlin/realm-database/crud/create.txt
+++ b/source/sdk/kotlin/realm-database/crud/create.txt
@@ -59,6 +59,11 @@ For more information about defining a dictionary property, refer to
 .. literalinclude:: /examples/generated/kotlin/CreateTest.snippet.create-dictionary.kt
    :language: kotlin
 
+.. include:: /includes/map-key-string-limitations.rst
+
+.. literalinclude:: /examples/generated/kotlin/CreateTest.snippet.percent-encode-disallowed-characters.kt
+   :language: kotlin
+
 .. _kotlin-create-asymmetric-object:
 
 Create an Asymmetric Object

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -262,6 +262,11 @@ or ``EmbeddedRealmObject``, the value must be declared nullable.
 .. literalinclude:: /examples/generated/kotlin/CreateTest.snippet.define-realm-dictionary-property.kt
    :language: kotlin
 
+.. include:: /includes/map-key-string-limitations.rst
+
+.. literalinclude:: /examples/generated/kotlin/CreateTest.snippet.percent-encode-disallowed-characters.kt
+   :language: kotlin
+
 .. _kotlin-additional-types:
 
 Additional Supported Data Types

--- a/source/sdk/node/model-data/data-types/dictionaries.txt
+++ b/source/sdk/node/model-data/data-types/dictionaries.txt
@@ -34,6 +34,9 @@ Realm disallows the use of ``.`` or ``$`` characters in dictionary keys.
 You can use percent encoding and decoding to store a dictionary key that 
 contains one of these disallowed characters.
 
+.. literalinclude:: /examples/generated/node/data-types.snippet.percent-encode-disallowed-characters.js
+   :language: javascript
+
 Create an Object with a  Dictionary Value
 -----------------------------------------
 Create an object with a dictionary value by running the :js-sdk:`realm.create()

--- a/source/sdk/node/model-data/data-types/dictionaries.txt
+++ b/source/sdk/node/model-data/data-types/dictionaries.txt
@@ -30,9 +30,7 @@ integers or ``"string{}"`` to specify that dictionary values must be strings.
 .. literalinclude:: /examples/generated/node/data-types.snippet.define-dictionary-in-schema.js
     :language: javascript
 
-Realm disallows the use of ``.`` or ``$`` characters in dictionary keys.
-You can use percent encoding and decoding to store a dictionary key that 
-contains one of these disallowed characters.
+.. include:: /includes/map-key-string-limitations.rst
 
 .. literalinclude:: /examples/generated/node/data-types.snippet.percent-encode-disallowed-characters.js
    :language: javascript

--- a/source/sdk/node/model-data/data-types/dictionaries.txt
+++ b/source/sdk/node/model-data/data-types/dictionaries.txt
@@ -30,6 +30,10 @@ integers or ``"string{}"`` to specify that dictionary values must be strings.
 .. literalinclude:: /examples/generated/node/data-types.snippet.define-dictionary-in-schema.js
     :language: javascript
 
+Realm disallows the use of ``.`` or ``$`` characters in dictionary keys.
+You can use percent encoding and decoding to store a dictionary key that 
+contains one of these disallowed characters.
+
 Create an Object with a  Dictionary Value
 -----------------------------------------
 Create an object with a dictionary value by running the :js-sdk:`realm.create()

--- a/source/sdk/react-native/model-data/data-types/dictionaries.txt
+++ b/source/sdk/react-native/model-data/data-types/dictionaries.txt
@@ -59,6 +59,12 @@ You can define define a dictionary of mixed values for a :ref:`Realm object mode
          :language: javascript
          :emphasize-lines: 6, 8
 
+Realm disallows the use of ``.`` or ``$`` characters in dictionary keys.
+You can use percent encoding and decoding to store a dictionary key that 
+contains one of these disallowed characters.
+
+.. literalinclude:: /examples/generated/node/data-types.snippet.percent-encode-disallowed-characters.js
+   :language: javascript
 
 Create an Object with a Dictionary Value
 ----------------------------------------

--- a/source/sdk/react-native/model-data/data-types/dictionaries.txt
+++ b/source/sdk/react-native/model-data/data-types/dictionaries.txt
@@ -59,9 +59,7 @@ You can define define a dictionary of mixed values for a :ref:`Realm object mode
          :language: javascript
          :emphasize-lines: 6, 8
 
-Realm disallows the use of ``.`` or ``$`` characters in dictionary keys.
-You can use percent encoding and decoding to store a dictionary key that 
-contains one of these disallowed characters.
+.. include:: /includes/map-key-string-limitations.rst
 
 .. literalinclude:: /examples/generated/node/data-types.snippet.percent-encode-disallowed-characters.js
    :language: javascript

--- a/source/sdk/swift/crud/create.txt
+++ b/source/sdk/swift/crud/create.txt
@@ -206,6 +206,10 @@ When you create an object that has a :swift-sdk:`map property
 .. literalinclude:: /examples/generated/code/start/CreateRealmObjects.snippet.map.swift
    :language: swift
 
+.. include:: /includes/map-key-string-limitations.rst
+
+.. literalinclude:: /examples/generated/code/start/CreateRealmObjects.snippet.percent-encode-disallowed-map-keys.swift
+
 .. _swift-create-object-mutableset-property:
 
 Create an Object with a MutableSet Property

--- a/source/sdk/swift/model-data/supported-types.txt
+++ b/source/sdk/swift/model-data/supported-types.txt
@@ -732,6 +732,10 @@ You can declare a Map as a property of an object:
        @Persisted var favoriteParksByCity: Map<String, String>
    }
 
+.. include:: /includes/map-key-string-limitations.rst
+
+.. literalinclude:: /examples/generated/code/start/CreateRealmObjects.snippet.percent-encode-disallowed-map-keys.swift
+
 .. note::
 
    When declaring default values for ``@Persisted`` Map property attributes, both


### PR DESCRIPTION
## Pull Request Info

Note for reviewer: the iOS tests are passing locally - the failure appears to be a problem with the CI. It's not actually running the tests - it's failing before the tests start running. I'll look into this in a separate ticket.

Test output from the local run is:

```
Test Suite 'RealmExamples.xctest' passed at 2023-07-14 16:37:33.861.
	 Executed 270 tests, with 0 failures (0 unexpected) in 160.970 (161.067) seconds
Test Suite 'Selected tests' passed at 2023-07-14 16:37:33.861.
	 Executed 270 tests, with 0 failures (0 unexpected) in 160.970 (161.067) seconds
```

### Jira

- https://jira.mongodb.org/browse/DOCSP-31233

### Staged Changes

- [Realm SDK docs](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31233/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
