### PR TITLE
(DOCSP-31037, DOCSP-30208) Address backlinks and unmanaged objects

### DIFF
--- a/examples/dart/pubspec.lock
+++ b/examples/dart/pubspec.lock
@@ -249,6 +249,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  gql:
+    dependency: transitive
+    description:
+      name: gql
+      sha256: "07ae289bc5ccfbfd143883bfe9a380f5bf52c94559ded740cf3fb152fcbdbe2e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1-alpha+1686240655988"
+  gql_dedupe_link:
+    dependency: transitive
+    description:
+      name: gql_dedupe_link
+      sha256: dac8e5eec5e9f6274302e5c01f77c7558f89d727f2c0dff7cda568c440a171cd
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4-alpha+1686240656097"
+  gql_error_link:
+    dependency: transitive
+    description:
+      name: gql_error_link
+      sha256: bfdb543137da89448cc5d003fd029c2e8718931d39d4a7dedb16f9169862fbb9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  gql_exec:
+    dependency: transitive
+    description:
+      name: gql_exec
+      sha256: "04fb14e41fdc3fafa80fa7218224bceba019e00b80de9130c2dd0a9a77c6392d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1-alpha+1686240655996"
+  gql_http_link:
+    dependency: transitive
+    description:
+      name: gql_http_link
+      sha256: "0789d397d46ce274942fcc73e18a080cd2584296dadc33d8ae53d0666d7fe981"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  gql_link:
+    dependency: transitive
+    description:
+      name: gql_link
+      sha256: ecf2419e6c543d1b8dedd7dbbc538ce037f4d53a3b5b7d694a98a7d636da2817
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1-alpha+1686240656001"
+  gql_transform_link:
+    dependency: transitive
+    description:
+      name: gql_transform_link
+      sha256: "0645fdd874ca1be695fd327271fdfb24c0cd6fa40774a64b946062f321a59709"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  graphql:
+    dependency: "direct main"
+    description:
+      name: graphql
+      sha256: "1e3720c13cd1c9a345fed40dfac35759b626ff907661567d299616e9d9903e0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.0-beta.5"
   graphs:
     dependency: transitive
     description:
@@ -257,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  hive:
+    dependency: transitive
+    description:
+      name: hive
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   http:
     dependency: transitive
     description:
@@ -353,6 +425,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  normalize:
+    dependency: transitive
+    description:
+      name: normalize
+      sha256: "8a60e37de5b608eeaf9b839273370c71ebba445e9f73b08eee7725e0d92dbc43"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.2+1"
   objectid:
     dependency: transitive
     description:
@@ -433,6 +513,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   sane_uuid:
     dependency: transitive
     description:
@@ -593,6 +681,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   vm_service:
     dependency: transitive
     description:

--- a/examples/dart/pubspec.yaml
+++ b/examples/dart/pubspec.yaml
@@ -12,8 +12,7 @@ dependencies:
   dart_jsonwebtoken: ^2.4.2
   faker: ^2.0.0
   test: ^1.20.1
-  # graphql has version mismatches with realm_dart v1.3.0
-  # graphql: ^5.1.1
+  graphql: ^5.1.3
 
 dev_dependencies:
   lints: ^1.0.1

--- a/examples/dart/test/backlinks_test.g.dart
+++ b/examples/dart/test/backlinks_test.g.dart
@@ -88,8 +88,13 @@ class Task extends _Task with RealmEntity, RealmObjectBase, RealmObject {
   set isComplete(bool value) => RealmObjectBase.set(this, 'isComplete', value);
 
   @override
-  RealmResults<User> get linkedUser =>
-      RealmObjectBase.get<User>(this, 'linkedUser') as RealmResults<User>;
+  RealmResults<User> get linkedUser {
+    if (!isManaged) {
+      throw RealmError('Using backlinks is only possible for managed objects.');
+    }
+    return RealmObjectBase.get<User>(this, 'linkedUser') as RealmResults<User>;
+  }
+
   @override
   set linkedUser(covariant RealmResults<User> value) =>
       throw RealmUnsupportedSetError();

--- a/source/sdk/flutter/realm-database/model-data/relationships.txt
+++ b/source/sdk/flutter/realm-database/model-data/relationships.txt
@@ -57,8 +57,8 @@ using a property of type ``List<T>`` in your application, where T is a Realm mod
 Inverse Relationship
 --------------------
 
-An **inverse relationship** links an object back to any other objects that refer
-to it in to-one or to-many relationships.
+An **inverse relationship** links a Realm object back to any other realm objects
+that refer to it in to-one or to-many relationships.
 
 Inverse relationships have the following properties:
 
@@ -70,6 +70,8 @@ Inverse relationships have the following properties:
 - You cannot manually set the value of an inverse relationship property.
   Instead, Realm updates implicit relationships when you add or remove
   an object in the relationship.
+- Backlinks only work with Realm objects. Objects that haven't been added to a
+  realm yet cannot use backlinks.
 
 For example, the to-many relationship "a User has many Tasks" does not
 automatically create the inverse relationship "a Task belongs to one User".
@@ -77,7 +79,7 @@ If you don't specify the inverse relationship in the Task object model, you need
 run a separate query to look up the user that is assigned to a given task.
 
 Use the `Backlink <https://pub.dev/documentation/realm_common/latest/realm_common/Backlink-class.html>`__
-property annotation to define a inverse relationship.
+property annotation to define an inverse relationship.
 Pass a `Symbol <https://api.dart.dev/stable/2.18.4/dart-core/Symbol/Symbol.html>`__
 of the field name of the to-one or to-many field for which you are creating the backlink
 as an argument to ``Backlink()``. Include an ``Iterable`` of the object model

--- a/source/sdk/flutter/realm-database/model-data/relationships.txt
+++ b/source/sdk/flutter/realm-database/model-data/relationships.txt
@@ -71,7 +71,7 @@ Inverse relationships have the following properties:
   Instead, Realm updates implicit relationships when you add or remove
   an object in the relationship.
 - Backlinks only work with Realm objects. Objects that haven't been added to a
-  realm yet cannot use backlinks.
+  realm yet do not have backlinks.
 
 For example, the to-many relationship "a User has many Tasks" does not
 automatically create the inverse relationship "a Task belongs to one User".


### PR DESCRIPTION
## Pull Request Info

Updated the `graphql` dependency for the Flutter SDK test suite. Also clarified how backlinks work (or, rather, don't) with unmanaged objects.

### Jira

- https://jira.mongodb.org/browse/DOCSP-31037
- https://jira.mongodb.org/browse/DOCSP-30208

### Staged Changes

- [Relationships](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31037/sdk/flutter/realm-database/model-data/relationships/#inverse-relationship)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

![](https://www.sunnyskyz.com/uploads/2015/05/sb1bs-turtle-hat-2.jpg)
