### PR TITLE
DOCSP-30342: Update Read & Write Data page with info on managed and unmanaged objects

### DIFF
--- a/source/sdk/kotlin/realm-database/write-transactions.txt
+++ b/source/sdk/kotlin/realm-database/write-transactions.txt
@@ -64,7 +64,13 @@ commits it or cancels it:
 Managed vs. Unmanaged Objects
 -----------------------------
 
-Realm objects written to a realm are either managed or unmanaged by Realm.
+Realm APIs may refer to objects as managed or unmanaged. When you create 
+a Realm object, it is unmanaged. You can then create a managed instance by 
+copying that object to a realm. 
+
+You can check if an object is managed with the 
+`isManaged() <{+kotlin-local-prefix+}io.realm.kotlin.ext/is-managed.html>`__  
+method.
 
 Managed Objects
 ~~~~~~~~~~~~~~~
@@ -72,10 +78,13 @@ Managed Objects
 **Managed objects** are Realm objects that persist in a realm. Managed objects 
 can only be accessed from an open realm. They can be automatically updated 
 with changes within write transactions as long as that realm remains open. 
+Managed objects are tied to the realm instance from which it originated 
+and cannot be written to another realm.
+
 You can use Realm APIs with managed objects, create relationships with 
 other objects, and observe managed Realm object for changes. 
 
-You create managed objects with 
+You create managed objects by copying unmanaged instances to a realm with 
 `Realm.copyToRealm() <{+kotlin-local-prefix+}io.realm.kotlin.dynamic/-dynamic-mutable-realm/copy-to-realm.html>`__. 
 See :ref:`Create Realm Objects <kotlin-create-a-new-object>` for more 
 information.
@@ -91,14 +100,12 @@ Unmanaged Objects
 
 **Unmanaged objects** are instances of Realm objects that
 behave like normal Kotlin objects, but they are not persisted in a realm.
+All Realm objects are unmanaged until you write them to a realm.
 You cannot use Realm APIs with unmanaged objects or observe them for changes.
 
-You can get an unmanaged object by manually constructing a Realm object 
-yourself or by calling 
+You can create an unmanaged object by manually constructing a Realm object 
+yourself or by copying a managed object with 
 `Realm.copyFromRealm() <{+kotlin-local-prefix+}io.realm.kotlin.ext/copy-from-realm.html>`__. 
-
-You can create a managed copy of an unmanaged object with 
-`Realm.copyToRealm() <{+kotlin-local-prefix+}io.realm.kotlin.dynamic/-dynamic-mutable-realm/copy-to-realm.html>`__. 
 
 .. _kotlin-open-a-transaction:
 

--- a/source/sdk/kotlin/realm-database/write-transactions.txt
+++ b/source/sdk/kotlin/realm-database/write-transactions.txt
@@ -52,7 +52,7 @@ condition when reading values from the realm within a
 transaction.
 
 When you are done with your transaction, Realm either
-**commits** it or **cancels** it:
+commits it or cancels it:
 
 - When Realm **commits** a transaction, Realm writes
   all changes to disk. For synced realms, the SDK queues the change
@@ -60,6 +60,45 @@ When you are done with your transaction, Realm either
 - When Realm **cancels** a write transaction or an operation in
   the transaction causes an error, all changes are discarded
   (or "rolled back").
+
+Managed vs. Unmanaged Objects
+-----------------------------
+
+Realm objects written to a realm are either managed or unmanaged by Realm.
+
+Managed Objects
+~~~~~~~~~~~~~~~
+
+**Managed objects** are Realm objects that persist in a realm. Managed objects 
+can only be accessed from an open realm. They can be automatically updated 
+with changes within write transactions as long as that realm remains open. 
+You can use Realm APIs with managed objects, create relationships with 
+other objects, and observe managed Realm object for changes. 
+
+You create managed objects with 
+`Realm.copyToRealm() <{+kotlin-local-prefix+}io.realm.kotlin.dynamic/-dynamic-mutable-realm/copy-to-realm.html>`__. 
+See :ref:`Create Realm Objects <kotlin-create-a-new-object>` for more 
+information.
+
+.. note:: 
+
+   You can :ref:`create managed asymmetric objects <kotlin-create-asymmetric-object>`. 
+   But because asymmetric objects are write-only, it isn't possible to 
+   access the managed data after it has been written.
+
+Unmanaged Objects
+~~~~~~~~~~~~~~~~~
+
+**Unmanaged objects** are instances of Realm objects that
+behave like normal Kotlin objects, but they are not persisted in a realm.
+You cannot use Realm APIs with unmanaged objects or observe them for changes.
+
+You can get an unmanaged object by manually constructing a Realm object 
+yourself or by calling 
+`Realm.copyFromRealm() <{+kotlin-local-prefix+}io.realm.kotlin.ext/copy-from-realm.html>`__. 
+
+You can create a managed copy of an unmanaged object with 
+`Realm.copyToRealm() <{+kotlin-local-prefix+}io.realm.kotlin.dynamic/-dynamic-mutable-realm/copy-to-realm.html>`__. 
 
 .. _kotlin-open-a-transaction:
 
@@ -86,3 +125,4 @@ the transaction immediately after the callback.
 
    .. literalinclude:: /examples/generated/kotlin/CRUDTest.snippet.run-a-transaction.kt
       :language: kotlin
+


### PR DESCRIPTION
## Pull Request Info

Add section describing managed vs. unmanaged objects to existing [Read and Write Data](https://www.mongodb.com/docs/realm/sdk/kotlin/realm-database/write-transactions/) page

### Jira

- https://jira.mongodb.org/browse/DOCSP-30342

### Staged Changes

- [Read & Write Data](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-30342-manage-section/sdk/kotlin/realm-database/write-transactions/) - updated page

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
