### PR TITLE
DOCSP-30337: Add Manage Sync Session - Kotlin SDK page

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/ManageSyncSession.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/ManageSyncSession.kt
@@ -12,7 +12,6 @@ import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.PrimaryKey
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.mongodb.kbson.BsonObjectId
@@ -64,17 +63,17 @@ class ManageSyncSession : RealmTest() {
                 })
             }
 
+            val upload = // :remove:
             // Wait for local changes to be uploaded to Atlas
             realm.syncSession.uploadAllLocalChanges(1.minutes)
             // :snippet-end:
+            assertTrue(upload)
             realm.write {
                 val tasks = query<SyncTask>().find()
-                assertEquals(1, tasks.size)
-                assertEquals("Review proposal", tasks.first().taskName)
                 delete(tasks)
                 assertEquals(0, tasks.size)
             }
-            delay(1000)
+            realm.syncSession.uploadAllLocalChanges()
             user.remove()
             realm.close()
         }
@@ -111,12 +110,10 @@ class ManageSyncSession : RealmTest() {
             assertEquals(SyncSession.State.ACTIVE, realm.syncSession.state)
             realm.write {
                 val tasks = query<SyncTask>().find()
-                assertEquals(1, tasks.size)
-                assertEquals("Submit expense report", tasks.first().taskName)
                 delete(tasks)
                 assertEquals(0, tasks.size)
             }
-            delay(1000)
+            realm.syncSession.uploadAllLocalChanges()
             user.remove()
             realm.close()
         }
@@ -157,12 +154,10 @@ class ManageSyncSession : RealmTest() {
             assertTrue(stream.first().isTransferComplete)
             realm.write {
                 val tasks = query<SyncTask>().find()
-                assertEquals(1, tasks.size)
-                assertEquals("Schedule appointment", tasks.first().taskName)
                 delete(tasks)
                 assertEquals(0, tasks.size)
             }
-            delay(1000)
+            realm.syncSession.uploadAllLocalChanges()
             user.remove()
             realm.close()
         }
@@ -203,12 +198,10 @@ class ManageSyncSession : RealmTest() {
             }
             realm.write {
                 val tasks = query<SyncTask>().find()
-                assertEquals(1, tasks.size)
-                assertEquals("Do a thing", tasks.first().taskName)
                 delete(tasks)
                 assertEquals(0, tasks.size)
             }
-            delay(1000)
+            realm.syncSession.uploadAllLocalChanges()
             flow.cancel()
             user.remove()
             realm.close()

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/ManageSyncSession.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/ManageSyncSession.kt
@@ -20,6 +20,7 @@ import org.mongodb.kbson.ObjectId
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
 
 
 // :replace-start: {
