### PR TITLE
(DOCSP-29773) Remove angle brackets from provider references

### DIFF
--- a/source/sdk/react-native/app-services/connect-to-app-services-app.txt
+++ b/source/sdk/react-native/app-services/connect-to-app-services-app.txt
@@ -28,8 +28,8 @@ Configure the App Client
 ------------------------
 
 To set up your App client, pass the App ID string
-to the ``id`` prop of the ``<AppProvider>``.
-Wrap any components that need to access the App with the ``<AppProvider>``.
+to the ``id`` prop of the ``AppProvider``.
+Wrap any components that need to access the App with the ``AppProvider``.
 
 
 .. literalinclude:: /examples/generated/react-native/ts/app-provider.test.snippet.app-provider.tsx
@@ -40,7 +40,7 @@ Wrap any components that need to access the App with the ``<AppProvider>``.
 Retrieve an Instance of the App Client
 --------------------------------------
 
-All components wrapped within an ``<AppProvider>`` can access the :js-sdk:`App <Realm.App.html>`
+All components wrapped within an ``AppProvider`` can access the :js-sdk:`App <Realm.App.html>`
 client with the ``useApp()`` hook. Using the App, you can authenticate users
 and access App Services.
 

--- a/source/sdk/react-native/app-services/query-mongodb.txt
+++ b/source/sdk/react-native/app-services/query-mongodb.txt
@@ -85,7 +85,7 @@ This returns a MongoDB service interface that you can use to access databases
 and collections in the cluster.
 
 If you are using ``@realm/react``, you can access the MongoDB client
-with the ``useUser()`` hook in a component wrapped by the ``<UserProvider>``.
+with the ``useUser()`` hook in a component wrapped by ``UserProvider``.
 
 .. tabs-realm-languages::
 

--- a/source/sdk/react-native/bootstrap-with-expo.txt
+++ b/source/sdk/react-native/bootstrap-with-expo.txt
@@ -63,11 +63,11 @@ The relevant files are as follows:
 
    * - Task.ts
      - A typescript file that defines a Task :ref:`object schema
-       <react-native-object-schemas>` and returns a ``<RealmProvider>`` and the hooks.
+       <react-native-object-schemas>` and returns a ``RealmProvider`` and the hooks.
       
    * - App.ts
      - The entry point to the application, which contains methods to create,
-       update, and delete tasks. The ``<RealmProvider>`` component wraps around
+       update, and delete tasks. The ``RealmProvider`` component wraps around
        the ``App`` component, providing your entire application with access to
        the realm.
 

--- a/source/sdk/react-native/crud.txt
+++ b/source/sdk/react-native/crud.txt
@@ -20,7 +20,7 @@ CRUD - React Native SDK
    Delete </sdk/react-native/crud/delete>
    Query Data </sdk/react-native/crud/query-data>
 
-Within a ``<RealmProvider>``, you can access a realm with
+Within a ``RealmProvider``, you can access a realm with
 the ``useRealm()`` hook. Then, you can create Realm objects
 using a :js-sdk:`Realm.write() <Realm.html#write>` transaction block.
 

--- a/source/sdk/react-native/manage-users/authenticate-users.txt
+++ b/source/sdk/react-native/manage-users/authenticate-users.txt
@@ -32,21 +32,21 @@ Before you can authenticate a user, you must:
 Configure User Authentication in Client
 ---------------------------------------
 
-Configure user authentication with the ``@realm/react`` ``<AppProvider>``
-and ``<UserProvider>`` components and ``useApp()`` and ``useUser()`` hooks.
+Configure user authentication with the ``@realm/react`` ``AppProvider``
+and ``UserProvider`` components and ``useApp()`` and ``useUser()`` hooks.
 
 To set up user authentication:
 
