### PR TITLE
(DOCSP-29619): Map a Class to a Different Persisted Name

### DIFF
--- a/examples/node/v12/__tests__/define-a-realm-object-schema.test.js
+++ b/examples/node/v12/__tests__/define-a-realm-object-schema.test.js
@@ -1,0 +1,71 @@
+import Realm from "realm";
+
+describe("Define a Realm Object Schema", () => {
+  test("should persist realm objects under the schema name, not class name", async () => {
+    const app = new Realm.App({
+      id: "js-flexible-oseso",
+    });
+
+    const anonymousUser = await app.logIn(Realm.Credentials.anonymous());
+
+    // :snippet-start: remap-class-name
+    class Task extends Realm.Object {
+      static schema = {
+        name: "Todo_Item",
+        properties: {
+          _id: "int",
+          name: "string",
+          owner_id: "string?",
+        },
+        primaryKey: "_id",
+      };
+    }
+
+    const config = {
+      schema: [Task],
+      sync: {
+        user: anonymousUser,
+        flexible: true,
+        initialSubscriptions: {
+          update: (subs, realm) => {
+            subs.add(
+              realm
+                .objects(`Todo_Item`)
+                .filtered(`owner_id == "${anonymousUser.id}"`)
+            );
+          },
+        },
+      },
+    };
+
+    const realm = await Realm.open(config);
+    expect(realm.isClosed).toBe(false); // :remove:
+
+    realm.write(() => {
+      realm.create(`Todo_Item`, {
+        _id: 12342245,
+        owner_id: anonymousUser.id,
+        name: "Test the Todo_Item object name",
+      });
+    });
+
+    const assignedTasks = realm.objects(`Todo_Item`);
+    // :snippet-end:
+
+    expect(assignedTasks.length).toBe(1);
+    await realm.syncSession?.uploadAllLocalChanges();
+
+    const mongodb = anonymousUser.mongoClient("mongodb-atlas");
+    const collection = mongodb.db("JSFlexibleSyncDB").collection("Todo_Item");
+    const retrievedTodoItem = await collection.findOne({
+      name: "Test the Todo_Item object name",
+    });
+    expect(retrievedTodoItem?.owner_id).toBe(anonymousUser.id);
+    const result = await collection.deleteOne({
+      owner_id: anonymousUser.id,
+    });
+    expect(result.deletedCount).toBe(1);
+  }, 30000);
+
+  expect.hasAssertions();
+});

