### PR TITLE
(DOCSP-29051): Flutter supports multi-process encrypted realm access

### DIFF
--- a/source/includes/encrypt-mult-processes.rst
+++ b/source/includes/encrypt-mult-processes.rst
@@ -1,6 +1,0 @@
-You cannot open the same encrypted realm from multiple processes.
-Attempting to do so will throw the following error:
-``Encrypted interprocess sharing is currently unsupported.``
-
-If multiple processes need to access a realm simultaneously, use an unencrypted realm. 
-

--- a/source/sdk/flutter/realm-database/realm-files/encrypt.txt
+++ b/source/sdk/flutter/realm-database/realm-files/encrypt.txt
@@ -67,7 +67,14 @@ to create a 64-bit key and store that key in a :ref:`user object <user-objects>`
 Accessing an Encrypted Realm from Multiple Processes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/encrypt-mult-processes.rst
+.. versionchanged:: 1.1.0
+
+Starting with Realm Flutter SDK version 1.1.0, Realm supports opening
+the same encrypted realm in multiple processes. 
+
+If your app uses Realm Flutter SDK version 1.1.0 or earlier, attempting to 
+open an encrypted realm from multiple processes throws this error:
+``Encrypted interprocess sharing is currently unsupported.``
 
 Example
 -------


### PR DESCRIPTION
## Pull Request Info

Realm Flutter SDK adopted a Core version that supports multi-process encrypted realm access in [v1.1.0](https://github.com/realm/realm-dart/releases/tag/1.1.0).

### Jira

- https://jira.mongodb.org/browse/DOCSP-29051

### Staged Changes

- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29051/sdk/flutter/realm-database/realm-files/encrypt/#accessing-an-encrypted-realm-from-multiple-processes)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-app-services update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