-#. Wrap all components you want to use with App Services in an ``<AppProvider>`` component.
-#. Inside of ``<AppProvider>``, wrap all components that you want to have access
-   to an authenticated user with a ``<UserProvider>`` component.
-#. In ``<UserProvider>``, include a ``fallback`` prop with another component
+#. Wrap all components you want to use with App Services in an ``AppProvider`` component.
+#. Inside of ``AppProvider``, wrap all components that you want to have access
+   to an authenticated user with a ``UserProvider`` component.
+#. In ``UserProvider``, include a ``fallback`` prop with another component
    that logs a user in. The app renders this component if there
    is no authenticated user.
-#. In the component passed to the ``<UserProvider>.fallback`` prop, authenticate a user
+#. In the component passed to the ``UserProvider.fallback`` prop, authenticate a user
    with ``Realm.App.logIn()``, which you can access with the ``useApp()`` hook.
 
-Components wrapped by ``<UserProvider>`` only render if your app has
+Components wrapped by ``UserProvider`` only render if your app has
 an authenticated user. These components can access the authenticated user
 with the ``useUser()`` hook.
 

--- a/source/sdk/react-native/manage-users/manage-email-password-users.txt
+++ b/source/sdk/react-native/manage-users/manage-email-password-users.txt
@@ -25,7 +25,7 @@ refer to :ref:`email-password-authentication` in the App Services documentation.
 Add AppProvider to Work with Email/Password Users
 -------------------------------------------------
 
-Wrap any components that need to manage email/password users with the ``<AppProvider>``.
+Wrap any components that need to manage email/password users with the ``AppProvider``.
 You can then access :js-sdk:`Realm.App.emailPasswordAuth <Realm.App.html#emailPasswordAuth>`
 to manage email/password authentication with the ``useApp()`` hook.
 

--- a/source/sdk/react-native/manage-users/manage-user-api-keys.txt
+++ b/source/sdk/react-native/manage-users/manage-user-api-keys.txt
@@ -20,7 +20,7 @@ client accessed with an authenticated user's :js-sdk:`User.apiKeys
 <Realm.User.html#apiKeys>` property.
 
 If you are using ``@realm/react``, you can access a user's ``ApiKeyAuth`` client
-with the ``useUser()`` hook in a component wrapped by ``<UserProvider>``.
+with the ``useUser()`` hook in a component wrapped by ``UserProvider``.
 
 .. literalinclude:: /examples/generated/react-native/ts/user-api-keys.test.snippet.user-api-key.tsx
    :language: typescript

--- a/source/sdk/react-native/manage-users/multi-user-applications.txt
+++ b/source/sdk/react-native/manage-users/multi-user-applications.txt
@@ -61,11 +61,11 @@ transition between states when certain events occur:
 Before You Begin
 ----------------
 
-If you're using ``@realm/react``, you must wrap any components that you want manage users
-with in the ``<AppProvider>`` component. Components wrapped with an ``AppProviders``
-can use ``useApp()`` hook to access the :js-sdk:`Realm.App <Realm.App.html>` client.
+If you're using ``@realm/react``, you must wrap any components that you want to manage users
+with in the ``AppProvider`` component. Components wrapped with an ``AppProvider``
+can use the ``useApp()`` hook to access the :js-sdk:`Realm.App <Realm.App.html>` client.
 
-For more information on using the ``<AppProvider>`` component and ``useApp()`` hook,
+For more information on using the ``AppProvider`` component and ``useApp()`` hook,
 refer to :ref:`Connect to an Atlas App Services App <react-native-connect-to-mongodb-realm-backend-app>`.
 
 

--- a/source/sdk/react-native/model-data.txt
+++ b/source/sdk/react-native/model-data.txt
@@ -53,7 +53,7 @@ validates each object to ensure that an object schema was provided for its type
 and that it meets all of the constraints specified in the schema.
 
 Using ``@realm/react``, you define a realm schema by passing individual object
-schemas to ``<RealmProvider>`` or ``createRealmContext()``.
+schemas to ``RealmProvider`` or ``createRealmContext()``.
 
 .. literalinclude:: /examples/generated/react-native/js/RealmConfig.snippet.create-realm-context.js
    :language: javascript

