### PR TITLE
(DOCSP-31532): Node.js migrate PBS to FS updates

### DIFF
--- a/source/sdk/node/sync.txt
+++ b/source/sdk/node/sync.txt
@@ -30,7 +30,7 @@ background thread between the device and your backend App.
 Device Sync has two sync modes: Flexible Sync and the older Partition-Based
 Sync. We recommend using the Flexible Sync mode for new apps. For more 
 information on using Partition-Based Sync, refer to :ref:`Partition-Based Sync
-– Node.js SDK <node-partition-based-sync>`. 
+- Node.js SDK <node-partition-based-sync>`. 
 
 When you use Sync in your client application, your implementation must match 
 the Sync Mode you select in your backend App configuration. You can only use 
@@ -75,16 +75,10 @@ Group Updates for Improved Performance
 
 .. include:: /includes/sync-memory-performance.rst
 
-.. _node-partition-based-sync-fundamentals:
+.. tip::
 
-Partition-Based Sync
---------------------
+   Device Sync supports two Sync Modes: Flexible Sync, and the older 
+   Partition-Based Sync. If your App Services backend uses Partition-Based 
+   Sync, refer to :ref:`node-partition-based-sync`.
 
-When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
-backend App configuration, your client implementation must include a 
-partition value. This is the value of the :ref:`partition key 
-<partition-key>` field you select when you configure Partition-Based Sync. 
-
-The partition value determines which data the client application can access.
-
-You pass in the partition value when you open a synced realm.
+   We recommend new apps use Flexible Sync.

--- a/source/sdk/node/sync/flexible-sync.txt
+++ b/source/sdk/node/sync/flexible-sync.txt
@@ -215,6 +215,8 @@ have taken more than 180 minutes.
    Attempting to update a subscription that has the
    ``SubscriptionOptions.throwOnUpdate`` field set to true, throw an exception.
 
+.. _node-remove-subscriptions:
+
 Remove Subscriptions
 ~~~~~~~~~~~~~~~~~~~~
 To remove subscriptions from the subscription set, you can:

--- a/source/sdk/node/sync/manage-sync-session.txt
+++ b/source/sdk/node/sync/manage-sync-session.txt
@@ -20,7 +20,7 @@ Prerequisites
 Before you can manage a sync session, you must perform the following:
 
 #. :ref:`Open a synced realm <node-open-a-synced-realm>`
-#. If you're using Flexible Sync, :ref:`add a sync subscription
+#. :ref:`Add a sync subscription
    <node-sync-subscribe-to-queryable-fields>`
 
 .. _node-access-sync-session:
@@ -68,51 +68,6 @@ When to Pause a Sync Session
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/when-to-pause-sync.rst
-
-.. _node-check-sync-progress:
-
-Check Upload & Download Progress for a Sync Session
----------------------------------------------------
-
-To check the upload and download progress for a sync session, add a progress
-notification using the :js-sdk:`syncSession.addProgressNotification() <Realm.App.Sync.Session.html#.addProgressNotification>` method.
-
-The ``syncSession.addProgressNotification()`` method takes in the following three parameters:
-
-- A ``direction`` parameter. 
-  Set to ``"upload"`` to register notifications for uploading data. 
-  Set to ``"download"`` to register notifications for downloading data.
-- A ``mode`` parameter. Set to ``"reportIndefinitely"`` 
-  for the notifications to continue until the callback is unregistered using
-  :js-sdk:`syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
-  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
-  until only the currently transferable bytes are synced.
-- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
-  ``transferred`` is the current number of bytes already transferred.
-  ``transferable`` is the total number of bytes already transferred
-  plus the number of bytes pending transfer.
-
-.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
-
-.. example::
-
-   In the following example, an application developer registers a callback on the ``syncSession`` to
-   listen for upload events indefinitely. The developer writes to the realm and
-   then unregisters the ``syncSession`` notification callback. 
-
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: typescript
-
-      .. literalinclude:: /examples/generated/node/device-sync.snippet.check-network-progress.ts
-        :language: typescript
-
-   .. tab::
-      :tabid: javascript
-
-      .. literalinclude:: /examples/generated/node/device-sync.snippet.check-network-progress.js
-        :language: javascript
 
 .. _node-check-network-connection:
 

--- a/source/sdk/node/sync/partition-based-sync.txt
+++ b/source/sdk/node/sync/partition-based-sync.txt
@@ -24,8 +24,8 @@ The information on this page is to support users who have existing apps that use
 
 .. _node-partition-based-sync-fundamentals:
 
-Partition-Based Sync
---------------------
+Partition Value
+---------------
 
 When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
 backend App configuration, your client implementation must include a 

--- a/source/sdk/node/sync/partition-based-sync.txt
+++ b/source/sdk/node/sync/partition-based-sync.txt
@@ -22,6 +22,20 @@ The information on this page is to support users who have existing apps that use
   You can only use one Sync mode for your application. You cannot mix Partition-Based
   Sync and Flexible Sync within the same app.
 
+.. _node-partition-based-sync-fundamentals:
+
+Partition-Based Sync
+--------------------
+
+When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
+backend App configuration, your client implementation must include a 
+partition value. This is the value of the :ref:`partition key 
+<partition-key>` field you select when you configure Partition-Based Sync. 
+
+The partition value determines which data the client application can access.
+
+You pass in the partition value when you open a synced realm.
+
 .. _node-partition-sync-open-realm:
 
 Open a Partition-Based Synced Realm
@@ -53,3 +67,123 @@ Open a Bundled Partition-Based Synced Realm
 When opening a :ref:`bundled synchronized realm <node-bundle-a-realm>` that uses Partition-Based Sync,
 you must use the same partition key that was used in the original realm configuration. If you use a
 different partition key, the SDK throw an error when opening the bundled realm. 
+
+.. _node-check-sync-progress:
+
+Check Upload & Download Progress for a Sync Session
+---------------------------------------------------
+
+Partition-Based Sync is currently the only Sync Mode that supports upload 
+and download progress notifications.
+
+To check the upload and download progress for a sync session, add a progress
+notification using the :js-sdk:`syncSession.addProgressNotification() <Realm.App.Sync.Session.html#.addProgressNotification>` method.
+
+The ``syncSession.addProgressNotification()`` method takes in the following three parameters:
+
+- A ``direction`` parameter. 
+  Set to ``"upload"`` to register notifications for uploading data. 
+  Set to ``"download"`` to register notifications for downloading data.
+- A ``mode`` parameter. Set to ``"reportIndefinitely"`` 
+  for the notifications to continue until the callback is unregistered using
+  :js-sdk:`syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
+  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
+  until only the currently transferable bytes are synced.
+- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
+  ``transferred`` is the current number of bytes already transferred.
+  ``transferable`` is the total number of bytes already transferred
+  plus the number of bytes pending transfer.
+
+.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
+
+.. example::
+
+   In the following example, an application developer registers a callback on the ``syncSession`` to
+   listen for upload events indefinitely. The developer writes to the realm and
+   then unregisters the ``syncSession`` notification callback. 
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: typescript
+
+      .. literalinclude:: /examples/generated/node/device-sync.snippet.check-network-progress.ts
+        :language: typescript
+
+   .. tab::
+      :tabid: javascript
+
+      .. literalinclude:: /examples/generated/node/device-sync.snippet.check-network-progress.js
+        :language: javascript
+
+.. _node-migrate-pbs-to-fs:
+
+Migrate from Partition-Based Sync to Flexible Sync
+--------------------------------------------------
+
+You can migrate your App Services Device Sync Mode from Partition-Based Sync 
+to Flexible Sync. Migrating is an automatic process that does not require 
+any changes to your application code. Automatic migration requires Realm 
+Node.js SDK version 11.10.0 or newer. 
+
+Migrating enables you to keep your existing App Services users and 
+authentication configuration. Flexible Sync provides more versatile permissions
+configuration options and more granular data synchronization.
+
+For more information about how to migrate your App Services App from 
+Partition-Based Sync to Flexible Sync, refer to :ref:`Migrate Device Sync Modes 
+<realm-sync-migrate-modes>`.
+
+.. _node-update-client-code-after-pbs-to-fs-migration:
+
+Updating Client Code After Migration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The automatic migration from Partition-Based Sync to Flexible Sync does not
+require any changes to your client code. However, to support this 
+functionality, Realm automatically handles the differences between the two 
+Sync Modes by:
+
+- Automatically creating Flexible Sync subscriptions for each object type 
+  where ``partitionKey == partitionValue``.
+- Injecting a ``partitionKey`` field into every object if one does not already 
+  exist. This is required for the automatic Flexible Sync subscription.
+
+If you need to make updates to your client code after migration, consider 
+updating your client codebase to remove hidden migration functionality.
+You might want update your client codebase when:
+
+- You add a new model or change a model in your client codebase
+- You add or change functionality that involves reading or writing Realm objects
+- You want to implement more fine-grained control over what data you sync
+
+Make these changes to convert your Partition-Based Sync client code to use 
+Flexible Sync:
+
+- Add ``flexible:true`` to your 
+  :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object 
+  where you :ref:`open a synced realm <node-flexible-sync-open-realm>`.
+- Add relevant properties to your object models to use in your Flexible Sync 
+  subscriptions. For example, you might add an ``ownerId`` property to enable
+  a user to sync only their own data.
+- Remove automatic Flexible Sync subscriptions and manually create the 
+  relevant subscriptions.
+
+For examples of Flexible Sync permissions strategies, including examples of 
+how to model data for these strategies, refer to :ref:`flexible-sync-permissions-guide`.
+
+Remove and Manually Create Subscriptions
+````````````````````````````````````````
+
+When you migrate from Partition-Based Sync to Flexible Sync, Realm
+automatically creates hidden Flexible Sync subscriptions for your app. The 
+next time you add or change subscriptions, we recommend that you:
+
+1. :ref:`Remove the automatically-generated subscriptions <node-remove-subscriptions>`. 
+2. :ref:`Manually add the relevant subscriptions in your client codebase <node-sync-add-subscription>`.
+
+This enables you to see all of your subscription logic together in your 
+codebase for future iteration and debugging.
+
+For more information about the automatically-generated Flexible Sync 
+subscriptions, refer to :ref:`realm-sync-migrate-client`.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-31532

### Staged Changes

- [Sync Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31532/sdk/node/sync/): Remove PBS, add tip about PBS being an older sync mode and recommending new apps use Flexible Sync 
- [Partition-Based Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31532/sdk/node/sync/partition-based-sync/): Add Migration info to page, move Progress Notification docs from Manage a Sync Session to this page since they only work with PBS right now
- [Manage a Sync Session](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31532/sdk/node/sync/manage-sync-session/): Remove Progress Notification documentation from the page since it only works with PBS

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