@@ -52,7 +53,7 @@ class ManageSyncSession : RealmTest() {
             Log.v("Successfully opened realm: ${realm.configuration}")
             // :snippet-start: wait-upload-download
             // Wait to download all pending changes from Atlas
-            realm.syncSession.downloadAllServerChanges()
+            realm.syncSession.downloadAllServerChanges(1.minutes)
 
             // Add data locally
             realm.write {
@@ -64,7 +65,7 @@ class ManageSyncSession : RealmTest() {
             }
 
             // Wait for local changes to be uploaded to Atlas
-            realm.syncSession.uploadAllLocalChanges()
+            realm.syncSession.uploadAllLocalChanges(1.minutes)
             // :snippet-end:
             realm.write {
                 val tasks = query<SyncTask>().find()

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/ManageSyncSession.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/ManageSyncSession.kt
@@ -184,8 +184,10 @@ class ManageSyncSession : RealmTest() {
             val flow = CoroutineScope(Dispatchers.Default).launch {
                 // :snippet-start: monitor-network-connection
                 val connectionFlow = realm.syncSession.connectionStateAsFlow()
-                connectionFlow.collect {
-                    Log.i("Connected to Atlas Device Sync server")
+                connectionFlow.collect { ConnectionStateChange ->
+                    if (ConnectionStateChange.newState == ConnectionState.CONNECTED) {
+                        Log.i("Connected to Atlas Device Sync server")
+                    }
                 }
                 // :snippet-end:
             }

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/ManageSyncSession.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/ManageSyncSession.kt
@@ -1,0 +1,213 @@
+package com.mongodb.realm.realmkmmapp
+
+import io.realm.kotlin.Realm
+import io.realm.kotlin.ext.query
+import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.mongodb.App
+import io.realm.kotlin.mongodb.Credentials
+import io.realm.kotlin.mongodb.sync.ConnectionState
+import io.realm.kotlin.mongodb.sync.Direction
+import io.realm.kotlin.mongodb.sync.ProgressMode
+import io.realm.kotlin.mongodb.sync.SyncConfiguration
+import io.realm.kotlin.mongodb.syncSession
+import io.realm.kotlin.types.RealmInstant
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.PrimaryKey
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.mongodb.kbson.BsonObjectId
+import org.mongodb.kbson.ObjectId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+
+// :replace-start: {
+//   "terms": {
+//      "SyncTask": "Task"
+//   }
+// }
+class ManageSyncSession : RealmTest() {
+
+    class SyncTask : RealmObject {
+        @PrimaryKey
+        var _id: ObjectId = BsonObjectId()
+        var taskName: String = ""
+        var assignee: String? = null
+        var completed: Boolean = false
+        var progressMinutes: Int = 0
+        var dueDate: RealmInstant? = null
+    }
+
+    val app = App.create(yourFlexAppId)
+    val credentials = Credentials.anonymous(reuseExisting = false)
+    @Test
+    fun waitForChangesUploadAndDownload() {
+        runBlocking {
+            val user = app.login(credentials)
+            val config = SyncConfiguration.Builder(user, setOf(SyncTask::class))
+                .initialSubscriptions { it.query<SyncTask>().subscribe() }
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: wait-upload-download
+            // Wait to download all pending changes from Atlas
+            realm.syncSession.downloadAllServerChanges()
+
+            // Add data locally
+            realm.write {
+                this.copyToRealm(SyncTask().apply {
+                    taskName = "Do the laundry"
+                    assignee = "Emma"
+                    progressMinutes = 0
+                })
+            }
+
+            // Wait for local changes to be uploaded to Atlas
+            realm.syncSession.uploadAllLocalChanges()
+            // :snippet-end:
+            realm.write {
+                val tasks = query<SyncTask>().find()
+                assertEquals(1, tasks.size)
+                assertEquals("Do the laundry", tasks.first().taskName)
+                delete(tasks)
+                assertEquals(0, tasks.size)
+            }
+            delay(1000)
+            user.remove()
+            realm.close()
+        }
+    }
+
+    @Test
+    fun pauseResumeSyncSession() {
+        runBlocking {
+            val user = app.login(credentials)
+            val config = SyncConfiguration.Builder(user, setOf(SyncTask::class))
+                .initialSubscriptions { it.query<SyncTask>().subscribe() }
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: pause-resume-sync
+            // Pause the sync session
+            // Data that you write while session is paused does not sync to Atlas
+            realm.syncSession.pause()
+
+            // Add data locally
+            realm.write {
+                this.copyToRealm(SyncTask().apply {
+                    taskName = "Submit expense report"
+                    assignee = "Kevin"
+                    progressMinutes = 0
+                })
+            }
+
+            // Resume sync session
+            // Local changes now sync to Atlas
+            realm.syncSession.resume()
+            // :snippet-end:
+            realm.write {
+                val tasks = query<SyncTask>().find()
+                assertEquals(1, tasks.size)
+                assertEquals("Submit expense report", tasks.first().taskName)
+                delete(tasks)
+                assertEquals(0, tasks.size)
+            }
+            delay(1000)
+            user.remove()
+            realm.close()
+        }
+    }
+
+    @Test
+    fun monitorSyncProgress() {
+        /*
+        NOTE: Kotlin does not currently support progress listeners for Flexible Sync
+        Requires PBS
+        */
+        runBlocking {
+            val app1 = App.create(yourAppId)
+            val user = app1.login(credentials)
+            val config = SyncConfiguration.Builder(user, PARTITION, setOf(SyncTask::class))
+                .name(PARTITION)
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: monitor-progress
+            val stream = realm.syncSession.progressAsFlow(
+                Direction.UPLOAD, ProgressMode.CURRENT_CHANGES
+            )
+            stream.collect { progress ->
+                if (progress.transferableBytes == progress.transferredBytes) {
+                    println("Upload complete")
+                }
+            }
+
+            // Upload data
+            realm.write {
+                this.copyToRealm(SyncTask().apply {
+                    taskName = "Schedule appointment"
+                    assignee = "Jane"
+                    progressMinutes = 0
+                })
+            }
+            // :snippet-end:
+            realm.write {
+                val tasks = query<SyncTask>().find()
+                assertEquals(1, tasks.size)
+                assertEquals("Schedule appointment", tasks.first().taskName)
+                delete(tasks)
+                assertEquals(0, tasks.size)
+            }
+            delay(1000)
+            user.remove()
+            realm.close()
+        }
+    }
+
+    @Test
+    fun monitorNetworkConnection() {
+        runBlocking {
+            val user = app.login(credentials)
+            val config = SyncConfiguration.Builder(user, setOf(SyncTask::class))
+                .initialSubscriptions { it.query<SyncTask>().subscribe() }
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration}")
+            // :snippet-start: get-network-connection
+            if (realm.syncSession.connectionState == ConnectionState.CONNECTED) {
+                Log.i("Connected to network")
+                // ... do something
+            }
+            // :snippet-end:
+            val flow = CoroutineScope(Dispatchers.Default).launch {
+                // :snippet-start: monitor-network-connection
+                val connectionFlow = realm.syncSession.connectionStateAsFlow()
+                connectionFlow.collect {
+                    Log.i("Connected to Atlas Device Sync server")
+                }
+                // :snippet-end:
+            }
+            realm.write {
+                this.copyToRealm(SyncTask().apply {
+                    taskName = "Do a thing"
+                    assignee = "Me"
+                    progressMinutes = 0
+                })
+            }
+            realm.write {
+                val tasks = query<SyncTask>().find()
+                assertEquals(1, tasks.size)
+                assertEquals("Do a thing", tasks.first().taskName)
+                delete(tasks)
+                assertEquals(0, tasks.size)
+            }
+            delay(1000)
+            flow.cancel()
+            user.remove()
+            realm.close()
+        }
+    }
+}
+// :replace-end:

--- a/source/examples/generated/kotlin/ManageSyncSession.snippet.get-network-connection.kt
+++ b/source/examples/generated/kotlin/ManageSyncSession.snippet.get-network-connection.kt
@@ -1,0 +1,4 @@
+if (realm.syncSession.connectionState == ConnectionState.CONNECTED) {
+    Log.i("Connected to network")
+    // ... do something
+}

--- a/source/examples/generated/kotlin/ManageSyncSession.snippet.monitor-network-connection.kt
+++ b/source/examples/generated/kotlin/ManageSyncSession.snippet.monitor-network-connection.kt
@@ -1,4 +1,6 @@
 val connectionFlow = realm.syncSession.connectionStateAsFlow()
-connectionFlow.collect {
-    Log.i("Connected to Atlas Device Sync server")
+connectionFlow.collect { ConnectionStateChange ->
+    if (ConnectionStateChange.newState == ConnectionState.CONNECTED) {
+        Log.i("Connected to Atlas Device Sync server")
+    }
 }

--- a/source/examples/generated/kotlin/ManageSyncSession.snippet.monitor-network-connection.kt
+++ b/source/examples/generated/kotlin/ManageSyncSession.snippet.monitor-network-connection.kt
@@ -1,0 +1,4 @@
+val connectionFlow = realm.syncSession.connectionStateAsFlow()
+connectionFlow.collect {
+    Log.i("Connected to Atlas Device Sync server")
+}

--- a/source/examples/generated/kotlin/ManageSyncSession.snippet.monitor-progress.kt
+++ b/source/examples/generated/kotlin/ManageSyncSession.snippet.monitor-progress.kt
@@ -1,0 +1,17 @@
+val stream = realm.syncSession.progressAsFlow(
+    Direction.UPLOAD, ProgressMode.CURRENT_CHANGES
+)
+stream.collect { progress ->
+    if (progress.transferableBytes == progress.transferredBytes) {
+        println("Upload complete")
+    }
+}
+
+// Upload data
+realm.write {
+    this.copyToRealm(Task().apply {
+        taskName = "Schedule appointment"
+        assignee = "Jane"
+        progressMinutes = 0
+    })
+}

--- a/source/examples/generated/kotlin/ManageSyncSession.snippet.monitor-progress.kt
+++ b/source/examples/generated/kotlin/ManageSyncSession.snippet.monitor-progress.kt
@@ -3,15 +3,6 @@ val stream = realm.syncSession.progressAsFlow(
 )
 stream.collect { progress ->
     if (progress.transferableBytes == progress.transferredBytes) {
-        println("Upload complete")
+        Log.i("Upload complete")
     }
-}
-
-// Upload data
-realm.write {
-    this.copyToRealm(Task().apply {
-        taskName = "Schedule appointment"
-        assignee = "Jane"
-        progressMinutes = 0
-    })
 }

--- a/source/examples/generated/kotlin/ManageSyncSession.snippet.pause-resume-sync.kt
+++ b/source/examples/generated/kotlin/ManageSyncSession.snippet.pause-resume-sync.kt
@@ -1,0 +1,16 @@
+// Pause the sync session
+// Data that you write while session is paused does not sync to Atlas
+realm.syncSession.pause()
+
+// Add data locally
+realm.write {
+    this.copyToRealm(Task().apply {
+        taskName = "Submit expense report"
+        assignee = "Kevin"
+        progressMinutes = 0
+    })
+}
+
+// Resume sync session
+// Local changes now sync to Atlas
+realm.syncSession.resume()

--- a/source/examples/generated/kotlin/ManageSyncSession.snippet.wait-upload-download.kt
+++ b/source/examples/generated/kotlin/ManageSyncSession.snippet.wait-upload-download.kt
@@ -1,0 +1,14 @@
+// Wait to download all pending changes from Atlas
+realm.syncSession.downloadAllServerChanges()
+
+// Add data locally
+realm.write {
+    this.copyToRealm(Task().apply {
+        taskName = "Do the laundry"
+        assignee = "Emma"
+        progressMinutes = 0
+    })
+}
+
+// Wait for local changes to be uploaded to Atlas
+realm.syncSession.uploadAllLocalChanges()

--- a/source/examples/generated/kotlin/ManageSyncSession.snippet.wait-upload-download.kt
+++ b/source/examples/generated/kotlin/ManageSyncSession.snippet.wait-upload-download.kt
@@ -4,7 +4,7 @@ realm.syncSession.downloadAllServerChanges()
 // Add data locally
 realm.write {
     this.copyToRealm(Task().apply {
-        taskName = "Do the laundry"
+        taskName = "Review proposal"
         assignee = "Emma"
         progressMinutes = 0
     })

--- a/source/examples/generated/kotlin/ManageSyncSession.snippet.wait-upload-download.kt
+++ b/source/examples/generated/kotlin/ManageSyncSession.snippet.wait-upload-download.kt
@@ -1,5 +1,5 @@
 // Wait to download all pending changes from Atlas
-realm.syncSession.downloadAllServerChanges()
+realm.syncSession.downloadAllServerChanges(1.minutes)
 
 // Add data locally
 realm.write {
@@ -11,4 +11,4 @@ realm.write {
 }
 
 // Wait for local changes to be uploaded to Atlas
-realm.syncSession.uploadAllLocalChanges()
+realm.syncSession.uploadAllLocalChanges(1.minutes)

--- a/source/examples/generated/kotlin/RealmModels.snippet.landing-page-model.kt
+++ b/source/examples/generated/kotlin/RealmModels.snippet.landing-page-model.kt
@@ -1,0 +1,6 @@
+class Frog : RealmObject {
+    var name: String = ""
+    var age: Int = 0
+    var species: String? = null
+    var owner: String? = null
+}

--- a/source/examples/generated/kotlin/RealmModels.snippet.landing-page-model.kt
+++ b/source/examples/generated/kotlin/RealmModels.snippet.landing-page-model.kt
@@ -1,6 +1,0 @@
-class Frog : RealmObject {
-    var name: String = ""
-    var age: Int = 0
-    var species: String? = null
-    var owner: String? = null
-}

--- a/source/sdk/kotlin/sync.txt
+++ b/source/sdk/kotlin/sync.txt
@@ -11,6 +11,7 @@ Device Sync - Kotlin SDK
    Configure & Open a Synced Realm </sdk/kotlin/sync/open-a-synced-realm>
    Manage Subscriptions </sdk/kotlin/sync/subscribe>
    Write to a Synced Realm </sdk/kotlin/sync/write-to-synced-realm>
+   Manage Sync Session </sdk/kotlin/sync/manage-sync-session>
    Handle Sync Errors </sdk/kotlin/sync/handle-sync-errors>
    Set the Client Log Level </sdk/kotlin/sync/log-level>
    Stream Data to Atlas </sdk/kotlin/sync/stream-data-to-atlas>

--- a/source/sdk/kotlin/sync/manage-sync-session.txt
+++ b/source/sdk/kotlin/sync/manage-sync-session.txt
@@ -49,7 +49,7 @@ server to your synced realm, call
 This method returns ``true`` when all changes have been downloaded.
 
 You can also include an optional ``timeout`` parameter to either method to 
-determine the maximum amount of time before an exception is thrown. Note that 
+determine the maximum amount of time before returning ``false``. Note that 
 the upload or download continues in the background even after returning ``false``.
 
 The following example demonstrates calling both methods with a timeout defined:

--- a/source/sdk/kotlin/sync/manage-sync-session.txt
+++ b/source/sdk/kotlin/sync/manage-sync-session.txt
@@ -40,11 +40,19 @@ Wait for Changes to Upload and Download
 
 To asynchronously wait for all changes to upload to Atlas from your synced realm,
 call
-`uploadAllLocalChanges <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/upload-all-local-changes.html>`__.
+`uploadAllLocalChanges <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/upload-all-local-changes.html>`__. 
+This method returns ``true`` when all changes have been uploaded. 
 
 To asynchronously wait for all changes on Atlas to download from the Device Sync 
 server to your synced realm, call 
 `downloadAllServerChanges <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/download-all-server-changes.html>`__.
+This method returns ``true`` when all changes have been downloaded.
+
+You can also include an optional ``timeout`` parameter to either method to 
+determine the maximum amount of time before an exception is thrown. Note that 
+the upload or download continues in the background even after returning ``false``.
+
+The following example demonstrates calling both methods with a timeout defined:
 
 .. literalinclude:: /examples/generated/kotlin/ManageSyncSession.snippet.wait-upload-download.kt
    :language: kotlin

--- a/source/sdk/kotlin/sync/manage-sync-session.txt
+++ b/source/sdk/kotlin/sync/manage-sync-session.txt
@@ -18,7 +18,6 @@ The sync session manages the following:
 
 - Uploading and downloading changes to the realm
 - Pausing and resuming sync
-- Monitoring sync progress
 - Monitoring network connectivity
 
 You can access the `SyncSession <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/index.html>`__ 

--- a/source/sdk/kotlin/sync/manage-sync-session.txt
+++ b/source/sdk/kotlin/sync/manage-sync-session.txt
@@ -88,10 +88,11 @@ When to Pause a Sync Session
 Monitor Network Connection
 --------------------------
 
-You can get the state of the current network connection with
-`connectionState <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/connection-state.html>`__.
-This returns a `connectionState <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-connection-state/index.html>`__ 
-enum that contains the network connection's state: 
+You can get the state of the current network connection by checking the
+`SyncSession.connectionState <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/connection-state.html>`__ property.
+This returns a `ConnectionState <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-connection-state/index.html>`__ 
+enum value that indicates the state of the network connection. The possible 
+states are:  
 ``CONNECTED``, ``DISCONNECTED``, or ``CONNECTING``.
 
 .. literalinclude:: /examples/generated/kotlin/ManageSyncSession.snippet.get-network-connection.kt

--- a/source/sdk/kotlin/sync/manage-sync-session.txt
+++ b/source/sdk/kotlin/sync/manage-sync-session.txt
@@ -1,0 +1,101 @@
+.. _kotlin-manage-sync-session:
+
+==================================
+Manage a Sync Session - Kotlin SDK
+==================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+When you use :ref:`Flexible Sync <flexible-sync>`, the Realm Kotlin SDK syncs 
+data with Atlas in the background using a sync session. The sync session starts 
+whenever you open a synced realm.
+
+The sync session manages the following:
+
+- Uploading and downloading changes to the realm
+- Pausing and resuming sync
+- Monitoring sync progress
+- Monitoring network connectivity
+
+You can access the `SyncSession <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/index.html>`__ 
+of any synced realm through the `realm.syncSession <{+kotlin-sync-prefix+}io.realm.kotlin.Realm/syncSession.html>`__
+property.
+
+Prerequisites
+-------------
+
+Before you can manage your sync session state, you must perform the following:
+
+#. :ref:`Configure Flexible Sync on the Atlas App Services backend <enable-flexible-sync>`.
+#. :ref:`Authenticate a user <kotlin-authenticate>` in your client app.
+#. :ref:`Open the synced realm <kotlin-open-a-synced-realm>`.
+
+.. _kotlin-sync-wait-for-changes:
+
+Wait for Changes to Upload and Download
+---------------------------------------
+
+To asynchronously wait for all changes to upload to Atlas from your synced realm,
+call
+`uploadAllLocalChanges <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/upload-all-local-changes.html>`__.
+
+To asynchronously wait for all changes on Atlas to download from the Device Sync 
+server to your synced realm, call 
+`downloadAllServerChanges <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/download-all-server-changes.html>`__.
+
+.. literalinclude:: /examples/generated/kotlin/ManageSyncSession.snippet.wait-upload-download.kt
+   :language: kotlin
+
+.. _kotlin-pause-resume-sync:
+
+Pause and Resume a Sync Session
+-------------------------------
+
+To pause syncing for a session, call 
+`syncSession.pause() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/pause.html>`__.
+The realm will not sync changes with Atlas while the session is paused.
+
+To resume syncing a changes, call 
+`syncSession.resume() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/resume.html>`__.
+
+You must manually call ``syncSession.pause()`` and ``syncSession.resume()`` for 
+each realm whose Sync session you want to pause and restart.
+The sync state of one session has no impact on other open sessions.
+
+The following code block demonstrates calling these methods:
+
+.. literalinclude:: /examples/generated/kotlin/ManageSyncSession.snippet.pause-resume-sync.kt
+   :language: kotlin
+
+When to Pause a Sync Session
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/when-to-pause-sync.rst
+
+.. _kotlin-monitor-network-connection:
+
+Monitor Network Connection
+--------------------------
+
+You can get the state of the current network connection with
+`connectionState <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/connection-state.html>`__.
+This returns a `connectionState <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-connection-state/index.html>`__ 
+enum that contains the network connection's state: 
+``CONNECTED``, ``DISCONNECTED``, or ``CONNECTING``.
+
+.. literalinclude:: /examples/generated/kotlin/ManageSyncSession.snippet.get-network-connection.kt
+   :language: kotlin
+
+Monitor the state of the network connection with
+`connectionStateAsFlow <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/connection-state-as-flow.html>`__.
+This property returns a Flow of 
+`ConnectionStateChange <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-connection-state-change/index.html>`__
+objects that updates when the network connection changes. You can access the 
+new and old ``ConnectionState`` from ``ConnectionStateChange``.
+
+.. literalinclude:: /examples/generated/kotlin/ManageSyncSession.snippet.monitor-network-connection.kt
+   :language: kotlin

--- a/source/sdk/kotlin/sync/partition-based-sync.txt
+++ b/source/sdk/kotlin/sync/partition-based-sync.txt
@@ -62,6 +62,12 @@ To adjust specific configuration settings, use the options provided by
 Check Upload & Download Progress for a Sync Session
 ---------------------------------------------------
 
+.. note:: 
+
+  The ``progressAsFlow()`` listener in the Kotlin SDK is only currently 
+  available for realms using Partition-Based Sync. The Kotlin SDK does not 
+  yet support progress listeners for Flexible Sync.
+
 To monitor Sync upload and download progress, call 
 `progressAsFlow() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/progress-as-flow.html>`__ 
 

--- a/source/sdk/kotlin/sync/partition-based-sync.txt
+++ b/source/sdk/kotlin/sync/partition-based-sync.txt
@@ -48,7 +48,6 @@ an instance of the realm:
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.open-a-synced-realm.kt
     :language: kotlin
-    :copyable: false
 
 Configure a Partition-Based Sync Realm
 --------------------------------------
@@ -59,7 +58,34 @@ To adjust specific configuration settings, use the options provided by
 
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.configure-a-synced-realm.kt
     :language: kotlin
-    :copyable: false
+
+Monitor Sync Upload Progress
+----------------------------
+
+To monitor Sync upload progress progress, call 
+`progressAsFlow() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/progress-as-flow.html>`__ 
+
+This method returns a Flow of 
+`Progress <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-progress/index.html>`__ 
+events. ``Progress`` provides the total 
+number of transferrable bytes and the remaining bytes to be transferred.
+
+``syncSession.progressAsFlow()`` takes two arguments:
+
+- A `Direction <{+kotlin-sync-prefix+}/io.realm.kotlin.mongodb.sync/-direction/index.html>`__
+  enum that can be set to ``UPLOAD`` or ``DOWNLOAD``.
+  This specifies that the progress stream tracks uploads or downloads.
+
+- A `ProgressMode <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-progress-mode/index.html>`__ 
+  enum that can be set to either: 
+  
+  - ``INDEFINITELY``: Sets notifications to continue until the callback is 
+    unregistered.
+  - ``CURRENT_CHANGES``: Sets notifications to continue until only the currently 
+    transferable bytes are synced.
+
+.. literalinclude:: /examples/generated/kotlin/ManageSyncSession.snippet.monitor-progress.kt
+   :language: kotlin
 
 .. _kotlin-migrate-pbs-to-fs:
 
@@ -77,7 +103,7 @@ configuration options and more granular data synchronization.
 
 For more information about how to migrate your App Services App from 
 Partition-Based Sync to Flexible Sync, refer to :ref:`Migrate Device Sync Modes 
-<realm-sync-migrate-modes>`.
+<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync-sync-migrate-modes>`.
 
 .. _kotlin-update-client-code-after-pbs-to-fs-migration:
 

--- a/source/sdk/kotlin/sync/partition-based-sync.txt
+++ b/source/sdk/kotlin/sync/partition-based-sync.txt
@@ -59,10 +59,10 @@ To adjust specific configuration settings, use the options provided by
 .. literalinclude:: /examples/generated/kotlin/SyncTest.snippet.configure-a-synced-realm.kt
     :language: kotlin
 
-Monitor Sync Upload Progress
-----------------------------
+Check Upload & Download Progress for a Sync Session
+---------------------------------------------------
 
-To monitor Sync upload progress progress, call 
+To monitor Sync upload and download progress, call 
 `progressAsFlow() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/progress-as-flow.html>`__ 
 
 This method returns a Flow of 

--- a/source/sdk/kotlin/sync/partition-based-sync.txt
+++ b/source/sdk/kotlin/sync/partition-based-sync.txt
@@ -68,8 +68,12 @@ Check Upload & Download Progress for a Sync Session
   available for realms using Partition-Based Sync. The Kotlin SDK does not 
   yet support progress listeners for Flexible Sync.
 
+You can monitor the upload and download progress of a sync session. The sync 
+session starts when you open a synced realm. For more information, refer to
+:ref:`Manage a Sync Session <kotlin-manage-sync-session>`.
+
 To monitor Sync upload and download progress, call 
-`progressAsFlow() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/progress-as-flow.html>`__ 
+`SyncSession.progressAsFlow() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-sync-session/progress-as-flow.html>`__ 
 
 This method returns a Flow of 
 `Progress <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-progress/index.html>`__ 
@@ -78,7 +82,7 @@ number of transferrable bytes and the remaining bytes to be transferred.
 
 ``syncSession.progressAsFlow()`` takes two arguments:
 
-- A `Direction <{+kotlin-sync-prefix+}/io.realm.kotlin.mongodb.sync/-direction/index.html>`__
+- A `Direction <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync/-direction/index.html>`__
   enum that can be set to ``UPLOAD`` or ``DOWNLOAD``.
   This specifies that the progress stream tracks uploads or downloads.
 

--- a/source/sdk/kotlin/sync/partition-based-sync.txt
+++ b/source/sdk/kotlin/sync/partition-based-sync.txt
@@ -103,7 +103,7 @@ configuration options and more granular data synchronization.
 
 For more information about how to migrate your App Services App from 
 Partition-Based Sync to Flexible Sync, refer to :ref:`Migrate Device Sync Modes 
-<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.sync-sync-migrate-modes>`.
+<realm-sync-migrate-modes>`.
 
 .. _kotlin-update-client-code-after-pbs-to-fs-migration:
 


### PR DESCRIPTION
## Pull Request Info

Add new Manage Sync Session page for Kotlin (progress listener added in https://github.com/realm/realm-kotlin/pull/1118)

> NOTE: Kotlin SDK doesn't currently support progress listener for Flexible Sync; only supported for PBS

### Jira

- https://jira.mongodb.org/browse/DOCSP-30337

### Staged Changes

- [Manage Sync Session](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-30337-manage-sync-sessions/sdk/kotlin/sync/manage-sync-session/) - new page
- [Partition-Based Sync](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-30337-manage-sync-sessions/sdk/kotlin/sync/partition-based-sync/#check-upload---download-progress-for-a-sync-session) - updated page

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