--- a/source/sdk/react-native/quick-start.txt
+++ b/source/sdk/react-native/quick-start.txt
@@ -93,8 +93,8 @@ to set up context and providers from ``@realm/react``. To learn more, refer to
 #. Create a realm context with ``createRealmContext()``. A realm context is a 
    `React Context object <https://reactjs.org/docs/context.html>`__ that contains
    React providers and hooks for working with your realm.
-#. Expose a realm with ``<RealmProvider>``. To expose a realm, you need a 
-   realm context. From that context, extract ``<RealmProvider>``, which 
+#. Expose a realm with ``RealmProvider``. To expose a realm, you need a 
+   realm context. From that context, extract ``RealmProvider``, which 
    contains your realm's context.
 
 .. tabs-realm-languages::
@@ -118,7 +118,7 @@ After you have a data model and a configured realm, you can create, read, update
 delete Realm objects.
 
 You must nest any components that perform these operations inside of a 
-``<RealmProvider>``. The ``useRealm()``, ``useQuery()``, and ``useObject()`` hooks 
+``RealmProvider``. The ``useRealm()``, ``useQuery()``, and ``useObject()`` hooks 
 enable you to perform read and write operations in your realm.
 
 
@@ -278,13 +278,13 @@ Configure and Access a Synced Realm
 
 To configure and access a synced realm:
 
-#. Initialize the App using ``<AppProvider>``
-#. Authenticate a User with ``<UserProvider>``
-#. Configure a Synced Realm with ``<RealmProvider>``
+#. Initialize the App using ``AppProvider``
+#. Authenticate a User with ``UserProvider``
+#. Configure a Synced Realm with ``RealmProvider``
 
 To learn more, refer to :ref:`Configure a Synced Realm <react-native-synced-realm>`.
 
-Initialize the App using <AppProvider>
+Initialize the App using AppProvider
 ``````````````````````````````````````
 
 To use App Services features, such as authentication and Device Sync, you must 
@@ -295,16 +295,16 @@ first access your App Services App using your App ID. You can
   :language: javascript
   :emphasize-lines: 6-8
 
-Authenticate a User with <UserProvider>
+Authenticate a User with UserProvider
 ```````````````````````````````````````
 
-Use the ``<UserProvider>`` to handle sections of your app that need an authenticated user.
+Use the ``UserProvider`` to handle sections of your app that need an authenticated user.
 
-To authenticate and log in a user, provide a ``fallback`` prop for ``<UserProvider>``. 
+To authenticate and log in a user, provide a ``fallback`` prop for ``UserProvider``. 
 This could be a log in screen component or a simple function that calls 
 :js-sdk:`App.logIn() <Realm.App.html#logIn>`. 
 
-Users can only access the parts of your app nested within ``<UserProvider>``
+Users can only access the parts of your app nested within ``UserProvider``
 after they have authenticated. If there's no authenticated user,
 the ``fallback`` component renders and nested components do not.
 
@@ -312,13 +312,13 @@ the ``fallback`` component renders and nested components do not.
   :language: javascript
   :emphasize-lines: 8-10
 
-Configure a Synced Realm with <RealmProvider>
+Configure a Synced Realm with RealmProvider
 `````````````````````````````````````````````
 
 After you have initialized your App, authenticated a user, and defined your
 object model, you can configure a synced realm. This is similar to configuring
 a local realm. However, you need to add some additional props to the
-``<RealmProvider>``.
+``RealmProvider``.
 
 #. Create the realm's :js-sdk:`Configuration <Realm.html#~Configuration>` object.
    The Configuration object defines the parameters of a realm and identifies it.
@@ -327,16 +327,16 @@ a local realm. However, you need to add some additional props to the
 #. Create a realm context with ``createRealmContext()``. A realm context is a 
    `React Context object <https://reactjs.org/docs/context.html>`__ that contains
    app-wide access to your realm.
-#. Extract the ``<RealmProvider>`` from the realm context, and then expose it
+#. Extract the ``RealmProvider`` from the realm context, and then expose it
    to your app.
