### PR TITLE
(DOCSP-32091): Swift: Actor-Isolated Realms wording clarifications

### DIFF
--- a/source/sdk/swift/actor-isolated-realm.txt
+++ b/source/sdk/swift/actor-isolated-realm.txt
@@ -11,8 +11,10 @@ Actor-Isolated Realms - Swift SDK
    :class: singlecol
 
 Starting with Realm Swift SDK version 10.39.0, Realm supports actor-isolated
-realm instances. You can safely use an actor-isolated realm with Swift concurrency
-language features instead of managing threads or dispatch queues.
+realm instances. You might want to use an actor-isolated realm if your app
+uses Swift concurrency language features. This functionality provides 
+an alternative to managing threads or dispatch queues to perform asynchronous 
+work.
 
 With an actor-isolated realm, you can use Swift's async/await syntax to:
 
@@ -139,8 +141,9 @@ And you might perform this write using Swift's async syntax:
 
 This does not block the calling thread while waiting to write. It does 
 not perform I/O on the calling thread. For small writes, this is safe to 
-use from ``@MainActor`` functions without blocking the UI. Sufficiently large 
-writes may still benefit from being done on a background thread. 
+use from ``@MainActor`` functions without blocking the UI. Writes that 
+negatively impact your app's performance due to complexity and/or platform 
+resource constraints may still benefit from being done on a background thread. 
 
 Asynchronous writes are only supported for actor-isolated Realms or in
 ``@MainActor`` functions.


### PR DESCRIPTION
## Pull Request Info

Note: this PR doesn't attempt to explain `@MainActor` vs. other actor usage, as requested in the docs feedback. The page links out to Swift's concurrency docs and relies on developers to have an understanding of Swift concurrency and know whether they need to use the `@MainActor` or whether another actor is more appropriate for their app.

### Jira

- https://jira.mongodb.org/browse/DOCSP-32091

### Staged Changes

- [Actor-Isolated Realms](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-32091/sdk/swift/actor-isolated-realm/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-app-services update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
