### PR TITLE
(DOCSP-31533): RN migrate PBS to FS updates

### DIFF
--- a/source/sdk/react-native/sync-data.txt
+++ b/source/sdk/react-native/sync-data.txt
@@ -81,8 +81,6 @@ Group Updates for Improved Performance
 
 .. include:: /includes/sync-memory-performance.rst
 
-.. _react-native-partition-based-sync-fundamentals:
-
 .. tip::
 
    Device Sync supports two Sync Modes: Flexible Sync, and the older 

--- a/source/sdk/react-native/sync-data.txt
+++ b/source/sdk/react-native/sync-data.txt
@@ -27,16 +27,6 @@ an :ref:`Atlas App Services backend <realm-cloud>`. When a client
 device is online, Sync asynchronously synchronizes data in a 
 background thread between the device and your backend App. 
 
-When you use Sync in your client application, your implementation must match 
-the Sync Mode you select in your backend App configuration. The Sync Mode
-options are:
-
-- Flexible Sync
-- Partition-Based Sync
-
-You can only use one Sync Mode for your application. You cannot mix 
-Partition-Based Sync and Flexible Sync within the same App.
-
 .. seealso::
 
    :ref:`enable-realm-sync`

--- a/source/sdk/react-native/sync-data.txt
+++ b/source/sdk/react-native/sync-data.txt
@@ -83,18 +83,10 @@ Group Updates for Improved Performance
 
 .. _react-native-partition-based-sync-fundamentals:
 
-Partition-Based Sync
---------------------
+.. tip::
 
-When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
-backend App configuration, your client implementation must include a 
-partition value. This is the value of the :ref:`partition key 
-<partition-key>` field you select when you configure Partition-Based Sync. 
+   Device Sync supports two Sync Modes: Flexible Sync, and the older 
+   Partition-Based Sync. If your App Services backend uses Partition-Based 
+   Sync, refer to :ref:`react-native-partition-realms`.
 
-The partition value determines which data the client application can access.
-
-You pass in the partition value when you open a synced realm.
-
-.. seealso::
-
-   - Learn how to configure and open a realm using :ref:`Partition-Based Sync <react-native-partition-sync-open-realm>`.
+   We recommend new apps use Flexible Sync.

--- a/source/sdk/react-native/sync-data/manage-sync-session.txt
+++ b/source/sdk/react-native/sync-data/manage-sync-session.txt
@@ -20,7 +20,7 @@ Prerequisites
 Before you can manage a sync session, you must perform the following:
 
 #. :ref:`Open a synced realm <react-native-open-a-synced-realm>`