-#. Add the ``sync`` property to ``<RealmProvider>`` and pass it a
+#. Add the ``sync`` property to ``RealmProvider`` and pass it a
    :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object.
    This sync object must contain ``flexible: true``.
 
 You need at least one sync subscription before you can read or write synced data.
 You can add subscriptions in your components or set up 
 :ref:`initial subscriptions <react-native-sync-bootstrap-initial-subscriptions>` on
-``<RealmProvider>``.
+``RealmProvider``.
 
 .. tabs-realm-languages::
 

--- a/source/sdk/react-native/realm-files/configure-a-realm.txt
+++ b/source/sdk/react-native/realm-files/configure-a-realm.txt
@@ -15,8 +15,8 @@ The ``@realm/react`` library exposes realms in your application using
 components. You can access realms with React hooks.
 
 To configure and open a local realm, create a Context with the realm's configuration. The 
-Context exports a ``<RealmProvider>`` component that exposes a configured realm. 
-All child components of ``<RealmProvider>`` can access the realm using hooks.
+Context exports a ``RealmProvider`` component that exposes a configured realm. 
+All child components of ``RealmProvider`` can access the realm using hooks.
 
 To learn how to open a realm using Device Sync, refer to 
 :ref:`Open a Synced Realm <react-native-open-a-synced-realm>`.
@@ -79,8 +79,8 @@ To encrypt a realm file on disk, refer to
 Expose a Realm
 --------------
 
-``<RealmProvider>`` is a wrapper that exposes a Context with Realm to 
-its child components. All child components inside ``<RealmProvider>`` have access 
+``RealmProvider`` is a wrapper that exposes a Context with Realm to 
+its child components. All child components inside ``RealmProvider`` have access 
 to hooks that let you read, write, and update data. This is what a local-only 
 realm wrapper might look like:
 
@@ -91,7 +91,7 @@ Expose More Than One Realm
 --------------------------
 
 You can open more than one realm at a time by creating additional Contexts and 
-``<RealmProvider>`` components.
+``RealmProvider`` components.
 
 .. literalinclude:: /examples/generated/react-native/ts/configure-realm-multiple.test.snippet.two-realm-contexts.tsx
    :language: javascript

--- a/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
+++ b/source/sdk/react-native/sync-data/configure-a-synced-realm.txt
@@ -42,12 +42,12 @@ By default, Realm syncs all data from the server before returning.
 If you want to sync data in the background, read the :ref:`Configure a Synced Realm
 While Offline <react-native-open-synced-realm-offline>` section.
 
-Nest <RealmProvider> within <AppProvider> and <UserProvider>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Nest RealmProvider within AppProvider and UserProvider
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To use a Flexible Sync realm with ``@realm/react``, you must nest ``<RealmProvider>``
-within ``<UserProvider>``. And ``<UserProvider>`` must be nested in ``<AppProvider>``. 
-This ensures that ``<RealmProvider>`` has all of the context it needs, like a 
+To use a Flexible Sync realm with ``@realm/react``, you must nest ``RealmProvider``
+within ``UserProvider``. And ``UserProvider`` must be nested in ``AppProvider``. 
+This ensures that ``RealmProvider`` has all of the context it needs, like a 
 logged-in user.
 
 Call ``createRealmContext()`` with 
@@ -58,26 +58,26 @@ The following example shows how to use these providers together in your app:
 .. literalinclude:: /examples/generated/react-native/ts/configure-realm-sync.test.snippet.configure-realm-sync-full.tsx
    :language: javascript
 
-For more information about configuring and using ``<AppProvider>``, check
+For more information about configuring and using ``AppProvider``, check
 out the :ref:`Connect To Atlas App Services page <react-native-app-client-configuration>`.
 
-You can also find information about ``<UserProvider>`` on the
+You can also find information about ``UserProvider`` on the
 :ref:`Authenticate Users page <react-native-authenticate-users>`.
 
 .. _react-native-flexible-sync-open-realm:
 
