### PR TITLE
Revert Sync progress change updates

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1257,4 +1257,4 @@ raw: ${prefix}/sdk/node/sync/multiplex-sync-sessions -> ${base}/sdk/node/sync/ma
 # Remove this very old legacy content that gets very few views and only shows Partition-Based Sync
 
 raw: ${prefix}/sdk/swift/sync/sync-realm-open-legacy -> ${base}/sdk/swift/sync/configure-and-open-a-synced-realm/
-raw: ${prefix}/sdk/swift/sync/sync-progress -> ${base}/sdk/swift/sync/partition-based-sync/
+raw: ${prefix}/sdk/swift/sync/sync-progress -> ${base}/sdk/swift/sync/sync-session/

--- a/source/sdk/node/sync/manage-sync-session.txt
+++ b/source/sdk/node/sync/manage-sync-session.txt
@@ -69,6 +69,51 @@ When to Pause a Sync Session
 
 .. include:: /includes/when-to-pause-sync.rst
 
+.. _node-check-sync-progress:
+
+Check Upload & Download Progress for a Sync Session
+---------------------------------------------------
+
+To check the upload and download progress for a sync session, add a progress
+notification using the :js-sdk:`syncSession.addProgressNotification() <Realm.App.Sync.Session.html#.addProgressNotification>` method.
+
+The ``syncSession.addProgressNotification()`` method takes in the following three parameters:
+
+- A ``direction`` parameter. 
+  Set to ``"upload"`` to register notifications for uploading data. 
+  Set to ``"download"`` to register notifications for downloading data.
+- A ``mode`` parameter. Set to ``"reportIndefinitely"`` 
+  for the notifications to continue until the callback is unregistered using
+  :js-sdk:`syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
+  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
+  until only the currently transferable bytes are synced.
+- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
+  ``transferred`` is the current number of bytes already transferred.
+  ``transferable`` is the total number of bytes already transferred
+  plus the number of bytes pending transfer.
+
+.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
+
+.. example::
+
+   In the following example, an application developer registers a callback on the ``syncSession`` to
+   listen for upload events indefinitely. The developer writes to the realm and
+   then unregisters the ``syncSession`` notification callback. 
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: typescript
+
+      .. literalinclude:: /examples/generated/node/device-sync.snippet.check-network-progress.ts
+        :language: typescript
+
+   .. tab::
+      :tabid: javascript
+
+      .. literalinclude:: /examples/generated/node/device-sync.snippet.check-network-progress.js
+        :language: javascript
+
 .. _node-check-network-connection:
 
 Check the Network Connection

--- a/source/sdk/node/sync/partition-based-sync.txt
+++ b/source/sdk/node/sync/partition-based-sync.txt
@@ -68,54 +68,6 @@ When opening a :ref:`bundled synchronized realm <node-bundle-a-realm>` that uses
 you must use the same partition key that was used in the original realm configuration. If you use a
 different partition key, the SDK throw an error when opening the bundled realm. 
 
-.. _node-check-sync-progress:
-
-Check Upload & Download Progress for a Sync Session
----------------------------------------------------
-
-Partition-Based Sync is currently the only Sync Mode that supports upload 
-and download progress notifications.
-
-To check the upload and download progress for a sync session, add a progress
-notification using the :js-sdk:`syncSession.addProgressNotification() <Realm.App.Sync.Session.html#.addProgressNotification>` method.
-
-The ``syncSession.addProgressNotification()`` method takes in the following three parameters:
-
-- A ``direction`` parameter. 
-  Set to ``"upload"`` to register notifications for uploading data. 
-  Set to ``"download"`` to register notifications for downloading data.
-- A ``mode`` parameter. Set to ``"reportIndefinitely"`` 
-  for the notifications to continue until the callback is unregistered using
-  :js-sdk:`syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
-  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
-  until only the currently transferable bytes are synced.
-- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
-  ``transferred`` is the current number of bytes already transferred.
-  ``transferable`` is the total number of bytes already transferred
-  plus the number of bytes pending transfer.
-
-.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
-
-.. example::
-
-   In the following example, an application developer registers a callback on the ``syncSession`` to
-   listen for upload events indefinitely. The developer writes to the realm and
-   then unregisters the ``syncSession`` notification callback. 
-
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: typescript
-
-      .. literalinclude:: /examples/generated/node/device-sync.snippet.check-network-progress.ts
-        :language: typescript
-
-   .. tab::
-      :tabid: javascript
-
-      .. literalinclude:: /examples/generated/node/device-sync.snippet.check-network-progress.js
-        :language: javascript
-
 .. _node-migrate-pbs-to-fs:
 
 Migrate from Partition-Based Sync to Flexible Sync

--- a/source/sdk/react-native/sync-data/manage-sync-session.txt
+++ b/source/sdk/react-native/sync-data/manage-sync-session.txt
@@ -60,6 +60,49 @@ When to Pause a Sync Session
 
 .. include:: /includes/when-to-pause-sync.rst
 
+.. _react-native-check-sync-progress:
+
+Check Upload & Download Progress for a Sync Session
+---------------------------------------------------
+
+To check the upload and download progress for a sync session, add a progress
+notification using the :js-sdk:`Realm.syncSession.addProgressNotification() <Realm.App.Sync.Session.html#.addProgressNotification>` method.
+
+The ``Realm.syncSession.addProgressNotification()`` method takes in the following three parameters:
+
+- A ``direction`` parameter.
+  Set to ``"upload"`` to register notifications for uploading data.
+  Set to ``"download"`` to register notifications for downloading data.
+- A ``mode`` parameter. Set to ``"reportIndefinitely"``
+  for the notifications to continue until the callback is unregistered using
+  :js-sdk:`Realm.syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
+  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
+  until only the currently transferable bytes are synced.
+- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
+  ``transferred`` is the current number of bytes already transferred.
+  ``transferable`` is the total number of bytes already transferred
+  plus the number of bytes pending transfer.
+
+.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
+
+The following example registers a callback on the ``syncSession`` to
+listen for upload events indefinitely. The example writes to the realm and
+then unregisters the ``syncSession`` notification callback.
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: typescript
+
+      .. literalinclude:: /examples/generated/react-native/ts/check-upload-download-progress.test.snippet.check-upload-download-progress.tsx
+         :language: typescript
+
+   .. tab::
+      :tabid: javascript
+
+      .. literalinclude:: /examples/generated/react-native/js/check-upload-download-progress.test.snippet.check-upload-download-progress.jsx
+         :language: javascript
+
 .. _react-native-check-network-connection:
 
 Check the Network Connection

--- a/source/sdk/react-native/sync-data/partition-based-sync.txt
+++ b/source/sdk/react-native/sync-data/partition-based-sync.txt
@@ -122,52 +122,6 @@ as an encrypted synced realm.
          .. literalinclude:: /examples/generated/node/open-and-close-a-realm.snippet.sync-encrypted-to-local-unencrypted.js
             :language: javascript
 
-.. _react-native-check-sync-progress:
-
-Check Upload & Download Progress for a Sync Session
----------------------------------------------------
-
-Partition-Based Sync is currently the only Sync Mode that supports upload 
-and download progress notifications.
-
-To check the upload and download progress for a sync session, add a progress
-notification using the :js-sdk:`Realm.syncSession.addProgressNotification() <Realm.App.Sync.Session.html#.addProgressNotification>` method.
-
-The ``Realm.syncSession.addProgressNotification()`` method takes in the following three parameters:
-
-- A ``direction`` parameter.
-  Set to ``"upload"`` to register notifications for uploading data.
-  Set to ``"download"`` to register notifications for downloading data.
-- A ``mode`` parameter. Set to ``"reportIndefinitely"``
-  for the notifications to continue until the callback is unregistered using
-  :js-sdk:`Realm.syncSession.removeProgressNotification() <Realm.App.Sync.Session.html#.removeProgressNotification>`.
-  Set to ``"forCurrentlyOutstandingWork"`` for the notifications to continue
-  until only the currently transferable bytes are synced.
-- A callback function parameter that has the arguments ``transferred`` and ``transferable``.
-  ``transferred`` is the current number of bytes already transferred.
-  ``transferable`` is the total number of bytes already transferred
-  plus the number of bytes pending transfer.
-
-.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
-
-The following example registers a callback on the ``syncSession`` to
-listen for upload events indefinitely. The example writes to the realm and
-then unregisters the ``syncSession`` notification callback.
-
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: typescript
-
-      .. literalinclude:: /examples/generated/react-native/ts/check-upload-download-progress.test.snippet.check-upload-download-progress.tsx
-         :language: typescript
-
-   .. tab::
-      :tabid: javascript
-
-      .. literalinclude:: /examples/generated/react-native/js/check-upload-download-progress.test.snippet.check-upload-download-progress.jsx
-         :language: javascript
-
 .. _react-native-migrate-pbs-to-fs:
 
 Migrate from Partition-Based Sync to Flexible Sync

