### PR TITLE
(DOCSP-31531): NET SDK Migrate PBS to FS updates

### DIFF
--- a/examples/dotnet/Examples/ClientResetExamples.cs
+++ b/examples/dotnet/Examples/ClientResetExamples.cs
@@ -33,7 +33,7 @@ namespace Examples
         {
             // :remove-start:
             app = App.Create(myRealmAppId);
-            user = await app.LogInAsync(Credentials.Anonymous());
+            user = await app.LogInAsync(Credentials.Anonymous(false));
             // :remove-end:
             var config = new FlexibleSyncConfiguration(user);
             config.ClientResetHandler = new DiscardUnsyncedChangesHandler()

--- a/examples/dotnet/Examples/ClientResetExamples.cs
+++ b/examples/dotnet/Examples/ClientResetExamples.cs
@@ -55,12 +55,17 @@ namespace Examples
                     // Automatic reset failed; handle the reset manually here
                 }
             };
-
-            //:remove-start:
-            config.Schema = new[] { typeof(Examples.Models.Plant) };
-            //:remove-end:
-            var realm = await Realm.GetInstanceAsync(config);
+            try
+            {
+                var realm = await Realm.GetInstanceAsync(config);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($@"Error creating or opening the
+                    realm file. {ex.Message}");
+            }
             // :snippet-end:
+            await user.LogOutAsync();
         }
 
         public async Task TestManualClientReset()
@@ -85,9 +90,6 @@ namespace Examples
             var fsConfig = new FlexibleSyncConfiguration(fsUser);
             fsConfig.ClientResetHandler =
                 new ManualRecoveryHandler(HandleClientResetError);
-            //:remove-start:
-            fsConfig.Schema = new[] { typeof(User) };
-            //:remove-end:
             var fsrealm = await Realm.GetInstanceAsync(fsConfig);
         }
 

--- a/examples/dotnet/Examples/FlexibleSyncExamples.cs
+++ b/examples/dotnet/Examples/FlexibleSyncExamples.cs
@@ -110,13 +110,9 @@ namespace Examples
                     realm.Subscriptions.Add(allTasks, new SubscriptionOptions { Name = "allTasks" });
                 }
             };
-            var realm = Realm.GetInstance(config);
+            var realm = Realm.GetInstanceAsync(config);
             // :replace-end:
             // :snippet-end:
-            realm.Subscriptions.Update(() =>
-            {
-                realm.Subscriptions.RemoveAll<MyTask>();
-            });
         }
 
         [Test]
@@ -138,9 +134,7 @@ namespace Examples
             {
                 // App must be online for user to authenticate
                 user = await app.LogInAsync(Credentials.Anonymous(false));
-
                 config = new FlexibleSyncConfiguration(app.CurrentUser!);
-
                 realm = await Realm.GetInstanceAsync(config);
                 // Go on to add or update subscriptions and use the realm
             }

--- a/examples/dotnet/Examples/FlexibleSyncExamples.cs
+++ b/examples/dotnet/Examples/FlexibleSyncExamples.cs
@@ -96,43 +96,26 @@ namespace Examples
             // :snippet-start: open-fs-realm
             // :replace-start: {
             //  "terms": {
-            //   "Config.FSAppId": "\"myRealmAppId\""}
+            //   "Config.FSAppId": "\"myRealmAppId\"",
+            //   "Credentials.Anonymous(false)": "Credentials.Anonymous()"}
             // }
             var app = App.Create(Config.FSAppId);
-            var user = await app.LogInAsync(Credentials.Anonymous());
+            var user = await app.LogInAsync(Credentials.Anonymous(false));
 
-            var config = new FlexibleSyncConfiguration(app.CurrentUser!);
-            config.Schema = new[]
+            var config = new FlexibleSyncConfiguration(app.CurrentUser!)
             {
-                typeof(MyTask)
+                PopulateInitialSubscriptions = (realm) =>
+                {
+                    var allTasks = realm.All<MyTask>();
+                    realm.Subscriptions.Add(allTasks, new SubscriptionOptions { Name = "allTasks" });
+                }
             };
             var realm = Realm.GetInstance(config);
-
-            var subscriptions = realm.Subscriptions;
-
-            subscriptions.Update(() =>
-            {
-                // subscribe to all Task objects, and give the subscription the name 'allTasks'
-                var allTasks = realm.All<MyTask>();
-                subscriptions
-                    .Add(allTasks,
-                        new SubscriptionOptions() { Name = "allTasks" });
-            });
-
-            try
-            {
-                await subscriptions.WaitForSynchronizationAsync();
-            }
-            catch (SubscriptionException ex)
-            {
-                // do something in response to the exception or log it
-                Console.WriteLine($@"The subscription set's state is Error and synchronization is paused:  {ex.Message}");
-            }
             // :replace-end:
             // :snippet-end:
-            subscriptions.Update(() =>
+            realm.Subscriptions.Update(() =>
             {
-                subscriptions.RemoveAll<MyTask>();
+                realm.Subscriptions.RemoveAll<MyTask>();
             });
         }
 
@@ -143,53 +126,38 @@ namespace Examples
             // :replace-start: {
             //  "terms": {
             //   "Config.FSAppId": "\"myRealmAppId\"",
-            //   "realm2":"realm"
+            //   "Credentials.Anonymous(false)": "Credentials.Anonymous()"
             //  }
             // }
             var app = App.Create(Config.FSAppId);
             Realms.Sync.User user;
             FlexibleSyncConfiguration config;
-            Realm realm2;
+            Realm realm;
 
             if (app.CurrentUser == null)
             {
                 // App must be online for user to authenticate
-                user = await app.LogInAsync(Credentials.Anonymous());
+                user = await app.LogInAsync(Credentials.Anonymous(false));
 
                 config = new FlexibleSyncConfiguration(app.CurrentUser!);
-                config.Schema = new[]
-                {
-                    typeof(MyTask)
-                };
-                realm2 = await Realm.GetInstanceAsync(config);
 
-                realm2.Subscriptions.Update(() =>
-                {
-                    // subscribe to all Task objects, and give the subscription the name 'allTasks'
-                    var allTasks = realm2.All<MyTask>();
-                    realm2.Subscriptions
-                        .Add(allTasks,
-                            new SubscriptionOptions() { Name = "allTasks" });
-                });
+                realm = await Realm.GetInstanceAsync(config);
+                // Go on to add or update subscriptions and use the realm
             }
             else 
             {
                 // This works whether online or offline
                 // It requires a user to have been previously authenticated
-                // and assumes you have already added Flexible Sync subscriptions
                 user = app.CurrentUser;
                 config = new FlexibleSyncConfiguration(user);
-                config.Schema = new[]
-                {
-                    typeof(MyTask)
-                };
-                realm2 = Realm.GetInstance(config);
+                realm = Realm.GetInstance(config);
+                // Go on to add or update subscriptions and use the realm
             }
             // :replace-end:
             // :snippet-end:
-            realm2.Subscriptions.Update(() =>
+            realm.Subscriptions.Update(() =>
             {
-                realm2.Subscriptions.RemoveAll<MyTask>();
+                realm.Subscriptions.RemoveAll<MyTask>();
             });
         }
 

--- a/examples/dotnet/Examples/FlexibleSyncExamples.cs
+++ b/examples/dotnet/Examples/FlexibleSyncExamples.cs
@@ -102,6 +102,10 @@ namespace Examples
             var user = await app.LogInAsync(Credentials.Anonymous());
 
             var config = new FlexibleSyncConfiguration(app.CurrentUser!);
+            config.Schema = new[]
+            {
+                typeof(MyTask)
+            };
             var realm = Realm.GetInstance(config);
 
             var subscriptions = realm.Subscriptions;
@@ -153,6 +157,10 @@ namespace Examples
                 user = await app.LogInAsync(Credentials.Anonymous());
 
                 config = new FlexibleSyncConfiguration(app.CurrentUser!);
+                config.Schema = new[]
+                {
+                    typeof(MyTask)
+                };
                 realm2 = await Realm.GetInstanceAsync(config);
 
                 realm2.Subscriptions.Update(() =>
@@ -171,6 +179,10 @@ namespace Examples
                 // and assumes you have already added Flexible Sync subscriptions
                 user = app.CurrentUser;
                 config = new FlexibleSyncConfiguration(user);
+                config.Schema = new[]
+                {
+                    typeof(MyTask)
+                };
                 realm2 = Realm.GetInstance(config);
             }
             // :replace-end:

--- a/examples/dotnet/Examples/OpenARealmExamples.cs
+++ b/examples/dotnet/Examples/OpenARealmExamples.cs
@@ -44,7 +44,7 @@ namespace Examples
                 //realm = await Realm.GetInstanceAsync(config);
                 // :uncomment-end:
             }
-            catch (RealmFileAccessErrorException ex)
+            catch (Exception ex)
             {
                 Console.WriteLine($@"Error creating or opening the
                     realm file. {ex.Message}");
@@ -58,7 +58,7 @@ namespace Examples
 
             // :snippet-start: open-synced-realm-synchronously
             // :uncomment-start:
-            // var synchronousRealm = await Realm.GetInstanceAsync(config);
+            // var synchronousRealm = await Realm.GetInstance(config);
             // :uncomment-end:
             // :snippet-end:
 

--- a/examples/dotnet/Examples/OpenARealmExamples.cs
+++ b/examples/dotnet/Examples/OpenARealmExamples.cs
@@ -58,7 +58,7 @@ namespace Examples
 
             // :snippet-start: open-synced-realm-synchronously
             // :uncomment-start:
-            // var synchronousRealm = await Realm.GetInstance(config);
+            // var synchronousRealm = Realm.GetInstance(config);
             // :uncomment-end:
             // :snippet-end:
 

--- a/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-a-flexible-synced-realm.cs
+++ b/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-a-flexible-synced-realm.cs
@@ -1,2 +1,0 @@
-var config = new FlexibleSyncConfiguration(app.CurrentUser);
-var realm = Realm.GetInstance(config);

--- a/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm-offline.cs
+++ b/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm-offline.cs
@@ -7,9 +7,7 @@ if (app.CurrentUser == null)
 {
     // App must be online for user to authenticate
     user = await app.LogInAsync(Credentials.Anonymous());
-
     config = new FlexibleSyncConfiguration(app.CurrentUser!);
-
     realm = await Realm.GetInstanceAsync(config);
     // Go on to add or update subscriptions and use the realm
 }

--- a/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm-offline.cs
+++ b/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm-offline.cs
@@ -9,23 +9,16 @@ if (app.CurrentUser == null)
     user = await app.LogInAsync(Credentials.Anonymous());
 
     config = new FlexibleSyncConfiguration(app.CurrentUser!);
-    realm = await Realm.GetInstanceAsync(config);
 
-    realm.Subscriptions.Update(() =>
-    {
-        // subscribe to all Task objects, and give the subscription the name 'allTasks'
-        var allTasks = realm.All<MyTask>();
-        realm.Subscriptions
-            .Add(allTasks,
-                new SubscriptionOptions() { Name = "allTasks" });
-    });
+    realm = await Realm.GetInstanceAsync(config);
+    // Go on to add or update subscriptions and use the realm
 }
 else 
 {
     // This works whether online or offline
     // It requires a user to have been previously authenticated
-    // and assumes you have already added Flexible Sync subscriptions
     user = app.CurrentUser;
     config = new FlexibleSyncConfiguration(user);
     realm = Realm.GetInstance(config);
+    // Go on to add or update subscriptions and use the realm
 }

--- a/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm-offline.cs
+++ b/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm-offline.cs
@@ -1,0 +1,31 @@
+var app = App.Create("myRealmAppId");
+Realms.Sync.User user;
+FlexibleSyncConfiguration config;
+Realm realm;
+
+if (app.CurrentUser == null)
+{
+    // App must be online for user to authenticate
+    user = await app.LogInAsync(Credentials.Anonymous());
+
+    config = new FlexibleSyncConfiguration(app.CurrentUser!);
+    realm = await Realm.GetInstanceAsync(config);
+
+    realm.Subscriptions.Update(() =>
+    {
+        // subscribe to all Task objects, and give the subscription the name 'allTasks'
+        var allTasks = realm.All<MyTask>();
+        realm.Subscriptions
+            .Add(allTasks,
+                new SubscriptionOptions() { Name = "allTasks" });
+    });
+}
+else 
+{
+    // This works whether online or offline
+    // It requires a user to have been previously authenticated
+    // and assumes you have already added Flexible Sync subscriptions
+    user = app.CurrentUser;
+    config = new FlexibleSyncConfiguration(user);
+    realm = Realm.GetInstance(config);
+}

--- a/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm-offline.cs
+++ b/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm-offline.cs
@@ -7,8 +7,8 @@ if (app.CurrentUser == null)
 {
     // App must be online for user to authenticate
     user = await app.LogInAsync(Credentials.Anonymous());
-    config = new FlexibleSyncConfiguration(app.CurrentUser!);
-    realm = await Realm.GetInstanceAsync(config);
+    config = new FlexibleSyncConfiguration(user);
+    realm = Realm.GetInstance(config);
     // Go on to add or update subscriptions and use the realm
 }
 else 

--- a/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm.cs
+++ b/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm.cs
@@ -1,26 +1,12 @@
 var app = App.Create("myRealmAppId");
 var user = await app.LogInAsync(Credentials.Anonymous());
 
-var config = new FlexibleSyncConfiguration(app.CurrentUser!);
+var config = new FlexibleSyncConfiguration(app.CurrentUser!)
+{
+    PopulateInitialSubscriptions = (realm) =>
+    {
+        var allTasks = realm.All<MyTask>();
+        realm.Subscriptions.Add(allTasks, new SubscriptionOptions { Name = "allTasks" });
+    }
+};
 var realm = Realm.GetInstance(config);
-
-var subscriptions = realm.Subscriptions;
-
-subscriptions.Update(() =>
-{
-    // subscribe to all Task objects, and give the subscription the name 'allTasks'
-    var allTasks = realm.All<MyTask>();
-    subscriptions
-        .Add(allTasks,
-            new SubscriptionOptions() { Name = "allTasks" });
-});
-
-try
-{
-    await subscriptions.WaitForSynchronizationAsync();
-}
-catch (SubscriptionException ex)
-{
-    // do something in response to the exception or log it
-    Console.WriteLine($@"The subscription set's state is Error and synchronization is paused:  {ex.Message}");
-}

--- a/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm.cs
+++ b/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm.cs
@@ -9,4 +9,4 @@ var config = new FlexibleSyncConfiguration(app.CurrentUser!)
         realm.Subscriptions.Add(allTasks, new SubscriptionOptions { Name = "allTasks" });
     }
 };