-Configure <RealmProvider>
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Configure RealmProvider
+~~~~~~~~~~~~~~~~~~~~~~~
 
 To configure a Flexible Sync realm, use ``@realm/react``'s ``createRealmContext()`` 
-function and its returned ``<RealmProvider>``.
+function and its returned ``RealmProvider``.
 
-In a ``<RealmProvider>`` that's nested in a ``<UserProvider>``, add a ``sync`` 
+In a ``RealmProvider`` that's nested in a ``UserProvider``, add a ``sync`` 
 property with a :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` 
 object that contains ``flexible: true``.
 
-Note that ``<UserProvider>`` automatically passes an authenticated user
-to ``<RealmProvider>``.
+Note that ``UserProvider`` automatically passes an authenticated user
+to ``RealmProvider``.
 
 .. literalinclude:: /examples/generated/react-native/ts/configure-realm-sync.test.snippet.configure-realm-sync-full.tsx
    :language: javascript
@@ -96,8 +96,8 @@ Using :js-sdk:`AppConfiguration.baseFilePath <Realm.App.html#~AppConfiguration>`
 and :js-sdk:`Realm.Configuration.path <Realm.html#~Configuration>`, you can
 control where Realm and metadata files are stored on client devices.
 
-To do so, set ``<AppProvider>.baseFilePath``. If ``baseFilePath`` is not set, the
-current work directory is used. You can also set ``<RealmProvider>.sync.path``
+To do so, set ``AppProvider.baseFilePath``. If ``baseFilePath`` is not set, the
+current work directory is used. You can also set ``RealmProvider.sync.path``
 for more control.
 
 .. tabs-realm-languages::
@@ -140,7 +140,7 @@ realm while offline. To do this, use a cached user and an
 :js-sdk:`OpenRealmBehaviorConfiguration
 <Realm.App.Sync.html#~OpenRealmBehaviorConfiguration>` object. 
 
-Within ``<RealmProvider>``'s sync configuration, set the optional ``newRealmFileBehavior`` 
+Within ``RealmProvider``'s sync configuration, set the optional ``newRealmFileBehavior`` 
 and ``existingRealmFileBehavior`` fields to your ``OpenRealmBehaviorConfiguration`` 
 object to enable background synchronization. 
 

--- a/source/sdk/react-native/sync-data/flexible-sync.txt
+++ b/source/sdk/react-native/sync-data/flexible-sync.txt
@@ -78,7 +78,7 @@ for it to stop attempting to sync matching data.
 Access Subscriptions
 ~~~~~~~~~~~~~~~~~~~~
 
-Within a ``<RealmProvider>`` that's configured for Flexible Sync, you can access
+Within a ``RealmProvider`` that's configured for Flexible Sync, you can access
 a collection of all subscriptions for your app. This is called a 
 :js-sdk:`SubscriptionSet <Realm.html#subscriptions>`.
 
@@ -144,7 +144,7 @@ Flexible Sync realm. Initial subscriptions let you define subscriptions when you
 :ref:`configure a synced realm <react-native-open-a-synced-realm>`.
 
 To open a synced realm with initial subscriptions, add an  ``initialSubscriptions`` 
-property to ``<RealmProvider>``'s 
+property to ``RealmProvider``'s 
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object.
 
 You **cannot** use the ``@realm/react`` library hooks ``useQuery`` and ``useObject``