--- a/source/sdk/swift/sync/partition-based-sync.txt
+++ b/source/sdk/swift/sync/partition-based-sync.txt
@@ -140,51 +140,6 @@ the App Services backend.
 .. literalinclude:: /examples/generated/code/start/ConvertSyncLocalRealms.snippet.convert-sync-to-local.swift
    :language: swift
 
-.. _swift-check-upload-download-progress:
-.. _ios-check-sync-progress:
-
-Check Upload & Download Progress for a Sync Session
----------------------------------------------------
-
-Partition-Based Sync is currently the only Sync Mode that supports upload 
-and download progress notifications.
-
-.. tabs-realm-languages::
-
-   .. tab::
-      :tabid: swift
-
-      You can add a progress notification using the synced realm's
-      SyncSession instance's
-      :swift-sdk:`addProgressNotification(for:mode:block:)
-      <Extensions/SyncSession.html#/s:So14RLMSyncSessionC10RealmSwiftE23addProgressNotification3for4mode5blockSo011RLMProgressG5TokenCSgAbCE0F9DirectionO_AbCE0F4ModeOyAbCE0F0VctF>`
-      method.
-
-      This method returns a token that you should retain until you wish
-      to stop observing upload or download progress. Note that if you
-      keep the token in a local variable, observation will stop when the
-      local variable goes out of scope.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.snippet.check-progress.swift
-         :language: swift
-
-   .. tab::
-      :tabid: objective-c
-
-      You can add a progress notification using the synced realm's
-      RLMSyncSession instance's
-      :objc-sdk:`[--addProgressNotificationForDirection:mode:block:]
-      <Classes/RLMSyncSession.html#/c:objc(cs)RLMSyncSession(im)addProgressNotificationForDirection:mode:block:>`
-      method.
-
-      This method returns a token that you should retain until you wish
-      to stop observing upload or download progress. Note that if you
-      keep the token in a local variable, observation will stop when the
-      local variable goes out of scope.
-
-      .. literalinclude:: /examples/generated/code/start/Sync.snippet.check-progress.m
-         :language: objectivec
-
 .. _ios-migrate-pbs-to-fs:
 
 Migrate from Partition-Based Sync to Flexible Sync