-var realm = Realm.GetInstance(config);
+var realm = await Realm.GetInstanceAsync(config);

--- a/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm.cs
+++ b/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm.cs
@@ -1,7 +1,8 @@
 var app = App.Create("myRealmAppId");
 var user = await app.LogInAsync(Credentials.Anonymous());
+Realm realm;
 
-var config = new FlexibleSyncConfiguration(app.CurrentUser!)
+var config = new FlexibleSyncConfiguration(user)
 {
     PopulateInitialSubscriptions = (realm) =>
     {
@@ -9,4 +10,12 @@ var config = new FlexibleSyncConfiguration(app.CurrentUser!)
         realm.Subscriptions.Add(allTasks, new SubscriptionOptions { Name = "allTasks" });
     }
 };
-var realm = await Realm.GetInstanceAsync(config);
+try
+{
+    realm = await Realm.GetInstanceAsync(config);
+}
+catch (Exception ex)
+{
+    Console.WriteLine($@"Error creating or opening the
+        realm file. {ex.Message}");
+}

--- a/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm.cs
+++ b/source/examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm.cs
@@ -1,0 +1,26 @@
+var app = App.Create("myRealmAppId");
+var user = await app.LogInAsync(Credentials.Anonymous());
+
+var config = new FlexibleSyncConfiguration(app.CurrentUser!);
+var realm = Realm.GetInstance(config);
+
+var subscriptions = realm.Subscriptions;
+
+subscriptions.Update(() =>
+{
+    // subscribe to all Task objects, and give the subscription the name 'allTasks'
+    var allTasks = realm.All<MyTask>();
+    subscriptions
+        .Add(allTasks,
+            new SubscriptionOptions() { Name = "allTasks" });
+});
+
+try
+{
+    await subscriptions.WaitForSynchronizationAsync();
+}
+catch (SubscriptionException ex)
+{
+    // do something in response to the exception or log it
+    Console.WriteLine($@"The subscription set's state is Error and synchronization is paused:  {ex.Message}");
+}

--- a/source/examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm-synchronously.cs
+++ b/source/examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm-synchronously.cs
@@ -1,1 +1,1 @@
-var synchronousRealm = await Realm.GetInstance(config);
+var synchronousRealm = Realm.GetInstance(config);

--- a/source/examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm-synchronously.cs
+++ b/source/examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm-synchronously.cs
@@ -1,1 +1,1 @@
-var synchronousRealm = await Realm.GetInstanceAsync(config);
+var synchronousRealm = await Realm.GetInstance(config);

--- a/source/examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm.cs
+++ b/source/examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm.cs
@@ -5,7 +5,7 @@ try
 {
     realm = await Realm.GetInstanceAsync(config);
 }
-catch (RealmFileAccessErrorException ex)
+catch (Exception ex)
 {
     Console.WriteLine($@"Error creating or opening the
         realm file. {ex.Message}");

--- a/source/sdk/dotnet/sync.txt
+++ b/source/sdk/dotnet/sync.txt
@@ -15,45 +15,15 @@ Sync Data Between Devices - .NET SDK
    Handle Sync Errors and Timeouts </sdk/dotnet/sync/handle-sync-errors>
    Client Resets </sdk/dotnet/sync/client-reset>
    Suspend or Resume a Sync Session </sdk/dotnet/sync/sync-session>
-   Check Upload & Download Progress </sdk/dotnet/sync/sync-progress>
+   Monitor Sync Status </sdk/dotnet/sync/sync-progress>
    Convert Between Non-Synced Realms and Synced Realms </sdk/dotnet/sync/convert-realm>
    Stream Data to Atlas </sdk/dotnet/sync/asymmetric-sync>
-
-Overview
---------
+   Partition-Based Sync </sdk/dotnet/sync/partition-based-sync>
 
 Atlas Device Sync automatically synchronizes data between client applications and 
 an :ref:`Atlas App Services backend <realm-cloud>`. When a client 
 device is online, Sync asynchronously synchronizes data in a 
 background thread between the device and your backend App. 
-
-When you use Sync in your client application, your implementation must match 
-the Sync Mode you select in your backend App configuration. The Sync Mode
-options are:
-
-- Partition-Based Sync
-- Flexible Sync
-
-You can only use one Sync Mode for your application. You cannot mix 
-Partition-Based Sync and Flexible Sync within the same App.
-
-.. seealso::
-
-   :ref:`enable-realm-sync`
-
-.. _dotnet-partition-based-sync-fundamentals:
-
-Partition-Based Sync
---------------------
-
-When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
-backend App configuration, your client implementation must include a 
-partition value. This is the value of the :ref:`partition key 
-<partition-key>` field you select when you configure Partition-Based Sync. 
-
-The partition value determines which data the client application can access.
-
-You pass in the partition value when you open a synced realm.
 
 .. _dotnet-flexible-sync-fundamentals:
 
@@ -84,6 +54,14 @@ To use Flexible Sync in your client application, open a synced realm
 with a Flexible Sync configuration. Then, manage subscriptions
 to determine which documents to sync.
 
+.. tip::
+
+   Device Sync supports two Sync Modes: Flexible Sync, and the older 
+   Partition-Based Sync. If your App Services backend uses Partition-Based 
+   Sync, refer to :ref:`dotnet-partition-based-sync`.
+
+   We recommend new apps use Flexible Sync.
+
 Group Updates for Improved Performance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -98,3 +76,5 @@ In this scenario, you can maximize sync performance by using
 :ref:`Data Ingest <dotnet-data-ingest>` to stream 
 data from the client application to a Flexible Sync-enabled Atlas App Services
 App.
+
+

--- a/source/sdk/dotnet/sync.txt
+++ b/source/sdk/dotnet/sync.txt
@@ -60,7 +60,7 @@ to determine which documents to sync.
    Partition-Based Sync. If your App Services backend uses Partition-Based 
    Sync, refer to :ref:`dotnet-partition-based-sync`.
 
-   We recommend new apps use Flexible Sync.
+   We recommend using Flexible Sync.
 
 Group Updates for Improved Performance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/sdk/dotnet/sync.txt
+++ b/source/sdk/dotnet/sync.txt
@@ -15,7 +15,7 @@ Sync Data Between Devices - .NET SDK
    Handle Sync Errors and Timeouts </sdk/dotnet/sync/handle-sync-errors>
    Client Resets </sdk/dotnet/sync/client-reset>
    Suspend or Resume a Sync Session </sdk/dotnet/sync/sync-session>
-   Monitor Sync Status </sdk/dotnet/sync/sync-progress>
+   Check Upload & Download Progress </sdk/dotnet/sync/sync-progress>
    Convert Between Non-Synced Realms and Synced Realms </sdk/dotnet/sync/convert-realm>
    Stream Data to Atlas </sdk/dotnet/sync/asymmetric-sync>
    Partition-Based Sync </sdk/dotnet/sync/partition-based-sync>

--- a/source/sdk/dotnet/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/dotnet/sync/configure-and-open-a-synced-realm.txt
@@ -101,46 +101,32 @@ With cached credentials, you can:
 - Open a synced realm after downloading changes from your App. 
   This requires the user to have an active internet connection.
 
+.. _dotnet-open-a-synced-realm:
 .. _dotnet-flexible-sync-open-realm:
 
-Open a Synced Realm with a Flexible Sync Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When you use Flexible Sync, pass the current user to a 
-:dotnet-sdk:`FlexibleSyncConfiguration <reference/Realms.Sync.FlexibleSyncConfiguration.html>`
-object to open a synced realm. 
-
-.. literalinclude:: /examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-a-flexible-synced-realm.cs
-   :language: csharp
-
-.. important:: Flexible Sync Requires a Subscription
-
-   You can't use a Flexible Sync realm until you add at least one subscription.
-   To learn how to add subscriptions, see: :ref:`<dotnet-sync-add-subscription>`.
-
-.. _dotnet-open-a-synced-realm:
-.. _dotnet-partition-sync-open-realm:
-
-Open a Partition-Based Sync Realm While Online
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Open a Synced Realm While Online
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The steps for opening a synced realm while online are:
 
 1. Your app code walks the user through :ref:`authenticating <dotnet-authenticate>`. 
 
 #. Create a 
-   :dotnet-sdk:`PartitionSyncConfiguration <reference/Realms.Sync.PartitionSyncConfiguration.html>` 
-   object that includes the :ref:`partition name <partition-value>` and 
-   the :dotnet-sdk:`User <reference/Realms.Sync.User.html>` object.
+   :dotnet-sdk:`FlexibleSyncConfiguration <reference/Realms.Sync.FlexibleSyncConfiguration.html>`
+   object that includes :dotnet-sdk:`User <reference/Realms.Sync.User.html>` 
+   object.
 
 #. Open a synced realm by calling the 
    :dotnet-sdk:`GetInstanceAsync() <reference/Realms.Realm.html#Realms_Realm_GetInstanceAsync_Realms_RealmConfigurationBase_System_Threading_CancellationToken_>` 
-   method, passing in the ``PartitionSyncConfiguration`` object.
+   method.
+
+#. If your FlexibleSyncConfiguration did not contain 
+   :ref:`initial subscriptions <dotnet-initial-subscriptions>`, 
+   :ref:`add a subscription <dotnet-add-subscription-to-set>`.
    
 The following code demonstrates these steps:
 
-.. literalinclude:: /examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm.cs
-   :language: csharp
+<ADD-FS-CODE-EXAMPLE-HERE>
 
 In the above example, the code shows how to open the realm *asynchronously* 
 by calling ``GetInstanceAsync()``. You can also open a realm *synchronously* 
@@ -151,15 +137,8 @@ method:
 .. literalinclude:: /examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm-synchronously.cs
    :language: csharp
 
-.. seealso::
-
-   :ref:`Partitions <sync-partitions>`
-
-   :ref:`Partition Strategies <partition-strategies>`
-
-
-Open a Partition-Based Sync Realm While Offline
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Open a Synced Realm While Offline
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once a user authenticates, the ``User`` object persists on the device until the 
 user logs off. This allows your app to 
@@ -171,8 +150,7 @@ The following code shows how to check if there is an existing ``User`` object.
 If none is found, it uses the process outlined about to obtain a user. If the 
 device already has a ``user``, it opens the synced realm with that user:
 
-.. literalinclude:: /examples/generated/dotnet/OpenARealmExamples.snippet.check-if-offline.cs
-   :language: csharp
+<ADD-FS-CODE-EXAMPLE-HERE>
 
 Configuring Timeouts with AppConfiguration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/sdk/dotnet/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/dotnet/sync/configure-and-open-a-synced-realm.txt
@@ -126,7 +126,8 @@ The steps for opening a synced realm while online are:
    
 The following code demonstrates these steps:
 
-<ADD-FS-CODE-EXAMPLE-HERE>
+.. literalinclude:: /examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm.cs
+   :language: csharp
 
 In the above example, the code shows how to open the realm *asynchronously* 
 by calling ``GetInstanceAsync()``. You can also open a realm *synchronously* 
@@ -150,7 +151,8 @@ The following code shows how to check if there is an existing ``User`` object.
 If none is found, it uses the process outlined about to obtain a user. If the 
 device already has a ``user``, it opens the synced realm with that user:
 
-<ADD-FS-CODE-EXAMPLE-HERE>
+.. literalinclude:: /examples/generated/dotnet-flexible-sync/FlexibleSyncExamples.snippet.open-fs-realm-offline.cs
+   :language: csharp
 
 Configuring Timeouts with AppConfiguration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/sdk/dotnet/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/dotnet/sync/configure-and-open-a-synced-realm.txt
@@ -138,7 +138,7 @@ method:
    :language: csharp
 
 Open a Synced Realm While Offline
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once a user authenticates, the ``User`` object persists on the device until the 
 user logs off. This allows your app to 

--- a/source/sdk/dotnet/sync/flexible-sync.txt
+++ b/source/sdk/dotnet/sync/flexible-sync.txt
@@ -106,6 +106,8 @@ You must have at least one subscription before you can read from or write
 to the realm. You can create one or more initial subscriptions when you 
 configure Flexible Sync, or you can add subscriptions after initialization. 
 
+.. _dotnet-initial-subscriptions:
+
 Bootstrap the Realm with Initial Subscriptions
 ``````````````````````````````````````````````
 
@@ -120,6 +122,7 @@ queries you want to use to bootstrap the realm, as shown in the following exampl
 .. literalinclude:: /examples/generated/dotnet/FlexibleSyncExamples.snippet.bootstrap-a-subscription.cs
    :language: csharp
 
+.. _dotnet-add-subscription-to-set:
 
 Add a Subscription
 ``````````````````

--- a/source/sdk/dotnet/sync/partition-based-sync.txt
+++ b/source/sdk/dotnet/sync/partition-based-sync.txt
@@ -95,7 +95,7 @@ device already has a ``user``, it opens the synced realm with that user:
 .. _dotnet-sync-status-change:
 
 Monitor Sync Progress
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 Partition-Based Sync is currently the only Sync Mode that supports upload 
 and download progress notifications.

--- a/source/sdk/dotnet/sync/partition-based-sync.txt
+++ b/source/sdk/dotnet/sync/partition-based-sync.txt
@@ -33,7 +33,6 @@ partition value. This is the value of the :ref:`partition key
 <partition-key>` field you select when you configure Partition-Based Sync. 
 
 The partition value determines which data the client application can access.
-
 You pass in the partition value when you open a synced realm.
 
 .. _dotnet-partition-sync-open-realm:
@@ -47,7 +46,7 @@ The steps for opening a synced realm while online are:
 
 #. Create a 
    :dotnet-sdk:`PartitionSyncConfiguration <reference/Realms.Sync.PartitionSyncConfiguration.html>` 
-   object that includes the :ref:`partition name <partition-value>` and 
+   object that includes the :ref:`partition value <partition-value>` and 
    the :dotnet-sdk:`User <reference/Realms.Sync.User.html>` object.
 
 #. Open a synced realm by calling the 

--- a/source/sdk/dotnet/sync/partition-based-sync.txt
+++ b/source/sdk/dotnet/sync/partition-based-sync.txt
@@ -91,69 +91,6 @@ device already has a ``user``, it opens the synced realm with that user:
 .. literalinclude:: /examples/generated/dotnet/OpenARealmExamples.snippet.check-if-offline.cs
    :language: csharp
 
-.. _dotnet-check-upload-download-progress:
-.. _dotnet-check-sync-progress:
-.. _dotnet-sync-status-change:
-
-Monitor Sync Progress
----------------------
-
-Partition-Based Sync is currently the only Sync Mode that supports upload 
-and download progress notifications.
-
-To monitor Sync progress, get the 
-sync session from the :dotnet-sdk:`Realms.Sync.SyncSession 
-<reference/Realms.Realm.html#Realms_Realm_SyncSession>` property, then add a 
-progress notification by calling the 
-:dotnet-sdk:`session.GetProgressObservable() <reference/Realms.Sync.Session.html#Realms_Sync_Session_GetProgressObservable_Realms_Sync_ProgressDirection_Realms_Sync_ProgressMode_>` 
-method.
-
-The ``session.GetProgressObservable`` method takes in the following two parameters:
-
-- A :dotnet-sdk:`ProgressDirection <reference/Realms.Sync.ProgressDirection.html>` 
-  parameter that can be set to ``Upload`` or ``Download``.
-  
-- A :dotnet-sdk:`ProgressMode <reference/Realms.Sync.ProgressMode.html>` parameter 
-  that can be set to ``ReportIndefinitely``
-  for the notifications to continue until the callback is unregistered, or 
-  ``ForCurrentlyOutstandingWork`` for the notifications to continue until only 
-  the currently transferable bytes are synced.
-
-When you `Subscribe <https://docs.microsoft.com/en-us/dotnet/api/system.iobservable-1.subscribe?view=net-6.0#system-iobservable-1-subscribe(system-iobserver((-0)))>`_ 
-to the notifications, you receive a 
-:dotnet-sdk:`SyncProgress <reference/Realms.Sync.SyncProgress.html>` 
-object that provides the total number of transferrable bytes and the remaining 
-bytes to be transferred.
-
-.. note:: 
-   
-   The number of transferred and transferable bytes are only estimates. 
-   The Sync changesets are compressed with 
-   `gzip <https://www.gnu.org/software/gzip/>`_ before transmitting, so 
-   the actual size of transmitted bytes will be smaller than the reported number  
-   of both transferable and transferred bytes.
-
-.. example::
-
-   In the following example, we subscribe to a progress 
-   observable on the ``session`` to listen for upload events indefinitely. When 
-   this callback is triggered, it prints the number of transferred 
-   bytes and the number of transferable bytes to the console.
-
-   .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.snippet.upload-download-progress-notification.cs
-      :language: csharp
-
-   Once you no longer wish to receive notifications, unregister the token by using 
-   ``token.Dispose()``
-
-.. note:: 
-   
-   The SDK optimizes download speeds by combining multiple changesets
-   into a single download message, up to 16 MB. Since the progress callback is
-   only invoked once before and after a download message is processed, this
-   means that you'll likely see ``transferredBytes`` change in increments of roughly
-   16 MB rather than continuously as the message is being downloaded.
-
 .. _dotnet-migrate-pbs-to-fs:
 
 Migrate from Partition-Based Sync to Flexible Sync

--- a/source/sdk/dotnet/sync/partition-based-sync.txt
+++ b/source/sdk/dotnet/sync/partition-based-sync.txt
@@ -1,0 +1,228 @@
+.. _dotnet-partition-based-sync:
+
+===============================
+Partition-Based Sync - .NET SDK
+===============================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Partition-Based Sync is an older mode for using Atlas Device Sync with the 
+Realm .NET SDK. We recommend using :ref:`Flexible Sync <dotnet-flexible-sync-fundamentals>` 
+for new apps. The information on this page is for users who are still 
+using Partition-Based Sync.
+
+.. tip::
+
+   Realm .NET SDK v11.1.0 and newer supports the ability to migrate from 
+   Partition-Based Sync to Flexible Sync. For more information, refer to: 
+   :ref:`dotnet-migrate-pbs-to-fs`.
+
+.. _dotnet-partition-based-sync-fundamentals:
+
+Partition Value
+---------------
+
+When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
+backend App configuration, your client implementation must include a 
+partition value. This is the value of the :ref:`partition key 
+<partition-key>` field you select when you configure Partition-Based Sync. 
+
+The partition value determines which data the client application can access.
+
+You pass in the partition value when you open a synced realm.
+
+.. _dotnet-partition-sync-open-realm:
+
+Open a Partition-Based Sync Realm While Online
+----------------------------------------------
+
+The steps for opening a synced realm while online are:
+
+1. Your app code walks the user through :ref:`authenticating <dotnet-authenticate>`. 
+
+#. Create a 
+   :dotnet-sdk:`PartitionSyncConfiguration <reference/Realms.Sync.PartitionSyncConfiguration.html>` 
+   object that includes the :ref:`partition name <partition-value>` and 
+   the :dotnet-sdk:`User <reference/Realms.Sync.User.html>` object.
+
+#. Open a synced realm by calling the 
+   :dotnet-sdk:`GetInstanceAsync() <reference/Realms.Realm.html#Realms_Realm_GetInstanceAsync_Realms_RealmConfigurationBase_System_Threading_CancellationToken_>` 
+   method, passing in the ``PartitionSyncConfiguration`` object.
+   
+The following code demonstrates these steps:
+
+.. literalinclude:: /examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm.cs
+   :language: csharp
+
+In the above example, the code shows how to open the realm *asynchronously* 
+by calling ``GetInstanceAsync()``. You can also open a realm *synchronously* 
+by calling the 
+:dotnet-sdk:`GetInstance() <reference/Realms.Realm.html#Realms_Realm_GetInstance_System_String_>` 
+method:
+
+.. literalinclude:: /examples/generated/dotnet/OpenARealmExamples.snippet.open-synced-realm-synchronously.cs
+   :language: csharp
+
+.. seealso::
+
+   :ref:`Partitions <sync-partitions>`
+
+   :ref:`Partition Strategies <partition-strategies>`
+
+
+Open a Partition-Based Sync Realm While Offline
+-----------------------------------------------
+
+Once a user authenticates, the ``User`` object persists on the device until the 
+user logs off. This allows your app to 
+:ref:`retrieve an existing user <dotnet-retrieve-current-user>` and open a 
+synced realm in an offline state. Changes that occur while offline will be 
+synced by the SDK once the device reconnects to your App.
+
+The following code shows how to check if there is an existing ``User`` object. 
+If none is found, it uses the process outlined about to obtain a user. If the 
+device already has a ``user``, it opens the synced realm with that user:
+
+.. literalinclude:: /examples/generated/dotnet/OpenARealmExamples.snippet.check-if-offline.cs
+   :language: csharp
+
+.. _dotnet-check-upload-download-progress:
+.. _dotnet-check-sync-progress:
+.. _dotnet-sync-status-change:
+
+Monitor Sync Progress
+~~~~~~~~~~~~~~~~~~~~~
+
+Partition-Based Sync is currently the only Sync Mode that supports upload 
+and download progress notifications.
+
+To monitor Sync progress, get the 
+sync session from the :dotnet-sdk:`Realms.Sync.SyncSession 
+<reference/Realms.Realm.html#Realms_Realm_SyncSession>` property, then add a 
+progress notification by calling the 
+:dotnet-sdk:`session.GetProgressObservable() <reference/Realms.Sync.Session.html#Realms_Sync_Session_GetProgressObservable_Realms_Sync_ProgressDirection_Realms_Sync_ProgressMode_>` 
+method.
+
+The ``session.GetProgressObservable`` method takes in the following two parameters:
+
+- A :dotnet-sdk:`ProgressDirection <reference/Realms.Sync.ProgressDirection.html>` 
+  parameter that can be set to ``Upload`` or ``Download``.
+  
+- A :dotnet-sdk:`ProgressMode <reference/Realms.Sync.ProgressMode.html>` parameter 
+  that can be set to ``ReportIndefinitely``
+  for the notifications to continue until the callback is unregistered, or 
+  ``ForCurrentlyOutstandingWork`` for the notifications to continue until only 
+  the currently transferable bytes are synced.
+
+When you `Subscribe <https://docs.microsoft.com/en-us/dotnet/api/system.iobservable-1.subscribe?view=net-6.0#system-iobservable-1-subscribe(system-iobserver((-0)))>`_ 
+to the notifications, you receive a 
+:dotnet-sdk:`SyncProgress <reference/Realms.Sync.SyncProgress.html>` 
+object that provides the total number of transferrable bytes and the remaining 
+bytes to be transferred.
+
+.. note:: 
+   
+   The number of transferred and transferable bytes are only estimates. 
+   The Sync changesets are compressed with 
+   `gzip <https://www.gnu.org/software/gzip/>`_ before transmitting, so 
+   the actual size of transmitted bytes will be smaller than the reported number  
+   of both transferable and transferred bytes.
+
+.. example::
+
+   In the following example, we subscribe to a progress 
+   observable on the ``session`` to listen for upload events indefinitely. When 
+   this callback is triggered, it prints the number of transferred 
+   bytes and the number of transferable bytes to the console.
+
+   .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.snippet.upload-download-progress-notification.cs
+      :language: csharp
+
+   Once you no longer wish to receive notifications, unregister the token by using 
+   ``token.Dispose()``
+
+.. note:: 
+   
+   The SDK optimizes download speeds by combining multiple changesets
+   into a single download message, up to 16 MB. Since the progress callback is
+   only invoked once before and after a download message is processed, this
+   means that you'll likely see ``transferredBytes`` change in increments of roughly
+   16 MB rather than continuously as the message is being downloaded.
+
+.. _dotnet-migrate-pbs-to-fs:
+
+Migrate from Partition-Based Sync to Flexible Sync
+--------------------------------------------------
+
+You can migrate your App Services Device Sync Mode from Partition-Based Sync 
+to Flexible Sync. Migrating is an automatic process that does not require 
+any changes to your application code. Automatic migration requires Realm 
+.NET SDK version 11.1.0 or newer. 
+
+Migrating enables you to keep your existing App Services users and 
+authentication configuration. Flexible Sync provides more versatile permissions
+configuration options and more granular data synchronization.
+
+For more information about how to migrate your App Services App from 
+Partition-Based Sync to Flexible Sync, refer to :ref:`Migrate Device Sync Modes 
+<realm-sync-migrate-modes>`.
+
+.. _dotnet-update-client-code-after-pbs-to-fs-migration:
+
+Updating Client Code After Migration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The automatic migration from Partition-Based Sync to Flexible Sync does not
+require any changes to your client code. However, to support this 
+functionality, Realm automatically handles the differences between the two 
+Sync Modes by:
+
+- Automatically creating Flexible Sync subscriptions for each object type 
+  where ``partitionKey == partitionValue``.
+- Injecting a ``partitionKey`` field into every object if one does not already 
+  exist. This is required for the automatic Flexible Sync subscription.
+
+If you need to make updates to your client code after migration, consider 
+updating your client codebase to remove hidden migration functionality.
+You might want update your client codebase when:
+
+- You add a new model or change a model in your client codebase
+- You add or change functionality that involves reading or writing Realm objects
+- You want to implement more fine-grained control over what data you sync
+
+Make these changes to convert your Partition-Based Sync client code to use 
+Flexible Sync:
+
+- Change your 
+  :dotnet-sdk:`PartitionSyncConfiguration <reference/Realms.Sync.PartitionSyncConfiguration.html>`
+  to a
+  :dotnet-sdk:`FlexibleSyncConfiguration <reference/Realms.Sync.FlexibleSyncConfiguration.html>`.
+- Add relevant properties to your object models to use in your Flexible Sync 
+  subscriptions. For example, you might add an ``ownerId`` property to enable
+  a user to sync only their own data.
+- Remove automatic Flexible Sync subscriptions and manually create the 
+  relevant subscriptions.
+
+For examples of Flexible Sync permissions strategies, including examples of 
+how to model data for these strategies, refer to :ref:`flexible-sync-permissions-guide`.
+
+Remove and Manually Create Subscriptions
+````````````````````````````````````````
+
+When you migrate from Partition-Based Sync to Flexible Sync, Realm
+automatically creates hidden Flexible Sync subscriptions for your app. The 
+next time you add or change subscriptions, we recommend that you:
+
+1. :ref:`Remove the automatically-generated subscriptions <dotnet-remove-subscriptions>`. 
+2. :ref:`Manually add the relevant subscriptions in your client codebase 
+   <dotnet-sync-add-subscription>`.
+
+This enables you to see all of your subscription logic together in your 
+codebase for future iteration and debugging.
+
+For more information about the automatically-generated Flexible Sync 
+subscriptions, refer to :ref:`realm-sync-migrate-client`.

--- a/source/sdk/dotnet/sync/partition-based-sync.txt
+++ b/source/sdk/dotnet/sync/partition-based-sync.txt
@@ -19,7 +19,8 @@ using Partition-Based Sync.
 
    Realm .NET SDK v11.1.0 and newer supports the ability to migrate from 
    Partition-Based Sync to Flexible Sync. For more information, refer to: 
-   :ref:`dotnet-migrate-pbs-to-fs`.
+   :ref:`dotnet-migrate-pbs-to-fs`. We recommend you migrate your older 
+   Partition-Based Sync apps to use Flexible Sync.
 
 .. _dotnet-partition-based-sync-fundamentals:
 

--- a/source/sdk/dotnet/sync/sync-progress.txt
+++ b/source/sdk/dotnet/sync/sync-progress.txt
@@ -1,9 +1,6 @@
-.. _dotnet-check-upload-download-progress:
-.. _dotnet-check-sync-progress:
-
-=============================================
-Check Upload and Download Progress - .NET SDK
-=============================================
+===============================
+Monitor Sync Status  - .NET SDK
+===============================
 
 .. contents:: On this page
    :local:
@@ -11,13 +8,9 @@ Check Upload and Download Progress - .NET SDK
    :depth: 2
    :class: singlecol
 
-
-Monitor Sync Progress and Status
---------------------------------
 You may want to know the status of Sync operations in your app. For 
 example, you might want specific code to run only after all of the data is 
-synced with App Services. You might also want to provide users with the 
-status of Sync operations. 
+synced with App Services.
 
 You can set up your Sync session to wait for changes to be uploaded 
 or downloaded. You can also configure your Sync session to
@@ -26,7 +19,8 @@ notify when the Sync connection status changes.
 .. _dotnet-check-sync-progress-wait-for-upload-or-download:
 
 Wait for Changes to be Uploaded or Downloaded
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------
+
 To asynchronously wait for your changes to be completed, get the sync session 
 from the :dotnet-sdk:`Realms.Sync.SyncSession
 <reference/Realms.Realm.html#Realms_Realm_SyncSession>`
@@ -39,68 +33,9 @@ methods. For example:
 .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.snippet.wait-for-changes-to-download-async-progress-notification.cs
    :language: csharp
 
-.. _dotnet-sync-status-change:
-
-Monitor Sync Progress
-~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
-
-To monitor Sync progress, get the 
-sync session from the :dotnet-sdk:`Realms.Sync.SyncSession 
-<reference/Realms.Realm.html#Realms_Realm_SyncSession>` property, then add a 
-progress notification by calling the 
-:dotnet-sdk:`session.GetProgressObservable() <reference/Realms.Sync.Session.html#Realms_Sync_Session_GetProgressObservable_Realms_Sync_ProgressDirection_Realms_Sync_ProgressMode_>` 
-method.
-
-The ``session.GetProgressObservable`` method takes in the following two parameters:
-
-- A :dotnet-sdk:`ProgressDirection <reference/Realms.Sync.ProgressDirection.html>` 
-  parameter that can be set to ``Upload`` or ``Download``.
-  
-- A :dotnet-sdk:`ProgressMode <reference/Realms.Sync.ProgressMode.html>` parameter 
-  that can be set to ``ReportIndefinitely``
-  for the notifications to continue until the callback is unregistered, or 
-  ``ForCurrentlyOutstandingWork`` for the notifications to continue until only 
-  the currently transferable bytes are synced.
-
-When you `Subscribe <https://docs.microsoft.com/en-us/dotnet/api/system.iobservable-1.subscribe?view=net-6.0#system-iobservable-1-subscribe(system-iobserver((-0)))>`_ 
-to the notifications, you receive a 
-:dotnet-sdk:`SyncProgress <reference/Realms.Sync.SyncProgress.html>` 
-object that provides the total number of transferrable bytes and the remaining 
-bytes to be transferred.
-
-.. note:: 
-   
-   The number of transferred and transferable bytes are only estimates. 
-   The Sync changesets are compressed with 
-   `gzip <https://www.gnu.org/software/gzip/>`_ before transmitting, so 
-   the actual size of transmitted bytes will be smaller than the reported number  
-   of both transferable and transferred bytes.
-
-.. example::
-
-   In the following example, we subscribe to a progress 
-   observable on the ``session`` to listen for upload events indefinitely. When 
-   this callback is triggered, it prints the number of transferred 
-   bytes and the number of transferable bytes to the console.
-
-   .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.snippet.upload-download-progress-notification.cs
-      :language: csharp
-
-   Once you no longer wish to receive notifications, unregister the token by using 
-   ``token.Dispose()``
-
-.. note:: 
-   
-   The SDK optimizes download speeds by combining multiple changesets
-   into a single download message, up to 16 MB. Since the progress callback is
-   only invoked once before and after a download message is processed, this
-   means that you'll likely see ``transferredBytes`` change in increments of roughly
-   16 MB rather than continuously as the message is being downloaded.
-
 Get Connection State Changes
 ----------------------------
+
 To get the connection state of a :dotnet-sdk:`SyncSession
 <reference/Realms.Realm.html#Realms_Realm_SyncSession>`, set an event handler
 on the :dotnet-sdk:`PropertyChanged <reference/Realms.Sync.Session.html#Realms_Sync_Session_PropertyChanged>`
@@ -125,4 +60,3 @@ object, and checking the Sync status:
 
 .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.snippet.connection-state.cs
    :language: csharp
-

--- a/source/sdk/dotnet/sync/sync-progress.txt
+++ b/source/sdk/dotnet/sync/sync-progress.txt
@@ -1,6 +1,9 @@
-===============================
-Monitor Sync Status  - .NET SDK
-===============================
+.. _dotnet-check-upload-download-progress:
+.. _dotnet-check-sync-progress:
+
+=============================================
+Check Upload and Download Progress - .NET SDK
+=============================================
 
 .. contents:: On this page
    :local:
@@ -8,9 +11,13 @@ Monitor Sync Status  - .NET SDK
    :depth: 2
    :class: singlecol
 
+
+Monitor Sync Progress and Status
+--------------------------------
 You may want to know the status of Sync operations in your app. For 
 example, you might want specific code to run only after all of the data is 
-synced with App Services.
+synced with App Services. You might also want to provide users with the 
+status of Sync operations. 
 
 You can set up your Sync session to wait for changes to be uploaded 
 or downloaded. You can also configure your Sync session to
@@ -19,8 +26,7 @@ notify when the Sync connection status changes.
 .. _dotnet-check-sync-progress-wait-for-upload-or-download:
 
 Wait for Changes to be Uploaded or Downloaded
----------------------------------------------
-
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 To asynchronously wait for your changes to be completed, get the sync session 
 from the :dotnet-sdk:`Realms.Sync.SyncSession
 <reference/Realms.Realm.html#Realms_Realm_SyncSession>`
@@ -33,9 +39,68 @@ methods. For example:
 .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.snippet.wait-for-changes-to-download-async-progress-notification.cs
    :language: csharp
 
+.. _dotnet-sync-status-change:
+
+Monitor Sync Progress
+~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
+
+To monitor Sync progress, get the 
+sync session from the :dotnet-sdk:`Realms.Sync.SyncSession 
+<reference/Realms.Realm.html#Realms_Realm_SyncSession>` property, then add a 
+progress notification by calling the 
+:dotnet-sdk:`session.GetProgressObservable() <reference/Realms.Sync.Session.html#Realms_Sync_Session_GetProgressObservable_Realms_Sync_ProgressDirection_Realms_Sync_ProgressMode_>` 
+method.
+
+The ``session.GetProgressObservable`` method takes in the following two parameters:
+
+- A :dotnet-sdk:`ProgressDirection <reference/Realms.Sync.ProgressDirection.html>` 
+  parameter that can be set to ``Upload`` or ``Download``.
+  
+- A :dotnet-sdk:`ProgressMode <reference/Realms.Sync.ProgressMode.html>` parameter 
+  that can be set to ``ReportIndefinitely``
+  for the notifications to continue until the callback is unregistered, or 
+  ``ForCurrentlyOutstandingWork`` for the notifications to continue until only 
+  the currently transferable bytes are synced.
+
+When you `Subscribe <https://docs.microsoft.com/en-us/dotnet/api/system.iobservable-1.subscribe?view=net-6.0#system-iobservable-1-subscribe(system-iobserver((-0)))>`_ 
+to the notifications, you receive a 
+:dotnet-sdk:`SyncProgress <reference/Realms.Sync.SyncProgress.html>` 
+object that provides the total number of transferrable bytes and the remaining 
+bytes to be transferred.
+
+.. note:: 
+   
+   The number of transferred and transferable bytes are only estimates. 
+   The Sync changesets are compressed with 
+   `gzip <https://www.gnu.org/software/gzip/>`_ before transmitting, so 
+   the actual size of transmitted bytes will be smaller than the reported number  
+   of both transferable and transferred bytes.
+
+.. example::
+
+   In the following example, we subscribe to a progress 
+   observable on the ``session`` to listen for upload events indefinitely. When 
+   this callback is triggered, it prints the number of transferred 
+   bytes and the number of transferable bytes to the console.
+
+   .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.snippet.upload-download-progress-notification.cs
+      :language: csharp
+
+   Once you no longer wish to receive notifications, unregister the token by using 
+   ``token.Dispose()``
+
+.. note:: 
+   
+   The SDK optimizes download speeds by combining multiple changesets
+   into a single download message, up to 16 MB. Since the progress callback is
+   only invoked once before and after a download message is processed, this
+   means that you'll likely see ``transferredBytes`` change in increments of roughly
+   16 MB rather than continuously as the message is being downloaded.
+
 Get Connection State Changes
 ----------------------------
-
 To get the connection state of a :dotnet-sdk:`SyncSession
 <reference/Realms.Realm.html#Realms_Realm_SyncSession>`, set an event handler
 on the :dotnet-sdk:`PropertyChanged <reference/Realms.Sync.Session.html#Realms_Sync_Session_PropertyChanged>`
@@ -60,3 +125,4 @@ object, and checking the Sync status:
 
 .. literalinclude:: /examples/generated/dotnet/ProgressNotifications.snippet.connection-state.cs
    :language: csharp
+   


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-31531

### Staged Changes

- [Sync Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31531/sdk/dotnet/sync/): Remove PBS info
- [Configure & Open a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31531/sdk/dotnet/sync/configure-and-open-a-synced-realm/): Remove PBS info to new PBS page. Add new Flexible Sync code examples for opening a realm. The other examples on this page should also be updated to show FS instead of PBS, but aren't necessarily a blocker for this PR.
- [Partition-Based Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31531/sdk/dotnet/sync/partition-based-sync/): New page with moved PBS content and new migration info

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
