### PR TITLE
(DOCSP-31530): Kotlin SDK migrate PBS to FS updates

### DIFF
--- a/source/sdk/kotlin/sync.txt
+++ b/source/sdk/kotlin/sync.txt
@@ -14,6 +14,7 @@ Device Sync - Kotlin SDK
    Handle Sync Errors </sdk/kotlin/sync/handle-sync-errors>
    Set the Client Log Level </sdk/kotlin/sync/log-level>
    Stream Data to Atlas </sdk/kotlin/sync/stream-data-to-atlas>
+   Partition-Based Sync </sdk/kotlin/sync/partition-based-sync>
 
 .. contents:: On this page
    :local:
@@ -27,22 +28,6 @@ Atlas Device Sync automatically synchronizes data between client applications an
 an :ref:`Atlas App Services backend <realm-cloud>`. When a client
 device is online, Sync asynchronously synchronizes data in a
 background thread between the device and your backend App.
-
-When you use Sync in your client application, your implementation must match
-the :ref:`Sync Mode <sync-modes>` you select in your backend App configuration.
-The Sync Mode options are:
-
-- Flexible Sync (recommended): lets you define a query in the client and sync only the
-  objects that match the query.
-- Partition-Based Sync: documents in a synced cluster form a "partition" by
-  having the same value for a field designated as "partition key". All documents
-  in a partition have the same read/write permissions for a given user.
-
-You can only use one Sync Mode for your application.
-
-.. seealso::
-
-   :ref:`enable-realm-sync`
 
 .. _kotlin-flexible-sync-fundamentals:
 
@@ -74,21 +59,10 @@ To use Flexible Sync in your client application, open a synced realm
 with an initial set of subscriptions to determine which documents to
 sync.
 
-Group Updates for Improved Performance
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. tip::
 
-.. include:: /includes/sync-memory-performance.rst
+   Device Sync supports two Sync Modes: Flexible Sync, and the older 
+   Partition-Based Sync. If your App Services backend uses Partition-Based 
+   Sync, refer to :ref:`kotlin-partition-based-sync`.
 
-.. _kotlin-partition-based-sync-fundamentals:
-
-Partition-Based Sync
---------------------
-
-When you select :ref:`Partition-Based Sync <partition-based-sync>` for your
-backend App configuration, your client implementation must include a
-partition value. This is the value of the :ref:`partition key
-<partition-key>` field you select when you configure Partition-Based Sync.
-
-The partition value determines which data the client application can access.
-
-You must provide a partition value when you open a synced realm.
+   We recommend new apps use Flexible Sync.

--- a/source/sdk/kotlin/sync/open-a-synced-realm.txt
+++ b/source/sdk/kotlin/sync/open-a-synced-realm.txt
@@ -29,7 +29,7 @@ Before you can access a synced realm from the client, you must:
 Open a Synced Realm
 -------------------
 
