### PR TITLE
(DOCSP-31727): Java SDK Migrate PBS to FS Updates

### DIFF
--- a/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/FlexibleSyncTest.java
+++ b/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/FlexibleSyncTest.java
@@ -97,6 +97,61 @@ public class FlexibleSyncTest extends RealmTest {
     }
 
     @Test
+    public void openARealmForReadWriteUIThread() {
+        Expectation expectation = new Expectation();
+        activity.runOnUiThread (() -> {
+            // :snippet-start: open-a-realm
+            // instantiate a Realm App connection
+            String appID = YOUR_APP_ID; // replace this with your App ID
+            App app = new App(new AppConfiguration.Builder(appID)
+                    .build());
+            // authenticate a user
+            Credentials credentials = Credentials.anonymous();
+            app.loginAsync(credentials, it -> {
+                if (it.isSuccess()) {
+                    User user = it.get();
+                    // add an initial subscription to the sync configuration
+                    // :snippet-start: fs-allow-queries-on-ui-thread
+                    SyncConfiguration config = new SyncConfiguration.Builder(app.currentUser())
+                            .allowQueriesOnUiThread(true)
+                            .allowWritesOnUiThread(true)
+                            .initialSubscriptions(new SyncConfiguration.InitialFlexibleSyncSubscriptions() {
+                                @Override
+                                public void configure(Realm realm, MutableSubscriptionSet subscriptions) {
+                                    subscriptions.add(Subscription.create("subscriptionName",
+                                            realm.where(Frog.class)
+                                                .equalTo("species", "spring peeper")));
+                                }
+                            })
+                            // :remove-start:
+                            .inMemory()
+                            .waitForInitialRemoteData(2112, TimeUnit.MILLISECONDS)
+                            // :remove-end:
+                            .build();
+
+                    Realm.getInstanceAsync(config, new Realm.Callback() {
+                        @Override
+                        public void onSuccess(Realm realm) {
+                            Log.v( 
+                                "EXAMPLE",
+                                "Successfully opened a realm with reads and writes allowed on the UI thread.");
+                            // :remove-start:
+                            realm.close();
+                            expectation.fulfill();
+                            // :remove-end:
+                        }
+                    });
+                    // :snippet-end:
+                } else {
+                    Log.e("EXAMPLE", "Failed to log in: " + it.getError().getErrorMessage());
+                }
+            });
+            // :snippet-end:
+        });
+        expectation.await();
+    }
+
+    @Test
     public void explicitlyNamedSubscription() {
         Expectation expectation = new Expectation();
         activity.runOnUiThread (() -> {

--- a/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/FlexibleSyncTest.java
+++ b/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/FlexibleSyncTest.java
@@ -100,7 +100,6 @@ public class FlexibleSyncTest extends RealmTest {
     public void openARealmForReadWriteUIThread() {
         Expectation expectation = new Expectation();
         activity.runOnUiThread (() -> {
-            // :snippet-start: open-a-realm
             // instantiate a Realm App connection
             String appID = YOUR_APP_ID; // replace this with your App ID
             App app = new App(new AppConfiguration.Builder(appID)
@@ -146,7 +145,6 @@ public class FlexibleSyncTest extends RealmTest {
                     Log.e("EXAMPLE", "Failed to log in: " + it.getError().getErrorMessage());
                 }
             });
-            // :snippet-end:
         });
         expectation.await();
     }

--- a/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/FlexibleSyncTest.java
+++ b/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/java/FlexibleSyncTest.java
@@ -111,15 +111,15 @@ public class FlexibleSyncTest extends RealmTest {
                     User user = it.get();
                     // add an initial subscription to the sync configuration
                     // :snippet-start: fs-allow-queries-on-ui-thread
-                    SyncConfiguration config = new SyncConfiguration.Builder(app.currentUser())
+                    SyncConfiguration config = new SyncConfiguration.Builder(user)
                             .allowQueriesOnUiThread(true)
                             .allowWritesOnUiThread(true)
                             .initialSubscriptions(new SyncConfiguration.InitialFlexibleSyncSubscriptions() {
                                 @Override
                                 public void configure(Realm realm, MutableSubscriptionSet subscriptions) {
-                                    subscriptions.add(Subscription.create("subscriptionName",
+                                    subscriptions.add(Subscription.create("springPeepers",
                                             realm.where(Frog.class)
-                                                .equalTo("species", "spring peeper")));
+                                                    .equalTo("species", "spring peeper")));
                                 }
                             })
                             // :remove-start:
@@ -131,9 +131,9 @@ public class FlexibleSyncTest extends RealmTest {
                     Realm.getInstanceAsync(config, new Realm.Callback() {
                         @Override
                         public void onSuccess(Realm realm) {
-                            Log.v( 
-                                "EXAMPLE",
-                                "Successfully opened a realm with reads and writes allowed on the UI thread.");
+                            Log.v(
+                                    "EXAMPLE",
+                                    "Successfully opened a realm with reads and writes allowed on the UI thread.");
                             // :remove-start:
                             realm.close();
                             expectation.fulfill();

--- a/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/FlexibleSyncTest.kt
+++ b/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/FlexibleSyncTest.kt
@@ -128,7 +128,7 @@ class FlexibleSyncTest : RealmTest() {
                         .initialSubscriptions { realm, subscriptions ->
                             subscriptions.add(
                                 Subscription.create(
-                                    "subscriptionName",
+                                    "springPeepers",
                                     realm.where(Frog::class.java)
                                         .equalTo("species", "spring peeper")
                                 )

--- a/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/FlexibleSyncTest.kt
+++ b/examples/java/sync/app/src/androidTest/java/com/mongodb/realm/examples/kotlin/FlexibleSyncTest.kt
@@ -102,6 +102,69 @@ class FlexibleSyncTest : RealmTest() {
     }
 
     @Test
+    fun openARealmForReadWriteUIThread() {
+        val expectation = Expectation()
+        activity!!.runOnUiThread {
+
+            // instantiate a Realm App connection
+            val appID: String = YOUR_APP_ID // replace this with your App ID
+            val app = App(
+                AppConfiguration.Builder(appID)
+                    .build()
+            )
+            // authenticate a user
+            val credentials = Credentials.anonymous()
+            app.loginAsync(
+                credentials
+            ) { it: App.Result<User?> ->
+                if (it.isSuccess) {
+                    val user = it.get()
+
+                    // add an initial subscription to the sync configuration
+                    // :snippet-start: fs-allow-queries-on-ui-thread
+                    val config = SyncConfiguration.Builder(app.currentUser())
+                        .allowQueriesOnUiThread(true)
+                        .allowWritesOnUiThread(true)
+                        .initialSubscriptions { realm, subscriptions ->
+                            subscriptions.add(
+                                Subscription.create(
+                                    "subscriptionName",
+                                    realm.where(Frog::class.java)
+                                        .equalTo("species", "spring peeper")
+                                )
+                            )
+                        }
+                        // :remove-start:
+                        .inMemory()
+                        .waitForInitialRemoteData(2112, TimeUnit.MILLISECONDS)
+                        // :remove-end:
+                        .build()
+
+                    Realm.getInstanceAsync(config, object : Realm.Callback() {
+                        override fun onSuccess(realm: Realm) {
+                            Log.v(
+                                "EXAMPLE",
+                                "Successfully opened a realm with reads and writes allowed on the UI thread."
+                            )
+                            // :remove-start:
+                            realm.close()
+                            expectation.fulfill()
+                            // :remove-end:
+                        }
+                    })
+                    // :snippet-end:
+                } else {
+                    Log.e(
+                        "EXAMPLE",
+                        "Failed to log in: " + it.error.errorMessage
+                    )
+                }
+            }
+        }
+        expectation.await()
+    }
+
+    @Test
     fun explicitlyNamedSubscription() {
         val expectation = Expectation()
         activity!!.runOnUiThread {

--- a/examples/java/sync/build.gradle
+++ b/examples/java/sync/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.31"
+    ext.kotlin_version = "1.6.0"
     repositories {
         google()
         jcenter()

--- a/source/examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.java
+++ b/source/examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.java
@@ -4,7 +4,7 @@ SyncConfiguration config = new SyncConfiguration.Builder(app.currentUser())
         .initialSubscriptions(new SyncConfiguration.InitialFlexibleSyncSubscriptions() {
             @Override
             public void configure(Realm realm, MutableSubscriptionSet subscriptions) {
-                subscriptions.add(Subscription.create("subscriptionName",
+                subscriptions.add(Subscription.create("springPeepers",
                         realm.where(Frog.class)
                             .equalTo("species", "spring peeper")));
             }

--- a/source/examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.java
+++ b/source/examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.java
@@ -1,0 +1,21 @@
+SyncConfiguration config = new SyncConfiguration.Builder(app.currentUser())
+        .allowQueriesOnUiThread(true)
+        .allowWritesOnUiThread(true)
+        .initialSubscriptions(new SyncConfiguration.InitialFlexibleSyncSubscriptions() {
+            @Override
+            public void configure(Realm realm, MutableSubscriptionSet subscriptions) {
+                subscriptions.add(Subscription.create("subscriptionName",
+                        realm.where(Frog.class)
+                            .equalTo("species", "spring peeper")));
+            }
+        })
+        .build();
+
+Realm.getInstanceAsync(config, new Realm.Callback() {
+    @Override
+    public void onSuccess(Realm realm) {
+        Log.v( 
+            "EXAMPLE",
+            "Successfully opened a realm with reads and writes allowed on the UI thread.");
+    }
+});

--- a/source/examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.kt
+++ b/source/examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.kt
@@ -1,0 +1,22 @@
+val config = SyncConfiguration.Builder(app.currentUser())
+    .allowQueriesOnUiThread(true)
+    .allowWritesOnUiThread(true)
+    .initialSubscriptions { realm, subscriptions ->
+        subscriptions.add(
+            Subscription.create(
+                "subscriptionName",
+                realm.where(Frog::class.java)
+                    .equalTo("species", "spring peeper")
+            )
+        )
+    }
+    .build()
+
+Realm.getInstanceAsync(config, object : Realm.Callback() {
+    override fun onSuccess(realm: Realm) {
+        Log.v(
+            "EXAMPLE",
+            "Successfully opened a realm with reads and writes allowed on the UI thread."
+        )
+    }
+})

--- a/source/examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.kt
+++ b/source/examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.kt
@@ -6,7 +6,7 @@ val config = SyncConfiguration.Builder(app.currentUser())
             Subscription.create(
                 "subscriptionName",
                 realm.where(Frog::class.java)
-                    .equalTo("species", "spring peeper")
+                    .equalTo("species", "springPeepers")
             )
         )
     }

--- a/source/includes/java-synchronous-reads-writes-ui-thread-fs.rst
+++ b/source/includes/java-synchronous-reads-writes-ui-thread-fs.rst
@@ -1,0 +1,35 @@
+.. important:: Synchronous Reads and Writes on the UI Thread
+   
+   By default, you can only read or write to a realm in your
+   application's UI thread using
+   :ref:`asynchronous transactions <java-async-api>`. That is,
+   you can only use ``Realm`` methods whose name ends with the word
+   ``Async`` in the main thread of your Android application unless you
+   explicitly allow the use of synchronous methods.
+
+   This restriction exists for the benefit of your application users:
+   performing read and write operations on the UI thread can lead to
+   unresponsive or slow UI interactions, so it's usually best to handle
+   these operations either asynchronously or in a background thread.
+   However, if your application requires the use of synchronous
+   realm reads or writes on the UI thread, you can explicitly allow
+   the use of synchronous methods with the following
+   ``SyncConfiguration`` options:
+
+   .. tabs-realm-languages::
+
+      .. tab::
+         :tabid: java
+
+         .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.java
+            :language: java
+            :emphasize-lines: 2,3
+            :copyable: false
+
+      .. tab::
+         :tabid: kotlin
+
+         .. literalinclude:: /examples/generated/java/sync/FlexibleSyncTest.snippet.fs-allow-queries-on-ui-thread.kt
+            :language: kotlin
+            :emphasize-lines: 2,3
+            :copyable: false

--- a/source/sdk/java/sync.txt
+++ b/source/sdk/java/sync.txt
@@ -17,6 +17,7 @@ Sync Data Between Devices - Java SDK
    Check Upload & Download Progress </sdk/java/sync/sync-progress>
    Check the Network Connection </sdk/java/sync/network-connection>
    Background Sync </sdk/java/sync/background-sync>
+   Partition-Based Sync </sdk/java/sync/partition-based-sync>
 
 .. contents:: On this page
    :local:
@@ -28,16 +29,6 @@ Atlas Device Sync automatically synchronizes data between client applications an
 an :ref:`Atlas App Services backend <realm-cloud>`. When a client 
 device is online, Sync asynchronously synchronizes data in a 
 background thread between the device and your backend App. 
-
-When you use Sync in your client application, your implementation must match 
-the Sync Mode you select in your backend App configuration. The Sync Mode
-options are:
-
-- Flexible Sync
-- Partition-Based Sync
-
-You can only use one Sync Mode for your application. You cannot mix 
-Partition-Based Sync and Flexible Sync within the same App.
 
 .. seealso::
 
@@ -76,20 +67,6 @@ Group Updates for Improved Performance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/sync-memory-performance.rst
-
-.. _java-partition-based-sync-fundamentals:
-
-Partition-Based Sync
---------------------
-
-When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
-backend App configuration, your client implementation must include a 
-partition value. This is the value of the :ref:`partition key 
-<partition-key>` field you select when you configure Partition-Based Sync. 
-
-The partition value determines which data the client application can access.
-
-You pass in the partition value when you open a synced realm.
 
 .. _java-sync-data:
 

--- a/source/sdk/java/sync.txt
+++ b/source/sdk/java/sync.txt
@@ -63,11 +63,6 @@ To use Flexible Sync in your client application, open a synced realm
 with a flexible sync configuration. Then, manage subscriptions
 to determine which documents to sync.
 
-Group Updates for Improved Performance
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/sync-memory-performance.rst
-
 .. _java-sync-data:
 
 Sync Data
@@ -86,3 +81,8 @@ local data, a background thread efficiently integrates, uploads, and downloads c
    could appear to hang as it waits for the background sync thread to finish a write
    transaction. Therefore, it's a best practice :ref:`never to write on the main thread
    when using Sync <java-threading-three-rules>`.
+
+Group Updates for Improved Performance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/sync-memory-performance.rst

--- a/source/sdk/java/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/java/sync/configure-and-open-a-synced-realm.txt
@@ -40,6 +40,7 @@ like opening a local realm, except you use ``SyncConfiguration``
 to customize the settings for synced realms.
 
 .. _java-synced-realm-configuration:
+.. _java-flexible-sync-open-realm:
 
 Synced Realm Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -47,60 +48,12 @@ Synced Realm Configuration
 To configure settings for a realm, create a
 :java-sdk:`SyncConfiguration <io/realm/mongodb/sync/SyncConfiguration.html>` with a
 :java-sdk:`SyncConfiguration.Builder <io/realm/mongodb/sync/SyncConfiguration.Builder.html>`.
-The following example configures a synced realm with:
 
-- partition-based Sync
-- synchronous reads explicitly allowed on the UI thread
-- synchronous writes explicitly allowed on the UI thread
-- explicit waiting for all backend changes to synchronize to the device
-  before returning an open realm
-- automatic compaction when launching the realm to save file space
-
-.. warning:: Production Applications Should Handle Client Resets
-
-   Applications used in production environments should handle client
-   reset errors. To learn more, see :ref:`Reset a Client Realm
-   <java-client-resets>`.
-
-.. tabs-realm-languages::
-   
-   .. tab::
-       :tabid: kotlin
-
-       .. literalinclude:: /examples/generated/java/sync/OpenARealmTest.snippet.configure-a-realm.kt
-         :language: kotlin
-
-   .. tab::
-       :tabid: java
-
-       .. literalinclude:: /examples/generated/java/sync/OpenARealmTest.snippet.configure-a-realm.java
-         :language: java
-
-.. include:: /includes/java-synchronous-reads-writes-ui-thread.rst
-
-.. _java-open-synced-realm:
-.. _java-open-a-synced-realm-while-online:
-
-Open a Synced Realm While Online
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/java-open-synced-realm.rst
-
-.. _java-open-a-synced-realm-while-offline:
-
-Open a Synced Realm While Offline
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can open a synced realm when offline with the exact same syntax
-that you use to :ref:`open a synced realm while online
-<java-open-a-synced-realm-while-online>`. Not all SDKs follow this
-pattern, so cross-platform developers should consult the documentation
-for each SDK to learn more.
-
-.. _java-flexible-sync-open-realm:
-
-Open a Synced Realm with a Flexible Sync Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To open a synced realm, call 
+:java-sdk:`getInstanceAsync()
+<io/realm/Realm.html#getInstanceAsync-io.realm.RealmConfiguration-io.realm.Realm.Callback->`, 
+passing in a :java-sdk:`SyncConfiguration <io/realm/mongodb/sync/SyncConfiguration.html>` 
+object.
 
 When your application uses Flexible Sync, call
 the :java-sdk:`initialSubscriptions()
@@ -109,9 +62,7 @@ sync configuration builder method
 with an instance of
 :java-sdk:`SyncConfiguration.InitialFlexibleSyncSubscriptions()
 <io/realm/mongodb/sync/SyncConfiguration.InitialFlexibleSyncSubscriptions.html>`
-to open a synced realm. While partition-based Sync requires a partition
-value when you instantiate your ``SyncConfiguration``, you should omit
-the partition value when you use Flexible Sync. In the ``configure()`` method, instantiate
+to open a synced realm. In the ``configure()`` method, instantiate
 an ``UnmanagedSubscription`` with a name and query using
 :java-sdk:`Subscription.create()
 <io/realm/mongodb/sync/Subscription.html#create(java.lang.String,io.realm.RealmQuery)>`.
@@ -140,6 +91,19 @@ parameter to add it to your subscriptions:
 
    For more information about subscriptions, see
    :ref:`Subscribe to Queryable Fields <java-sync-subscribe-to-queryable-fields>`.
+
+.. include:: /includes/java-synchronous-reads-writes-ui-thread-fs.rst
+
+.. _java-open-a-synced-realm-while-offline:
+
+Open a Synced Realm While Offline
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can open a synced realm when offline with the exact same syntax
+that you use to :ref:`open a synced realm while online
+<java-open-a-synced-realm-while-online>`. Not all SDKs follow this
+pattern, so cross-platform developers should consult the documentation
+for each SDK to learn more.
 
 .. _java-close-a-synced-realm:
 

--- a/source/sdk/java/sync/partition-based-sync.txt
+++ b/source/sdk/java/sync/partition-based-sync.txt
@@ -1,0 +1,172 @@
+.. _java-partition-based-sync:
+
+===============================
+Partition-Based Sync - Java SDK
+===============================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Partition-Based Sync is an older mode for using Atlas Device Sync with the 
+Realm Java SDK. We recommend using :ref:`Flexible Sync <java-flexible-sync-fundamentals>` 
+for new apps. The information on this page is for users who are still 
+using Partition-Based Sync.
+
+.. tip::
+
+   Realm Java SDK v10.16.0 and newer supports the ability to migrate from 
+   Partition-Based Sync to Flexible Sync. For more information, refer to: 
+   :ref:`java-migrate-pbs-to-fs`.
+
+For more information about Partition-Based Sync and how to configure it
+in Atlas App Services, refer to :ref:`Partition-Based Sync <partition-based-sync>`
+in the App Services documentation.
+
+.. _java-partition-based-sync-fundamentals:
+
+Partition Value
+---------------
+
+When you select :ref:`Partition-Based Sync <partition-based-sync>` for your 
+backend App configuration, your client implementation must include a 
+partition value. This is the value of the :ref:`partition key 
+<partition-key>` field you select when you configure Partition-Based Sync. 
+
+The partition value determines which data the client application can access.
+
+You pass in the partition value when you open a synced realm.
+
+Open a Synced Realm
+--------------------
+
+To configure settings for a realm, create a
+:java-sdk:`SyncConfiguration <io/realm/mongodb/sync/SyncConfiguration.html>` with a
+:java-sdk:`SyncConfiguration.Builder <io/realm/mongodb/sync/SyncConfiguration.Builder.html>`.
+
+The following example configures a synced realm with:
+
+- partition-based Sync
+- synchronous reads explicitly allowed on the UI thread
+- synchronous writes explicitly allowed on the UI thread
+- explicit waiting for all backend changes to synchronize to the device
+  before returning an open realm
+- automatic compaction when launching the realm to save file space
+
+.. warning:: Production Applications Should Handle Client Resets
+
+   Applications used in production environments should handle client
+   reset errors. To learn more, see :ref:`Reset a Client Realm
+   <java-client-resets>`.
+
+.. tabs-realm-languages::
+   
+   .. tab::
+       :tabid: kotlin
+
+       .. literalinclude:: /examples/generated/java/sync/OpenARealmTest.snippet.configure-a-realm.kt
+         :language: kotlin
+
+   .. tab::
+       :tabid: java
+
+       .. literalinclude:: /examples/generated/java/sync/OpenARealmTest.snippet.configure-a-realm.java
+         :language: java
+
+.. include:: /includes/java-synchronous-reads-writes-ui-thread.rst
+
+.. _java-open-synced-realm:
+.. _java-open-a-synced-realm-while-online:
+
+Open a Synced Realm While Online
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/java-open-synced-realm.rst
+
+.. _java-open-a-synced-realm-while-offline:
+
+Open a Synced Realm While Offline
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can open a synced realm when offline with the exact same syntax
+that you use to :ref:`open a synced realm while online
+<java-open-a-synced-realm-while-online>`. Not all SDKs follow this
+pattern, so cross-platform developers should consult the documentation
+for each SDK to learn more.
+
+.. _java-migrate-pbs-to-fs:
+
+Migrate from Partition-Based Sync to Flexible Sync
+--------------------------------------------------
+
+You can migrate your App Services Device Sync Mode from Partition-Based Sync 
+to Flexible Sync. Migrating is an automatic process that does not require 
+any changes to your application code. Automatic migration requires Realm 
+Java SDK version 10.16.0 or newer. 
+
+Migrating enables you to keep your existing App Services users and 
+authentication configuration. Flexible Sync provides more versatile permissions
+configuration options and more granular data synchronization.
+
+For more information about how to migrate your App Services App from 
+Partition-Based Sync to Flexible Sync, refer to :ref:`Migrate Device Sync Modes 
+<realm-sync-migrate-modes>`.
+
+.. _java-update-client-code-after-pbs-to-fs-migration:
+
+Updating Client Code After Migration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The automatic migration from Partition-Based Sync to Flexible Sync does not
+require any changes to your client code. However, to support this 
+functionality, Realm automatically handles the differences between the two 
+Sync Modes by:
+
+- Automatically creating Flexible Sync subscriptions for each object type 
+  where ``partitionKey == partitionValue``.
+- Injecting a ``partitionKey`` field into every object if one does not already 
+  exist. This is required for the automatic Flexible Sync subscription.
+
+If you need to make updates to your client code after migration, consider 
+updating your client codebase to remove hidden migration functionality.
+You might want update your client codebase when:
+
+- You add a new model or change a model in your client codebase
+- You add or change functionality that involves reading or writing Realm objects
+- You want to implement more fine-grained control over what data you sync
+
+Make these changes to convert your Partition-Based Sync client code to use 
+Flexible Sync:
+
+- Update your :java-sdk:`SyncConfiguration.Builder 
+  <io/realm/mongodb/sync/SyncConfiguration.Builder.html>` to use 
+  :ref:`Flexible Sync <java-flexible-sync-open-realm>`. This involves
+  removing the ``partitionValue`` and adding a set of initial subscriptions, 
+  if needed.
+- Add relevant properties to your object models to use in your Flexible Sync 
+  subscriptions. For example, you might add an ``ownerId`` property to enable
+  a user to sync only their own data.
+- Remove automatic Flexible Sync subscriptions. If you did not add initial 
+  subscriptions in the ``SyncConfiguration.Builder``, manually create the
+  relevant subscriptions.
+
+For examples of Flexible Sync permissions strategies, including examples of 
+how to model data for these strategies, refer to :ref:`flexible-sync-permissions-guide`.
+
+Remove and Manually Create Subscriptions
+````````````````````````````````````````
+
+When you migrate from Partition-Based Sync to Flexible Sync, Realm
+automatically creates hidden Flexible Sync subscriptions for your app. The 
+next time you add or change subscriptions, we recommend that you:
+
+1. :ref:`Remove the automatically-generated subscriptions <java-remove-subscriptions>`. 
+2. :ref:`Manually add the relevant subscriptions in your client codebase <java-sync-add-subscription>`.
+
+This enables you to see all of your subscription logic together in your 
+codebase for future iteration and debugging.
+
+For more information about the automatically-generated Flexible Sync 
+subscriptions, refer to :ref:`realm-sync-migrate-client`.


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-31727

### Staged Changes

- [Sync Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31727/sdk/java/sync/): Remove PBS mentions
- [Partition-Based Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31727/sdk/java/sync/partition-based-sync/): New page with moved PBS info and PBS to FS migration info
- [Configure & Open a Synced Realm](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-31727/sdk/java/sync/configure-and-open-a-synced-realm/): Remove PBS info, update the "Synchronous Reads & Writes on the UI Thread" `Important` callout to show FS code examples

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
