### PR TITLE
DOCSP-31611: Update inverse relationship example to initialize with empty list

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
@@ -56,7 +56,7 @@ class User: RealmObject {
     @PrimaryKey
     var _id: ObjectId = ObjectId()
     var name: String = ""
-    var posts: RealmList<Post>? = realmListOf()
+    var posts: RealmList<Post> = realmListOf()
 }
 // :snippet-end:
 

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
@@ -56,7 +56,7 @@ class User: RealmObject {
     @PrimaryKey
     var _id: ObjectId = ObjectId()
     var name: String = ""
-    var posts: RealmList<Post>? = null
+    var posts: RealmList<Post>? = realmListOf()
 }
 // :snippet-end:
 

--- a/source/examples/generated/kotlin/SchemaTest.snippet.inverse-relationship-user.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.inverse-relationship-user.kt
@@ -2,5 +2,5 @@ class User: RealmObject {
     @PrimaryKey
     var _id: ObjectId = ObjectId()
     var name: String = ""
-    var posts: RealmList<Post>? = null
+    var posts: RealmList<Post>? = realmListOf()
 }

--- a/source/examples/generated/kotlin/SchemaTest.snippet.inverse-relationship-user.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.inverse-relationship-user.kt
@@ -2,5 +2,5 @@ class User: RealmObject {
     @PrimaryKey
     var _id: ObjectId = ObjectId()
     var name: String = ""
-    var posts: RealmList<Post>? = realmListOf()
+    var posts: RealmList<Post> = realmListOf()
 }

--- a/source/sdk/kotlin/realm-database/schemas/relationships.txt
+++ b/source/sdk/kotlin/realm-database/schemas/relationships.txt
@@ -67,9 +67,12 @@ To-Many Relationship
 --------------------
 
 A to-many relationship means that an object is related in a specific way
-to multiple objects. You can create a relationship between one object
+to multiple objects. 
+
+You can create a relationship between one object
 and any number of objects using a field of type ``RealmList<T>`` where
-``T`` is a Realm object in your application:
+``T`` is a Realm object in your application. Note that lists or sets of 
+``RealmObject`` cannot have null elements.
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.to-many-relationship.kt
    :language: kotlin

--- a/source/sdk/kotlin/realm-database/schemas/relationships.txt
+++ b/source/sdk/kotlin/realm-database/schemas/relationships.txt
@@ -72,7 +72,8 @@ to multiple objects.
 You can create a relationship between one object
 and any number of objects using a field of type ``RealmList<T>`` where
 ``T`` is a Realm object in your application. Note that lists or sets of 
-``RealmObject`` cannot have null elements.
+``RealmObject`` cannot have null elements and must be initialized with 
+``realmListOf()`` or ``realmSetOf()``.
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.to-many-relationship.kt
    :language: kotlin


### PR DESCRIPTION
## Pull Request Info

Correct example that shows a null list of realm objects. Lists of ``RealmObjects`` cannot be `null`; should initialize with an empty list instead. 

### Jira

- https://jira.mongodb.org/browse/DOCSP-31611

### Staged Changes

- [Relationships - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-31611/sdk/kotlin/realm-database/schemas/relationships/#inverse-relationships)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
