### PR TITLE
DOCSP-30334: Add Kotlin User Metadata page

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/AuthenticationTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/AuthenticationTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.mongodb.kbson.BsonDocument
 import org.mongodb.kbson.BsonInt32
-import org.mongodb.kbson.BsonInt64
 import org.mongodb.kbson.BsonString
 import kotlin.test.*
 
@@ -330,7 +329,7 @@ class AuthenticationTest: RealmTest() {
 
     @Test
     fun userMetaData() {
-        val email = getRandom()
+        val email = getRandomEmail()
         val password = getRandom()
         val app = App.create(FLEXIBLE_APP_ID)
         runBlocking {
@@ -344,17 +343,10 @@ class AuthenticationTest: RealmTest() {
             val userEmail = user.profileAsBsonDocument()["email"]
             Log.i("The logged-in user's email is: $userEmail")
             // :snippet-end:
-            val expectedEmail = if (userEmail is BsonInt64) {
-                userEmail.value.toString()
-            } else {
-                userEmail.toString()
-            }
-            assertEquals(email, expectedEmail)
+            assertEquals(email, userEmail?.asString()?.value)
             user.delete()
             app.close()
         }
-
-
     }
 }
 // :replace-end:

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/RealmTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/RealmTest.kt
@@ -20,6 +20,14 @@ open class RealmTest {
         return Random.nextLong(from = 100000, until = 100000000000).toString()
     }
 
+    fun getRandomEmail(): String {
+        val allowedChars = ('a'..'z') + ('0'..'9')
+        val randomString = (1..10)
+            .map { allowedChars.random() }
+            .joinToString("")
+        return "$randomString@example.com"
+    }
+
     fun getEncryptionKey(seed: Long? = null): ByteArray {
         // generate a new 64-byte encryption key
         val key = ByteArray(64)

--- a/source/examples/generated/kotlin/AuthenticationTest.snippet.get-user-metadata.kt
+++ b/source/examples/generated/kotlin/AuthenticationTest.snippet.get-user-metadata.kt
@@ -1,0 +1,6 @@
+// Log in a user
+val user = app.login(Credentials.emailPassword(email, password))
+
+// Access the user's metadata
+val userEmail = user.profileAsBsonDocument()["email"]
+Log.i("The logged-in user's email is: $userEmail")

--- a/source/sdk/dotnet/manage-users/user-metadata.txt
+++ b/source/sdk/dotnet/manage-users/user-metadata.txt
@@ -22,7 +22,7 @@ object. You cannot edit user metadata through a ``User`` object.
 The ``Profile`` property on the ``User`` object returns a 
 :dotnet-sdk:`UserProfile <reference/Realms.Sync.UserProfile.html>` object
 of a logged-in user. The following example shows how to get a user's email from 
-the metatdata:
+the metadata:
 
 .. literalinclude:: /examples/generated/dotnet/UserLinkExamples.snippet.user-metadata.cs
    :language: csharp

--- a/source/sdk/kotlin/users.txt
+++ b/source/sdk/kotlin/users.txt
@@ -103,7 +103,9 @@ refer to :ref:`Custom User Data <kotlin-custom-user-data>`.
 Read User Metadata from Login Providers
 ---------------------------------------
 
-Some authentication providers enable developers to access user metadata, such
-as full name or email address. When you configure these metadata fields on 
-the App Services application, you can 
-:ref:`access user metadata <kotlin-read-user-metadata>` from your client app. 
+Some authentication providers enable developers to access 
+:ref:`user metadata <auth-provider-metadata>` , such as full name or email 
+address. When you configure these metadata fields on the App Services 
+application, you can access this metadata from you client app. 
+For more information on working with user metadata, refer to
+:ref:`Read a User's Metadata <kotlin-read-user-metadata>`. 

--- a/source/sdk/kotlin/users.txt
+++ b/source/sdk/kotlin/users.txt
@@ -10,6 +10,7 @@ Manage Users - Kotlin SDK
    Link User Identities </sdk/kotlin/users/link-credentials>
    Create & Manage User API Keys </sdk/kotlin/users/manage-user-api-keys>
    Custom User Data </sdk/kotlin/users/custom-user-data>
+   User Metadata </sdk/kotlin/users/user-metadata>
    Delete Users </sdk/kotlin/users/delete-users>
 
 .. contents:: On this page
@@ -98,3 +99,11 @@ such as a preferred language or local timezone, and read it from your client app
 
 For more information on working with custom user data,
 refer to :ref:`Custom User Data <kotlin-custom-user-data>`.
+
+Read User Metadata from Login Providers
+---------------------------------------
+
+Some authentication providers enable developers to access user metadata, such
+as full name or email address. When you configure these metadata fields on 
+the App Services application, you can 
+:ref:`access user metadata <kotlin-read-user-metadata>` from your client app. 

--- a/source/sdk/kotlin/users/user-metadata.txt
+++ b/source/sdk/kotlin/users/user-metadata.txt
@@ -1,0 +1,52 @@
+.. _kotlin-user-metadata:
+
+==========================
+User Metadata - Kotlin SDK
+==========================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+You can associate custom :ref:`metadata <user-metadata>` with each user 
+of your App. For example, you might store a user's preferred language, 
+date of birth, or any other information that you want to associate with 
+the user.
+
+.. _kotlin-read-user-metadata:
+
+Read a User's Metadata
+----------------------
+
+You can read the user metadata of a currently logged-in user through 
+that user's 
+`User <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-user/index.html>`__ 
+object. You cannot edit user metadata through a ``User`` object. 
+
+To read the data, call the 
+`profileAsBsonDocument <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.ext/profile-as-bson-document.html>`__ 
+method on the ``User`` object of a logged-in user:
+
+.. literalinclude:: /examples/generated/kotlin/AuthenticationTest.snippet.get-user-metadata.kt
+   :language: kotlin
+
+User metadata options vary depending on which provider you're using and
+:ref:`which metadata fields you enable <configure-user-metadata-on-the-backend>`. 
+
+.. include:: /includes/stale-user-metadata.rst
+
+.. _kotlin-configure-user-metadata:
+
+Configure User Metadata
+-----------------------
+
+.. include:: /includes/configure-user-metadata.rst
+
+.. _kotlin-update-user-metadata:
+
+Update User Metadata
+--------------------
+
+.. include:: /includes/update-user-metadata.rst

--- a/source/sdk/kotlin/users/user-metadata.txt
+++ b/source/sdk/kotlin/users/user-metadata.txt
@@ -10,10 +10,10 @@ User Metadata - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-You can associate custom :ref:`metadata <user-metadata>` with each user 
-of your App. For example, you might store a user's preferred language, 
-date of birth, or any other information that you want to associate with 
-the user.
+Atlas App Services can read :ref:`user metadata <auth-provider-metadata>` 
+from authentication providers. Then, App Services exposes each user's 
+data in a field of their user object. For example, you might want to 
+access a user's name, email, birthday, or gender.
 
 .. _kotlin-read-user-metadata:
 
@@ -33,9 +33,27 @@ method on the ``User`` object of a logged-in user:
    :language: kotlin
 
 User metadata options vary depending on which provider you're using and
-:ref:`which metadata fields you enable <configure-user-metadata-on-the-backend>`. 
+:ref:`which metadata fields you enable <configure-user-metadata-on-the-backend>`.
 
 .. include:: /includes/stale-user-metadata.rst
+
+Serializable User Metadata 
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.9.0
+
+Kotlin SDK version 1.9.0 introduced an API that supports: 
+
+- A limited but stable EJSON encoder for user metadata returned by ``User.profileAsBsonDocument()``
+- An experimental EJSON encoder that supports full document serialization for user 
+  metadata returned by the `User.profile() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.ext/profile.html>`__ 
+  extension method. This encoder and method requires experimental opt-in. 
+
+You must add the official
+`Kotlin Serialization <https://github.com/Kotlin/kotlinx.serialization>`__ library
+to your project to use Realm Kotlin SDK's EJSON serialization.
+For more information, refer to 
+:ref:`Serialization <kotlin-serialization>`. 
 
 .. _kotlin-configure-user-metadata:
 

--- a/source/sdk/swift/users/user-metadata.txt
+++ b/source/sdk/swift/users/user-metadata.txt
@@ -15,7 +15,7 @@ User Metadata - Swift SDK
 Read a User's Metadata
 ----------------------
 
-You can read the :ref:`user metadata <user-metadata>` of a
+You can read the :ref:`user metadata <auth-provider-metadata>` of a
 currently logged-in user through that user's ``User`` object. You cannot
 edit user metadata through a ``User`` object. 
 

--- a/source/sdk/swift/work-with-users.txt
+++ b/source/sdk/swift/work-with-users.txt
@@ -116,6 +116,6 @@ Read User Metadata from Login Providers
 
 Some authentication providers enable developers to access user metadata, such
 as full name or email address. When you configure these metadata fields on 
-the App Services application, you can read this medata from your client app. A
+the App Services application, you can read this metadata from your client app. A
 user object has a ``profile`` property that you can use to :ref:`access 
 user metadata <ios-read-user-metadata>`.


### PR DESCRIPTION
## Pull Request Info

Add new User Metadata - Kotlin SDK page

### Jira

- https://jira.mongodb.org/browse/DOCSP-30334

### Staged Changes

- [User Metadata](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-30334-user-metadata/sdk/kotlin/users/user-metadata/) - new page
- [Manage Users](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-30334-user-metadata/sdk/kotlin/users/) - updated page

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any - see [DOCSP-32114](https://jira.mongodb.org/browse/DOCSP-32114)
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
