### PR TITLE
DOCSP-28410: Add link from SDK Model pages to App Services schema mapping page

### DIFF
--- a/source/includes/map-to-bson-type.rst
+++ b/source/includes/map-to-bson-type.rst
@@ -1,0 +1,3 @@
+To map a specific Realm data type to a BSON type in an 
+App Services Schema, refer to :ref:`<sync-data-model-mapping>` in the Atlas 
+App Services documentation.

--- a/source/includes/map-to-bson-type.rst
+++ b/source/includes/map-to-bson-type.rst
@@ -1,3 +1,3 @@
-To map a specific Realm data type to a BSON type in an 
+To map a specific data type to a BSON data type in an 
 App Services Schema, refer to :ref:`<sync-data-model-mapping>` in the Atlas 
 App Services documentation.

--- a/source/includes/map-to-bson-type.rst
+++ b/source/includes/map-to-bson-type.rst
@@ -1,3 +1,3 @@
-To map a specific data type to a BSON data type in an 
+To learn how specific data types are mapped to BSON types in an 
 App Services Schema, refer to :ref:`<sync-data-model-mapping>` in the Atlas 
 App Services documentation.

--- a/source/sdk/cpp/model-data/supported-types.txt
+++ b/source/sdk/cpp/model-data/supported-types.txt
@@ -18,6 +18,11 @@ Optionals use the class template
 Property Cheat Sheet
 --------------------
 
+You can use the following types to define your object model
+properties.
+
+.. include:: /includes/map-to-bson-type.rst
+
 .. tabs::
 
    .. tab:: Current

--- a/source/sdk/dotnet/model-data/data-types/field-types.txt
+++ b/source/sdk/dotnet/model-data/data-types/field-types.txt
@@ -20,6 +20,8 @@ The .NET SDK supports three categories of data types:
 - :ref:`MongoDB.Bson types <dotnet-bsontypes>`
 - :ref:`Realm-Specific types <dotnet-realmtypes>`
 
+.. include:: /includes/map-to-bson-type.rst
+
 .. _dotnet-dotnettypes:
 
 .NET Types

--- a/source/sdk/flutter/realm-database/model-data/data-types.txt
+++ b/source/sdk/flutter/realm-database/model-data/data-types.txt
@@ -13,6 +13,8 @@ Data Types - Flutter SDK
 The Flutter SDK supports Dart-language data types, a limited subset of
 `BSON <https://bsonspec.org/>`__ types, and :wikipedia:`UUID <Universally_unique_identifier>`.
 
+.. include:: /includes/map-to-bson-type.rst
+
 .. _flutter-dart-types:
 
 Dart Types

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -14,6 +14,8 @@ Data Types - Kotlin SDK
 The Kotlin SDK supports Kotlin data types, a limited subset of
 `BSON <https://bsonspec.org/>`__ types, and :wikipedia:`UUID <Universally_unique_identifier>`.
 
+.. include:: /includes/map-to-bson-type.rst
+
 .. _kotlin-data-types:
 
 Supported Types

--- a/source/sdk/node/model-data/data-types/field-types.txt
+++ b/source/sdk/node/model-data/data-types/field-types.txt
@@ -27,3 +27,5 @@ Realm supports the following field data types:
 - ``set`` is based on the JavaScript :mdn:`Set <Web/JavaScript/Reference/Global_Objects/Set>` type. ``Realm Set`` is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
 - ``mixed`` is a property type that can hold different data types. The ``Mixed`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
 - ``uuid`` is a universally unique identifier from :js-sdk:`Realm.BSON <Realm.html#.BSON>`. The ``UUID`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
+
+.. include:: /includes/map-to-bson-type.rst

--- a/source/sdk/react-native/model-data/data-types/property-types.txt
+++ b/source/sdk/react-native/model-data/data-types/property-types.txt
@@ -32,3 +32,6 @@ Realm supports the following property data types:
   :realm-react-sdk:`Realm.BSON <modules/Realm.BSON.html>`. The ``UUID`` data
   type is available in the :github:`realm-js@10.5.0 release 
   <realm/realm-js/releases/tag/v10.5.0>`.
+
+.. include:: /includes/map-to-bson-type.rst
+   

--- a/source/sdk/swift/model-data/supported-types.txt
+++ b/source/sdk/swift/model-data/supported-types.txt
@@ -122,6 +122,13 @@ having to refresh it or validate that it is up-to-date.
 Supported Property Types
 ------------------------
 
+You can use the following types to define your object model
+properties.
+
+.. include:: /includes/map-to-bson-type.rst 
+
+See also :ref:`<swift-model-data-device-sync>`.
+
 Property Cheat Sheet
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -132,9 +139,6 @@ Property Cheat Sheet
 
       .. versionchanged:: 10.10.0
          ``@Persisted`` property declaration syntax
-
-      You can use the following types to define your object model
-      properties:
 
       .. list-table::
          :header-rows: 1
@@ -303,9 +307,6 @@ Property Cheat Sheet
    .. tab:: Objective-C
       :tabid: objective-c
 
-      You can use the following types to define your object model
-      properties:
-
       .. list-table::
          :header-rows: 1
          :stub-columns: 1
@@ -433,9 +434,6 @@ Property Cheat Sheet
 
       .. versionchanged:: 10.8.0
          ``RealmProperty`` replaces ``RealmOptional``
-
-      You can use the following types to define your object model
-      properties:
 
       .. list-table::
          :header-rows: 1


### PR DESCRIPTION
## Pull Request Info

Bug Bash ticket: Point users to where they can see property type > BSON type mappings 

### Jira

- https://jira.mongodb.org/browse/DOCSP-28410

### Staged Changes

- [C++](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-28410-data-model-mapping/sdk/cpp/model-data/supported-types/#property-cheat-sheet)
- [Flutter](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-28410-data-model-mapping/sdk/flutter/realm-database/model-data/data-types/)
- [Kotlin](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-28410-data-model-mapping/sdk/kotlin/realm-database/schemas/supported-types/)
- [.NET](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-28410-data-model-mapping/sdk/dotnet/model-data/data-types/field-types/)
- [Node](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-28410-data-model-mapping/sdk/node/model-data/data-types/field-types/)
- [RN](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-28410-data-model-mapping/sdk/react-native/model-data/data-types/property-types/)
- [Swift](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-28410-data-model-mapping/sdk/swift/model-data/supported-types/#supported-property-types)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