-To open a :ref:`flexible sync <flexible-sync>` realm,
+To open a :ref:`Flexible Sync <flexible-sync>` realm,
 pass a user and a set of Realm object schemas to
 `SyncConfiguration.Builder()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__. Next, create a set of initial subscriptions with the ``initialSubscriptions()``

--- a/source/sdk/kotlin/sync/open-a-synced-realm.txt
+++ b/source/sdk/kotlin/sync/open-a-synced-realm.txt
@@ -24,71 +24,39 @@ Before you can access a synced realm from the client, you must:
 #. :ref:`Authenticate a user <kotlin-authenticate>` in
    your client project.
 
+.. _kotlin-flexible-sync-open-realm:
+
 Open a Synced Realm
 -------------------
 
-.. tabs::
+To open a :ref:`flexible sync <flexible-sync>` realm,
+pass a user and a set of Realm object schemas to
+`SyncConfiguration.Builder()
+<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__. Next, create a set of initial subscriptions with the ``initialSubscriptions()``
+builder method. Finally, pass the configuration to `Realm.open()
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__ to open
+an instance of the realm:
 
-   .. tab:: Flexible Sync
-      :tabid: flex-sync
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.open-a-flexible-sync-realm.kt
+   :language: kotlin
+   :copyable: false
 
-      To open a :ref:`flexible sync <flexible-sync>` realm,
-      pass a user and a set of Realm object schemas to
-      `SyncConfiguration.Builder()
-      <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__. Next, create a set of initial subscriptions with the ``initialSubscriptions()``
-      builder method. Finally, pass the configuration to `Realm.open()
-      <{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__ to open
-      an instance of the realm:
+For more information on bootstrapping the realm with initial subscriptions
+and managing your synced realm subscriptions, 
+refer to :ref:`Manage Sync Subscriptions <kotlin-sync-add-initial-subscriptions>`.
 
-      .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.open-a-flexible-sync-realm.kt
-         :language: kotlin
-         :copyable: false
-      
-      For more information on bootstrapping the realm with initial subscriptions
-      and managing your synced realm subscriptions, 
-      refer to :ref:`Manage Sync Subscriptions <kotlin-sync-add-initial-subscriptions>`.
-
-   .. tab:: Partition Based Sync
-      :tabid: pbs
-
-      To open a :ref:`partition-based sync <partition-based-sync>` realm,
-      pass a user, a partition, and a set of Realm object schemas to
-      `SyncConfiguration.Builder()
-      <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__.
-      Then, pass the configuration to `Realm.open()
-      <{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__ to open
-      an instance of the realm:
-
-      .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.open-a-synced-realm.kt
-         :language: kotlin
-         :copyable: false
+.. _kotlin-flexible-sync-configuration:
 
 Configure a Synced Realm
 ------------------------
 
-.. tabs::
+To adjust specific configuration settings, use the options provided by
+`SyncConfiguration.Builder
+<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/index.html>`__:
 
-   .. tab:: Flexible Sync
-      :tabid: flex-sync
-
-      To adjust specific configuration settings, use the options provided by
-      `SyncConfiguration.Builder
-      <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/index.html>`__:
-
-      .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.configure-a-flexible-sync-realm.kt
-         :language: kotlin
-         :copyable: false
-
-   .. tab:: Partition Based Sync
-      :tabid: pbs
-
-      To adjust specific configuration settings, use the options provided by
-      `SyncConfiguration.Builder
-      <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/index.html>`__:
-
-      .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.configure-a-synced-realm.kt
-         :language: kotlin
-         :copyable: false
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.configure-a-flexible-sync-realm.kt
+   :language: kotlin
+   :copyable: false
 
 .. _kotlin-download-changes-before-open:
 

--- a/source/sdk/kotlin/sync/partition-based-sync.txt
+++ b/source/sdk/kotlin/sync/partition-based-sync.txt
@@ -1,0 +1,138 @@
+.. _kotlin-partition-based-sync:
+
+=================================
+Partition-Based Sync - Kotlin SDK
+=================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Partition-Based Sync is an older mode for using Atlas Device Sync with the 
+Realm Kotlin SDK. We recommend using :ref:`Flexible Sync <kotlin-flexible-sync-fundamentals>` 
+for new apps. The information on this page is for users who are still 
+using Partition-Based Sync.
+
+.. tip::
+
+   Realm Kotlin SDK v1.9.0 and newer supports the ability to migrate from 
+   Partition-Based Sync to Flexible Sync. For more information, refer to: 
+   :ref:`kotlin-migrate-pbs-to-fs`.
+
+.. _kotlin-partition-based-sync-fundamentals:
+
+Partition-Based Sync
+--------------------
+
+When you select :ref:`Partition-Based Sync <partition-based-sync>` for your
+backend App configuration, your client implementation must include a
+partition value. This is the value of the :ref:`partition key
+<partition-key>` field you select when you configure Partition-Based Sync.
+
+The partition value determines which data the client application can access.
+
+You must provide a partition value when you open a synced realm.
+
+Open a Partition-Based Sync Realm
+---------------------------------
+
+To open a :ref:`partition-based sync <partition-based-sync>` realm,
+pass a user, a partition, and a set of Realm object schemas to
+`SyncConfiguration.Builder()
+<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__.
+Then, pass the configuration to `Realm.open()
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__ to open
+an instance of the realm:
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.open-a-synced-realm.kt
+    :language: kotlin
+    :copyable: false
+
+Configure a Partition-Based Sync Realm
+--------------------------------------
+
+To adjust specific configuration settings, use the options provided by
+`SyncConfiguration.Builder
+<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/index.html>`__:
+
+.. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.configure-a-synced-realm.kt
+    :language: kotlin
+    :copyable: false
+
+.. _kotlin-migrate-pbs-to-fs:
+
+Migrate from Partition-Based Sync to Flexible Sync
+--------------------------------------------------
+
+You can migrate your App Services Device Sync Mode from Partition-Based Sync 
+to Flexible Sync. Migrating is an automatic process that does not require 
+any changes to your application code. Automatic migration requires Realm 
+Kotlin SDK version 1.9.0 or newer. 
+
+Migrating enables you to keep your existing App Services users and 
+authentication configuration. Flexible Sync provides more versatile permissions
+configuration options and more granular data synchronization.
+
+For more information about how to migrate your App Services App from 
+Partition-Based Sync to Flexible Sync, refer to :ref:`Migrate Device Sync Modes 
+<realm-sync-migrate-modes>`.
+
+.. _kotlin-update-client-code-after-pbs-to-fs-migration:
+
+Updating Client Code After Migration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The automatic migration from Partition-Based Sync to Flexible Sync does not
+require any changes to your client code. However, to support this 
+functionality, Realm automatically handles the differences between the two 
+Sync Modes by:
+
+- Automatically creating Flexible Sync subscriptions for each object type 
+  where ``partitionKey == partitionValue``.
+- Injecting a ``partitionKey`` field into every object if one does not already 
+  exist. This is required for the automatic Flexible Sync subscription.
+
+If you need to make updates to your client code after migration, consider 
+updating your client codebase to remove hidden migration functionality.
+You might want update your client codebase when:
+
+- You add a new model or change a model in your client codebase
+- You add or change functionality that involves reading or writing Realm objects
+- You want to implement more fine-grained control over what data you sync
+
+Make these changes to convert your Partition-Based Sync client code to use 
+Flexible Sync:
+
+- Update your `SyncConfiguration.Builder()
+  <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__ 
+  to use :ref:`flexible sync <kotlin-flexible-sync-open-realm>`. This involves
+  removing the partition key and adding a set of initial subscriptions, 
+  if needed.
+- Add relevant properties to your object models to use in your Flexible Sync 
+  subscriptions. For example, you might add an ``ownerId`` property to enable
+  a user to sync only their own data.
+- Remove automatic Flexible Sync subscriptions and manually create the 
+  relevant subscriptions.
+
+For examples of Flexible Sync permissions strategies, including examples of 
+how to model data for these strategies, refer to :ref:`flexible-sync-permissions-guide`.
+
+Remove and Manually Create Subscriptions
+````````````````````````````````````````
+
+When you migrate from Partition-Based Sync to Flexible Sync, Realm
+automatically creates hidden Flexible Sync subscriptions for your app. The 
+next time you add or change subscriptions, we recommend that you:
+
+1. :ref:`Remove the automatically-generated subscriptions <kotlin-remove-subscriptions>`. 
+2. :ref:`Subscribe to queries <kotlin-flexible-sync-results-subscribe-api>` 
+   or :ref:`Manually add the relevant subscriptions in your client codebase 
+   <kotlin-sync-add-subscription>`.
+
+This enables you to see all of your subscription logic together in your 
+codebase for future iteration and debugging.
+
+For more information about the automatically-generated Flexible Sync 
+subscriptions, refer to :ref:`realm-sync-migrate-client`.