--- a/examples/node/v12/__tests__/define-a-realm-object-schema.test.js
+++ b/examples/node/v12/__tests__/define-a-realm-object-schema.test.js
@@ -11,6 +11,8 @@ describe("Define a Realm Object Schema", () => {
     // :snippet-start: remap-class-name
     class Task extends Realm.Object {
       static schema = {
+        // Set the schema's `name` property to the name you want to store.
+        // Here, we store items as `Todo_Item` instead of the class's `Task` name.
         name: "Todo_Item",
         properties: {
           _id: "int",
@@ -22,6 +24,8 @@ describe("Define a Realm Object Schema", () => {
     }
 
     const config = {
+      // Use the class name in the Configuration's `schema` property when
+      // opening the realm.
       schema: [Task],
       sync: {
         user: anonymousUser,
@@ -30,6 +34,7 @@ describe("Define a Realm Object Schema", () => {
           update: (subs, realm) => {
             subs.add(
               realm
+                // Use the mapped name in Flexible Sync subscriptions.
                 .objects(`Todo_Item`)
                 .filtered(`owner_id == "${anonymousUser.id}"`)
             );
@@ -42,6 +47,7 @@ describe("Define a Realm Object Schema", () => {
     expect(realm.isClosed).toBe(false); // :remove:
 
     realm.write(() => {
+      // Use the mapped name when performing CRUD operations.
       realm.create(`Todo_Item`, {
         _id: 12342245,
         owner_id: anonymousUser.id,
@@ -49,6 +55,7 @@ describe("Define a Realm Object Schema", () => {
       });
     });
 
+    // Use the mapped name when performing CRUD operations.
     const assignedTasks = realm.objects(`Todo_Item`);
     // :snippet-end:
 

--- a/examples/node/v12/__tests__/define-a-realm-object-schema.test.ts
+++ b/examples/node/v12/__tests__/define-a-realm-object-schema.test.ts
@@ -15,6 +15,8 @@ describe("Define a Realm Object Schema", () => {
       owner_id?: string;
 
       static schema = {
+        // Set the schema's `name` property to the name you want to store.
+        // Here, we store items as `Todo_Item` instead of the class's `Task` name.
         name: "Todo_Item",
         properties: {
           _id: "int",
@@ -26,6 +28,8 @@ describe("Define a Realm Object Schema", () => {
     }
 
     const config: Realm.Configuration = {
+      // Use the class name in the Configuration's `schema` property when
+      // opening the realm.
       schema: [Task],
       sync: {
         user: anonymousUser,
@@ -34,6 +38,7 @@ describe("Define a Realm Object Schema", () => {
           update: (subs, realm) => {
             subs.add(
               realm
+                // Use the mapped name in Flexible Sync subscriptions.
                 .objects(`Todo_Item`)
                 .filtered(`owner_id == "${anonymousUser.id}"`)
             );
@@ -46,6 +51,7 @@ describe("Define a Realm Object Schema", () => {
     expect(realm.isClosed).toBe(false); // :remove:
 
     realm.write(() => {
+      // Use the mapped name when performing CRUD operations.
       realm.create(`Todo_Item`, {
         _id: 12342245,
         owner_id: anonymousUser.id,
@@ -53,6 +59,7 @@ describe("Define a Realm Object Schema", () => {
       });
     });
 
+    // Use the mapped name when performing CRUD operations.
     const assignedTasks = realm.objects(`Todo_Item`);
     // :snippet-end:
 

--- a/examples/node/v12/__tests__/define-a-realm-object-schema.test.ts
+++ b/examples/node/v12/__tests__/define-a-realm-object-schema.test.ts
@@ -1,0 +1,80 @@
+import Realm from "realm";
+
+describe("Define a Realm Object Schema", () => {
+  test("should persist realm objects under the schema name, not class name", async () => {
+    const app = new Realm.App({
+      id: "js-flexible-oseso",
+    });
+
+    const anonymousUser = await app.logIn(Realm.Credentials.anonymous());
+
+    // :snippet-start: remap-class-name
+    class Task extends Realm.Object<Task> {
+      _id!: number;
+      name!: string;
+      owner_id?: string;
+
+      static schema = {
+        name: "Todo_Item",
+        properties: {
+          _id: "int",
+          name: "string",
+          owner_id: "string?",
+        },
+        primaryKey: "_id",
+      };
+    }
+
+    const config: Realm.Configuration = {
+      schema: [Task],
+      sync: {
+        user: anonymousUser,
+        flexible: true,
+        initialSubscriptions: {
+          update: (subs, realm) => {
+            subs.add(
+              realm
+                .objects(`Todo_Item`)
+                .filtered(`owner_id == "${anonymousUser.id}"`)
+            );
+          },
+        },
+      },
+    };
+
+    const realm = await Realm.open(config);
+    expect(realm.isClosed).toBe(false); // :remove:
+
+    realm.write(() => {
+      realm.create(`Todo_Item`, {
+        _id: 12342245,
+        owner_id: anonymousUser.id,
+        name: "Test the Todo_Item object name",
+      });
+    });
+
+    const assignedTasks = realm.objects(`Todo_Item`);
+    // :snippet-end:
+
+    expect(assignedTasks.length).toBe(1);
+    await realm.syncSession?.uploadAllLocalChanges();
+
+    type Document = Realm.Services.MongoDB.Document;
+    type MongoDBCollection<T extends Document> =
+      Realm.Services.MongoDB.MongoDBCollection<T>;
+    const mongodb = anonymousUser.mongoClient("mongodb-atlas");
+    const collection = mongodb
+      .db("JSFlexibleSyncDB")
+      .collection<Task>("Todo_Item");
+    const retrievedTodoItem = await collection.findOne({
+      name: "Test the Todo_Item object name",
+    });
+    expect(retrievedTodoItem?.owner_id).toBe(anonymousUser.id);
+    const result = await collection.deleteOne({
+      owner_id: anonymousUser.id,
+    });
+    expect(result.deletedCount).toBe(1);
+  }, 30000);
+
+  expect.hasAssertions();
+});

--- a/examples/node/v12/package-lock.json
+++ b/examples/node/v12/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "fs-extra": "^11.1.1",
-        "realm": "^12.0.0-rc.1"
+        "realm": "^12.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.21.8",
@@ -3608,7 +3608,6 @@
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
       "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
-      "peer": true,
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -7469,19 +7468,19 @@
       }
     },
     "node_modules/realm": {
-      "version": "12.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-12.0.0-rc.1.tgz",
-      "integrity": "sha512-eP0OqspgxYgU8EFzuFgFojuYaN5SHWwfEykFhnof4Zoh4HKXuyA29RgNvoQnaBQkVcZeST+4eG1w0nzbh/UQ/Q==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-12.0.0.tgz",
+      "integrity": "sha512-QaFnn92eCwpWCvbnxE26N0mAHhuXRwtM23JF0tA5fKtTA+djj1+LhuT/iGJryCrGVbN8m++EOBsvWgGG8hpsuw==",
       "hasInstallScript": true,
       "dependencies": {
+        "bson": "^4.7.2",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.9",
         "node-machine-id": "^1.1.12",
         "prebuild-install": "^7.1.1"
       },
       "peerDependencies": {
-        "bson": "^4",
-        "react-native": "^0.71.0"
+        "react-native": ">=0.71.0"
       },
       "peerDependenciesMeta": {
         "react-native": {
@@ -11053,7 +11052,6 @@
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
       "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
-      "peer": true,
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -13867,10 +13865,11 @@
       }
     },
     "realm": {
-      "version": "12.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-12.0.0-rc.1.tgz",
-      "integrity": "sha512-eP0OqspgxYgU8EFzuFgFojuYaN5SHWwfEykFhnof4Zoh4HKXuyA29RgNvoQnaBQkVcZeST+4eG1w0nzbh/UQ/Q==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-12.0.0.tgz",
+      "integrity": "sha512-QaFnn92eCwpWCvbnxE26N0mAHhuXRwtM23JF0tA5fKtTA+djj1+LhuT/iGJryCrGVbN8m++EOBsvWgGG8hpsuw==",
       "requires": {
+        "bson": "^4.7.2",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.9",
         "node-machine-id": "^1.1.12",

--- a/examples/node/v12/package.json
+++ b/examples/node/v12/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "fs-extra": "^11.1.1",
-    "realm": "^12.0.0-rc.1"
+    "realm": "^12.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",

--- a/source/examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.js
+++ b/source/examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.js
@@ -1,5 +1,7 @@
 class Task extends Realm.Object {
   static schema = {
+    // Set the schema's `name` property to the name you want to store.
+    // Here, we store items as `Todo_Item` instead of the class's `Task` name.
     name: "Todo_Item",
     properties: {
       _id: "int",
@@ -11,6 +13,8 @@ class Task extends Realm.Object {
 }
 
 const config = {
+  // Use the class name in the Configuration's `schema` property when
+  // opening the realm.
   schema: [Task],
   sync: {
     user: anonymousUser,
@@ -19,6 +23,7 @@ const config = {
       update: (subs, realm) => {
         subs.add(
           realm
+            // Use the mapped name in Flexible Sync subscriptions.
             .objects(`Todo_Item`)
             .filtered(`owner_id == "${anonymousUser.id}"`)
         );
@@ -30,6 +35,7 @@ const config = {
 const realm = await Realm.open(config);
 
 realm.write(() => {
+  // Use the mapped name when performing CRUD operations.
   realm.create(`Todo_Item`, {
     _id: 12342245,
     owner_id: anonymousUser.id,
@@ -37,4 +43,5 @@ realm.write(() => {
   });
 });
 
+// Use the mapped name when performing CRUD operations.
 const assignedTasks = realm.objects(`Todo_Item`);

--- a/source/examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.js
+++ b/source/examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.js
@@ -1,0 +1,40 @@
+class Task extends Realm.Object {
+  static schema = {
+    name: "Todo_Item",
+    properties: {
+      _id: "int",
+      name: "string",
+      owner_id: "string?",
+    },
+    primaryKey: "_id",
+  };
+}
+
+const config = {
+  schema: [Task],
+  sync: {
+    user: anonymousUser,
+    flexible: true,
+    initialSubscriptions: {
+      update: (subs, realm) => {
+        subs.add(
+          realm
+            .objects(`Todo_Item`)
+            .filtered(`owner_id == "${anonymousUser.id}"`)
+        );
+      },
+    },
+  },
+};
+
+const realm = await Realm.open(config);
+
+realm.write(() => {
+  realm.create(`Todo_Item`, {
+    _id: 12342245,
+    owner_id: anonymousUser.id,
+    name: "Test the Todo_Item object name",
+  });
+});
+
+const assignedTasks = realm.objects(`Todo_Item`);

--- a/source/examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.ts
+++ b/source/examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.ts
@@ -1,0 +1,44 @@
+class Task extends Realm.Object<Task> {
+  _id!: number;
+  name!: string;
+  owner_id?: string;
+
+  static schema = {
+    name: "Todo_Item",
+    properties: {
+      _id: "int",
+      name: "string",
+      owner_id: "string?",
+    },
+    primaryKey: "_id",
+  };
+}
+
+const config: Realm.Configuration = {
+  schema: [Task],
+  sync: {
+    user: anonymousUser,
+    flexible: true,
+    initialSubscriptions: {
+      update: (subs, realm) => {
+        subs.add(
+          realm
+            .objects(`Todo_Item`)
+            .filtered(`owner_id == "${anonymousUser.id}"`)
+        );
+      },
+    },
+  },
+};
+
+const realm = await Realm.open(config);
+
+realm.write(() => {
+  realm.create(`Todo_Item`, {
+    _id: 12342245,
+    owner_id: anonymousUser.id,
+    name: "Test the Todo_Item object name",
+  });
+});
+
+const assignedTasks = realm.objects(`Todo_Item`);

--- a/source/examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.ts
+++ b/source/examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.ts
@@ -4,6 +4,8 @@ class Task extends Realm.Object<Task> {
   owner_id?: string;
 
   static schema = {
+    // Set the schema's `name` property to the name you want to store.
+    // Here, we store items as `Todo_Item` instead of the class's `Task` name.
     name: "Todo_Item",
     properties: {
       _id: "int",
@@ -15,6 +17,8 @@ class Task extends Realm.Object<Task> {
 }
 
 const config: Realm.Configuration = {
+  // Use the class name in the Configuration's `schema` property when
+  // opening the realm.
   schema: [Task],
   sync: {
     user: anonymousUser,
@@ -23,6 +27,7 @@ const config: Realm.Configuration = {
       update: (subs, realm) => {
         subs.add(
           realm
+            // Use the mapped name in Flexible Sync subscriptions.
             .objects(`Todo_Item`)
             .filtered(`owner_id == "${anonymousUser.id}"`)
         );
@@ -34,6 +39,7 @@ const config: Realm.Configuration = {
 const realm = await Realm.open(config);
 
 realm.write(() => {
+  // Use the mapped name when performing CRUD operations.
   realm.create(`Todo_Item`, {
     _id: 12342245,
     owner_id: anonymousUser.id,
@@ -41,4 +47,5 @@ realm.write(() => {
   });
 });
 
+// Use the mapped name when performing CRUD operations.
 const assignedTasks = realm.objects(`Todo_Item`);

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -196,14 +196,19 @@ Map a Model or Class to a Different Name
 
 You can use the `MapTo <https://pub.dev/documentation/realm_common/latest/realm_common/MapTo-class.html>`__
 annotation to map a Realm object model or property to a different stored 
-name in Realm. This can be useful in the following scenarios:
+name in Realm. This can be useful in the following scenarios. For example:
 
-- Working with one realm from different Realm SDKs
-- Migrating Realm object models
-- Adhering to certain code style conventions
+- To make it easier to work across platforms where naming conventions 
+  differ. For example, if your Device Sync schema property names use snake 
+  case, while your project uses camel case.
+- To change a class or field name without forcing a migration.
+- To support multiple model classes with the same name in different packages.
+- To use a class name that is longer than the 57-character limit enforced 
+  by Realm.
 
-If you're using Atlas Device Sync, the name that you map is used as the
-persisted :ref:`App Services Schema <schemas>` name.
+If you're using Atlas Device Sync, the name that you specify in the  
+``MapTo`` annotation is used as the persisted :ref:`App Services Schema 
+<schemas>` name.
 
 .. tabs::
 

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -191,23 +191,35 @@ refer to :ref:`Relationships <flutter-client-relationships>`.
 
 .. _flutter-map-model-name:
 
-Map Realm Model to Different Name
----------------------------------
+Map a Model or Class to a Different Name
+----------------------------------------
 
 You can use the `MapTo <https://pub.dev/documentation/realm_common/latest/realm_common/MapTo-class.html>`__
-annotation to map a Realm object model to a different model name in Realm.
-This can be useful in the following scenarios:
+annotation to map a Realm object model or property to a different stored 
+name in Realm. This can be useful in the following scenarios:
 
 - Working with one realm from different Realm SDKs
 - Migrating Realm object models
 - Adhering to certain code style conventions
 
-If you're using Atlas Device Sync, the name that you map to corresponds
-with the :ref:`App Services Schema <schemas>` name.
+If you're using Atlas Device Sync, the name that you map is used as the
+persisted :ref:`App Services Schema <schemas>` name.
 
-.. literalinclude:: /examples/generated/flutter/define_realm_model_test.snippet.map-to.dart
-   :language: dart
-   :emphasize-lines: 2
+.. tabs::
+
+   .. tab:: Map a Class Name
+      :tabid: remap-class
+
+      .. literalinclude:: /examples/generated/flutter/define_realm_model_test.snippet.map-to.dart
+         :language: dart
+         :emphasize-lines: 2
+
+   .. tab:: Map a Property Name
+      :tabid: remap-property
+
+      .. literalinclude:: /examples/generated/flutter/schemas.snippet.property-annotations.dart
+         :language: dart
+         :emphasize-lines: 15-16
 
 .. _flutter-generate-realm-object:
 

--- a/source/sdk/flutter/realm-database/model-data/property-annotations.txt
+++ b/source/sdk/flutter/realm-database/model-data/property-annotations.txt
@@ -61,16 +61,28 @@ Important aspects of primary keys:
 
 .. _flutter-map-property:
 
-Map a Property to a Different Name
-----------------------------------
+Map a Property or Class to a Different Name
+-------------------------------------------
 
 The `MapTo <https://pub.dev/documentation/realm_common/latest/realm_common/MapTo-class.html>`__ annotation
-indicates that a property should be persisted under a different name.
+indicates that a model or property should be persisted under a different name.
 It's useful when opening a Realm across different bindings where code style conventions can differ.
 
-.. literalinclude:: /examples/generated/flutter/schemas.snippet.property-annotations.dart
-   :language: dart
-   :emphasize-lines: 15-16
+.. tabs::
+
+   .. tab:: Map a Class Name
+      :tabid: remap-class
+
+      .. literalinclude:: /examples/generated/flutter/define_realm_model_test.snippet.map-to.dart
+         :language: dart
+         :emphasize-lines: 2
+
+   .. tab:: Map a Property Name
+      :tabid: remap-property
+
+      .. literalinclude:: /examples/generated/flutter/schemas.snippet.property-annotations.dart
+         :language: dart
+         :emphasize-lines: 15-16
 
 .. _flutter-ignore-property:
 

--- a/source/sdk/flutter/realm-database/model-data/property-annotations.txt
+++ b/source/sdk/flutter/realm-database/model-data/property-annotations.txt
@@ -66,7 +66,13 @@ Map a Property or Class to a Different Name
 
 The `MapTo <https://pub.dev/documentation/realm_common/latest/realm_common/MapTo-class.html>`__ annotation
 indicates that a model or property should be persisted under a different name.
-It's useful when opening a Realm across different bindings where code style conventions can differ.
+It's useful when opening a Realm across different bindings where code style 
+conventions can differ. For example:
+
+- To make it easier to work across platforms where naming conventions 
+  differ. For example, if your Device Sync schema property names use snake 
+  case, while your project uses camel case.
+- To change a class or field name without forcing a migration.
 
 .. tabs::
 

--- a/source/sdk/node/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/node/model-data/define-a-realm-object-model.txt
@@ -173,6 +173,7 @@ the ``miles`` property:
    :emphasize-lines: 8
 
 .. _node-remap-a-property:
+.. _node-remap-a-class:
 
 Map a Property or Class to a Different Name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -199,7 +200,7 @@ any schema errors reported also use the persisted name.
 
 .. tabs::
 
-   .. tab:: Remap a Class
+   .. tab:: Map a Class Name
       :tabid: remap-class
 
       To use a different class name in your code than is stored in a realm,
@@ -229,7 +230,7 @@ any schema errors reported also use the persisted name.
                :language: javascript
                :emphasize-lines: 3, 14, 22, 33, 40
 
-   .. tab:: Remap a Property
+   .. tab:: Map a Property Name
       :tabid: remap-property
 
       To use a different property name in your code than is stored in

--- a/source/sdk/node/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/node/model-data/define-a-realm-object-model.txt
@@ -174,20 +174,75 @@ the ``miles`` property:
 
 .. _node-remap-a-property:
 
-Remap a Property
-~~~~~~~~~~~~~~~~
+Map a Property or Class to a Different Name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To use a different property name in your code than is stored in
-a realm, set ``mapTo`` to the name of the property as it appears in
-your code.
-   
-In the following ``Car`` object schema, Realm stores the car's 
-model name with the snake case ``model_name`` property. The schema maps the property 
-to ``modelName`` for objects used in client code.
+By default, Realm uses the name defined in the model class to represent 
+classes and fields internally. In some cases, you might want to change 
+this behavior:
 
-.. literalinclude:: /examples/generated/node/define-a-realm-object-schema.snippet.define-advanced-properties.js
-   :language: javascript
-   :emphasize-lines: 7
+- To make it easier to work across platforms where naming conventions 
+  differ. For example, if your Device Sync schema property names use snake 
+  case, while your project uses camel case.
+- To change a class or field name without forcing a migration.
+- To support multiple model classes with the same simple name in 
+  different packages.
+- To use a class name that is longer than the 57-character limit enforced 
+  by Realm.
+
+You can map a class or property name in your code to a different name to
+store in a realm. If you write to a synced realm, the Sync schema sees the 
+values stored using the persisted class or property name.
+
+Note that migrations must use the persisted class or property name, and 
+any schema errors reported also use the persisted name.
+
+.. tabs::
+
+   .. tab:: Remap a Class
+      :tabid: remap-class
+
+      To use a different class name in your code than is stored in a realm,
+      set the ``name`` property of your Realm object's schema to the name
+      that you want to use to store the object.
+
+      You must use the class name in the configuration when you open the realm,
+      but use the persisted name when you perform CRUD operations with
+      the item, or in a Flexible Sync Subscription.
+
+      In the following example, Realm stores objects created with the 
+      ``Task`` class as ``Todo_Item``.
+
+      .. tabs-realm-languages::
+
+         .. tab::
+            :tabid: typescript
+      
+            .. literalinclude::  /examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.ts
+               :language: typescript
+               :emphasize-lines: 7, 18, 26, 37, 44
+         
+         .. tab::
+            :tabid: javascript
+
+            .. literalinclude::  /examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.js
+               :language: javascript
+               :emphasize-lines: 3, 14, 22, 33, 40
+
+   .. tab:: Remap a Property
+      :tabid: remap-property
+
+      To use a different property name in your code than is stored in
+      a realm, set ``mapTo`` to the name of the property as it appears in
+      your code.
+         
+      In the following ``Car`` object schema, Realm stores the car's 
+      model name with the snake case ``model_name`` property. The schema maps the property 
+      to ``modelName`` for objects used in client code.
+
+      .. literalinclude:: /examples/generated/node/define-a-realm-object-schema.snippet.define-advanced-properties.js
+         :language: javascript
+         :emphasize-lines: 7
 
 .. _node-define-relationship-properties:
 

--- a/source/sdk/node/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/node/model-data/define-a-realm-object-model.txt
@@ -230,7 +230,7 @@ any schema errors reported also use the persisted name.
 
             .. literalinclude::  /examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.js
                :language: javascript
-               :emphasize-lines: 5, 16, 26, 38, 46
+               :emphasize-lines: 5, 18, 27, 39, 47
 
    .. tab:: Map a Property Name
       :tabid: remap-property

--- a/source/sdk/node/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/node/model-data/define-a-realm-object-model.txt
@@ -180,14 +180,13 @@ Map a Property or Class to a Different Name
 
 By default, Realm uses the name defined in the model class to represent 
 classes and fields internally. In some cases, you might want to change 
-this behavior:
+this behavior. For example:
 
 - To make it easier to work across platforms where naming conventions 
   differ. For example, if your Device Sync schema property names use snake 
   case, while your project uses camel case.
 - To change a class or field name without forcing a migration.
-- To support multiple model classes with the same simple name in 
-  different packages.
+- To support multiple model classes with the same name in different packages.
 - To use a class name that is longer than the 57-character limit enforced 
   by Realm.
 
@@ -203,13 +202,16 @@ any schema errors reported also use the persisted name.
    .. tab:: Map a Class Name
       :tabid: remap-class
 
-      To use a different class name in your code than is stored in a realm,
-      set the ``name`` property of your Realm object's schema to the name
-      that you want to use to store the object.
+      To use a different class name in your code than is stored in a realm:
 
-      You must use the class name in the configuration when you open the realm,
-      but use the persisted name when you perform CRUD operations with
-      the item, or in a Flexible Sync Subscription.
+      1. Set the ``name`` property of your Realm object's **schema** to the name
+         that you want to use to store the object.
+
+      #. Use the **class** name in the Realm configuration's ``schema`` property
+         when you :ref:`open the realm <node-open-a-local-realm>`.
+
+      #. Use the mapped name for performing CRUD operations or when defining 
+         Flexible Sync Subscriptions.
 
       In the following example, Realm stores objects created with the 
       ``Task`` class as ``Todo_Item``.
@@ -221,14 +223,14 @@ any schema errors reported also use the persisted name.
       
             .. literalinclude::  /examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.ts
                :language: typescript
-               :emphasize-lines: 7, 18, 26, 37, 44
+               :emphasize-lines: 9, 22, 31, 43, 51
          
          .. tab::
             :tabid: javascript
 
             .. literalinclude::  /examples/generated/node/v12/define-a-realm-object-schema.test.snippet.remap-class-name.js
                :language: javascript
-               :emphasize-lines: 3, 14, 22, 33, 40
+               :emphasize-lines: 5, 16, 26, 38, 46
 
    .. tab:: Map a Property Name
       :tabid: remap-property


### PR DESCRIPTION
## Pull Request Info

The Jira ticket also requests adding this in Java and React Native, which I'm not doing in this ticket. We're generally not updating the Java docs except for bugs, so that's a won't do. With the v12 release it probably makes sense to do the React Native stuff in v12, so I'll split that to a separate ticket for later. This functionality is not available in Swift, and already has examples in Flutter - I've just cross-posted them for this ticket.

### Jira

- https://jira.mongodb.org/browse/DOCSP-29619

### Staged Changes

- [Node.js - Define an Object Model](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29619/sdk/node/model-data/define-a-realm-object-model/#map-a-property-or-class-to-a-different-name)
- [Flutter - Define an Object Model](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29619/sdk/flutter/realm-database/model-data/define-realm-object-schema/#map-a-model-or-class-to-a-different-name)
- [Flutter - Property Annotations](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29619/sdk/flutter/realm-database/model-data/property-annotations/#map-a-property-or-class-to-a-different-name)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