--- a/source/sdk/react-native/sync-data/handle-sync-errors.txt
+++ b/source/sdk/react-native/sync-data/handle-sync-errors.txt
@@ -20,7 +20,7 @@ API calls.
 Set an error handler by registering an error callback as part of the
 :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>`.
 If you're using ``@realm/react``, pass the ``SyncConfiguration`` object
-to the ``sync`` property of a ``<RealmProvider>``.
+to the ``sync`` property of a ``RealmProvider``.
 
 .. literalinclude:: /examples/generated/react-native/ts/handle-sync-errors.test.snippet.handle-sync-error.tsx
    :language: javascript

--- a/source/sdk/react-native/sync-data/manage-sync-session.txt
+++ b/source/sdk/react-native/sync-data/manage-sync-session.txt
@@ -23,7 +23,7 @@ Before you can manage a sync session, you must perform the following:
 #. If you're using Flexible Sync, :ref:`add a sync subscription
    <react-native-sync-subscribe-to-queryable-fields>`
 #. Wrap components that use the ``useRealm()`` hook for a synced realm
-   with the ``<AppProvider>``, ``<UserProvider>``, and ``<RealmProvider>`` components.
+   with the ``AppProvider``, ``UserProvider``, and ``RealmProvider`` components.
    For more information on configuring and opening a synced realm,
    refer to :ref:`Open a Synced Realm <react-native-open-a-synced-realm>`.
 

--- a/source/sdk/react-native/sync-data/partition-based-sync.txt
+++ b/source/sdk/react-native/sync-data/partition-based-sync.txt
@@ -24,14 +24,14 @@ Configure a Partition-Based Sync Realm
 --------------------------------------
 
 To open a Flexible Sync realm, use ``@realm/react``'s ``createRealmContext()`` 
-function and its returned ``<RealmProvider>``.
+function and its returned ``RealmProvider``.
 
-In a ``<RealmProvider>`` that's nested in a ``<UserProvider>``, add a ``sync`` 
+In a ``RealmProvider`` that's nested in a ``UserProvider``, add a ``sync`` 
 property with a :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` 
 object that contains ``flexible: true``.
 
-Note that ``<UserProvider>`` automatically passes an authenticated user
-to ``<RealmProvider>``.
+Note that ``UserProvider`` automatically passes an authenticated user
+to ``RealmProvider``.
 
 .. literalinclude:: /examples/generated/react-native/ts/configure-realm-sync.test.snippet.partition-based-config.tsx
    :language: javascript

--- a/source/sdk/react-native/use-realm-react.txt
+++ b/source/sdk/react-native/use-realm-react.txt
@@ -96,17 +96,17 @@ to the classes you have created. Pass the configuration object to the
 
 .. _react-native-realm-provider:
 
-<RealmProvider>
----------------
+RealmProvider
+-------------
 
 Wrap the component needing access to Realm, typically near the top
-of your application, with the ``<RealmProvider>`` component included in the
+of your application, with the ``RealmProvider`` component included in the
 ``Context`` object, which was returned from ``createRealmContext()``.  The
-``<RealmProvider>`` provides child components access to the configured
+``RealmProvider`` provides child components access to the configured
 Realm through the hooks included in the ``Context`` object.
 
 For simple use-cases, you may want to wrap your entire application in the
-``<RealmProvider>`` component, such as the example below. For additional security,
+``RealmProvider`` component, such as the example below. For additional security,
 you may only want to give access to the opened realm to specific screens, or
 after the user has logged-in.
 
@@ -117,14 +117,14 @@ Import the ``Context`` object that you created. In the example below, the
 ``Context`` object is called ``TaskContext`` since it refers to the Realm ``Context`` of
 the Task. You can :mdn:`Destructure
 <Web/JavaScript/Reference/Operators/Destructuring_assignment#object_destructuring>`
-the ``TaskContext`` object to get its ``<RealmProvider>``. 
+the ``TaskContext`` object to get its ``RealmProvider``. 
 
 .. literalinclude:: /examples/generated/expo/AppWrapper.snippet.import-task-context.tsx
     :language: typescript
 
-Wrap the ``<RealmProvider>`` around the component that you want
+Wrap the ``RealmProvider`` around the component that you want
 to give access to the configured realm. In the example below, we give the entire
-app access to the realm by wrapping the ``<RealmProvider>`` around
+app access to the realm by wrapping the ``RealmProvider`` around
 the ``App`` component, which renders the application.
 
 .. literalinclude:: /examples/generated/expo/AppWrapper.snippet.wrap-app-within-realm-provider.tsx
