### PR TITLE
DOCSP-28146: Fix incorrect ObjectId link in Node Quick Start

### DIFF
--- a/source/sdk/node/quick-start.txt
+++ b/source/sdk/node/quick-start.txt
@@ -43,7 +43,7 @@ Object Properties <node-define-a-property>`.
 The following code shows how to define an object model for a ``Task`` object. In this example:
   
 - The ``primaryKey`` is the ``_id`` of type ``int``. Another common type used for 
-  primary keys is :js-sdk:`ObjectId <Realm.Object.html#objectId>`.
+  primary keys is :manual:`ObjectId </reference/method/ObjectId/>`.
 - The ``name`` field is required.
 - The ``status`` and ``owner_id`` fields are optional, denoted by the question 
   mark immediately after the data type.

--- a/source/sdk/node/quick-start.txt
+++ b/source/sdk/node/quick-start.txt
@@ -43,7 +43,7 @@ Object Properties <node-define-a-property>`.
 The following code shows how to define an object model for a ``Task`` object. In this example:
   
 - The ``primaryKey`` is the ``_id`` of type ``int``. Another common type used for 
-  primary keys is :manual:`ObjectId </reference/method/ObjectId/>`.
+  primary keys is :ref:`ObjectId <node-data-types-field-types>`.
 - The ``name`` field is required.
 - The ``status`` and ``owner_id`` fields are optional, denoted by the question 
   mark immediately after the data type.


### PR DESCRIPTION
## Pull Request Info

Bug bash: Link should point to [BSON package](https://www.mongodb.com/docs/manual/reference/method/ObjectId/)

### Jira

- https://jira.mongodb.org/browse/DOCSP-28146

### Staged Changes

- [Quick Start - Node.js SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-28146-js-objectid/sdk/node/quick-start/#define-your-object-model)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