--- a/source/sdk/kotlin/sync/partition-based-sync.txt
+++ b/source/sdk/kotlin/sync/partition-based-sync.txt
@@ -23,8 +23,8 @@ using Partition-Based Sync.
 
 .. _kotlin-partition-based-sync-fundamentals:
 
-Partition-Based Sync
---------------------
+Partition Value
+---------------
 
 When you select :ref:`Partition-Based Sync <partition-based-sync>` for your
 backend App configuration, your client implementation must include a

--- a/source/sdk/kotlin/sync/partition-based-sync.txt
+++ b/source/sdk/kotlin/sync/partition-based-sync.txt
@@ -108,7 +108,7 @@ Flexible Sync:
 - Update your `SyncConfiguration.Builder()
   <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__ 
   to use :ref:`flexible sync <kotlin-flexible-sync-open-realm>`. This involves
-  removing the partition key and adding a set of initial subscriptions, 
+  removing the ``partitionValue`` and adding a set of initial subscriptions, 
   if needed.
 - Add relevant properties to your object models to use in your Flexible Sync 
   subscriptions. For example, you might add an ``ownerId`` property to enable

--- a/source/sdk/kotlin/sync/partition-based-sync.txt
+++ b/source/sdk/kotlin/sync/partition-based-sync.txt
@@ -38,7 +38,7 @@ You must provide a partition value when you open a synced realm.
 Open a Partition-Based Sync Realm
 ---------------------------------
 
-To open a :ref:`partition-based sync <partition-based-sync>` realm,
+To open a :ref:`Partition-Based Sync <partition-based-sync>` realm,
 pass a user, a partition, and a set of Realm object schemas to
 `SyncConfiguration.Builder()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__.
@@ -107,7 +107,7 @@ Flexible Sync:
 
 - Update your `SyncConfiguration.Builder()
   <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-configuration/-builder/-builder.html>`__ 
-  to use :ref:`flexible sync <kotlin-flexible-sync-open-realm>`. This involves
+  to use :ref:`Flexible Sync <kotlin-flexible-sync-open-realm>`. This involves
   removing the ``partitionValue`` and adding a set of initial subscriptions, 
   if needed.
 - Add relevant properties to your object models to use in your Flexible Sync 

--- a/source/sdk/kotlin/sync/write-to-synced-realm.txt
+++ b/source/sdk/kotlin/sync/write-to-synced-realm.txt
@@ -279,3 +279,8 @@ about compensating write errors:
 - The primary key is the ``objectId`` of the specific object the client attempted to write. 
 - The ``table "Item"`` refers to the Atlas collection where this object would sync.
 - The reason ``object is outside of the current query view`` in this example is because the query subscription was set to require the object's ``complexity`` property to be less than or equal to ``4``, and the client attempted to write an object outside of this boundary.
+
+Group Writes for Improved Performance
+-------------------------------------
+
+.. include:: /includes/sync-memory-performance.rst


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-31530

### Staged Changes

- [Sync Device Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31530/sdk/kotlin/sync/): Remove PBS info
- [Partition-Based Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31530/sdk/kotlin/sync/partition-based-sync/): New page with PBS info
- [Configure & Open a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31530/sdk/kotlin/sync/open-a-synced-realm/): Remove PBS info to new PBS page
- [Write Data to a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31530/sdk/kotlin/sync/write-to-synced-realm/): Move "Group Write" info to the recently-added page where it seems more relevant

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
