### PR TITLE
DOCSP-32246: Remove instances of `kotlin-sdk` role

### DIFF
--- a/source/sdk/kotlin/realm-database/crud/read.txt
+++ b/source/sdk/kotlin/realm-database/crud/read.txt
@@ -124,8 +124,8 @@ Full-Text Search (FTS) indexes support:
   (``-``) like ``full-text`` are split into two tokens. 
 
 For more information on features of the FTS index, see the API reference for 
-the :kotlin-sdk:`@FullText <library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin.types.annotations/
--full-text/index.html>` index annotation. 
+the `@FullText <{+kotlin-local-prefix+}io.realm.kotlin.types.annotations/
+-full-text/index.html>`__ index annotation. 
 
 .. _kotlin-sort-queries:
 

--- a/source/sdk/kotlin/realm-database/realm-files/compact-realm.txt
+++ b/source/sdk/kotlin/realm-database/realm-files/compact-realm.txt
@@ -37,14 +37,12 @@ Realm Configuration File
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can configure Realm to compact the realm file each time it is opened
-by setting a callback for the :kotlin-sdk:`compactOnLaunch 
-<library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin/-configuration/
--shared-builder/compact-on-launch.html?query=fun%20compactOnLaunch(callback:
-%20CompactOnLaunchCallback%20=%20Realm.DEFAULT_COMPACT_ON_LAUNCH_CALLBACK):%20S>` function
+by setting a callback for the `compactOnLaunch 
+<{+kotlin-local-prefix+}io.realm.kotlin/-configuration/-shared-builder/compact-on-launch.html>`__ function
 for the configuration. When you call ``compactOnLaunch`` for the 
-configuration, the :kotlin-sdk:`DEFAULT_COMPACT_ON_LAUNCH_CALLBACK 
-<library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin/-realm/-companion/
--d-e-f-a-u-l-t_-c-o-m-p-a-c-t_-o-n_-l-a-u-n-c-h_-c-a-l-l-b-a-c-k.html>` 
+configuration, the `DEFAULT_COMPACT_ON_LAUNCH_CALLBACK 
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/
+-d-e-f-a-u-l-t_-c-o-m-p-a-c-t_-o-n_-l-a-u-n-c-h_-c-a-l-l-b-a-c-k.html>`__ 
 will trigger if the file is above 50 MB and 50% or more of the space in 
 the realm file is unused. You can specify custom compaction settings 
 when calling ``compactOnLaunch`` depending on your applications needs.
@@ -56,9 +54,8 @@ The following code example shows how to do this:
 Realm.compactRealm Method
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Alternatively, you can compact a realm file without having to open it by calling 
-the :kotlin-sdk:`compactRealm <library-base/-realm%20-kotlin%20-s-d-k/
-io.realm.kotlin/-realm/-companion/compact-realm.html?query=fun%20compactRealm
-(configuration:%20Configuration):%20Boolean>` method:
+the `compactRealm <{+kotlin-local-prefix+}
+io.realm.kotlin/-realm/-companion/compact-realm.html>`__ method:
 
 .. literalinclude:: /examples/generated/kotlin/Compacting.snippet.compactRealm.kt
    :language: kotlin
@@ -68,8 +65,7 @@ and false if not.
 
 .. important::
 
-   :kotlin-sdk:`compactRealm <library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin/-realm/
-   -companion/compact-realm.html?query=fun%20compactRealm(configuration:%20Configuration):%20Boolean>` 
+   `compactRealm <{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/compact-realm.html>`__ 
    is not available on Windows (JVM), and will throw a 
    `NotImplementedError <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-not-implemented-error/>`_ there.
 
@@ -78,9 +74,8 @@ Make a Compacted Copy
 
 You can save a compacted (and optionally :ref:`encrypted
 <kotlin-encrypt-a-realm>`) copy of a realm to another file location
-with the :kotlin-sdk:`Realm.writeCopyTo
-<library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin/-realm/write-copy-to.html
-?query=abstract%20fun%20writeCopyTo(targetConfiguration:%20Configuration)>`
+with the `Realm.writeCopyTo
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm/write-copy-to.html>`__
 method. The destination file cannot already exist.
 
 .. important::
@@ -95,13 +90,3 @@ Tips for Manually Compacting a Realm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/compaction-tips.rst
-
-
-
-
-
-
-
-
-
-

--- a/source/sdk/kotlin/realm-database/schemas/property-annotations.txt
+++ b/source/sdk/kotlin/realm-database/schemas/property-annotations.txt
@@ -220,9 +220,9 @@ for multiple words and phrases and excluding others.
 For more information on querying full-text indexes, see 
 :ref:`Filter with Full Text Search <kotlin-filter-fts>`.
 
-To create a FTS index on a property, use the :kotlin-sdk:`@FullText
-<library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin.types.annotations
-/-full-text/index.html>` annotation. This enables full-text queries
+To create a FTS index on a property, use the `@FullText
+<{+kotlin-local-prefix+}io.realm.kotlin.types.annotations
+/-full-text/index.html>`__ annotation. This enables full-text queries
 on the property. In the following example, we mark the ``genre`` 
 property with the FTS annotation:
 
@@ -230,16 +230,16 @@ property with the FTS annotation:
   :language: kotlin
   :emphasize-lines: 7-8
 
-You cannot combine :kotlin-sdk:`@Index 
-<library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin.types.annotations
-/-index/index.html>` and :kotlin-sdk:`@FullText
-<library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin.types.annotations
-/-full-text/index.html>` on the same property.
+You cannot combine `@Index 
+<{+kotlin-local-prefix+}io.realm.kotlin.types.annotations
+/-index/index.html>`__ and `@FullText
+<{+kotlin-local-prefix+}io.realm.kotlin.types.annotations
+/-full-text/index.html>`__ on the same property.
 
 .. note:: Character Limitations for Full-Text Search Indexes
 
   For Full-Text Search (FTS) indexes, only ASCII and Latin-1 alphanumerical 
-  chars are included in the index (most western languages). See the :kotlin-sdk:`@FullText 
-  <library-base/-realm%20-kotlin%20-s-d-k/io.realm.kotlin.types.annotations/
-  -full-text/index.html>` for more information on current FTS index constraints.
+  chars are included in the index (most western languages). See the `@FullText 
+  <{+kotlin-local-prefix+}io.realm.kotlin.types.annotations/
+  -full-text/index.html>`__ for more information on current FTS index constraints.
 


### PR DESCRIPTION
## Pull Request Info

https://github.com/mongodb/snooty-parser/pull/506 will update `kotlin-sdk` role to point to the base library. This replaces any current instances of the `kotlin-sdk` role with source constants, so links don't break after that PR merges. 

[DOCSP-32519](https://jira.mongodb.org/browse/DOCSP-32519) will replace all source constants with the newly defined kotlin roles after the merge 🎉 

### Jira

- https://jira.mongodb.org/browse/DOCSP-32246

### Staged Changes

- https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-32246-kotlin-sdk-role/

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