--- a/source/sdk/swift/sync/sync-session.txt
+++ b/source/sdk/swift/sync/sync-session.txt
@@ -64,3 +64,47 @@ When to Pause a Sync Session
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/when-to-pause-sync.rst
+
+.. _swift-check-upload-download-progress:
+.. _ios-check-sync-progress:
+
+Check Upload & Download Progress for a Sync Session
+---------------------------------------------------
+
+.. include:: /includes/flex-sync-unsupported-progress-notifications.rst
+
+.. tabs-realm-languages::
+
+   .. tab::
+      :tabid: swift
+
+      You can add a progress notification using the synced realm's
+      SyncSession instance's
+      :swift-sdk:`addProgressNotification(for:mode:block:)
+      <Extensions/SyncSession.html#/s:So14RLMSyncSessionC10RealmSwiftE23addProgressNotification3for4mode5blockSo011RLMProgressG5TokenCSgAbCE0F9DirectionO_AbCE0F4ModeOyAbCE0F0VctF>`
+      method.
+
+      This method returns a token that you should retain until you wish
+      to stop observing upload or download progress. Note that if you
+      keep the token in a local variable, observation will stop when the
+      local variable goes out of scope.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.snippet.check-progress.swift
+         :language: swift
+
+   .. tab::
+      :tabid: objective-c
+
+      You can add a progress notification using the synced realm's
+      RLMSyncSession instance's
+      :objc-sdk:`[--addProgressNotificationForDirection:mode:block:]
+      <Classes/RLMSyncSession.html#/c:objc(cs)RLMSyncSession(im)addProgressNotificationForDirection:mode:block:>`
+      method.
+
+      This method returns a token that you should retain until you wish
+      to stop observing upload or download progress. Note that if you
+      keep the token in a local variable, observation will stop when the
+      local variable goes out of scope.
+
+      .. literalinclude:: /examples/generated/code/start/Sync.snippet.check-progress.m
+         :language: objectivec


### PR DESCRIPTION
## Pull Request Info

I moved the progress notification documentation to the new PBS page as part of the PBS to FS migration work, but upload progress works for both FS and PBS - the only thing that doesn't work properly in FS is download progress. Moving the content back onto the relevant pages.

### Staged Changes

- [Node.js - Manage a Sync Session](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/revert-sync-progress-changes/sdk/node/sync/manage-sync-session/): Re-add progress notification info
- [Node.js - PBS](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/revert-sync-progress-changes/sdk/node/sync/partition-based-sync/): Remove progress notification info
- [React Native - Manage a Sync Session](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/revert-sync-progress-changes/sdk/react-native/sync-data/manage-sync-session/): Re-add progress notification info
- [React Native - PBS](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/revert-sync-progress-changes/sdk/react-native/sync-data/partition-based-sync/): Remove progress notification info
- [Swift - Manage Sync Sessions](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/revert-sync-progress-changes/sdk/swift/sync/sync-session/): Re-add progress notification info
- [Swift - PBS](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/revert-sync-progress-changes/sdk/swift/sync/partition-based-sync/): Remove progress notification info

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