-#. If you're using Flexible Sync, :ref:`add a sync subscription
+#. :ref:`Add a sync subscription
    <react-native-sync-subscribe-to-queryable-fields>`
 #. Wrap components that use the ``useRealm()`` hook for a synced realm
    with the ``AppProvider``, ``UserProvider``, and ``RealmProvider`` components.
@@ -59,49 +59,6 @@ When to Pause a Sync Session
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/when-to-pause-sync.rst
-
-.. _react-native-check-sync-progress:
-
-Check Upload & Download Progress for a Sync Session
----------------------------------------------------
-
-To check the upload and download progress for a sync session, add a progress
-notification using the :js-sdk:`Realm.syncSession.addProgressNotification() <Realm.App.Sync.Session.html#.addProgressNotification>` method.
-
-The ``Realm.syncSession.addProgressNotification()`` method takes in the following three parameters:
-
-- A ``direction`` parameter.
-  Set to ``"upload"`` to register notifications for uploading data.
-  Set to ``"download"`` to register notifications for downloading data.
-- A ``mode`` parameter. Set to ``"reportIndefinitely"``
-  for the notifications to continue until the callback is unregistered using
-  :js-sdk:`Realm.syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
-  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
-  until only the currently transferable bytes are synced.
-- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
-  ``transferred`` is the current number of bytes already transferred.
-  ``transferable`` is the total number of bytes already transferred
-  plus the number of bytes pending transfer.
-
-.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
-
-The following example registers a callback on the ``syncSession`` to
-listen for upload events indefinitely. The example writes to the realm and
-then unregisters the ``syncSession`` notification callback.
-
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: typescript
-
-      .. literalinclude:: /examples/generated/react-native/ts/check-upload-download-progress.test.snippet.check-upload-download-progress.tsx
-         :language: typescript
-
-   .. tab::
-      :tabid: javascript
-
-      .. literalinclude:: /examples/generated/react-native/js/check-upload-download-progress.test.snippet.check-upload-download-progress.jsx
-         :language: javascript
 
 .. _react-native-check-network-connection:
 

--- a/source/sdk/react-native/sync-data/partition-based-sync.txt
+++ b/source/sdk/react-native/sync-data/partition-based-sync.txt
@@ -18,6 +18,20 @@ For more information about Partition-Based Sync and how to configure it
 in Atlas App Services, refer to :ref:`Partition-Based Sync <partition-based-sync>`
 in the App Services documentation.
 
+.. _react-native-partition-based-sync-fundamentals:
+
+Partition-Based Sync
+--------------------
+
+When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
+backend App configuration, your client implementation must include a 
+partition value. This is the value of the :ref:`partition key 
+<partition-key>` field you select when you configure Partition-Based Sync.
+
+The partition value determines which data the client application can access.
+
+You pass in the partition value when you open a synced realm.
+
 .. _react-native-partition-sync-open-realm:
 
 Configure a Partition-Based Sync Realm

--- a/source/sdk/react-native/sync-data/partition-based-sync.txt
+++ b/source/sdk/react-native/sync-data/partition-based-sync.txt
@@ -10,9 +10,11 @@ Partition-Based Sync - React Native SDK
    :depth: 2
    :class: singlecol
 
-Partition-Based Sync is an older mode for using Atlas Device Sync with the Realm 
-React Native SDK. We recommend using Flexible Sync for new apps. The information 
-on this page is for users who are still using Partition-Based Sync.
+Partition-Based Sync is an older mode for using Atlas Device Sync with the 
+Realm React Native SDK. We recommend using 
+:ref:`Flexible Sync <react-native-flexible-sync-fundamentals>` 
+for new apps. The information on this page is for users who are still 
+using Partition-Based Sync.
 
 For more information about Partition-Based Sync and how to configure it
 in Atlas App Services, refer to :ref:`Partition-Based Sync <partition-based-sync>`

--- a/source/sdk/react-native/sync-data/partition-based-sync.txt
+++ b/source/sdk/react-native/sync-data/partition-based-sync.txt
@@ -20,8 +20,8 @@ in the App Services documentation.
 
 .. _react-native-partition-based-sync-fundamentals:
 
-Partition-Based Sync
---------------------
+Partition Value
+---------------
 
 When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
 backend App configuration, your client implementation must include a 

--- a/source/sdk/react-native/sync-data/partition-based-sync.txt
+++ b/source/sdk/react-native/sync-data/partition-based-sync.txt
@@ -105,3 +105,121 @@ as an encrypted synced realm.
 
          .. literalinclude:: /examples/generated/node/open-and-close-a-realm.snippet.sync-encrypted-to-local-unencrypted.js
             :language: javascript
+
+.. _react-native-check-sync-progress:
+
+Check Upload & Download Progress for a Sync Session
+---------------------------------------------------
+
+Partition-Based Sync is currently the only Sync Mode that supports upload 
+and download progress notifications.
+
+To check the upload and download progress for a sync session, add a progress
+notification using the :js-sdk:`Realm.syncSession.addProgressNotification() <Realm.App.Sync.Session.html#.addProgressNotification>` method.
+
+The ``Realm.syncSession.addProgressNotification()`` method takes in the following three parameters:
+
+- A ``direction`` parameter.
+  Set to ``"upload"`` to register notifications for uploading data.
+  Set to ``"download"`` to register notifications for downloading data.
+- A ``mode`` parameter. Set to ``"reportIndefinitely"``
+  for the notifications to continue until the callback is unregistered using
+  :js-sdk:`Realm.syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
+  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
+  until only the currently transferable bytes are synced.
+- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
+  ``transferred`` is the current number of bytes already transferred.
+  ``transferable`` is the total number of bytes already transferred
+  plus the number of bytes pending transfer.
+
+.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
+
+The following example registers a callback on the ``syncSession`` to
+listen for upload events indefinitely. The example writes to the realm and
+then unregisters the ``syncSession`` notification callback.
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: typescript
+
+      .. literalinclude:: /examples/generated/react-native/ts/check-upload-download-progress.test.snippet.check-upload-download-progress.tsx
+         :language: typescript
+
+   .. tab::
+      :tabid: javascript
+
+      .. literalinclude:: /examples/generated/react-native/js/check-upload-download-progress.test.snippet.check-upload-download-progress.jsx
+         :language: javascript
+
+.. _react-native-migrate-pbs-to-fs:
+
+Migrate from Partition-Based Sync to Flexible Sync
+--------------------------------------------------
+
+You can migrate your App Services Device Sync Mode from Partition-Based Sync 
+to Flexible Sync. Migrating is an automatic process that does not require 
+any changes to your application code. Automatic migration requires Realm 
+Node.js SDK version 11.10.0 or newer. 
+
+Migrating enables you to keep your existing App Services users and 
+authentication configuration. Flexible Sync provides more versatile permissions
+configuration options and more granular data synchronization.
+
+For more information about how to migrate your App Services App from 
+Partition-Based Sync to Flexible Sync, refer to :ref:`Migrate Device Sync Modes 
+<realm-sync-migrate-modes>`.
+
+.. _react-native-update-client-code-after-pbs-to-fs-migration:
+
+Updating Client Code After Migration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The automatic migration from Partition-Based Sync to Flexible Sync does not
+require any changes to your client code. However, to support this 
+functionality, Realm automatically handles the differences between the two 
+Sync Modes by:
+
+- Automatically creating Flexible Sync subscriptions for each object type 
+  where ``partitionKey == partitionValue``.
+- Injecting a ``partitionKey`` field into every object if one does not already 
+  exist. This is required for the automatic Flexible Sync subscription.
+
+If you need to make updates to your client code after migration, consider 
+updating your client codebase to remove hidden migration functionality.
+You might want update your client codebase when:
+
+- You add a new model or change a model in your client codebase
+- You add or change functionality that involves reading or writing Realm objects
+- You want to implement more fine-grained control over what data you sync
+
+Make these changes to convert your Partition-Based Sync client code to use 
+Flexible Sync:
+
+- Add ``flexible:true`` to your 
+  :js-sdk:`SyncConfiguration <Realm.App.Sync.html#~SyncConfiguration>` object 
+  where you :ref:`open a synced realm <react-native-flexible-sync-open-realm>`.
+- Add relevant properties to your object models to use in your Flexible Sync 
+  subscriptions. For example, you might add an ``ownerId`` property to enable
+  a user to sync only their own data.
+- Remove automatic Flexible Sync subscriptions and manually create the 
+  relevant subscriptions.
+
+For examples of Flexible Sync permissions strategies, including examples of 
+how to model data for these strategies, refer to :ref:`flexible-sync-permissions-guide`.
+
+Remove and Manually Create Subscriptions
+````````````````````````````````````````
+
+When you migrate from Partition-Based Sync to Flexible Sync, Realm
+automatically creates hidden Flexible Sync subscriptions for your app. The 
+next time you add or change subscriptions, we recommend that you:
+
+1. :ref:`Remove the automatically-generated subscriptions <react-native-remove-subscription>`. 
+2. :ref:`Manually add the relevant subscriptions in your client codebase <react-native-sync-add-subscription>`.
+
+This enables you to see all of your subscription logic together in your 
+codebase for future iteration and debugging.
+
+For more information about the automatically-generated Flexible Sync 
+subscriptions, refer to :ref:`realm-sync-migrate-client`.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-31533

### Staged Changes

- [Sync Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31533/sdk/react-native/sync-data/): Remove PBS, add tip about PBS being an older sync mode and recommending new apps use Flexible Sync
- [Partition-Based Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31533/sdk/react-native/sync-data/partition-based-sync/): Add Migration info to page, move Progress Notification docs from Manage a Sync Session to this page since they only work with PBS right now
- [Manage a Sync Session](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31533/sdk/react-native/sync-data/manage-sync-session/): Remove Progress Notification documentation from the page since it only works with PBS

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