@@ -134,11 +134,11 @@ Dynamically Update the Realm Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can dynamically update the Realm configuration by setting
-:reactjs:`props <docs/components-and-props.html>` on the ``<RealmProvider>``
-component. The props you set on the ``<RealmProvider>`` will overwrite any
+:reactjs:`props <docs/components-and-props.html>` on the ``RealmProvider``
+component. The props you set on the ``RealmProvider`` will overwrite any
 property passed into ``createRealmContext()``.
 
-In the following example, we update the ``<RealmProvider>`` with a :js-sdk:`sync
+In the following example, we update the ``RealmProvider`` with a :js-sdk:`sync
 configuration <Realm.App.Sync.html#~SyncConfiguration>` and a ``fallback``
 property that is used to render a temporary ``LoadingSpinner`` component while
 waiting for Device Sync to fully synchronize data before opening the realm:
@@ -149,7 +149,7 @@ waiting for Device Sync to fully synchronize data before opening the realm:
 The Realm Hooks
 ---------------
 
-Once you have wrapped your component with your ``<RealmProvider>``, your component
+Once you have wrapped your component with your ``RealmProvider``, your component
 and its child components will have access to the ``useRealm()``,
 ``useObject()``, and ``useQuery()`` hooks.
 
@@ -224,12 +224,12 @@ To learn how to render a :ref:`filtered <react-native-filter-results>` or
 
 .. _react-native-app-provider:
 
-<AppProvider>
--------------
+AppProvider
+-----------
 
 To use Realm features such as authentication and sync, use the
-``<AppProvider>`` to initiate a new :js-sdk:`Realm.App <Realm.App.html>`. Wrap the
-``<AppProvider>`` outside of the ``<RealmProvider>`` and any components which need
+``AppProvider`` to initiate a new :js-sdk:`Realm.App <Realm.App.html>`. Wrap the
+``AppProvider`` outside of the ``RealmProvider`` and any components which need
 access to the :ref:`useApp <react-native-use-app-hook>` hook.
 
 .. literalinclude:: /examples/generated/expo/AppWrapper.snippet.wrap-app-within-app-provider.tsx
@@ -253,27 +253,27 @@ then use the app instance to log in with email/password authentication.
 
 .. _react-native-user-provider:
 
-<UserProvider>
---------------
+UserProvider
+------------
 
-The ``<UserProvider>`` provides a :js-sdk:`Realm user <Realm.User.html>` for its
+The ``UserProvider`` provides a :js-sdk:`Realm user <Realm.User.html>` for its
 child components to access.
 
-The ``<UserProvider>``:
+The ``UserProvider``:
 
 - contains an optional ``fallback`` property that renders a Login component when
   the user has not authenticated.
 - renders its child components only if the user is logged in or has
   no fallback property.
 
-When the ``<UserProvider>`` wraps the ``<RealmProvider>``, the ``<RealmProvider>``
+When the ``UserProvider`` wraps the ``RealmProvider``, the ``RealmProvider``
 automatically sets the logged-in user for your sync configuration. This means
 you do not need to specify your user in your sync configuration object.
 
 In the following example, we pass a Login component to the fallback property of
-``<UserProvider>``. Once the user has logged in, the Login component disappears
+``UserProvider``. Once the user has logged in, the Login component disappears
 from the view, and the ``App`` is rendered. We wrap the ``App`` in a
-``<RealmProvider>`` with a sync configuration to give the ``App`` access to a
+``RealmProvider`` with a sync configuration to give the ``App`` access to a
 synced realm. If the user logs out, the application falls back to
 the Login component.
 


### PR DESCRIPTION
## Pull Request Info

In the initial `realm/react` work, we decided to use angle brackets to highlight providers. The React Native docs use this convention (inconsistently) when referring the React Native components.

After thinking it over, the convention is easily conflated with our style guide's placeholder variable convention, which also uses angle brackets.

We should remove all instances of angle brackets for providers for two reasons:

Prevent confusion with placholder variables
Visually clean up docs flow


### Jira

- https://jira.mongodb.org/browse/DOCSP-29773

### Staged Changes

- [Lots of Pages – all in React Native SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29773/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-app-services update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
