### PR TITLE
DOCSP-30216: Document Kotlin Subscription API 

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
@@ -430,15 +430,12 @@ class SyncTest: RealmTest() {
     fun addANamedSubscriptionTest() {
         val credentials = Credentials.anonymous(reuseExisting = false)
         runBlocking {
-            // :snippet-start: open-flex-sync-app
-            // Login with authorized user and open a realm with a SyncConfiguration
             val app = App.create(yourFlexAppId)
             val user = app.login(credentials)
             val flexSyncConfig = SyncConfiguration.Builder(user, setOf(Team::class, SyncTask::class))
                 .build()
             val realm = Realm.open(flexSyncConfig)
             Log.v("Successfully opened realm: ${realm.configuration}")
-            // :snippet-end:
             // :snippet-start: add-a-named-subscription
             // Add a subscription named "team_developer_education"
             realm.subscriptions.update{ realm ->
@@ -614,16 +611,22 @@ class SyncTest: RealmTest() {
 
     @Test
     fun removeSingleSubscriptionTest() {
-        val app = App.create(yourFlexAppId)
         runBlocking {
             val credentials = Credentials.anonymous(reuseExisting = false)
+            // :snippet-start: open-flex-sync-app
+            // Login with authorized user and define a Flexible Sync SyncConfiguration
+            val app = App.create(yourFlexAppId)
             val user = app.login(credentials)
             val flexSyncConfig = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
-                .initialSubscriptions { realm -> add(realm.query<Team>("$0 IN members", "Bob Smith"),
-                    "bob_smith_teams") }
+                .initialSubscriptions {
+                    // Define the initial subscription set for the realm ...
+                        realm -> add(realm.query<Team>("$0 IN members", "Bob Smith"), "bob_smith_teams") // :remove:
+                }
                 .build()
+            // Open the synced realm and manage subscriptions
             val realm = Realm.open(flexSyncConfig)
             Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-end:
             // :snippet-start: remove-single-subscription
             realm.subscriptions.update {
                 add(

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
@@ -4,6 +4,7 @@ import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
 import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.ext.query
+import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.log.LogLevel
 import io.realm.kotlin.log.RealmLog
@@ -11,16 +12,19 @@ import io.realm.kotlin.log.RealmLogger
 import io.realm.kotlin.mongodb.App
 import io.realm.kotlin.mongodb.Credentials
 import io.realm.kotlin.mongodb.exceptions.ClientResetRequiredException
+import io.realm.kotlin.mongodb.ext.subscribe
 import io.realm.kotlin.mongodb.subscriptions
-import io.realm.kotlin.mongodb.sync.SyncConfiguration
+import io.realm.kotlin.mongodb.sync.*
 import io.realm.kotlin.mongodb.syncSession
 import io.realm.kotlin.query.RealmResults
-import io.realm.kotlin.mongodb.sync.*
+import io.realm.kotlin.types.RealmInstant
+import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.PrimaryKey
 import org.mongodb.kbson.ObjectId
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -29,7 +33,8 @@ import kotlin.time.Duration.Companion.seconds
 //     "yourAppId": "YOUR_APP_ID",
 //     "yourFlexAppId": "YOUR_APP_ID",
 //      "strategy2": "clientResetStrategy",
-//      "strategy3": "clientResetStrategy"
+//      "strategy3": "clientResetStrategy",
+//      "SyncTask": "Task"
 //   }
 // }
 class SyncTest: RealmTest() {
@@ -38,6 +43,34 @@ class SyncTest: RealmTest() {
         @PrimaryKey
         var _id: ObjectId = ObjectId()
         var name: String = ""
+    }
+
+    // :snippet-start: flexible-sync-models
+    class SyncTask : RealmObject {
+        @PrimaryKey
+        var _id: ObjectId = ObjectId()
+        var taskName: String = ""
+        var assignee: String? = null
+        var completed: Boolean = false
+        var progressMinutes: Int = 0
+        var dueDate: RealmInstant? = null
+    }
+
+    class Team : RealmObject {
+        @PrimaryKey
+        var _id: ObjectId = ObjectId()
+        var teamName: String = ""
+        var tasks: RealmList<SyncTask>? = null
+        var members: RealmList<String> = realmListOf()
+    }
+    // :snippet-end:
+
+
+    companion object {
+        private val credentials = Credentials.anonymous(reuseExisting = false)
+        const val yourFlexAppId = "your-flex-app-id"
+        const val PARTITION = "myPartition"
+        const val FLEXIBLE_APP_ID = "flexible-app-id"
     }
 
     @Test
@@ -342,30 +375,97 @@ class SyncTest: RealmTest() {
 
     @Test
     fun addASubscriptionTest() {
-        val app = App.create(yourFlexAppId)
         runBlocking {
-            val user = app.login(Credentials.anonymous())
-            val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-                .initialSubscriptions { realm ->
-                    add(
-                        realm.query<Toad>(
-                            "name == $0",
-                            "name value"
-                        ),
-                        "subscription name"
-                    )
-                }
+            val app = App.create(yourFlexAppId)
+            val user = app.login(credentials)
+            val flexSyncConfig = SyncConfiguration.Builder(user, setOf(Team::class, SyncTask::class))
+                .initialSubscriptions {realm -> add(realm.query<Team>("teamName == $0", "Developer Education")) }
                 .build()
-            val realm = Realm.open(config)
+            // :snippet-end:
+            val realm = Realm.open(flexSyncConfig)
+            Log.v("Successfully opened realm: ${realm.configuration}")
             // :snippet-start: add-a-subscription
             realm.subscriptions.update {
-                this.add(
-                    realm.query<Toad>("name == $0", "another name value"),
-                    "another subscription name"
+                add(
+                    realm.query<SyncTask>("progressMinutes >= 60")
                 )
             }
             // :snippet-end:
+            val subscriptions = realm.subscriptions.size
+            assertEquals(2, subscriptions)
+            user.delete()
+            realm.close()
+        }
+    }
+
+    @Test
+    fun addASubscriptionQueryTest() {
+        runBlocking {
+            val app = App.create(yourFlexAppId)
+            val user = app.login(credentials)
+            // :snippet-start: initialize-subscribe-query-realm-app
+            // Bootstrap the realm with an initial query to subscribe to
+            val flexSyncConfig =
+                SyncConfiguration.Builder(user, setOf(Team::class, SyncTask::class))
+                    .initialSubscriptions { realm ->
+                        add(
+                            realm.query<Team>("$0 IN members", "Bob Smith"),
+                            "bob_smith_teams"
+                        )
+                    }
+                    .build()
+            // :snippet-end:
+            val realm = Realm.open(flexSyncConfig)
             Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: subscribe-unnamed-query
+            // Subscribe to a specific query
+            val realmResults = realm.query<SyncTask>("progressMinutes >= $0", 60)
+                .subscribe()
+
+            // Subscribe to all objects of a specific type
+            val realmQuery = realm.query<Team>()
+            realmQuery.subscribe()
+            // :snippet-end:
+            val subscriptions = realm.subscriptions.size
+            assertEquals(3, subscriptions)
+            user.delete()
+            realm.close()
+        }
+    }
+
+    @Test
+    fun addANamedSubscriptionTest() {
+        val credentials = Credentials.anonymous(reuseExisting = false)
+        runBlocking {
+            // :snippet-start: open-flex-sync-app
+            // Login with authorized user and open a realm with a SyncConfiguration
+            val app = App.create(yourFlexAppId)
+            val user = app.login(credentials)
+            val flexSyncConfig = SyncConfiguration.Builder(user, setOf(Team::class, SyncTask::class))
+                .build()
+            val realm = Realm.open(flexSyncConfig)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-end:
+            // :snippet-start: add-a-named-subscription
+            // Add a subscription named "team_developer_education"
+            realm.subscriptions.update{ realm ->
+                    add(
+                        realm.query<Team>("teamName == $0", "Developer Education"),
+                        "team_dev_ed"
+                    )
+                }
+            // :snippet-end:
+            // :snippet-start: subscribe-named-query
+            val results = realm.query<Team>("teamName == $0", "Developer Education")
+                .subscribe("team_developer_education")
+            // :snippet-end:
+            val subscriptions = realm.subscriptions.size
+            assertEquals(2, subscriptions)
+            val namedSubscription1 = realm.subscriptions.findByName("team_developer_education")
+            assertEquals("team_developer_education", namedSubscription1?.name)
+            val namedSubscription2 = realm.subscriptions.findByName("team_dev_ed")
+            assertEquals("team_dev_ed", namedSubscription2?.name)
+            user.delete()
             realm.close()
         }
     }
@@ -373,32 +473,40 @@ class SyncTest: RealmTest() {
     @Test
     fun waitForSubscriptionChangesTest() {
         val app = App.create(yourFlexAppId)
+        val credentials = Credentials.anonymous(reuseExisting = false)
         runBlocking {
-            val user = app.login(Credentials.anonymous())
-            val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-                .initialSubscriptions { realm ->
-                    add(
-                        realm.query<Toad>(
-                            "name == $0",
-                            "name value"
-                        ),
-                        "subscription name"
-                    )
-                }
+            val user = app.login(credentials)
+            val config = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
+                .initialSubscriptions { realm -> add(realm.query<Team>()) }
                 .build()
             val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration}")
             // :snippet-start: wait-for-subscription-changes
-            // make an update to the list of subscriptions
+            // Update the list of subscriptions
             realm.subscriptions.update {
                 this.add(
-                    realm.query<Toad>("name == $0", "another name value"),
-                    "another subscription name"
+                    realm.query<Team>("$0 IN members", "Jane Doe"),
+                    "jane_doe_teams"
                 )
             }
-            // wait for subscription to fully synchronize changes
+            // Wait for subscription to fully synchronize changes
             realm.subscriptions.waitForSynchronization(Duration.parse("10s"))
             // :snippet-end:
-            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: subscribe-wait-for-sync
+            val results = realm.query<Team>("$0 IN members", "Bob Smith")
+                .subscribe("bob_smith_teams", updateExisting = false, WaitForSync.ALWAYS)
+
+            // After waiting for sync, the results set contains all the objects
+            // that match the query - in our case, 1
+            println("The number of teams that have Bob Smith as a member is ${results.size}")
+            // :snippet-end:
+            val subscriptions = realm.subscriptions.size
+            assertEquals(3, subscriptions)
+            val namedSubscription1 = realm.subscriptions.findByName("bob_smith_teams")
+            assertEquals("bob_smith_teams", namedSubscription1?.name)
+            val namedSubscription2 = realm.subscriptions.findByName("jane_doe_teams")
+            assertEquals("jane_doe_teams", namedSubscription2?.name)
+            user.delete()
             realm.close()
         }
     }
@@ -407,71 +515,103 @@ class SyncTest: RealmTest() {
     fun updateSubscriptionByNameTest() {
         val app = App.create(yourFlexAppId)
         runBlocking {
-            val user = app.login(Credentials.anonymous())
-            // :snippet-start: update-subscriptions-by-name
-            // create an initial subscription named "subscription name"
-            val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-                .initialSubscriptions { realm ->
-                    add(
-                        realm.query<Toad>(
-                            "name == $0",
-                            "name value"
-                        ),
-                        "subscription name"
-                    )
-                }
+            val credentials = Credentials.anonymous(reuseExisting = false)
+            val user = app.login(credentials)
+            val flexSyncConfig = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
+                .initialSubscriptions { realm -> add(realm.query<Team>()) }
                 .build()
-            val realm = Realm.open(config)
-            // to update that subscription, add another subscription with the same name
-            // it will replace the existing subscription
+            val realm = Realm.open(flexSyncConfig)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: update-subscriptions-by-name
+            // Create a subscription named "bob_smith_teams"
             realm.subscriptions.update {
                 this.add(
-                    realm.query<Toad>("name == $0", "another name value"),
-                    "subscription name",
-                    updateExisting = true
+                    realm.query<Team>("$0 IN members", "Bob Smith"),
+                    "bob_smith_teams"
+                )
+            }
+
+            // Set `updateExisting` to true to replace the existing
+            // "bob_smith_teams" subscription
+            realm.subscriptions.update {
+                this.add(
+                    realm.query<Team>("$0 IN members AND $1 IN members", "Bob Smith", "Jane Doe"),
+                    "bob_smith_teams", updateExisting = true
                 )
             }
             // :snippet-end:
-            Log.v("Successfully opened realm: ${realm.configuration}")
+            val subscriptions = realm.subscriptions.size
+            assertEquals(2, subscriptions)
+            val namedSubscription1 = realm.subscriptions.findByName("bob_smith_teams")
+            assertEquals("bob_smith_teams", namedSubscription1?.name)
+            user.delete()
             realm.close()
         }
     }
 
     @Test
+    fun updateSubscribeAPIByNameTest() {
+        val app = App.create(yourFlexAppId)
+        runBlocking {
+            val credentials = Credentials.anonymous(reuseExisting = false)
+            val user = app.login(credentials)
+            val flexSyncConfig = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
+                .initialSubscriptions { it.query<Team>().subscribe() }
+                .build()
+            val realm = Realm.open(flexSyncConfig)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: update-query-by-name
+            // Create a subscription named "bob_smith_teams"
+            val results = realm.query<Team>("$0 IN members", "Bob Smith")
+                .subscribe("bob_smith_teams")
+
+            // Add another subscription with the same name with `updateExisting` set to true
+            // to replace the existing subscription
+            val updateResults =
+                    realm.query<Team>("$0 IN members AND teamName == $1", "Bob Smith", "QA")
+                        .subscribe("bob_smith_teams", updateExisting = true)
+            // :snippet-end:
+            val subscriptions = realm.subscriptions.size
+            assertEquals(2, subscriptions)
+            val namedSubscription1 = realm.subscriptions.findByName("bob_smith_teams")
+            assertEquals("bob_smith_teams", namedSubscription1?.name)
+            user.delete()
+            realm.close()
+        }
+    }
+
+
+    @Test
     fun updateSubscriptionByQueryTest() {
         val app = App.create(yourFlexAppId)
         runBlocking {
-            val user = app.login(Credentials.anonymous())
-            val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-                .initialSubscriptions { realm ->
-                    add(
-                        realm.query<Toad>(
-                            "name == $0",
-                            "name value"
-                        )
-                    )
-                }
+            val credentials = Credentials.anonymous(reuseExisting = false)
+            val user = app.login(credentials)
+            val config = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
+                .initialSubscriptions {it.query<Team>("teamName == $0", "Developer Education").subscribe() }
                 .build()
             val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration}")
             // :snippet-start: update-subscriptions-by-query
             val subscription =
                 realm.subscriptions.findByQuery(
-                    realm.query<Toad>("name == $0", "name value")
+                    realm.query<Team>("teamName == $0", "Developer Education")
                 )
             if (subscription != null) {
                 realm.subscriptions.update {
                     this.remove(subscription)
                     this.add(
-                        realm.query<Toad>(
-                            "name == $0",
-                            "another name value"
-                        ),
-                        "subscription name"
+                        realm.query<Team>("teamName == $0", "DevEd"),
+                        "team_developer_education"
                     )
                 }
             }
             // :snippet-end:
-            Log.v("Successfully opened realm: ${realm.configuration}")
+            val subscriptions = realm.subscriptions.size
+            assertEquals(1, subscriptions)
+            val namedSubscription1 = realm.subscriptions.findByName("team_developer_education")
+            assertEquals("team_developer_education", namedSubscription1?.name)
+            user.delete()
             realm.close()
         }
     }
@@ -480,27 +620,33 @@ class SyncTest: RealmTest() {
     fun removeSingleSubscriptionTest() {
         val app = App.create(yourFlexAppId)
         runBlocking {
-            val user = app.login(Credentials.anonymous())
-            // :snippet-start: remove-single-subscription
-            // create an initial subscription named "subscription name"
-            val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-                .initialSubscriptions { realm ->
-                    add(
-                        realm.query<Toad>(
-                            "name == $0",
-                            "name value"
-                        ),
-                        "subscription name"
-                    )
-                }
+            val credentials = Credentials.anonymous(reuseExisting = false)
+            val user = app.login(credentials)
+            val flexSyncConfig = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
+                .initialSubscriptions { realm -> add(realm.query<Team>("$0 IN members", "Bob Smith"),
+                    "bob_smith_teams") }
                 .build()
-            val realm = Realm.open(config)
-            // remove subscription by name
+            val realm = Realm.open(flexSyncConfig)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: remove-single-subscription
             realm.subscriptions.update {
-                this.remove("subscription name")
+                this.add(
+                    realm.query<Team>("$0 IN members", "Bob Smith"),
+                    "bob_smith_teams"
+                )
+            }
+
+            // Wait for synchronization to complete before updating subscriptions
+            realm.subscriptions.waitForSynchronization(Duration.parse("10s"))
+
+            // Remove subscription by name
+            realm.subscriptions.update {
+                this.remove("bob_smith_teams")
             }
             // :snippet-end:
-            Log.v("Successfully opened realm: ${realm.configuration}")
+            val subscriptions = realm.subscriptions.size
+            assertEquals(0, subscriptions)
+            user.delete()
             realm.close()
         }
     }
@@ -509,29 +655,33 @@ class SyncTest: RealmTest() {
     fun removeSubscriptionsOfTypeTest() {
         val app = App.create(yourFlexAppId)
         runBlocking {
-            val user = app.login(Credentials.anonymous())
-            // :snippet-start: remove-all-subscriptions-to-an-object-type
-            // create an initial subscription named "subscription name"
-            val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-                .initialSubscriptions { realm ->
-                    add(
-                        realm.query<Toad>(
-                            "name == $0",
-                            "name value"
-                        ),
-                        "subscription name"
-                    )
-                }
+            val credentials = Credentials.anonymous(reuseExisting = false)
+            val user = app.login(credentials)
+            val flexSyncConfig = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
+                .initialSubscriptions { realm -> add(realm.query<SyncTask>() ) }
                 .build()
-            val realm = Realm.open(config)
-            // wait for synchronization to complete before editing subscriptions
-            realm.subscriptions.waitForSynchronization(Duration.parse("10s"))
-            // remove all subscriptions to type Toad
+            val realm = Realm.open(flexSyncConfig)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: remove-all-subscriptions-to-an-object-type
             realm.subscriptions.update {
-                this.removeAll(Toad::class)
+                this.add(
+                        realm.query<Team>("$0 IN members", "Bob Smith"),
+                    "bob_smith_teams")
+            }
+
+            // Wait for synchronization to complete before updating subscriptions
+            realm.subscriptions.waitForSynchronization(Duration.parse("10s"))
+
+            // Remove all subscriptions to type Team
+            realm.subscriptions.update {
+                removeAll(Team::class)
             }
             // :snippet-end:
-            Log.v("Successfully opened realm: ${realm.configuration}")
+            val subscriptions = realm.subscriptions.size
+            assertEquals(1, subscriptions)
+            val namedSubscription1 = realm.subscriptions.findByName("bob_smith_teams")
+            assertNull(namedSubscription1?.name)
+            user.delete()
             realm.close()
         }
     }
@@ -540,28 +690,51 @@ class SyncTest: RealmTest() {
     fun removeAllSubscriptionsTest() {
         val app = App.create(yourFlexAppId)
         runBlocking {
-            val user = app.login(Credentials.anonymous())
-            // :snippet-start: remove-all-subscriptions
-            // create an initial subscription named "subscription name"
-            val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-                .initialSubscriptions { realm ->
-                    add(
-                        realm.query<Toad>(
-                            "name == $0",
-                            "name value"
-                        ),
-                        "subscription name"
-                    )
-                }
+            val credentials = Credentials.anonymous(reuseExisting = false)
+            val user = app.login(credentials)
+            val flexSyncConfig = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
+                .initialSubscriptions { realm -> add(realm.query<Team>()) }
                 .build()
-            val realm = Realm.open(config)
-
-            // remove all subscriptions
+            val realm = Realm.open(flexSyncConfig)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: remove-all-subscriptions
+            // Remove all subscriptions
             realm.subscriptions.update {
                 this.removeAll()
             }
             // :snippet-end:
+            val subscriptions = realm.subscriptions.size
+            assertEquals(0, subscriptions)
+            user.delete()
+            realm.close()
+        }
+    }
+
+    @Test
+    fun removeAllUnnamedSubscriptionsTest() {
+        val app = App.create(yourFlexAppId)
+        runBlocking {
+            val credentials = Credentials.anonymous(reuseExisting = false)
+            val user = app.login(credentials)
+            val flexSyncConfig = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
+                .initialSubscriptions { realm ->
+                    add(realm.query<Team>("$0 IN members", "Bob Smith"), "bob_smith_teams") }
+                .build()
+            val realm = Realm.open(flexSyncConfig)
             Log.v("Successfully opened realm: ${realm.configuration}")
+
+            val unnamedSubscription = realm.query<Team>("$0 IN members", "Jane Doe")
+            // :snippet-start: remove-all-unnamed-subscriptions
+            // Remove all unnamed (anonymous) subscriptions
+            realm.subscriptions.update {
+                this.removeAll(anonymousOnly = true)
+            }
+            // :snippet-end:
+            val subscriptions = realm.subscriptions.size
+            assertEquals(1, subscriptions)
+            val namedSubscription1 = realm.subscriptions.findByName("bob_smith_teams")
+            assertEquals("bob_smith_teams", namedSubscription1?.name)
+            user.delete()
             realm.close()
         }
     }

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
@@ -495,6 +495,7 @@ class SyncTest: RealmTest() {
             // that match the query - in our case, 1
             println("The number of teams that have Bob Smith as a member is ${results.size}")
             // :snippet-end:
+            assertEquals(1, results.size)
             val subscriptionCount = realm.subscriptions.size
             assertEquals(3, subscriptionCount)
             val namedSubscription1 = realm.subscriptions.findByName("bob_smith_teams")

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
@@ -65,14 +65,6 @@ class SyncTest: RealmTest() {
     }
     // :snippet-end:
 
-
-    companion object {
-        private val credentials = Credentials.anonymous(reuseExisting = false)
-        const val yourFlexAppId = "your-flex-app-id"
-        const val PARTITION = "myPartition"
-        const val FLEXIBLE_APP_ID = "flexible-app-id"
-    }
-
     @Test
     fun openASyncedRealmTest() {
         // :snippet-start: open-a-synced-realm
@@ -377,11 +369,11 @@ class SyncTest: RealmTest() {
     fun addASubscriptionTest() {
         runBlocking {
             val app = App.create(yourFlexAppId)
+            val credentials = Credentials.anonymous(reuseExisting = false)
             val user = app.login(credentials)
             val flexSyncConfig = SyncConfiguration.Builder(user, setOf(Team::class, SyncTask::class))
                 .initialSubscriptions {realm -> add(realm.query<Team>("teamName == $0", "Developer Education")) }
                 .build()
-            // :snippet-end:
             val realm = Realm.open(flexSyncConfig)
             Log.v("Successfully opened realm: ${realm.configuration}")
             // :snippet-start: add-a-subscription
@@ -402,6 +394,7 @@ class SyncTest: RealmTest() {
     fun addASubscriptionQueryTest() {
         runBlocking {
             val app = App.create(yourFlexAppId)
+            val credentials = Credentials.anonymous(reuseExisting = false)
             val user = app.login(credentials)
             // :snippet-start: initialize-subscribe-query-realm-app
             // Bootstrap the realm with an initial query to subscribe to
@@ -484,7 +477,7 @@ class SyncTest: RealmTest() {
             // :snippet-start: wait-for-subscription-changes
             // Update the list of subscriptions
             realm.subscriptions.update {
-                this.add(
+                add(
                     realm.query<Team>("$0 IN members", "Jane Doe"),
                     "jane_doe_teams"
                 )
@@ -525,7 +518,7 @@ class SyncTest: RealmTest() {
             // :snippet-start: update-subscriptions-by-name
             // Create a subscription named "bob_smith_teams"
             realm.subscriptions.update {
-                this.add(
+                add(
                     realm.query<Team>("$0 IN members", "Bob Smith"),
                     "bob_smith_teams"
                 )
@@ -534,7 +527,7 @@ class SyncTest: RealmTest() {
             // Set `updateExisting` to true to replace the existing
             // "bob_smith_teams" subscription
             realm.subscriptions.update {
-                this.add(
+                add(
                     realm.query<Team>("$0 IN members AND $1 IN members", "Bob Smith", "Jane Doe"),
                     "bob_smith_teams", updateExisting = true
                 )
@@ -593,14 +586,17 @@ class SyncTest: RealmTest() {
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration}")
             // :snippet-start: update-subscriptions-by-query
+            // Search for the subscription by query
             val subscription =
                 realm.subscriptions.findByQuery(
                     realm.query<Team>("teamName == $0", "Developer Education")
                 )
+
+            // Remove the returned subscription and add the updated query
             if (subscription != null) {
                 realm.subscriptions.update {
-                    this.remove(subscription)
-                    this.add(
+                    remove(subscription)
+                    add(
                         realm.query<Team>("teamName == $0", "DevEd"),
                         "team_developer_education"
                     )
@@ -630,7 +626,7 @@ class SyncTest: RealmTest() {
             Log.v("Successfully opened realm: ${realm.configuration}")
             // :snippet-start: remove-single-subscription
             realm.subscriptions.update {
-                this.add(
+                add(
                     realm.query<Team>("$0 IN members", "Bob Smith"),
                     "bob_smith_teams"
                 )
@@ -641,7 +637,7 @@ class SyncTest: RealmTest() {
 
             // Remove subscription by name
             realm.subscriptions.update {
-                this.remove("bob_smith_teams")
+                remove("bob_smith_teams")
             }
             // :snippet-end:
             val subscriptions = realm.subscriptions.size
@@ -664,7 +660,7 @@ class SyncTest: RealmTest() {
             Log.v("Successfully opened realm: ${realm.configuration}")
             // :snippet-start: remove-all-subscriptions-to-an-object-type
             realm.subscriptions.update {
-                this.add(
+                add(
                         realm.query<Team>("$0 IN members", "Bob Smith"),
                     "bob_smith_teams")
             }
@@ -700,7 +696,7 @@ class SyncTest: RealmTest() {
             // :snippet-start: remove-all-subscriptions
             // Remove all subscriptions
             realm.subscriptions.update {
-                this.removeAll()
+                removeAll()
             }
             // :snippet-end:
             val subscriptions = realm.subscriptions.size
@@ -727,7 +723,7 @@ class SyncTest: RealmTest() {
             // :snippet-start: remove-all-unnamed-subscriptions
             // Remove all unnamed (anonymous) subscriptions
             realm.subscriptions.update {
-                this.removeAll(anonymousOnly = true)
+                removeAll(anonymousOnly = true)
             }
             // :snippet-end:
             val subscriptions = realm.subscriptions.size

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SyncTest.kt
@@ -437,11 +437,11 @@ class SyncTest: RealmTest() {
             val realm = Realm.open(flexSyncConfig)
             Log.v("Successfully opened realm: ${realm.configuration}")
             // :snippet-start: add-a-named-subscription
-            // Add a subscription named "team_developer_education"
-            realm.subscriptions.update{ realm ->
+            // Add a subscription named "team_dev_ed"
+            realm.subscriptions.update { realm ->
                     add(
                         realm.query<Team>("teamName == $0", "Developer Education"),
-                        "team_dev_ed"
+                        name = "team_dev_ed"
                     )
                 }
             // :snippet-end:
@@ -629,7 +629,7 @@ class SyncTest: RealmTest() {
             val flexSyncConfig = SyncConfiguration.Builder(user, setOf(SyncTask::class, Team::class))
                 .initialSubscriptions {
                     // Define the initial subscription set for the realm ...
-                        realm -> add(realm.query<Team>("$0 IN members", "Bob Smith"), "bob_smith_teams") // :remove:
+                   realm -> add(realm.query<Team>("$0 IN members", "Bob Smith"), "bob_smith_teams") // :remove:
                 }
                 .build()
             // Open the synced realm and manage subscriptions
@@ -679,7 +679,7 @@ class SyncTest: RealmTest() {
             // :snippet-start: remove-all-subscriptions-to-an-object-type
             realm.subscriptions.update {
                 add(
-                        realm.query<Team>("$0 IN members", "Bob Smith"),
+                    realm.query<Team>("$0 IN members", "Bob Smith"),
                     "bob_smith_teams")
             }
 

--- a/source/examples/generated/kotlin/SyncTest.snippet.add-a-named-subscription.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.add-a-named-subscription.kt
@@ -1,0 +1,7 @@
+// Add a subscription named "team_developer_education"
+realm.subscriptions.update{ realm ->
+        add(
+            realm.query<Team>("teamName == $0", "Developer Education"),
+            "team_developer_education"
+        )
+    }

--- a/source/examples/generated/kotlin/SyncTest.snippet.add-a-named-subscription.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.add-a-named-subscription.kt
@@ -1,7 +1,7 @@
-// Add a subscription named "team_developer_education"
-realm.subscriptions.update{ realm ->
+// Add a subscription named "team_dev_ed"
+realm.subscriptions.update { realm ->
         add(
             realm.query<Team>("teamName == $0", "Developer Education"),
-            "team_dev_ed"
+            name = "team_dev_ed"
         )
     }

--- a/source/examples/generated/kotlin/SyncTest.snippet.add-a-named-subscription.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.add-a-named-subscription.kt
@@ -2,6 +2,6 @@
 realm.subscriptions.update{ realm ->
         add(
             realm.query<Team>("teamName == $0", "Developer Education"),
-            "team_developer_education"
+            "team_dev_ed"
         )
     }

--- a/source/examples/generated/kotlin/SyncTest.snippet.add-a-subscription.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.add-a-subscription.kt
@@ -1,5 +1,5 @@
 realm.subscriptions.update {
     add(
-        realm.query<Task>("progressMinutes >= 60")
+        realm.query<Task>("progressMinutes >= $0",60)
     )
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.add-a-subscription.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.add-a-subscription.kt
@@ -1,6 +1,5 @@
 realm.subscriptions.update {
-    this.add(
-        realm.query<Toad>("name == $0", "another name value"),
-        "another subscription name"
+    add(
+        realm.query<Task>("progressMinutes >= 60")
     )
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.flexible-sync-models.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.flexible-sync-models.kt
@@ -1,0 +1,17 @@
+class Task : RealmObject {
+    @PrimaryKey
+    var _id: ObjectId = ObjectId()
+    var taskName: String = ""
+    var assignee: String? = null
+    var completed: Boolean = false
+    var progressMinutes: Int = 0
+    var dueDate: RealmInstant? = null
+}
+
+class Team : RealmObject {
+    @PrimaryKey
+    var _id: ObjectId = ObjectId()
+    var teamName: String = ""
+    var tasks: RealmList<Task>? = null
+    var members: RealmList<String> = realmListOf()
+}

--- a/source/examples/generated/kotlin/SyncTest.snippet.flexible-sync-models.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.flexible-sync-models.kt
@@ -12,6 +12,6 @@ class Team : RealmObject {
     @PrimaryKey
     var _id: ObjectId = ObjectId()
     var teamName: String = ""
-    var tasks: RealmList<Task>? = null
+    var tasks: RealmList<Task>? = realmListOf()
     var members: RealmList<String> = realmListOf()
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.initialize-subscribe-query-realm-app-rerun.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.initialize-subscribe-query-realm-app-rerun.kt
@@ -1,0 +1,9 @@
+// `rerunOnOpen` lets the app recalculate this query every time the app opens
+val rerunOnOpenConfig =
+    SyncConfiguration.Builder(user, setOf(Team::class, Task::class))
+        .initialSubscriptions(rerunOnOpen = true) { realm ->
+            add(
+                realm.query<Team>("completed == $0", false)
+            )
+        }
+        .build()

--- a/source/examples/generated/kotlin/SyncTest.snippet.initialize-subscribe-query-realm-app.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.initialize-subscribe-query-realm-app.kt
@@ -1,5 +1,5 @@
 // Bootstrap the realm with an initial query to subscribe to
-val initializedFlexSyncConfig =
+val flexSyncConfig =
     SyncConfiguration.Builder(user, setOf(Team::class, Task::class))
         .initialSubscriptions { realm ->
             add(

--- a/source/examples/generated/kotlin/SyncTest.snippet.initialize-subscribe-query-realm-app.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.initialize-subscribe-query-realm-app.kt
@@ -1,0 +1,10 @@
+// Bootstrap the realm with an initial query to subscribe to
+val initializedFlexSyncConfig =
+    SyncConfiguration.Builder(user, setOf(Team::class, Task::class))
+        .initialSubscriptions { realm ->
+            add(
+                realm.query<Team>("$0 IN members", "Bob Smith"),
+                "bob_smith_teams"
+            )
+        }
+        .build()

--- a/source/examples/generated/kotlin/SyncTest.snippet.open-flex-sync-app.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.open-flex-sync-app.kt
@@ -1,0 +1,7 @@
+// Login with authorized user and open a realm with a SyncConfiguration
+val app = App.create(YOUR_APP_ID)
+val user = app.login(credentials)
+val flexSyncConfig = SyncConfiguration.Builder(user, setOf(Team::class, Task::class))
+    .build()
+val realm = Realm.open(flexSyncConfig)
+Log.v("Successfully opened realm: ${realm.configuration}")

--- a/source/examples/generated/kotlin/SyncTest.snippet.open-flex-sync-app.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.open-flex-sync-app.kt
@@ -1,7 +1,11 @@
-// Login with authorized user and open a realm with a SyncConfiguration
+// Login with authorized user and define a Flexible Sync SyncConfiguration
 val app = App.create(YOUR_APP_ID)
 val user = app.login(credentials)
-val flexSyncConfig = SyncConfiguration.Builder(user, setOf(Team::class, Task::class))
+val flexSyncConfig = SyncConfiguration.Builder(user, setOf(Task::class, Team::class))
+    .initialSubscriptions {
+        // Define the initial subscription set for the realm ...
+    }
     .build()
+// Open the synced realm and manage subscriptions
 val realm = Realm.open(flexSyncConfig)
 Log.v("Successfully opened realm: ${realm.configuration}")

--- a/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions-to-an-object-type.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions-to-an-object-type.kt
@@ -1,6 +1,6 @@
 realm.subscriptions.update {
     add(
-            realm.query<Team>("$0 IN members", "Bob Smith"),
+        realm.query<Team>("$0 IN members", "Bob Smith"),
         "bob_smith_teams")
 }
 

--- a/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions-to-an-object-type.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions-to-an-object-type.kt
@@ -1,5 +1,5 @@
 realm.subscriptions.update {
-    this.add(
+    add(
             realm.query<Team>("$0 IN members", "Bob Smith"),
         "bob_smith_teams")
 }
@@ -9,5 +9,5 @@ realm.subscriptions.waitForSynchronization(Duration.parse("10s"))
 
 // Remove all subscriptions to type Team
 realm.subscriptions.update {
-    this.removeAll(Team::class)
+    removeAll(Team::class)
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions-to-an-object-type.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions-to-an-object-type.kt
@@ -1,19 +1,13 @@
-// create an initial subscription named "subscription name"
-val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-    .initialSubscriptions { realm ->
-        add(
-            realm.query<Toad>(
-                "name == $0",
-                "name value"
-            ),
-            "subscription name"
-        )
-    }
-    .build()
-val realm = Realm.open(config)
-// wait for synchronization to complete before editing subscriptions
-realm.subscriptions.waitForSynchronization(Duration.parse("10s"))
-// remove all subscriptions to type Toad
 realm.subscriptions.update {
-    this.removeAll(Toad::class)
+    this.add(
+            realm.query<Team>("$0 IN members", "Bob Smith"),
+        "bob_smith_teams")
+}
+
+// Wait for synchronization to complete before updating subscriptions
+realm.subscriptions.waitForSynchronization(Duration.parse("10s"))
+
+// Remove all subscriptions to type Team
+realm.subscriptions.update {
+    this.removeAll(Team::class)
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions.kt
@@ -1,18 +1,4 @@
-// create an initial subscription named "subscription name"
-val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-    .initialSubscriptions { realm ->
-        add(
-            realm.query<Toad>(
-                "name == $0",
-                "name value"
-            ),
-            "subscription name"
-        )
-    }
-    .build()
-val realm = Realm.open(config)
-
-// remove all subscriptions
+// Remove all subscriptions
 realm.subscriptions.update {
     this.removeAll()
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions.kt
@@ -1,4 +1,4 @@
 // Remove all subscriptions
 realm.subscriptions.update {
-    this.removeAll()
+    removeAll()
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.remove-all-unnamed-subscriptions.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.remove-all-unnamed-subscriptions.kt
@@ -1,4 +1,4 @@
 // Remove all unnamed (anonymous) subscriptions
 realm.subscriptions.update {
-    this.removeAll(anonymousOnly = true)
+    removeAll(anonymousOnly = true)
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.remove-all-unnamed-subscriptions.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.remove-all-unnamed-subscriptions.kt
@@ -1,0 +1,4 @@
+// Remove all unnamed (anonymous) subscriptions
+realm.subscriptions.update {
+    this.removeAll(anonymousOnly = true)
+}

--- a/source/examples/generated/kotlin/SyncTest.snippet.remove-single-subscription.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.remove-single-subscription.kt
@@ -1,5 +1,5 @@
 realm.subscriptions.update {
-    this.add(
+    add(
         realm.query<Team>("$0 IN members", "Bob Smith"),
         "bob_smith_teams"
     )
@@ -10,5 +10,5 @@ realm.subscriptions.waitForSynchronization(Duration.parse("10s"))
 
 // Remove subscription by name
 realm.subscriptions.update {
-    this.remove("bob_smith_teams")
+    remove("bob_smith_teams")
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.remove-single-subscription.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.remove-single-subscription.kt
@@ -1,17 +1,14 @@
-// create an initial subscription named "subscription name"
-val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-    .initialSubscriptions { realm ->
-        add(
-            realm.query<Toad>(
-                "name == $0",
-                "name value"
-            ),
-            "subscription name"
-        )
-    }
-    .build()
-val realm = Realm.open(config)
-// remove subscription by name
 realm.subscriptions.update {
-    this.remove("subscription name")
+    this.add(
+        realm.query<Team>("$0 IN members", "Bob Smith"),
+        "bob_smith_teams"
+    )
+}
+
+// Wait for synchronization to complete before updating subscriptions
+realm.subscriptions.waitForSynchronization(Duration.parse("10s"))
+
+// Remove subscription by name
+realm.subscriptions.update {
+    this.remove("bob_smith_teams")
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.subscribe-named-query.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.subscribe-named-query.kt
@@ -1,2 +1,3 @@
+// Add a subscription named "team_developer_education"
 val results = realm.query<Team>("teamName == $0", "Developer Education")
     .subscribe("team_developer_education")

--- a/source/examples/generated/kotlin/SyncTest.snippet.subscribe-named-query.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.subscribe-named-query.kt
@@ -1,0 +1,2 @@
+val results = realm.query<Team>("teamName == $0", "Developer Education")
+    .subscribe("team_developer_education")

--- a/source/examples/generated/kotlin/SyncTest.snippet.subscribe-unnamed-query.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.subscribe-unnamed-query.kt
@@ -1,0 +1,7 @@
+// Subscribe to a specific query
+val realmResults = realm.query<Task>("progressMinutes >= $0", 60)
+    .subscribe()
+
+// Subscribe to all objects of a specific type
+val realmQuery = realm.query<Team>()
+realmQuery.subscribe()

--- a/source/examples/generated/kotlin/SyncTest.snippet.subscribe-wait-for-sync.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.subscribe-wait-for-sync.kt
@@ -1,0 +1,6 @@
+val results = realm.query<Team>("$0 IN members", "Bob Smith")
+    .subscribe("bob_smith_teams", updateExisting = false, WaitForSync.ALWAYS)
+
+// After waiting for sync, the results set contains all the objects
+// that match the query - in our case, 1
+println("The number of teams that have Bob Smith as a member is ${results.size}")

--- a/source/examples/generated/kotlin/SyncTest.snippet.update-query-by-name.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.update-query-by-name.kt
@@ -1,0 +1,9 @@
+// Create a subscription named "bob_smith_teams"
+val results = realm.query<Team>("$0 IN members", "Bob Smith")
+    .subscribe("bob_smith_teams")
+
+// Add another subscription with the same name with `updateExisting` set to true
+// to replace the existing subscription
+val updateResults =
+        realm.query<Team>("$0 IN members AND teamName == $1", "Bob Smith", "QA")
+            .subscribe("bob_smith_teams", updateExisting = true)

--- a/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-name.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-name.kt
@@ -1,6 +1,6 @@
 // Create a subscription named "bob_smith_teams"
 realm.subscriptions.update {
-    this.add(
+    add(
         realm.query<Team>("$0 IN members", "Bob Smith"),
         "bob_smith_teams"
     )
@@ -9,7 +9,7 @@ realm.subscriptions.update {
 // Set `updateExisting` to true to replace the existing
 // "bob_smith_teams" subscription
 realm.subscriptions.update {
-    this.add(
+    add(
         realm.query<Team>("$0 IN members AND $1 IN members", "Bob Smith", "Jane Doe"),
         "bob_smith_teams", updateExisting = true
     )

--- a/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-name.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-name.kt
@@ -1,22 +1,16 @@
-// create an initial subscription named "subscription name"
-val config = SyncConfiguration.Builder(user, setOf(Toad::class))
-    .initialSubscriptions { realm ->
-        add(
-            realm.query<Toad>(
-                "name == $0",
-                "name value"
-            ),
-            "subscription name"
-        )
-    }
-    .build()
-val realm = Realm.open(config)
-// to update that subscription, add another subscription with the same name
-// it will replace the existing subscription
+// Create a subscription named "bob_smith_teams"
 realm.subscriptions.update {
     this.add(
-        realm.query<Toad>("name == $0", "another name value"),
-        "subscription name",
-        updateExisting = true
+        realm.query<Team>("$0 IN members", "Bob Smith"),
+        "bob_smith_teams"
+    )
+}
+
+// Set `updateExisting` to true to replace the existing
+// "bob_smith_teams" subscription
+realm.subscriptions.update {
+    this.add(
+        realm.query<Team>("$0 IN members AND $1 IN members", "Bob Smith", "Jane Doe"),
+        "bob_smith_teams", updateExisting = true
     )
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-query.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-query.kt
@@ -1,16 +1,13 @@
 val subscription =
     realm.subscriptions.findByQuery(
-        realm.query<Toad>("name == $0", "name value")
+        realm.query<Task>("teamName == $0", "Developer Education")
     )
 if (subscription != null) {
     realm.subscriptions.update {
         this.remove(subscription)
         this.add(
-            realm.query<Toad>(
-                "name == $0",
-                "another name value"
-            ),
-            "subscription name"
+            realm.query<Task>("teamName == $0", "DevEd"),
+            "team_developer_education"
         )
     }
 }

--- a/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-query.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-query.kt
@@ -1,12 +1,15 @@
+// Search for the subscription by query
 val subscription =
     realm.subscriptions.findByQuery(
-        realm.query<Task>("teamName == $0", "Developer Education")
+        realm.query<Team>("teamName == $0", "Developer Education")
     )
+
+// Remove the returned subscription and add the updated query
 if (subscription != null) {
     realm.subscriptions.update {
-        this.remove(subscription)
-        this.add(
-            realm.query<Task>("teamName == $0", "DevEd"),
+        remove(subscription)
+        add(
+            realm.query<Team>("teamName == $0", "DevEd"),
             "team_developer_education"
         )
     }

--- a/source/examples/generated/kotlin/SyncTest.snippet.wait-for-subscription-changes.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.wait-for-subscription-changes.kt
@@ -1,9 +1,9 @@
-// make an update to the list of subscriptions
+// Update the list of subscriptions
 realm.subscriptions.update {
     this.add(
-        realm.query<Toad>("name == $0", "another name value"),
-        "another subscription name"
+        realm.query<Team>("$0 IN members", "Bob Smith"),
+        "bob_smith_teams"
     )
 }
-// wait for subscription to fully synchronize changes
+// Wait for subscription to fully synchronize changes
 realm.subscriptions.waitForSynchronization(Duration.parse("10s"))

--- a/source/examples/generated/kotlin/SyncTest.snippet.wait-for-subscription-changes.kt
+++ b/source/examples/generated/kotlin/SyncTest.snippet.wait-for-subscription-changes.kt
@@ -1,8 +1,8 @@
 // Update the list of subscriptions
 realm.subscriptions.update {
-    this.add(
-        realm.query<Team>("$0 IN members", "Bob Smith"),
-        "bob_smith_teams"
+    add(
+        realm.query<Team>("$0 IN members", "Jane Doe"),
+        "jane_doe_teams"
     )
 }
 // Wait for subscription to fully synchronize changes

--- a/source/sdk/kotlin/sync/open-a-synced-realm.txt
+++ b/source/sdk/kotlin/sync/open-a-synced-realm.txt
@@ -43,6 +43,10 @@ Open a Synced Realm
       .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.open-a-flexible-sync-realm.kt
          :language: kotlin
          :copyable: false
+      
+      For more information on bootstrapping the realm with initial subscriptions
+      and managing your synced realm subscriptions, 
+      refer to :ref:`Manage Sync Subscriptions <kotlin-sync-add-initial-subscriptions>`.
 
    .. tab:: Partition Based Sync
       :tabid: pbs

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -64,12 +64,19 @@ You can:
 - Update subscriptions with new queries
 - Remove individual subscriptions or all subscriptions for an object type
 
-Subscriptions to Object Types
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Subscribe to Object Types
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You subscribe to queries for the :ref:`object types <kotlin-define-a-new-object-type>` 
-defined in your client data model. Note the following if your app uses 
-:ref:`linked objects <kotlin-relationships>` or :ref:`asymmetric objects <kotlin-asymmetric-objects>`:
+defined in your client data model and specified in your Flexible Sync configuration
+when you open the synced realm. 
+
+You must subscribe to all object types that you want to :ref:`write to a synced realm <kotlin-write-synced-realm>`. For example, if your app includes a ``Task`` 
+object type and a ``Team`` object type, you would include both in your sync 
+configuration and subscribe to a query for each object type.
+
+However, note the following if you use :ref:`linked objects <kotlin-relationships>` or 
+:ref:`asymmetric objects <kotlin-asymmetric-objects>` in your app:
 
 Linked Objects
 ``````````````
@@ -171,6 +178,7 @@ by setting ``updateExisting`` to ``true``:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.update-query-by-name.kt
    :language: kotlin
+   :emphasize-lines: 8
 
 This updates the subscription, similar to :ref:`manually updating a subscription <kotlin-sync-add-subscription>`.
 
@@ -180,7 +188,11 @@ Wait for a Query Subscription to Sync
 When you subscribe to a query's results set, that set does not contain objects until it syncs. If 
 your app creates objects, you may not need to download synced data before the user works with it. 
 However, if your app requires data from the server before the user can work with it, you can 
-specify that a subscription should wait for data to sync:   
+specify that the app should wait for data to sync. This blocks app execution until the 
+data syncs from the server. 
+
+wait for wait for sync blocks app execution until data syncs from the server
+
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.subscribe-wait-for-sync.kt
    :language: kotlin
@@ -190,19 +202,17 @@ This option uses the
 enum, whose values are:
 
 - ``FIRST_TIME``: (Default) Wait to download matching objects when your app initially creates the 
-    subscription. Otherwise, return without waiting for new downloads. The app must have an 
-    internet connection to download the data when you initially add the subscription. You can 
-    optionally specify a ``timeout`` value.
+   subscription. Otherwise, return without waiting for new downloads. The app must have an 
+   internet connection to download the data when you initially add the subscription. You can 
+   optionally specify a ``timeout`` value.
 
 - ``ALWAYS``: Wait to download matching objects every time the ``.subscribe()`` method is called. 
-    The app must have an internet connection to download the data. You can optionally specify a 
-    ``timeout`` value.
+   The app must have an internet connection to download the data. You can optionally specify a 
+   ``timeout`` value.
 
 - ``NEVER``: Never wait to download matching objects. The app needs an internet connection for the 
-    user to authenticate the first time the app launches but can open offline on subsequent 
-    launches using cached credentials.
-
-When 
+   user to authenticate the first time the app launches but can open offline on subsequent 
+   launches using cached credentials.
 
 .. _kotlin-manually-manage-subscription:
 

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -49,54 +49,55 @@ open a synced realm and subscribe to queries for the objects you want to read an
 write.
 
 In the client application, you add, update, and remove subscriptions to specific 
-queries on the queryable fields. This will determine which data syncs to the client device.
-
-.. note::
-
-   .. versionadded:: 1.10.0
-
-   To simplify subscription management, Realm Kotlin SDK version 1.10.0 adds an
-   experimental ``.subscribe()`` API to subscribe directly to a ``RealmQuery`` or 
-   a ``RealmResults``. This API 
-   abstracts away the details of manually adding subscriptions through subscription sets.
+queries on the queryable fields. This determines which data syncs to the client device.
 
 You can:
 
 - Add subscriptions with an optional subscription name:
   
-  - In Kotlin SDK version 1.10.0 or newer, use ``.subscribe()`` to subscribe to a query and automatically add the subscription to the subscription set
-  - Manually add a subscription to the subscription set
+  - In Kotlin SDK version 1.10.0 and later, use ``.subscribe()`` to subscribe to 
+    a ``RealmQuery`` or a ``RealmResults``. This automatically adds the subscription 
+    to the subscription set.
+  - Manually add a subscription to the subscription set with the ``subscriptions`` API.
   
 - React to subscription state
 - Update subscriptions with new queries
 - Remove individual subscriptions or all subscriptions for an object type
 
-Linked Objects and Asymmetric Objects 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Subscriptions to Object Types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If your app uses **linked objects**, you must add both the object itself and its linked 
-object to the subscription set to see the actual linked object.
+You subscribe to queries for the :ref:`object types <kotlin-define-a-new-object-type>` 
+defined in your client data model. Note the following if your app uses 
+:ref:`linked objects <kotlin-relationships>` or :ref:`asymmetric objects <kotlin-asymmetric-objects>`:
+
+Linked Objects
+``````````````
+
+If your app uses **linked objects**, you *must* add both the object itself 
+and its linked object to the subscription set to see the actual linked object.
+
 When your subscription results contain an object with a property that links 
 to an object not contained in the results, the link appears to be null.
 There is no way to distinguish whether that property's value is 
 legitimately null or whether the object it links to exists but is out of
 view of the query subscription.
 
+Asymmetric Objects
+``````````````````
+
 If your app uses :ref:`Data Ingest <optimize-data-ingest>` to 
 unidirectionally sync **asymmetric objects**, you *cannot* create subscriptions for 
-those objects. If you have asymmetric objects and non-asymmetric objects in the 
-same realm, you can add a Flexible Sync subscription query for *only* the 
+those objects. If your app contains asymmetric objects and non-asymmetric objects in the 
+same realm, you can add Flexible Sync subscription queries for the
 non-asymmetric objects.
 
 About the Examples on This Page
 -------------------------------
 
-The examples on this page use a simple data set for a
-task list app. The two Realm object types are ``Team``
-and ``Task``. A ``Task`` has a ``taskName``, assignee's name, and
-completed flag. There is also a count of minutes spent working on it, 
-and a due date. A ``Team`` has a ``teamName``, zero or more 
-``Tasks``, and a list of ``members``.
+The examples on this page use a data set for a task list app. 
+
+The two Realm object types are ``Team``and ``Task``: 
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.flexible-sync-models.kt
    :language: kotlin
@@ -154,24 +155,11 @@ You can later use this name to :ref:`update the subscription's query
 <kotlin-update-query-subscription>` or :ref:`remove the 
 query by name <kotlin-remove-query-by-name>`.
 
+To add a name to the subscription, pass a string when you call ``.subscribe()``:
+
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.subscribe-named-query.kt
    :language: kotlin
-
-Wait for a Query Subscription to Sync
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When you subscribe to a query's results set, that set does not contain objects until it syncs. If your app creates objects, you may not need to download synced data before the user works with it. However, if your app requires data from the server before the user can work with it, you can specify that a subscription should wait for data to sync:   
-
-.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.subscribe-wait-for-sync.kt
-   :language: kotlin
-
-This option uses the `WaitForSync <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-wait-for-sync/index.html>`__ enum, whose values are:
-
-- ``FIRST_TIME``: (Default) Wait to download matching objects when your app initially creates the subscription. Otherwise, return without waiting for new downloads. The app must have an internet connection to download the data when you initially add the subscription. You can optionally specify a ``timeout`` value.
-
-- ``ALWAYS``: Wait to download matching objects every time the ``.subscribe()`` method is called. The app must have an internet connection to download the data. You can optionally specify a ``timeout`` value.
-
-- ``NEVER``: Never wait to download matching objects. The app needs an internet connection for the user to authenticate the first time the app launches but can open offline on subsequent launches using cached credentials.
+   :emphasize-lines: 3
 
 .. _kotlin-update-query-subscription:
 
@@ -186,19 +174,52 @@ by setting ``updateExisting`` to ``true``:
 
 This updates the subscription, similar to :ref:`manually updating a subscription <kotlin-sync-add-subscription>`.
 
+Wait for a Query Subscription to Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you subscribe to a query's results set, that set does not contain objects until it syncs. If 
+your app creates objects, you may not need to download synced data before the user works with it. 
+However, if your app requires data from the server before the user can work with it, you can 
+specify that a subscription should wait for data to sync:   
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.subscribe-wait-for-sync.kt
+   :language: kotlin
+
+This option uses the 
+`WaitForSync <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-wait-for-sync/index.html>`__ 
+enum, whose values are:
+
+- ``FIRST_TIME``: (Default) Wait to download matching objects when your app initially creates the 
+    subscription. Otherwise, return without waiting for new downloads. The app must have an 
+    internet connection to download the data when you initially add the subscription. You can 
+    optionally specify a ``timeout`` value.
+
+- ``ALWAYS``: Wait to download matching objects every time the ``.subscribe()`` method is called. 
+    The app must have an internet connection to download the data. You can optionally specify a 
+    ``timeout`` value.
+
+- ``NEVER``: Never wait to download matching objects. The app needs an internet connection for the 
+    user to authenticate the first time the app launches but can open offline on subsequent 
+    launches using cached credentials.
+
+When 
+
 .. _kotlin-manually-manage-subscription:
 
 Manually Manage Subscriptions
 -----------------------------
 
 In the client application, use the 
-``subscriptions`` API to manually manage a set of subscriptions to specific queries on 
-queryable fields, which determine which data syncs to the client device.
+``subscriptions`` API to manually manage a set of subscriptions. With this API,
+you can add, update, or remove specific queries on 
+queryable fields. These queries determine which data syncs to the client device.
 
-To automatically add subscriptions to a ``MutableSubscriptionSet`` directly 
-from a ``RealmQuery`` or a ``RealmResults``, you can use 
-the :ref:`.subscribe() API <kotlin-flexible-sync-results-subscribe-api>` with 
-Kotlin SDK version 1.10.0 or newer.
+To , you can use 
+ 
+In Kotlin SDK version 1.10.0 and later, you can automatically add subscriptions 
+with the :ref:`.subscribe() API <kotlin-flexible-sync-results-subscribe-api>`.
+This API adds subscriptions to a ``MutableSubscriptionSet`` directly from a 
+``RealmQuery`` or a ``RealmResults``.
 
 .. _kotlin-sync-add-subscription:
 

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -70,15 +70,22 @@ You can:
 - Update subscriptions with new queries
 - Remove individual subscriptions or all subscriptions for an object type
 
+Linked Objects and Asymmetric Objects 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. important:: Asymmetric Realm Objects
+If your app uses **linked objects**, you must add both an object and its linked 
+object to the subscription set to see a linked object.
+When your subscription results contain an object with a property that links 
+to an object not contained in the results, the link appears to be null.
+There is no way to distinguish whether that property's value is 
+legitimately null or whether the object it links to exists but is out of
+view of the query subscription.
 
-   If your app uses :ref:`Data Ingest <optimize-data-ingest>` to 
-   unidirectionally sync an `AsymmetricRealmObject <{+kotlin-sync-prefix+}io.realm.kotlin.types/-asymmetric-realm-object/index.html>`__ 
-   via an Atlas App Services App, you *cannot* create subscriptions for 
-   those objects.
-   If you have asymmetric objects and non-asymmetric objects in the same realm, you can add a
-   Flexible Sync subscription query for *only* the non-asymmetric objects. 
+If your app uses :ref:`Data Ingest <optimize-data-ingest>` to 
+unidirectionally sync **asymmetric objects**, you *cannot* create subscriptions for 
+those objects. If you have asymmetric objects and non-asymmetric objects in the 
+same realm, you can add a Flexible Sync subscription query for *only* the 
+non-asymmetric objects.
 
 About the Examples on This Page
 -------------------------------

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -17,20 +17,21 @@ To use Flexible Sync in the SDK:
 
 #. :ref:`Configure Flexible Sync on the backend <enable-flexible-sync>` and define your :ref:`queryable fields <queryable-fields>`.
 #. :ref:`Authenticate a user <kotlin-authenticate>` in your client app.
-#. :ref:`Open the synced Realm with a Flexible Sync configuration <kotlin-open-a-synced-realm>`
-#. :ref:`Add subscriptions to the client application <kotlin-sync-add-subscription>` to indicate which data to sync.
+#. :ref:`Open the synced realm with a Flexible Sync configuration <kotlin-open-a-synced-realm>` 
+   and an initial set of subscriptions to determine which data to sync.
 
-When you configure Flexible Sync on the backend, you specify which 
-fields your client application can query using **subscriptions**. 
+Subscriptions
+-------------
+
+When you configure Flexible Sync on the backend, you specify which fields your 
+client application can query using **subscriptions**. 
 
 Each subscription corresponds to a query on **queryable fields** for a 
-specific object type. You can create multiple subscriptions on 
-different object types and multiple subscriptions on the same 
-object type. See :ref:`Queryable Fields <queryable-fields>` 
+specific object type. See :ref:`Queryable Fields <queryable-fields>` 
 in the App Services documentation for more information.
 
-For each subscription, Realm looks for data matching the query. 
-Data matching the query, where the user has the appropriate 
+For each query subscription, Realm looks for data matching the query. 
+Data matching the subscription, where the user has the appropriate 
 permissions, syncs between clients and the backend application.
 
 You can construct queries with :ref:`Realm Query Language <realm-query-language>`.
@@ -41,39 +42,13 @@ You can construct queries with :ref:`Realm Query Language <realm-query-language>
    Query Language. See :ref:`Flexible Sync RQL Limitations 
    <kotlin-flexible-sync-rql-limitations>` for details.
 
-Manage Subscriptions in Your Client App
----------------------------------------
-
-With an authenticated user and a Flexible Sync configuration, you can
-open a synced realm and subscribe to queries for the objects you want to read and
-write.
-
-In the client application, you add, update, and remove subscriptions to specific 
-queries on the queryable fields. This determines which data syncs to the client device.
-
-You can:
-
-- Add subscriptions with an optional subscription name:
-  
-  - In Kotlin SDK version 1.10.0 and later, use ``.subscribe()`` to subscribe to 
-    a ``RealmQuery`` or a ``RealmResults``. This automatically adds the subscription 
-    to the subscription set.
-  - Manually add a subscription to the subscription set with the ``subscriptions`` API.
-  
-- React to subscription state
-- Update subscriptions with new queries
-- Remove individual subscriptions or all subscriptions for an object type
-
 Subscribe to Object Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You subscribe to queries for the :ref:`object types <kotlin-define-a-new-object-type>` 
-defined in your client data model and specified in your Flexible Sync configuration
-when you open the synced realm. 
-
-You must subscribe to all object types that you want to :ref:`write to a synced realm <kotlin-write-synced-realm>`. For example, if your app includes a ``Task`` 
-object type and a ``Team`` object type, you would include both in your sync 
-configuration and subscribe to a query for each object type.
+Subscription sets are based on :ref:`object type <kotlin-define-object-model>`. 
+You might have multiple subscriptions if you have 
+many types of Realm objects. You can also have multiple subscriptions on the same 
+object type. 
 
 However, note the following if you use :ref:`linked objects <kotlin-relationships>` or 
 :ref:`asymmetric objects <kotlin-asymmetric-objects>` in your app:
@@ -99,12 +74,31 @@ those objects. If your app contains asymmetric objects and non-asymmetric object
 same realm, you can add Flexible Sync subscription queries for the
 non-asymmetric objects.
 
+Manage Subscriptions in Your Client App
+---------------------------------------
+
+In the client application, you add, update, and remove subscriptions to specific 
+queries on the queryable fields. This determines which data syncs to the client device.
+
+You can:
+
+- Add subscriptions with an optional subscription name:
+  
+  - In Kotlin SDK version 1.10.0 and later, use ``.subscribe()`` to subscribe to 
+    a ``RealmQuery`` or a ``RealmResults``. This automatically adds the subscription 
+    to the subscription set.
+  - Manually add a subscription to the subscription set with the ``subscriptions`` API.
+  
+- React to subscription state
+- Update subscriptions with new queries
+- Remove individual subscriptions or all subscriptions for an object type
+
 About the Examples on This Page
 -------------------------------
 
 The examples on this page use a data set for a task list app. 
 
-The two Realm object types are ``Team``and ``Task``: 
+The two Realm object types are ``Team`` and ``Task``: 
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.flexible-sync-models.kt
    :language: kotlin
@@ -178,7 +172,7 @@ by setting ``updateExisting`` to ``true``:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.update-query-by-name.kt
    :language: kotlin
-   :emphasize-lines: 8
+   :emphasize-lines: 9
 
 This updates the subscription, similar to :ref:`manually updating a subscription <kotlin-sync-add-subscription>`.
 
@@ -188,11 +182,8 @@ Wait for a Query Subscription to Sync
 When you subscribe to a query's results set, that set does not contain objects until it syncs. If 
 your app creates objects, you may not need to download synced data before the user works with it. 
 However, if your app requires data from the server before the user can work with it, you can 
-specify that the app should wait for data to sync. This blocks app execution until the 
+specify that the app should wait for data to sync. This blocks app execution until 
 data syncs from the server. 
-
-wait for wait for sync blocks app execution until data syncs from the server
-
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.subscribe-wait-for-sync.kt
    :language: kotlin
@@ -201,18 +192,11 @@ This option uses the
 `WaitForSync <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-wait-for-sync/index.html>`__ 
 enum, whose values are:
 
-- ``FIRST_TIME``: (Default) Wait to download matching objects when your app initially creates the 
-   subscription. Otherwise, return without waiting for new downloads. The app must have an 
-   internet connection to download the data when you initially add the subscription. You can 
-   optionally specify a ``timeout`` value.
+- ``FIRST_TIME``: (Default) Wait to download matching objects when your app initially creates the subscription. Otherwise, return without waiting for new downloads. The app must have an internet connection to download the data when you initially add the subscription. You can optionally specify a ``timeout`` value.
 
-- ``ALWAYS``: Wait to download matching objects every time the ``.subscribe()`` method is called. 
-   The app must have an internet connection to download the data. You can optionally specify a 
-   ``timeout`` value.
+- ``ALWAYS``: Wait to download matching objects every time the ``.subscribe()`` method is called. The app must have an internet connection to download the data. You can optionally specify a ``timeout`` value.
 
-- ``NEVER``: Never wait to download matching objects. The app needs an internet connection for the 
-   user to authenticate the first time the app launches but can open offline on subsequent 
-   launches using cached credentials.
+- ``NEVER``: Never wait to download matching objects. The app needs an internet connection for the user to authenticate the first time the app launches but can open offline on subsequent launches using cached credentials.
 
 .. _kotlin-manually-manage-subscription:
 
@@ -223,8 +207,6 @@ In the client application, use the
 ``subscriptions`` API to manually manage a set of subscriptions. With this API,
 you can add, update, or remove specific queries on 
 queryable fields. These queries determine which data syncs to the client device.
-
-To , you can use 
  
 In Kotlin SDK version 1.10.0 and later, you can automatically add subscriptions 
 with the :ref:`.subscribe() API <kotlin-flexible-sync-results-subscribe-api>`.
@@ -356,6 +338,7 @@ a subscription with ``add()``:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-name.kt
    :language: kotlin
+   :emphasize-lines: 14
 
 You cannot update subscriptions created without a name. However, you can
 look up unnamed subscriptions by their query, remove them from the

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -18,19 +18,19 @@ To use Flexible Sync in the SDK:
 #. :ref:`Configure Flexible Sync on the backend <enable-flexible-sync>` and define your :ref:`queryable fields <queryable-fields>`.
 #. :ref:`Authenticate a user <kotlin-authenticate>` in your client app.
 #. :ref:`Open the synced Realm with a Flexible Sync configuration <kotlin-open-a-synced-realm>`
-#. :ref:`Add subscriptions to the client application <kotlin-sync-add-subscription>`
+#. :ref:`Add subscriptions to the client application <kotlin-sync-add-subscription>` to indicate which data to sync.
 
 When you configure Flexible Sync on the backend, you specify which 
 fields your client application can query using **subscriptions**. 
 
 Each subscription corresponds to a query on **queryable fields** for a 
-specific object type. You can create multiple subscription sets on 
-different object types and even query multiple times on the same 
+specific object type. You can create multiple subscriptions on 
+different object types and multiple subscriptions on the same 
 object type. See :ref:`Queryable Fields <queryable-fields>` 
 in the App Services documentation for more information.
 
-For each query subscription, Realm looks for data matching the query. 
-Data matching the subscription, where the user has the appropriate 
+For each subscription, Realm looks for data matching the query. 
+Data matching the query, where the user has the appropriate 
 permissions, syncs between clients and the backend application.
 
 You can construct queries with :ref:`Realm Query Language <realm-query-language>`.
@@ -45,19 +45,20 @@ Manage Subscriptions in Your Client App
 ---------------------------------------
 
 With an authenticated user and a Flexible Sync configuration, you can
-open a synced realm and query for the objects you want to read and
+open a synced realm and subscribe to queries for the objects you want to read and
 write.
 
 In the client application, you add, update, and remove subscriptions to specific 
-queries on queryable fields, which determine which data syncs to the client device.
+queries on the queryable fields. This will determine which data syncs to the client device.
 
 .. note::
 
    .. versionadded:: 1.10.0
 
    To simplify subscription management, Realm Kotlin SDK version 1.10.0 adds an
-   experimental ``.subscribe()`` API to subscribe to a query's ``RealmResults`` set. This API 
-   abstracts away the details of manually adding subscriptions.
+   experimental ``.subscribe()`` API to subscribe directly to a ``RealmQuery`` or 
+   a ``RealmResults``. This API 
+   abstracts away the details of manually adding subscriptions through subscription sets.
 
 You can:
 
@@ -73,8 +74,8 @@ You can:
 Linked Objects and Asymmetric Objects 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If your app uses **linked objects**, you must add both an object and its linked 
-object to the subscription set to see a linked object.
+If your app uses **linked objects**, you must add both the object itself and its linked 
+object to the subscription set to see the actual linked object.
 When your subscription results contain an object with a property that links 
 to an object not contained in the results, the link appears to be null.
 There is no way to distinguish whether that property's value is 
@@ -117,7 +118,7 @@ To simplify subscription management, Realm Kotlin SDK version 1.10.0
 adds an experimental 
 `.subscribe() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.ext/subscribe.html>`__ 
 API to subscribe to a ``RealmQuery`` or ``RealmResults`` set. This API abstracts 
-away the details of manually adding and removing subscriptions.
+away the details of manually adding and removing subscriptions through subscription sets.
 
 You can:
 
@@ -135,7 +136,7 @@ Subscribe to a Query
 ~~~~~~~~~~~~~~~~~~~~
 
 You can ``.subscribe()`` to a query to create a subscription
-for objects matching the query:
+for objects matching a specific query:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.subscribe-unnamed-query.kt
    :language: kotlin
@@ -166,9 +167,9 @@ When you subscribe to a query's results set, that set does not contain objects u
 
 This option uses the `WaitForSync <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-wait-for-sync/index.html>`__ enum, whose values are:
 
-- ``FIRST_TIME``: (Default) Wait to download matching objects when your app creates the subscription. Otherwise, return without waiting for new downloads. The app must have an internet connection when you add the subscription. You can optionally specify a ``timeout`` value.
+- ``FIRST_TIME``: (Default) Wait to download matching objects when your app initially creates the subscription. Otherwise, return without waiting for new downloads. The app must have an internet connection to download the data when you initially add the subscription. You can optionally specify a ``timeout`` value.
 
-- ``ALWAYS``: Wait to download matching objects every time your app launches. The app must have an internet connection at every launch. You can optionally specify a ``timeout`` value.
+- ``ALWAYS``: Wait to download matching objects every time the ``.subscribe()`` method is called. The app must have an internet connection to download the data. You can optionally specify a ``timeout`` value.
 
 - ``NEVER``: Never wait to download matching objects. The app needs an internet connection for the user to authenticate the first time the app launches but can open offline on subsequent launches using cached credentials.
 
@@ -194,7 +195,8 @@ In the client application, use the
 ``subscriptions`` API to manually manage a set of subscriptions to specific queries on 
 queryable fields, which determine which data syncs to the client device.
 
-To automatically add subscriptions to a ``MutableSubscriptionSet``, you can use 
+To automatically add subscriptions to a ``MutableSubscriptionSet`` directly 
+from a ``RealmQuery`` or a ``RealmResults``, you can use 
 the :ref:`.subscribe() API <kotlin-flexible-sync-results-subscribe-api>` with 
 Kotlin SDK version 1.10.0 or newer.
 
@@ -231,8 +233,8 @@ You can also specify a subscription name when you create the subscription:
    If your subscription results contain an object with a property that links 
    to an object not contained in the results, the link appears to be null.
    There is no way to distinguish whether that property's value is 
-   legitimately null or whether the object it links to exists but is out of
-   view of the query subscription.
+   legitimately null or whether the object it links to exists but is not available
+   to the client due to missing subscriptions.
 
 .. _kotlin-sync-add-initial-subscriptions:
 
@@ -421,7 +423,7 @@ API Efficiency
 Managing multiple subscriptions with the ``.subscribe()`` 
 API described in the :ref:`kotlin-flexible-sync-results-subscribe-api` section
 is less efficient than performing batch updates when you 
-manually manage subscriptions. For better performance when 
+manually manage subscriptions through the subscription set API. For better performance when 
 making multiple subscription changes, use the ``subscriptions.update`` API described in the 
 :ref:`kotlin-manually-manage-subscription` section.
 

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -10,37 +10,30 @@ Manage Sync Subscriptions - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-Flexible Sync uses subscriptions and permissions to determine which
-data to sync with your App.
-
-Prerequisites
--------------
+:ref:`Flexible Sync <flexible-sync>` uses subscriptions and permissions to determine which
+data to sync with your App. This page details how to manage subscriptions for Flexible Sync.
 
 To use Flexible Sync in the SDK:
 
-- :ref:`Configure Flexible Sync on the backend <enable-flexible-sync>`
-- :ref:`Authenticate a user <kotlin-authenticate>` in
-  your client app.
-- :ref:`Open the synced Realm with a Flexible Sync configuration <kotlin-open-a-synced-realm>`
+#. :ref:`Configure Flexible Sync on the backend <enable-flexible-sync>` and define your :ref:`queryable fields <queryable-fields>`.
+#. :ref:`Authenticate a user <kotlin-authenticate>` in your client app.
+#. :ref:`Open the synced Realm with a Flexible Sync configuration <kotlin-open-a-synced-realm>`
+#. :ref:`Add subscriptions to the client application <kotlin-sync-add-subscription>`
 
-You can add, update, and remove query subscriptions to determine which data 
-syncs to the client device.
+When you configure Flexible Sync on the backend, you specify which 
+fields your client application can query using **subscriptions**. 
 
-If your app uses :ref:`Data Ingest <optimize-data-ingest>` to 
-unidirectionally sync an `AsymmetricRealmObject <{+kotlin-sync-prefix+}io.realm.kotlin.types/-asymmetric-realm-object/index.html>`__ 
-via an Atlas App Services App, you *cannot* create subscriptions for 
-those objects.
-If you have asymmetric objects and non-asymmetric objects in the same realm, you can add a
-Flexible Sync subscription query for *only* the non-asymmetric objects. 
+Each subscription corresponds to a query on **queryable fields** for a 
+specific object type. You can create multiple subscription sets on 
+different object types and even query multiple times on the same 
+object type. See :ref:`Queryable Fields <queryable-fields>` 
+in the App Services documentation for more information.
 
-Subscriptions
--------------
+For each query subscription, Realm looks for data matching the query. 
+Data matching the subscription, where the user has the appropriate 
+permissions, syncs between clients and the backend application.
 
-When you configure Flexible Sync on the backend, you specify which fields
-your client application can query. In the client application, use the 
-``subscriptions`` API to manage a set of subscriptions to specific queries on 
-queryable fields. You can construct queries with
-:ref:`Realm Query Language <realm-query-language>`.
+You can construct queries with :ref:`Realm Query Language <realm-query-language>`.
 
 .. important::
 
@@ -48,42 +41,180 @@ queryable fields. You can construct queries with
    Query Language. See :ref:`Flexible Sync RQL Limitations 
    <kotlin-flexible-sync-rql-limitations>` for details.
 
+Manage Subscriptions in Your Client App
+---------------------------------------
+
+With an authenticated user and a Flexible Sync configuration, you can
+open a synced realm and query for the objects you want to read and
+write.
+
+In the client application, you add, update, and remove subscriptions to specific 
+queries on queryable fields, which determine which data syncs to the client device.
+
+.. note::
+
+   .. versionadded:: 1.10.0
+
+   To simplify subscription management, Realm Kotlin SDK version 1.10.0 adds an
+   experimental ``.subscribe()`` API to subscribe to a query's ``RealmResults`` set. This API 
+   abstracts away the details of manually adding subscriptions.
+
 You can:
 
-- Add subscriptions
+- Add subscriptions with an optional subscription name:
+  
+  - In Kotlin SDK version 1.10.0 or newer, use ``.subscribe()`` to subscribe to a query and automatically add the subscription to the subscription set
+  - Manually add a subscription to the subscription set
+  
 - React to subscription state
 - Update subscriptions with new queries
 - Remove individual subscriptions or all subscriptions for an object type
 
-Data matching the subscription, where the user has the appropriate 
-permissions, syncs between clients and the backend application.
 
-You can specify an optional string name for your subscription.
+.. important:: Asymmetric Realm Objects
 
-.. tip:: Always Specify a Subscription Name
+   If your app uses :ref:`Data Ingest <optimize-data-ingest>` to 
+   unidirectionally sync an `AsymmetricRealmObject <{+kotlin-sync-prefix+}io.realm.kotlin.types/-asymmetric-realm-object/index.html>`__ 
+   via an Atlas App Services App, you *cannot* create subscriptions for 
+   those objects.
+   If you have asymmetric objects and non-asymmetric objects in the same realm, you can add a
+   Flexible Sync subscription query for *only* the non-asymmetric objects. 
 
-   Always specify a subscription name if your application uses multiple
-   subscriptions. This makes your subscriptions easier to look up,
-   update, and delete elsewhere in your app.
+About the Examples on This Page
+-------------------------------
 
-When you create a subscription, Realm looks for data matching a query on a
-specific object type. You can create multiple subscription sets on different 
-object types, and even query multiple times on the same object type.
+The examples on this page use a simple data set for a
+task list app. The two Realm object types are ``Team``
+and ``Task``. A ``Task`` has a ``taskName``, assignee's name, and
+completed flag. There is also a count of minutes spent working on it, 
+and a due date. A ``Team`` has a ``teamName``, zero or more 
+``Tasks``, and a list of ``members``.
 
-Subscription names must be unique. Adding a subscription 
-with the same name as an existing subscription throws an error.
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.flexible-sync-models.kt
+   :language: kotlin
 
-.. _kotlin-add-subscription:
+The examples on this page also assume you have an authorized user and a 
+Flexible Sync `SyncConfiguration() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/index.html>`__:
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.open-flex-sync-app.kt
+   :language: kotlin
+
+.. _kotlin-flexible-sync-results-subscribe-api:
+
+Subscribe to Queries
+--------------------
+
+.. versionadded:: 1.10.0
+
+To simplify subscription management, Realm Kotlin SDK version 1.10.0
+adds an experimental 
+`.subscribe() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.ext/subscribe.html>`__ 
+API to subscribe to a ``RealmQuery`` or ``RealmResults`` set. This API abstracts 
+away the details of manually adding and removing subscriptions.
+
+You can:
+
+- Automatically subscribe to a query with an optional name
+- Update a named subscription with a new query
+
+If you need more control over subscriptions for performance optimization or 
+business logic reasons, you can 
+:ref:`manually manage the subscription set <kotlin-manually-manage-subscription>` 
+using the ``subscriptions`` API. See the 
+:ref:`Performance Considerations <kotlin-flex-sync-performance-considerations>` 
+section for more information.
+
+Subscribe to a Query
+~~~~~~~~~~~~~~~~~~~~
+
+You can ``.subscribe()`` to a query to create a subscription
+for objects matching the query:
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.subscribe-unnamed-query.kt
+   :language: kotlin
+
+This creates an unnamed subscription and adds it to the
+``MutableSubscriptionSet``, similar to 
+:ref:`manually creating a subscription <kotlin-sync-add-subscription>`.
+
+Subscribe to a Query with a Name
+````````````````````````````````
+
+If your app works with multiple subscriptions or if you want to update
+a subscription, you may want to add a name when you subscribe to a query.
+You can later use this name to :ref:`update the subscription's query 
+<kotlin-update-query-subscription>` or :ref:`remove the 
+query by name <kotlin-remove-query-by-name>`.
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.subscribe-named-query.kt
+   :language: kotlin
+
+Wait for a Query Subscription to Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you subscribe to a query's results set, that set does not contain objects until it syncs. If your app creates objects, you may not need to download synced data before the user works with it. However, if your app requires data from the server before the user can work with it, you can specify that a subscription should wait for data to sync:   
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.subscribe-wait-for-sync.kt
+   :language: kotlin
+
+This option uses the `WaitForSync <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-wait-for-sync/index.html>`__ enum, whose values are:
+
+- ``FIRST_TIME``: (Default) Wait to download matching objects when your app creates the subscription. Otherwise, return without waiting for new downloads. The app must have an internet connection when you add the subscription. You can optionally specify a ``timeout`` value.
+
+- ``ALWAYS``: Wait to download matching objects every time your app launches. The app must have an internet connection at every launch. You can optionally specify a ``timeout`` value.
+
+- ``NEVER``: Never wait to download matching objects. The app needs an internet connection for the user to authenticate the first time the app launches but can open offline on subsequent launches using cached credentials.
+
+.. _kotlin-update-query-subscription:
+
+Update a Query Subscription
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can update a named query subscription with a new query
+by setting ``updateExisting`` to ``true``:
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.update-query-by-name.kt
+   :language: kotlin
+
+This updates the subscription, similar to :ref:`manually updating a subscription <kotlin-sync-add-subscription>`.
+
+.. _kotlin-manually-manage-subscription:
+
+Manually Manage Subscriptions
+-----------------------------
+
+In the client application, use the 
+``subscriptions`` API to manually manage a set of subscriptions to specific queries on 
+queryable fields, which determine which data syncs to the client device.
+
+To automatically add subscriptions to a ``MutableSubscriptionSet``, you can use 
+the :ref:`.subscribe() API <kotlin-flexible-sync-results-subscribe-api>` with 
+Kotlin SDK version 1.10.0 or newer.
+
+.. _kotlin-sync-add-subscription:
 
 Add a Subscription
-------------------
+~~~~~~~~~~~~~~~~~~
 
-Add a subscription in a subscriptions update block. You append each
+You can add an unnamed subscription or a named subscription.
+
+.. tip:: Specify a Subscription Name
+
+   Always specify a subscription name if your application uses 
+   multiple subscriptions. This makes your subscriptions easier to 
+   look up, update, and delete elsewhere in your app.
+
+To manually create a subscription, add the subscription in a 
+subscriptions update block. You append each
 new subscription to the client's Realm subscriptions.
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.add-a-subscription.kt
    :language: kotlin
-   :copyable: false
+
+You can also specify a subscription name when you create the subscription: 
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.add-a-named-subscription.kt
+   :language: kotlin
 
 .. important:: Object Links
 
@@ -93,8 +224,41 @@ new subscription to the client's Realm subscriptions.
    If your subscription results contain an object with a property that links 
    to an object not contained in the results, the link appears to be null.
    There is no way to distinguish whether that property's value is 
-   legitimately null, or whether the object it links to exists but is out of
+   legitimately null or whether the object it links to exists but is out of
    view of the query subscription.
+
+.. _kotlin-sync-add-initial-subscriptions:
+
+Bootstrap the Realm with Initial Subscriptions
+``````````````````````````````````````````````
+
+You must have at least one subscription before you can read 
+from or write to the realm. You can bootstrap a realm with an 
+initial subscription set when you open it with the 
+`SyncConfiguration() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/index.html>`__.
+See :ref:`Open a Synced Realm <kotlin-open-a-synced-realm>` for more information.
+
+Pass the ``initialSubscriptions`` parameter with the 
+subscription queries you want to use to bootstrap the realm:
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.initialize-subscribe-query-realm-app.kt
+   :language: kotlin
+
+If your app needs to rerun this initial subscription every 
+time the app starts, you can pass an additional parameter: 
+``rerunOnOpen``. This is a boolean that denotes whether the 
+initial subscription should re-run every time the 
+app starts. You might need to do this to re-run dynamic time 
+ranges or other queries that require a re-computation of 
+static variables for the subscription.
+
+In this example, we only want incomplete tasks. With
+``rerunOnOpen`` set to ``true``, the query dynamically 
+recalculates the relevant objects to sync based on the 
+desired query results every time the app starts:
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.initialize-subscribe-query-realm-app-rerun.kt
+   :language: kotlin
 
 .. _kotlin-sync-check-subscription-state:
 
@@ -105,14 +269,15 @@ Writing an update to the subscription set locally is only one component
 of changing a subscription. After the local subscription change, the client
 synchronizes with the server to resolve any updates to the data due to 
 the subscription change. This could mean adding or removing data from the 
-synced realm. Use the `SynConfiguration.waitForInitialRemoteData()
+synced realm. 
+
+Use the `SyncConfiguration.waitForInitialRemoteData()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/wait-for-initial-remote-data.html>`__
 builder method to force your application to block until client subscription
 data synchronizes to the backend before opening the realm:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.wait-for-subscription-changes.kt
    :language: kotlin
-   :copyable: false
 
 You can also use `SubscriptionSet.waitForSynchronization()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-subscription-set/wait-for-synchronization.html>`__
@@ -137,20 +302,20 @@ new instance of the subscription set before you can write to it.
 .. _kotlin-update-subscriptions-with-new-query:
 
 Update Subscriptions with a New Query
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can update subscriptions using
 `SubscriptionSet.update()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-subscription-set/update.html>`__.
+
 In this example, we use `MutableSubscriptionSet.add()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-mutable-subscription-set/add.html>`__.
-to update the query for the subscription named "subscription name".
+to update the query for the subscription named ``"bob_smith_teams"``.
 You must set the ``updateExisting`` parameter to ``true`` to update
 a subscription with ``add()``:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-name.kt
    :language: kotlin
-   :copyable: false
 
 You cannot update subscriptions created without a name. However, you can
 look up unnamed subscriptions by their query, remove them from the
@@ -158,24 +323,26 @@ subscription set, then add a new subscription with an updated query:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.update-subscriptions-by-query.kt
    :language: kotlin
-   :copyable: false
 
 .. _kotlin-remove-subscriptions:
 
 Remove Subscriptions
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 To remove subscriptions, you can:
 
 - Remove a single subscription query
 - Remove all subscriptions to a specific object type
 - Remove all subscriptions
+- Remove all unnamed subscriptions
 
 When you remove a subscription query, Realm asynchronously removes the
 synced data that matched the query from the client device.
 
+.. _kotlin-remove-query-by-name:
+
 Remove a Single Subscription
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+````````````````````````````
 
 You can remove a specific subscription query
 using `MutableSubscriptionSet.remove()
@@ -186,10 +353,9 @@ subscription to ``remove()``, or pass the subscription name directly to
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.remove-single-subscription.kt
    :language: kotlin
-   :copyable: false
 
 Remove All Subscriptions to an Object Type
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``````````````````````````````````````````
 
 If you want to remove all subscriptions to a specific object type, pass
 a class to the `MutableSubscriptionSet.removeAll()
@@ -198,10 +364,9 @@ method:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions-to-an-object-type.kt
    :language: kotlin
-   :copyable: false
 
 Remove All Subscriptions
-~~~~~~~~~~~~~~~~~~~~~~~~
+````````````````````````
 
 To remove all subscriptions from the subscription set, use
 `MutableSubscriptionSet.removeAll()
@@ -216,7 +381,20 @@ with no arguments:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.remove-all-subscriptions.kt
    :language: kotlin
-   :copyable: false
+
+Remove All Unnamed Subscriptions
+````````````````````````````````
+
+.. versionadded:: 1.10.0
+
+You may want to remove unnamed subscriptions that are transient or dynamically 
+generated, but leave named subscriptions in place.
+
+You can remove all unnamed (anonymous) subscriptions from the subscription set by 
+setting ``anonymousOnly`` to ``true`` when you call the ``removeAll`` method:
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.remove-all-unnamed-subscriptions.kt
+   :language: kotlin
 
 .. _kotlin-flexible-sync-rql-limitations:
 
@@ -224,3 +402,23 @@ Flexible Sync RQL Limitations
 -----------------------------
 
 .. include:: /includes/flex-sync-limitations.rst
+
+.. _kotlin-flex-sync-performance-considerations:
+
+Performance Considerations
+--------------------------
+
+API Efficiency
+~~~~~~~~~~~~~~
+
+Managing multiple subscriptions with the ``.subscribe()`` 
+API described in the :ref:`kotlin-flexible-sync-results-subscribe-api` section
+is less efficient than performing batch updates when you 
+manually manage subscriptions. For better performance when 
+making multiple subscription changes, use the ``subscriptions.update`` API described in the 
+:ref:`kotlin-manually-manage-subscription` section.
+
+Group Updates for Improved Performance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/sync-memory-performance.rst

--- a/source/sdk/kotlin/sync/subscribe.txt
+++ b/source/sdk/kotlin/sync/subscribe.txt
@@ -62,7 +62,7 @@ and its linked object to the subscription set to see the actual linked object.
 When your subscription results contain an object with a property that links 
 to an object not contained in the results, the link appears to be null.
 There is no way to distinguish whether that property's value is 
-legitimately null or whether the object it links to exists but is out of
+null or whether the object it links to exists but is out of
 view of the query subscription.
 
 Asymmetric Objects
@@ -84,10 +84,13 @@ You can:
 
 - Add subscriptions with an optional subscription name:
   
-  - In Kotlin SDK version 1.10.0 and later, use ``.subscribe()`` to subscribe to 
+  - In Kotlin SDK version 1.10.0 and later, you can use ``.subscribe()`` to subscribe to 
     a ``RealmQuery`` or a ``RealmResults``. This automatically adds the subscription 
-    to the subscription set.
-  - Manually add a subscription to the subscription set with the ``subscriptions`` API.
+    to the subscription set. 
+  - Manually add a subscription to the subscription set with the ``subscriptions`` API. 
+    Use this API if you need more control over subscriptions for performance optimization or
+    business logic reasons. See the :ref:`Performance Considerations <kotlin-flex-sync-performance-considerations>` 
+    section for more information.
   
 - React to subscription state
 - Update subscriptions with new queries
@@ -144,8 +147,9 @@ for objects matching a specific query:
    :language: kotlin
 
 This creates an unnamed subscription and adds it to the
-``MutableSubscriptionSet``, similar to 
-:ref:`manually creating a subscription <kotlin-sync-add-subscription>`.
+``MutableSubscriptionSet``, instead of requiring you to 
+:ref:`manually add the subscription <kotlin-sync-add-subscription>` to the
+subscription set. 
 
 Subscribe to a Query with a Name
 ````````````````````````````````
@@ -174,7 +178,9 @@ by setting ``updateExisting`` to ``true``:
    :language: kotlin
    :emphasize-lines: 9
 
-This updates the subscription, similar to :ref:`manually updating a subscription <kotlin-sync-add-subscription>`.
+This updates the subscription automatically, instead of requiring you to  
+:ref:`manually update the subscription <kotlin-sync-add-subscription>` in the 
+subscription set.
 
 Wait for a Query Subscription to Sync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -246,7 +252,7 @@ You can also specify a subscription name when you create the subscription:
    If your subscription results contain an object with a property that links 
    to an object not contained in the results, the link appears to be null.
    There is no way to distinguish whether that property's value is 
-   legitimately null or whether the object it links to exists but is not available
+   null or whether the object it links to exists but is not available
    to the client due to missing subscriptions.
 
 .. _kotlin-sync-add-initial-subscriptions:


### PR DESCRIPTION
## Pull Request Info

- Add [`.subscribe()`](https://www.mongodb.com/docs/realm/sdk/kotlin/sync/subscribe/) info to existing [Manage Subscriptions](https://www.mongodb.com/docs/realm/sdk/kotlin/sync/subscribe/) page
- Update existing examples to use new `Team` and `Task` object models for consistency

### Jira

- https://jira.mongodb.org/browse/DOCSP-30216

### Staged Changes

- [Manage Sync Subscriptions - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-30216-flex-sync/sdk/kotlin/sync/subscribe/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
