### PR TITLE
Fix version number on log level page

### DIFF
--- a/source/sdk/kotlin/sync/log-level.txt
+++ b/source/sdk/kotlin/sync/log-level.txt
@@ -10,7 +10,7 @@ Set the Client Log Level - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-Realm Kotlin SDK v10.8.0 and Later
+Realm Kotlin SDK v1.8.0 and Later
 ----------------------------------
 
 You can set or change your app's log level to develop or debug your 
@@ -25,7 +25,7 @@ enum to specify the level of data you want to receive. If the log level
 priority is equal to or higher than the priority defined in ``RealmLog.level``,
 Realm logs the event.
 
-Unlike the pre-10.8.0 logging APIs, you can change the log level at any point
+Unlike the pre-1.8.0 logging APIs, you can change the log level at any point
 during the app's lifecycle from this global singleton.
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.set-log-level-realmlog.kt
@@ -60,10 +60,10 @@ You can also remove a specific logger, or remove all loggers, including the syst
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.set-custom-realmlog-logger.kt
    :language: kotlin
 
-Realm Kotlin SDK v10.7.1 and Earlier
+Realm Kotlin SDK v1.7.1 and Earlier
 ------------------------------------
 
-These APIs and their associated types are deprecated in version 10.8.0.
+These APIs and their associated types are deprecated in version 1.8.0.
 
 You can set the Device Sync client log level on the 
 `SyncConfiguration <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/index.html>`__


### PR DESCRIPTION
## Pull Request Info

No Jira - fixing version numbers throughout [Set the Client Log Level](https://www.mongodb.com/docs/realm/sdk/kotlin/sync/log-level/#realm-kotlin-sdk-v10.8.0-and-later) page (should be `1.x.x` not `10.x.x`)

### Staged Changes

- [Set the Client Log Level - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/no-jira-version-fix/sdk/kotlin/sync/log-level/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
