### PR TITLE
(DOCSP-32426): Swift: Query MongoDB Test Fixes and Remove PBS from Examples

### DIFF
--- a/examples/ios/Examples/MongoDBRemoteAccess.swift
+++ b/examples/ios/Examples/MongoDBRemoteAccess.swift
@@ -13,98 +13,87 @@ class CoffeeDrink: Object {
     @Persisted var name: String
     @Persisted var beanRegion: String?
     @Persisted var containsDairy: Bool
-    @Persisted var _partition: String
+    @Persisted var storeNumber: Int
 }
 // :snippet-end:
 
 class MongoDBRemoteAccessTestCase: XCTestCase {
-
+    let appClient = App(id: "swift-flexible-vkljj")
+    
+    // MARK: Insert One
     func testInsertOne() {
         let expectation = XCTestExpectation(description: "A document is inserted")
+        let expectation2 = XCTestExpectation(description: "The document is deleted")
 
-        app.login(credentials: Credentials.anonymous) { (result) in
+        // :snippet-start: insert-sample-data
+        appClient.login(credentials: Credentials.anonymous) { (result) in // :emphasize:
             // Remember to dispatch back to the main thread in completion handlers
             // if you want to do anything on the UI.
+            // :emphasize-start:
             DispatchQueue.main.async {
                 switch result {
                 case .failure(let error):
                     print("Login failed: \(error)")
                 case .success(let user):
                     print("Login as \(user) succeeded!")
-                    // Continue below
-                }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
+                    // :emphasize-end:
+                    // mongodb-atlas is the cluster service name
+                    let mongoClient = user.mongoClient("mongodb-atlas") // :emphasize:
 
-                // Select the database
-                let database = client.database(named: "ios")
+                    // Select the database
+                    let database = mongoClient.database(named: "ios") // :emphasize:
 
-                // Select the collection
-                let collection = database.collection(withName: "CoffeeDrinks")
+                    // Select the collection
+                    let collection = database.collection(withName: "CoffeeDrinks") // :emphasize:
 
-                // :snippet-start: insert-one
-                // This document represents a CoffeeDrink object
-                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 43"]
+                    // :snippet-start: insert-one
+                    // This document represents a CoffeeDrink object
+                    let drink: Document = [ "name": "Colombian Blend", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 43]
 
-                // Insert the document into the collection
-                collection.insertOne(drink) { result in
-                    switch result {
-                    case .failure(let error):
-                        print("Call to MongoDB failed: \(error.localizedDescription)")
-                        return
-                    case .success(let objectId):
-                        // Success returns the objectId for the inserted document
-                        print("Successfully inserted a document with id: \(objectId)")
-                        // :remove-start:
-                        expectation.fulfill()
-                        // :remove-end:
+                    // Insert the document into the collection
+                    collection.insertOne(drink) { result in
+                        switch result {
+                        case .failure(let error):
+                            print("Call to MongoDB failed: \(error.localizedDescription)")
+                            return
+                        case .success(let objectId):
+                            // Success returns the objectId for the inserted document
+                            print("Successfully inserted a document with id: \(objectId)")
+                            // :remove-start:
+                            expectation.fulfill()
+                            sleep(1)
+                            deleteInsertOneTestDocument()
+                            // :remove-end:
+                        }
+                    }
+                    // :snippet-end:
+                    
+                    func deleteInsertOneTestDocument() {
+                        collection.deleteOneDocument(filter: drink) { deletedResult in
+                            switch deletedResult {
+                            case .failure(let error):
+                                print("Failed to delete a document: \(error.localizedDescription)")
+                                return
+                            case .success(let deletedResult):
+                                XCTAssertEqual(deletedResult, 1)
+                                expectation2.fulfill()
+                            }
+                        }
                     }
                 }
-                // :snippet-end:
             }
         }
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testAsyncAwaitInsert() async {
-        do {
-            // Use the async method to login
-            let user = try await app.login(credentials: Credentials.anonymous)
-            print("Login as \(user) succeeded!")
-        } catch {
-            print("Login failed: \(error.localizedDescription)")
-        }
-
-        // mongodb-atlas is the cluster service name
-        let client = app.currentUser!.mongoClient("mongodb-atlas")
-
-        // Select the database
-        let database = client.database(named: "ios")
-
-        // Select the collection
-        let collection = database.collection(withName: "CoffeeDrinks")
-
-        // :snippet-start: async-await-insert
-        // This document represents a CoffeeDrink object
-        let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 43"]
-
-        do {
-            // Use the async collection method to insert the document
-            let objectId = try await collection.insertOne(drink)
-            // :remove-start:
-            XCTAssertNotNil(objectId)
-            // :remove-end:
-            print("Successfully inserted a document with id: \(objectId)")
-        } catch {
-            print("Call to MongoDB failed: \(error.localizedDescription)")
-        }
         // :snippet-end:
+        wait(for: [expectation, expectation2], timeout: 20)
     }
 
+    // MARK: Insert Many
     func testInsertMany() {
         let expectation = XCTestExpectation(description: "Multiple documents are inserted")
+        let expectation2 = XCTestExpectation(description: "Coffee drinks named 'Bean of the Day' are deleted")
+        let expectation3 = XCTestExpectation(description: "A coffee drink named 'Maple Latte' is deleted")
 
-        app.login(credentials: Credentials.anonymous) { (result) in // :emphasize:
+        appClient.login(credentials: Credentials.anonymous) { (result) in // :emphasize:
             DispatchQueue.main.async {
                 switch result {
                 case .failure(let error):
@@ -114,16 +103,16 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                     // Continue below
                 }
 
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
 
                 let database = client.database(named: "ios") // :emphasize:
 
                 let collection = database.collection(withName: "CoffeeDrinks")
 
                 // :snippet-start: insert-many
-                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 42"]
-                let drink2: Document = [ "name": "Maple Latte", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": "true", "_partition": "Store 42"]
-                let drink3: Document = [ "name": "Bean of the Day", "beanRegion": "San Marcos, Guatemala", "containsDairy": "false", "_partition": "Store 47"]
+                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
+                let drink2: Document = [ "name": "Maple Latte", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": true, "storeNumber": 42]
+                let drink3: Document = [ "name": "Bean of the Day", "beanRegion": "San Marcos, Guatemala", "containsDairy": false, "storeNumber": 47]
 
                 // Insert the documents into the collection
                 collection.insertMany([drink, drink2, drink3]) { result in
@@ -136,167 +125,51 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                         // :remove-start:
                         XCTAssertEqual(objectIds.count, 3)
                         expectation.fulfill()
+                        sleep(1)
+                        deleteInsertManyTestDocuments()
                         // :remove-end:
                     }
                 }
                 // :snippet-end:
-            }
-        }
-        wait(for: [expectation], timeout: 10)
-    }
+                
+                func deleteInsertManyTestDocuments() {
+                    let filter1: Document = ["name": "Bean of the Day"]
+                    let filter2: Document = ["name": "Maple Latte"]
 
-    func testFindOneDocument() {
-        let expectation = XCTestExpectation(description: "A single document is returned")
-
-        app.login(credentials: Credentials.anonymous) { (result) in
-            // Remember to dispatch back to the main thread in completion handlers
-            // if you want to do anything on the UI.
-            DispatchQueue.main.async {
-                switch result {
-                case .failure(let error):
-                    print("Login failed: \(error)")
-                case .success(let user):
-                    print("Login as \(user) succeeded!")
-                }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
-
-                // Select the database
-                let database = client.database(named: "ios")
-
-                // Select the collection
-                let collection = database.collection(withName: "CoffeeDrinks")
-
-                // :snippet-start: find-one
-                let queryFilter: Document = ["name": "Maple Latte"]
-
-                collection.findOneDocument(filter: queryFilter) { result in
-
-                    switch result {
-                    case .failure(let error):
-                        print("Did not find matching documents: \(error.localizedDescription)")
-                        return
-                    case .success(let document):
-                        print("Found a matching document: \(document)")
-                        // :remove-start:
-                        XCTAssertNotNil(document)
-                        expectation.fulfill()
-                        // :remove-end:
-                    }
-                }
-                // :snippet-end:
-            }
-        }
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testFindManyDocuments() {
-        let expectation = XCTestExpectation(description: "Two documents are returned")
-
-        app.login(credentials: Credentials.anonymous) { (result) in
-            // Remember to dispatch back to the main thread in completion handlers
-            // if you want to do anything on the UI.
-            DispatchQueue.main.async {
-                switch result {
-                case .failure(let error):
-                    print("Login failed: \(error)")
-                case .success(let user):
-                    print("Login as \(user) succeeded!")
-                }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
-
-                // Select the database
-                let database = client.database(named: "ios")
-
-                // Select the collection
-                let collection = database.collection(withName: "CoffeeDrinks")
-
-                // :snippet-start: find-many
-                let queryFilter: Document = ["name": "Americano"]
-
-                collection.find(filter: queryFilter) { result in
-                    switch result {
-                    case .failure(let error):
-                        print("Call to MongoDB failed: \(error.localizedDescription)")
-                        return
-                    case .success(let documents):
-                        print("Results: ")
-                        for document in documents {
-                            print("Coffee drink: \(document)")
-                        }
-                        // :remove-start:
-                        XCTAssertEqual(documents.count, 2)
-                        expectation.fulfill()
-                        // :remove-end:
-                    }
-                }
-                // :snippet-end:
-            }
-        }
-        wait(for: [expectation], timeout: 10)
-    }
-    
-    func testFindAndSortManyDocuments() {
-        let expectation = XCTestExpectation(description: "Two documents are returned, sorted")
-
-        app.login(credentials: Credentials.anonymous) { (result) in
-            // Remember to dispatch back to the main thread in completion handlers
-            // if you want to do anything on the UI.
-            DispatchQueue.main.async {
-                switch result {
-                case .failure(let error):
-                    print("Login failed: \(error)")
-                case .success(let user):
-                    print("Login as \(user) succeeded!")
-                }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
-
-                // Select the database
-                let database = client.database(named: "ios")
-
-                // Select the collection
-                let collection = database.collection(withName: "CoffeeDrinks")
-
-                // :snippet-start: find-and-sort
-                let queryFilter: Document = ["name": "Americano"]
-                let findOptions = FindOptions(0, nil, [["beanRegion": 1]])
-
-                collection.find(filter: queryFilter, options: findOptions) { result in
-                    switch result {
-                    case .failure(let error):
-                        print("Call to MongoDB failed: \(error.localizedDescription)")
-                        return
-                    case .success(let documents):
-                        print("Results: ")
-                        for document in documents {
-                            print("Coffee drink: \(document)")
-                        }
-                        // :remove-start:
-                        XCTAssertEqual(documents.count, 2)
-                        // Unwrap the value of the beanRegion in the first document to verify
-                        // the sort worked properly
-                        let firstDocument = documents[0]
-                        if let unwrappedBeanRegion = firstDocument["beanRegion"] {
-                            if let unwrappedAnyBson = unwrappedBeanRegion {
-                                XCTAssertEqual(unwrappedAnyBson, "San Marcos, Guatemala")
-                                expectation.fulfill()
+                    collection.deleteManyDocuments(filter: filter1) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete a document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            print("Successfully deleted \(deletedResult) documents.")
+                            XCTAssertEqual(deletedResult, 2)
+                            expectation2.fulfill()
+                            collection.deleteOneDocument(filter: filter2) { deletedResult in
+                                switch deletedResult {
+                                case .failure(let error):
+                                    print("Failed to delete a document: \(error.localizedDescription)")
+                                    return
+                                case .success(let deletedResult):
+                                    XCTAssertEqual(deletedResult, 1)
+                                    expectation3.fulfill()
+                                }
                             }
                         }
-                        // :remove-end:
                     }
                 }
-                // :snippet-end:
             }
         }
-        wait(for: [expectation], timeout: 10)
+        wait(for: [expectation, expectation2, expectation3], timeout: 20)
     }
 
-    func testCountDocuments() {
-        let expectation = XCTestExpectation(description: "Returns a count of documents")
+    // MARK: Find One
+    func testFindOneDocument() {
+        let expectation = XCTestExpectation(description: "A test document is inserted")
+        let expectation2 = XCTestExpectation(description: "The test document is returned")
+        let expectation3 = XCTestExpectation(description: "The test document is deleted")
 
-        app.login(credentials: Credentials.anonymous) { (result) in
+        appClient.login(credentials: Credentials.anonymous) { (result) in
             // Remember to dispatch back to the main thread in completion handlers
             // if you want to do anything on the UI.
             DispatchQueue.main.async {
@@ -306,91 +179,73 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 case .success(let user):
                     print("Login as \(user) succeeded!")
                 }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
-
-                // Select the database
+                
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
                 let database = client.database(named: "ios")
-
-                // Select the collection
                 let collection = database.collection(withName: "CoffeeDrinks")
-
-                // :snippet-start: count
-                let queryFilter: Document = ["name": "Bean of the Day"]
-
-                collection.count(filter: queryFilter) { result in
+                
+                // Insert a drink for the test
+                let drink: Document = [ "name": "Colombian Blend", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 43]
+                collection.insertOne(drink) { result in
                     switch result {
                     case .failure(let error):
                         print("Call to MongoDB failed: \(error.localizedDescription)")
                         return
-                    case .success(let count):
-                        print("Found this many documents in the collection matching the filter: \(count)")
-                        // :remove-start:
-                        XCTAssertNotNil(count)
+                    case .success(let objectId):
+                        // Success returns the objectId for the inserted document
+                        print("Successfully inserted a document with id: \(objectId)")
                         expectation.fulfill()
-                        // :remove-end:
+                        sleep(1)
+                        findOneDocument()
+                        sleep(1)
+                        deleteFindOneTestDocument()
                     }
                 }
-                // :snippet-end:
-            }
-        }
-        wait(for: [expectation], timeout: 10)
-    }
+                
+                func findOneDocument() {
+                    // :snippet-start: find-one
+                    let queryFilter: Document = ["name": "Colombian Blend"]
 
-    func testUpdateOneDocument() {
-        let expectation = XCTestExpectation(description: "Updates a single document")
-
-        app.login(credentials: Credentials.anonymous) { (result) in
-            // Remember to dispatch back to the main thread in completion handlers
-            // if you want to do anything on the UI.
-            DispatchQueue.main.async {
-                switch result {
-                case .failure(let error):
-                    print("Login failed: \(error)")
-                case .success(let user):
-                    print("Login as \(user) succeeded!")
-                }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
-
-                // Select the database
-                let database = client.database(named: "ios")
-
-                // Select the collection
-                let collection = database.collection(withName: "CoffeeDrinks")
-
-                // :snippet-start: update-one
-                let queryFilter: Document = ["name": "Bean of the Day", "_partition": "Store 42"]
-                let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
-
-                collection.updateOneDocument(filter: queryFilter, update: documentUpdate) { result in
-                    switch result {
-                    case .failure(let error):
-                        print("Failed to update document: \(error.localizedDescription)")
-                        return
-                    case .success(let updateResult):
-                        if updateResult.matchedCount == 1 && updateResult.modifiedCount == 1 {
-                            print("Successfully updated a matching document.")
-                        } else {
-                            print("Did not update a document")
+                    collection.findOneDocument(filter: queryFilter) { result in
+                        switch result {
+                        case .failure(let error):
+                            print("Did not find matching documents: \(error.localizedDescription)")
+                            return
+                        case .success(let document):
+                            print("Found a matching document: \(String(describing: document))")
+                            // :remove-start:
+                            XCTAssertNotNil(document)
+                            expectation2.fulfill()
+                            // :remove-end:
                         }
-                        // :remove-start:
-                        XCTAssertEqual(updateResult.matchedCount, 1)
-                        XCTAssertEqual(updateResult.modifiedCount, 1)
-                        expectation.fulfill()
-                        // :remove-end:
                     }
-                // :snippet-end:
+                    // :snippet-end:
+                }
+                
+                func deleteFindOneTestDocument() {
+                    collection.deleteOneDocument(filter: drink) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete a document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            XCTAssertEqual(deletedResult, 1)
+                            expectation3.fulfill()
+                        }
+                    }
                 }
             }
         }
-        wait(for: [expectation], timeout: 10)
+        wait(for: [expectation, expectation2, expectation3], timeout: 20)
     }
 
-    func testUpdateManyDocuments() {
-        let expectation = XCTestExpectation(description: "Updates many documents")
+    // MARK: Find Many
+    func testFindManyDocuments() {
+        let expectation = XCTestExpectation(description: "Insert two test documents")
+        let expectation2 = XCTestExpectation(description: "Two documents are returned")
+        let expectation3 = XCTestExpectation(description: "Two test documents are deleted")
 
-        app.login(credentials: Credentials.anonymous) { (result) in
+        appClient.login(credentials: Credentials.anonymous) { (result) in
             // Remember to dispatch back to the main thread in completion handlers
             // if you want to do anything on the UI.
             DispatchQueue.main.async {
@@ -400,58 +255,436 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 case .success(let user):
                     print("Login as \(user) succeeded!")
                 }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
 
-                // Select the database
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
                 let database = client.database(named: "ios")
-
-                // Select the collection
                 let collection = database.collection(withName: "CoffeeDrinks")
+                
+                // Insert test documents to find
+                let drink: Document = [ "name": "Americano", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
+                let drink2: Document = [ "name": "Americano", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": true, "storeNumber": 42]
 
-                // :snippet-start: update-many
-                let queryFilter: Document = ["name": "Bean of the Day"]
-                // :remove-start:
-                // Set initial values so there's something to update
-                let setDefaults: Document = ["$set": ["containsDairy": "false"]]
-                collection.updateManyDocuments(filter: queryFilter, update: setDefaults) { result in
+                collection.insertMany([drink, drink2]) { result in
                     switch result {
                     case .failure(let error):
                         print("Call to MongoDB failed: \(error.localizedDescription)")
                         return
-                    case .success(let result):
-                        XCTAssertNotNil(result.matchedCount)
-                        XCTAssertNotNil(result.modifiedCount)
-                        print("Successfully set defaults for \(result.modifiedCount) documents.")
-                    }
-                }
-                // :remove-end:
-
-                let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
-                collection.updateManyDocuments(filter: queryFilter, update: documentUpdate) { result in
-                    switch result {
-                    case .failure(let error):
-                        print("Failed to update document: \(error.localizedDescription)")
-                        return
-                    case .success(let updateResult):
-                        print("Successfully updated \(updateResult.modifiedCount) documents.")
-                        // :remove-start:
-                        XCTAssertNotNil(updateResult.matchedCount)
-                        XCTAssertNotNil(updateResult.modifiedCount)
+                    case .success(let objectIds):
+                        print("Successfully inserted \(objectIds.count) new documents.")
+                        XCTAssertEqual(objectIds.count, 2)
                         expectation.fulfill()
-                        // :remove-end:
+                        sleep(1)
+                        findManyDocuments()
+                        sleep(1)
+                        deleteFindManyTestDocuments()
                     }
                 }
-                // :snippet-end:
+                
+                func findManyDocuments() {
+                    // :snippet-start: find-many
+                    let queryFilter: Document = ["name": "Americano"]
+
+                    collection.find(filter: queryFilter) { result in
+                        switch result {
+                        case .failure(let error):
+                            print("Call to MongoDB failed: \(error.localizedDescription)")
+                            return
+                        case .success(let bsonDocumentArray):
+                            print("Results: ")
+                            for bsonDocument in bsonDocumentArray {
+                                print("Coffee drink named: \(String(describing: bsonDocument["name"]))")
+                            }
+                            // :remove-start:
+                            XCTAssertEqual(bsonDocumentArray.count, 2)
+                            expectation2.fulfill()
+                            // :remove-end:
+                        }
+                    }
+                    // :snippet-end:
+                }
+                
+                func deleteFindManyTestDocuments() {
+                    // Delete the test documents
+                    let queryFilter: Document = ["name": "Americano"]
+                    collection.deleteManyDocuments(filter: queryFilter) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete a document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            print("Successfully deleted \(deletedResult) documents.")
+                            XCTAssertEqual(deletedResult, 2)
+                            expectation3.fulfill()
+                        }
+                    }
+                }
             }
         }
-        wait(for: [expectation], timeout: 10)
+        wait(for: [expectation, expectation2, expectation3], timeout: 20)
+    }
+    
+    // MARK: Find and Sort Many
+    func testFindAndSortManyDocuments() {
+        let expectation = XCTestExpectation(description: "Insert two test documents")
+        let expectation2 = XCTestExpectation(description: "Two documents are returned, sorted")
+        let expectation3 = XCTestExpectation(description: "Two test documents are deleted")
+
+        appClient.login(credentials: Credentials.anonymous) { (result) in
+            // Remember to dispatch back to the main thread in completion handlers
+            // if you want to do anything on the UI.
+            DispatchQueue.main.async {
+                switch result {
+                case .failure(let error):
+                    print("Login failed: \(error)")
+                case .success(let user):
+                    print("Login as \(user) succeeded!")
+                }
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
+                let database = client.database(named: "ios")
+                let collection = database.collection(withName: "CoffeeDrinks")
+                
+                // Insert test documents to find
+                let drink: Document = [ "name": "Americano", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
+                let drink2: Document = [ "name": "Americano", "beanRegion": "San Marcos, Guatemala", "containsDairy": true, "storeNumber": 42]
+
+                collection.insertMany([drink, drink2]) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Call to MongoDB failed: \(error.localizedDescription)")
+                        return
+                    case .success(let objectIds):
+                        print("Successfully inserted \(objectIds.count) new documents.")
+                        XCTAssertEqual(objectIds.count, 2)
+                        expectation.fulfill()
+                        sleep(1)
+                        findAndSortDocuments()
+                        sleep(1)
+                        deleteFindAndSortTestDocuments()
+                    }
+                }
+                
+                func findAndSortDocuments() {
+                    // :snippet-start: find-and-sort
+                    let queryFilter: Document = ["name": "Americano"]
+                    let findOptions = FindOptions(0, nil, [["beanRegion": 1]])
+                    
+                    collection.find(filter: queryFilter, options: findOptions) { result in
+                        switch result {
+                        case .failure(let error):
+                            print("Call to MongoDB failed: \(error.localizedDescription)")
+                            return
+                        case .success(let documents):
+                            print("Results: ")
+                            for document in documents {
+                                print("Coffee drink: \(document)")
+                            }
+                            // :remove-start:
+                            XCTAssertEqual(documents.count, 2)
+                            // Unwrap the value of the beanRegion in the first document to verify
+                            // the sort worked properly
+                            let firstDocument = documents[0]
+                            if let unwrappedBeanRegion = firstDocument["beanRegion"] {
+                                if let unwrappedAnyBson = unwrappedBeanRegion {
+                                    XCTAssertEqual(unwrappedAnyBson, "San Marcos, Guatemala")
+                                    expectation2.fulfill()
+                                }
+                            }
+                            // :remove-end:
+                        }
+                    }
+                    // :snippet-end:
+                }
+                
+                func deleteFindAndSortTestDocuments() {
+                    let queryFilter: Document = ["name": "Americano"]
+                    collection.deleteManyDocuments(filter: queryFilter) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete a document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            print("Successfully deleted \(deletedResult) documents.")
+                            XCTAssertEqual(deletedResult, 2)
+                            expectation3.fulfill()
+                        }
+                    }
+                }
+            }
+        }
+        wait(for: [expectation, expectation2, expectation3], timeout: 20)
     }
 
+    // MARK: Count
+    func testCountDocuments() {
+        let expectation = XCTestExpectation(description: "Inserts test documents")
+        let expectation2 = XCTestExpectation(description: "Returns a count of documents")
+        let expectation3 = XCTestExpectation(description: "Deletes test documents")
+
+        appClient.login(credentials: Credentials.anonymous) { (result) in
+            // Remember to dispatch back to the main thread in completion handlers
+            // if you want to do anything on the UI.
+            DispatchQueue.main.async {
+                switch result {
+                case .failure(let error):
+                    print("Login failed: \(error)")
+                case .success(let user):
+                    print("Login as \(user) succeeded!")
+                }
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
+                let database = client.database(named: "ios")
+                let collection = database.collection(withName: "CoffeeDrinks")
+
+                // Insert test documents to find
+                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
+                let drink2: Document = [ "name": "Bean of the Day", "beanRegion": "San Marcos, Guatemala", "containsDairy": true, "storeNumber": 42]
+                
+                collection.insertMany([drink, drink2]) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Call to MongoDB failed: \(error.localizedDescription)")
+                        return
+                    case .success(let objectIds):
+                        print("Successfully inserted \(objectIds.count) new documents.")
+                        XCTAssertEqual(objectIds.count, 2)
+                        expectation.fulfill()
+                        sleep(1)
+                        countDocuments()
+                        sleep(1)
+                        deleteCountDocumentsTestDocuments()
+                    }
+                }
+                
+                func countDocuments() {
+                    // :snippet-start: count
+                    let queryFilter: Document = ["name": "Bean of the Day"]
+
+                    collection.count(filter: queryFilter) { result in
+                        switch result {
+                        case .failure(let error):
+                            print("Call to MongoDB failed: \(error.localizedDescription)")
+                            return
+                        case .success(let count):
+                            print("Found this many documents in the collection matching the filter: \(count)")
+                            // :remove-start:
+                            XCTAssertEqual(count, 2)
+                            expectation2.fulfill()
+                            // :remove-end:
+                        }
+                    }
+                    // :snippet-end:
+                }
+                
+                func deleteCountDocumentsTestDocuments() {
+                    let queryFilter: Document = ["name": "Bean of the Day"]
+                    collection.deleteManyDocuments(filter: queryFilter) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete a document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            print("Successfully deleted \(deletedResult) documents.")
+                            XCTAssertEqual(deletedResult, 2)
+                            expectation3.fulfill()
+                        }
+                    }
+                }
+            }
+        }
+        wait(for: [expectation, expectation2, expectation3], timeout: 10)
+    }
+
+    // MARK: Update One
+    func testUpdateOneDocument() {
+        let expectation = XCTestExpectation(description: "Insert a test document")
+        let expectation2 = XCTestExpectation(description: "Updates the test document")
+        let expectation3 = XCTestExpectation(description: "Deletes the test document")
+
+        appClient.login(credentials: Credentials.anonymous) { (result) in
+            // Remember to dispatch back to the main thread in completion handlers
+            // if you want to do anything on the UI.
+            DispatchQueue.main.async {
+                switch result {
+                case .failure(let error):
+                    print("Login failed: \(error)")
+                case .success(let user):
+                    print("Login as \(user) succeeded!")
+                }
+                
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
+                let database = client.database(named: "ios")
+                let collection = database.collection(withName: "CoffeeDrinks")
+
+                // Insert a test drink
+                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
+                collection.insertOne(drink) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Call to MongoDB failed: \(error.localizedDescription)")
+                        return
+                    case .success(let objectId):
+                        // Success returns the objectId for the inserted document
+                        print("Successfully inserted a document with id: \(objectId)")
+                        expectation.fulfill()
+                        sleep(1)
+                        updateOneDocument()
+                        sleep(1)
+                        deleteUpdateOneTestDocument()
+                    }
+                }
+                
+                func updateOneDocument() {
+                    // :snippet-start: update-one
+                    let queryFilter: Document = ["name": "Bean of the Day", "storeNumber": 42]
+                    let documentUpdate: Document = ["$set": ["containsDairy": true]]
+                    
+                    collection.updateOneDocument(filter: queryFilter, update: documentUpdate) { result in
+                        switch result {
+                        case .failure(let error):
+                            print("Failed to update document: \(error.localizedDescription)")
+                            return
+                        case .success(let updateResult):
+                            if updateResult.matchedCount == 1 && updateResult.modifiedCount == 1 {
+                                print("Successfully updated a matching document.")
+                            } else {
+                                print("Did not update a document")
+                            }
+                            // :remove-start:
+                            // updateOneDocument does not actually returned the updated document
+                            // we can confirm that one document matched the query and was updated
+                            // but do additional work later to verify it has the updated value
+                            XCTAssertEqual(updateResult.matchedCount, 1)
+                            XCTAssertEqual(updateResult.modifiedCount, 1)
+                            // Actually retrieve the updated document to verify it has the new value
+                            collection.findOneDocument(filter: queryFilter) { result in
+                                switch result {
+                                case .failure(let error):
+                                    print("Did not find matching documents: \(error.localizedDescription)")
+                                    return
+                                case .success(let document):
+                                    // Unwrapping the returned BSON values in Swift is involves a lot of optional checks,
+                                    // but this verifies that the updated value for the test document is now "true"
+                                    if let unwrappedDocument = document {
+                                        let possibleContainsDairyKey = unwrappedDocument["containsDairy"]
+                                        if let containsDairyDocumentBson = possibleContainsDairyKey {
+                                            let possibleContainsDairyValue = containsDairyDocumentBson?.boolValue
+                                            if let actualContainsDairyBoolValue = possibleContainsDairyValue {
+                                                XCTAssertTrue(actualContainsDairyBoolValue)
+                                                expectation2.fulfill()
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            // :remove-end:
+                        }
+                        // :snippet-end:
+                    }
+                }
+                
+                func deleteUpdateOneTestDocument() {
+                    let queryFilter: Document = ["name": "Bean of the Day", "storeNumber": 42]
+                    collection.deleteOneDocument(filter: queryFilter) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete a document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            XCTAssertEqual(deletedResult, 1)
+                            expectation3.fulfill()
+                        }
+                    }
+                }
+            }
+        }
+        wait(for: [expectation, expectation2, expectation3], timeout: 20)
+    }
+
+    // MARK: Update Many
+    func testUpdateManyDocuments() {
+        let expectation = XCTestExpectation(description: "Insert two test documents")
+        let expectation2 = XCTestExpectation(description: "Update the test documents")
+        let expectation3 = XCTestExpectation(description: "Delete the test documents")
+
+        appClient.login(credentials: Credentials.anonymous) { (result) in
+            // Remember to dispatch back to the main thread in completion handlers
+            // if you want to do anything on the UI.
+            DispatchQueue.main.async {
+                switch result {
+                case .failure(let error):
+                    print("Login failed: \(error)")
+                case .success(let user):
+                    print("Login as \(user) succeeded!")
+                }
+                
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
+                let database = client.database(named: "ios")
+                let collection = database.collection(withName: "CoffeeDrinks")
+                
+                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": true, "storeNumber": 42]
+                let drink2: Document = [ "name": "Bean of the Day", "beanRegion": "San Marcos, Guatemala", "containsDairy": true, "storeNumber": 42]
+
+                collection.insertMany([drink, drink2]) { result in
+                    switch result {
+                    case .failure(let error):
+                        print("Call to MongoDB failed: \(error.localizedDescription)")
+                        return
+                    case .success(let objectIds):
+                        print("Successfully inserted \(objectIds.count) new documents.")
+                        XCTAssertEqual(objectIds.count, 2)
+                        expectation.fulfill()
+                        sleep(1)
+                        updateManyDocuments()
+                        sleep(1)
+                        deleteUpdateManyTestDocuments()
+                    }
+                }
+                
+                func updateManyDocuments() {
+                    // :snippet-start: update-many
+                    let queryFilter: Document = ["name": "Bean of the Day"]
+                    let documentUpdate: Document = ["$set": ["containsDairy": true]]
+                    
+                    collection.updateManyDocuments(filter: queryFilter, update: documentUpdate) { result in
+                        switch result {
+                        case .failure(let error):
+                            print("Failed to update document: \(error.localizedDescription)")
+                            return
+                        case .success(let updateResult):
+                            print("Successfully updated \(updateResult.modifiedCount) documents.")
+                            // :remove-start:
+                            XCTAssertNotNil(updateResult.matchedCount)
+                            XCTAssertNotNil(updateResult.modifiedCount)
+                            expectation2.fulfill()
+                            // :remove-end:
+                        }
+                    }
+                    // :snippet-end:
+                }
+                
+                func deleteUpdateManyTestDocuments() {
+                    let queryFilter: Document = ["name": "Bean of the Day"]
+                    collection.deleteManyDocuments(filter: queryFilter) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete a document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            print("Successfully deleted \(deletedResult) documents.")
+                            XCTAssertEqual(deletedResult, 2)
+                            expectation3.fulfill()
+                        }
+                    }
+                }
+            }
+        }
+        wait(for: [expectation, expectation2, expectation3], timeout: 25)
+    }
+
+    // MARK: Upsert
     func testUpsertDocuments() {
         let expectation = XCTestExpectation(description: "Upsert, then delete a document")
 
-        app.login(credentials: Credentials.anonymous) { (result) in
+        appClient.login(credentials: Credentials.anonymous) { (result) in
             // Remember to dispatch back to the main thread in completion handlers
             // if you want to do anything on the UI.
             DispatchQueue.main.async {
@@ -461,18 +694,14 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 case .success(let user):
                     print("Login as \(user) succeeded!")
                 }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
 
-                // Select the database
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
                 let database = client.database(named: "ios")
-
-                // Select the collection
                 let collection = database.collection(withName: "CoffeeDrinks")
 
                 // :snippet-start: upsert
-                let queryFilter: Document = ["name": "Bean of the Day", "_partition": "Store 55"]
-                let documentUpdate: Document = ["name": "Bean of the Day", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": "false", "_partition": "Store 55"]
+                let queryFilter: Document = ["name": "Bean of the Day", "storeNumber": 55]
+                let documentUpdate: Document = ["name": "Bean of the Day", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": false, "storeNumber": 55]
 
                 collection.updateOneDocument(filter: queryFilter, update: documentUpdate, upsert: true) { result in
                     switch result {
@@ -481,23 +710,12 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                         return
                     case .success(let updateResult):
                         // :remove-start:
-                        XCTAssertNotNil(updateResult.objectId)
+                        XCTAssertNotNil(updateResult.documentId)
                         // :remove-end:
-                        if updateResult.objectId != nil {
-                            print("Successfully upserted a document with id: \(updateResult.objectId)")
+                        if let unwrappedDocumentId = updateResult.documentId {
+                            print("Successfully upserted a document with id: \(unwrappedDocumentId)")
                             // :remove-start:
-                            // Delete the document so the test will pass next time
-                            collection.deleteOneDocument(filter: documentUpdate) { deletedResult in
-                                switch deletedResult {
-                                case .failure(let error):
-                                    print("Failed to delete newly upserted document: \(error.localizedDescription)")
-                                    return
-                                case .success(let deletedResult):
-                                    XCTAssertEqual(deletedResult, 1)
-                                    print("Successfully deleted upserted document")
-                                    expectation.fulfill()
-                                }
-                            }
+                            deleteUpsertTestDocument()
                             // :remove-end:
                         } else {
                             print("Did not upsert a document")
@@ -505,15 +723,31 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                     }
                 }
                 // :snippet-end:
+                
+                func deleteUpsertTestDocument() {
+                    // Delete the document so the test will pass next time
+                    collection.deleteOneDocument(filter: documentUpdate) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete newly upserted document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            XCTAssertEqual(deletedResult, 1)
+                            print("Successfully deleted upserted document")
+                            expectation.fulfill()
+                        }
+                    }
+                }
             }
         }
         wait(for: [expectation], timeout: 10)
     }
 
+    // MARK: Delete One
     func testDeleteOneDocument() {
         let expectation = XCTestExpectation(description: "Insert, then delete a document")
 
-        app.login(credentials: Credentials.anonymous) { (result) in
+        appClient.login(credentials: Credentials.anonymous) { (result) in
             // Remember to dispatch back to the main thread in completion handlers
             // if you want to do anything on the UI.
             DispatchQueue.main.async {
@@ -523,20 +757,12 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 case .success(let user):
                     print("Login as \(user) succeeded!")
                 }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
 
-                // Select the database
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
                 let database = client.database(named: "ios")
-
-                // Select the collection
                 let collection = database.collection(withName: "CoffeeDrinks")
 
-                // Insert a document so we can delete it. This query filter and document
-                // duplicate what is visible in the code block, but was at the wrong level
-                // of indent when starting the code block here, so we've declared it again
-                // in the code snippet with a slightly different name.
-                let document: Document = ["name": "Mocha", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": "true", "_partition": "Store 17"]
+                let document: Document = ["name": "Mocha", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": true, "storeNumber": 17]
                 collection.insertOne(document) { result in
                     switch result {
                     case .failure(let error):
@@ -545,33 +771,38 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                     case .success(let objectId):
                         XCTAssertNotNil(objectId)
                         print("Successfully inserted a document with id: \(objectId)")
-                        // :snippet-start: delete-one
-                        let queryFilter: Document = ["name": "Mocha", "_partition": "Store 17"]
-                        collection.deleteOneDocument(filter: queryFilter) { deletedResult in
-                            switch deletedResult {
-                            case .failure(let error):
-                                print("Failed to delete a document: \(error.localizedDescription)")
-                                return
-                            case .success(let deletedResult):
-                                print("Successfully deleted a document.")
-                                // :remove-start:
-                                XCTAssertEqual(deletedResult, 1)
-                                expectation.fulfill()
-                                // :remove-end:
-                            }
-                        }
-                        // :snippet-end:
+                        deleteOneDocument()
                     }
+                }
+                
+                func deleteOneDocument() {
+                    // :snippet-start: delete-one
+                    let queryFilter: Document = ["name": "Mocha", "storeNumber": 17]
+                    collection.deleteOneDocument(filter: queryFilter) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete a document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            print("Successfully deleted a document.")
+                            // :remove-start:
+                            XCTAssertEqual(deletedResult, 1)
+                            expectation.fulfill()
+                            // :remove-end:
+                        }
+                    }
+                    // :snippet-end:
                 }
             }
         }
         wait(for: [expectation], timeout: 10)
     }
 
+    // MARK: Delete Many
     func testDeleteManyDocuments() {
         let expectation = XCTestExpectation(description: "Insert and then delete multiple documents")
 
-        app.login(credentials: Credentials.anonymous) { (result) in
+        appClient.login(credentials: Credentials.anonymous) { (result) in
             // Remember to dispatch back to the main thread in completion handlers
             // if you want to do anything on the UI.
             DispatchQueue.main.async {
@@ -582,18 +813,14 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                     print("Login as \(user) succeeded!")
                     // Continue below
                 }
-                // mongodb-atlas is the cluster service name
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
 
-                // Select the database
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
                 let database = client.database(named: "ios")
-
-                // Select the collection
                 let collection = database.collection(withName: "CoffeeDrinks")
 
-                let drink: Document = [ "name": "Caramel Latte", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 22"]
-                let drink2: Document = [ "name": "Caramel Latte", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": "true", "_partition": "Store 24"]
-                let drink3: Document = [ "name": "Caramel Latte", "beanRegion": "San Marcos, Guatemala", "containsDairy": "false", "_partition": "Store 35"]
+                let drink: Document = [ "name": "Caramel Latte", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 22]
+                let drink2: Document = [ "name": "Caramel Latte", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": true, "storeNumber": 24]
+                let drink3: Document = [ "name": "Caramel Latte", "beanRegion": "San Marcos, Guatemala", "containsDairy": false, "storeNumber": 35]
 
                 // Insert the example data into the collection
                 collection.insertMany([drink, drink2, drink3]) { result in
@@ -604,30 +831,35 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                     case .success(let objectIds):
                         print("Successfully inserted \(objectIds.count) new documents.")
                         XCTAssertEqual(objectIds.count, 3)
-                        // :snippet-start: delete-many
-                        let filter: Document = ["name": "Caramel Latte"]
-
-                        collection.deleteManyDocuments(filter: filter) { deletedResult in
-                            switch deletedResult {
-                            case .failure(let error):
-                                print("Failed to delete a document: \(error.localizedDescription)")
-                                return
-                            case .success(let deletedResult):
-                                print("Successfully deleted \(deletedResult) documents.")
-                                // :remove-start:
-                                XCTAssertEqual(deletedResult, 3)
-                                expectation.fulfill()
-                                // :remove-end:
-                            }
-                        }
-                        // :snippet-end:
+                        deleteManyDocuments()
                     }
+                }
+                
+                func deleteManyDocuments() {
+                    // :snippet-start: delete-many
+                    let filter: Document = ["name": "Caramel Latte"]
+
+                    collection.deleteManyDocuments(filter: filter) { deletedResult in
+                        switch deletedResult {
+                        case .failure(let error):
+                            print("Failed to delete a document: \(error.localizedDescription)")
+                            return
+                        case .success(let deletedResult):
+                            print("Successfully deleted \(deletedResult) documents.")
+                            // :remove-start:
+                            XCTAssertEqual(deletedResult, 3)
+                            expectation.fulfill()
+                            // :remove-end:
+                        }
+                    }
+                    // :snippet-end:
                 }
             }
         }
         wait(for: [expectation], timeout: 10)
     }
 
+    // MARK: ChangeEventDelegate
     // :snippet-start: change-event-delegate
     class MyChangeStreamDelegate: ChangeEventDelegate {
         // :remove-start:
@@ -688,11 +920,13 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
     }
     // :snippet-end:
     
+    // MARK: Watch for Changes
     func testWatchForChangesInMDBCollection() {
         let expectation = XCTestExpectation(description: "Get notifications when documents are inserted")
+        let expectation2 = XCTestExpectation(description: "Delete the test document")
 
         // :snippet-start: watch-collection
-        app.login(credentials: Credentials.anonymous) { (result) in
+        appClient.login(credentials: Credentials.anonymous) { (result) in
             DispatchQueue.main.async {
                 switch result {
                 case .failure(let error):
@@ -703,7 +937,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 }
                 
                 // Set up the client, database, and collection.
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
                 let database = client.database(named: "ios")
                 let collection = database.collection(withName: "CoffeeDrinks")
                 
@@ -719,7 +953,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 delegate.expectEvent()
                 // :remove-end:
                 // Adding a document triggers a change event.
-                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 42"]
+                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
                 
                 collection.insertOne(drink) { result in
                     switch result {
@@ -746,18 +980,32 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 delegate.waitForClose()
                 sleep(3)
                 expectation.fulfill()
+                collection.deleteOneDocument(filter: drink) { deletedResult in
+                    switch deletedResult {
+                    case .failure(let error):
+                        print("Failed to delete a document: \(error.localizedDescription)")
+                        return
+                    case .success(let deletedResult):
+                        print("Successfully deleted a document.")
+                        XCTAssertEqual(deletedResult, 1)
+                        expectation2.fulfill()
+                    }
+                }
                 // :remove-end:
             }
         }
         // :snippet-end:
-        wait(for: [expectation], timeout: 75)
+        wait(for: [expectation, expectation2], timeout: 75)
     }
 
+    // MARK: Watch for Changes with Filter
     func testWatchForChangesInMDBCollectionWithFilter() {
-        let expectation = XCTestExpectation(description: "Get a notification when a specific document is updated")
+        let expectation = XCTestExpectation(description: "Insert a test document")
+        let expectation2 = XCTestExpectation(description: "Get a notification when a specific document is updated")
+        let expectation3 = XCTestExpectation(description: "Delete the test document")
 
         // :snippet-start: watch-collection-with-filter
-        app.login(credentials: Credentials.anonymous) { (result) in
+        appClient.login(credentials: Credentials.anonymous) { (result) in
             DispatchQueue.main.async {
                 switch result {
                 case .failure(let error):
@@ -768,12 +1016,12 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 }
                 
                 // Set up the client, database, and collection.
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
                 let database = client.database(named: "ios")
                 let collection = database.collection(withName: "CoffeeDrinks")
                 // :remove-start:
                 // Populate test data so we have something to watch
-                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 42"]
+                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
                 var drinkObjectId: ObjectId = ObjectId()
                 collection.insertOne(drink) { result in
                     switch result {
@@ -786,6 +1034,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                         let objectIdValue = objectId.objectIdValue
                         guard let unwrappedObjectIdValue = objectIdValue else { return }
                         drinkObjectId.self = unwrappedObjectIdValue
+                        expectation.fulfill()
                     }
                     sleep(2)
                 }
@@ -806,7 +1055,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 // :remove-end:
                 // An update to a relevant document triggers a change event.
                 let queryFilter: Document = ["_id": AnyBSON(drinkObjectId) ]
-                let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
+                let documentUpdate: Document = ["$set": ["containsDairy": true]]
 
                 collection.updateOneDocument(filter: queryFilter, update: documentUpdate) { result in
                     switch result {
@@ -832,19 +1081,33 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 sleep(3)
                 delegate.waitForClose()
                 sleep(3)
-                expectation.fulfill()
+                expectation2.fulfill()
+                collection.deleteOneDocument(filter: queryFilter) { deletedResult in
+                    switch deletedResult {
+                    case .failure(let error):
+                        print("Failed to delete a document: \(error.localizedDescription)")
+                        return
+                    case .success(let deletedResult):
+                        print("Successfully deleted a document.")
+                        XCTAssertEqual(deletedResult, 1)
+                        expectation3.fulfill()
+                    }
+                }
                 // :remove-end:
             }
         }
         // :snippet-end:
-        wait(for: [expectation], timeout: 75)
+        wait(for: [expectation, expectation2, expectation3], timeout: 75)
     }
     
+    // MARK: Watch for Changes with Match
     func testWatchForChangesInMDBCollectionWithMatch() {
-        let expectation = XCTestExpectation(description: "Get notifications for documents that match a filter")
+        let expectation = XCTestExpectation(description: "Insert a test document")
+        let expectation2 = XCTestExpectation(description: "Get a notification when a specific document is updated")
+        let expectation3 = XCTestExpectation(description: "Delete the test document")
 
         // :snippet-start: watch-collection-with-match
-        app.login(credentials: Credentials.anonymous) { (result) in
+        appClient.login(credentials: Credentials.anonymous) { (result) in
             DispatchQueue.main.async {
                 switch result {
                 case .failure(let error):
@@ -855,12 +1118,12 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 }
                 
                 // Set up the client, database, and collection.
-                let client = app.currentUser!.mongoClient("mongodb-atlas")
+                let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
                 let database = client.database(named: "ios")
                 let collection = database.collection(withName: "CoffeeDrinks")
                 // :remove-start:
                 // Populate test data so we have something to watch
-                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 42"]
+                let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
                 var drinkObjectId: ObjectId = ObjectId()
                 collection.insertOne(drink) { result in
                     switch result {
@@ -873,6 +1136,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                         let objectIdValue = objectId.objectIdValue
                         guard let unwrappedObjectIdValue = objectIdValue else { return }
                         drinkObjectId.self = unwrappedObjectIdValue
+                        expectation.fulfill()
                     }
                     sleep(3)
                 }
@@ -883,7 +1147,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 // both of which are optional arguments.
                 let queue = DispatchQueue(label: "io.realm.watchQueue")
                 let delegate =  MyChangeStreamDelegate(testCase: self)
-                let matchFilter = [ "fullDocument._partition": AnyBSON("Store 42") ]
+                let matchFilter = [ "fullDocument.storeNumber": AnyBSON(42) ]
                 let changeStream = collection.watch(matchFilter: matchFilter, delegate: delegate, queue: queue)
                 // :remove-start:
                 sleep(3)
@@ -893,7 +1157,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 // :remove-end:
                 // An update to a relevant document triggers a change event.
                 let queryFilter: Document = ["_id": AnyBSON(drinkObjectId) ]
-                let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
+                let documentUpdate: Document = ["$set": ["containsDairy": true]]
 
                 collection.updateOneDocument(filter: queryFilter, update: documentUpdate) { result in
                     switch result {
@@ -919,12 +1183,64 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 sleep(5)
                 delegate.waitForClose()
                 sleep(5)
-                expectation.fulfill()
+                expectation2.fulfill()
+                collection.deleteOneDocument(filter: queryFilter) { deletedResult in
+                    switch deletedResult {
+                    case .failure(let error):
+                        print("Failed to delete a document: \(error.localizedDescription)")
+                        return
+                    case .success(let deletedResult):
+                        print("Successfully deleted a document.")
+                        XCTAssertEqual(deletedResult, 1)
+                        expectation3.fulfill()
+                    }
+                }
                 // :remove-end:
             }
         }
         // :snippet-end:
-        wait(for: [expectation], timeout: 75)
+        wait(for: [expectation, expectation2, expectation3], timeout: 75)
+    }
+}
+
+// MARK: Async APIs
+class MongoDBRemoteAccessTestCaseAsyncAPIs: XCTestCase {
+    let appClient = App(id: "swift-flexible-vkljj")
+    
+    func testAsyncAwaitInsert() async {
+        do {
+            // Use the async method to login
+            let user = try await appClient.login(credentials: Credentials.anonymous)
+            print("Login as \(user) succeeded!")
+        } catch {
+            print("Login failed: \(error.localizedDescription)")
+        }
+
+        let client = appClient.currentUser!.mongoClient("mongodb-atlas")
+        let database = client.database(named: "ios")
+        let collection = database.collection(withName: "CoffeeDrinks")
+
+        // :snippet-start: async-await-insert
+        // This document represents a CoffeeDrink object
+        let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 43]
+
+        do {
+            // Use the async collection method to insert the document
+            let objectId = try await collection.insertOne(drink)
+            // :remove-start:
+            XCTAssertNotNil(objectId)
+            // :remove-end:
+            print("Successfully inserted a document with id: \(objectId)")
+        } catch {
+            print("Call to MongoDB failed: \(error.localizedDescription)")
+        }
+        // :snippet-end:
+        do {
+            let deletedCount = try await collection.deleteOneDocument(filter: drink)
+            XCTAssertEqual(deletedCount, 1)
+        } catch {
+            print("Failed to delete the test document: \(error.localizedDescription)")
+        }
     }
     
 #if swift(>=5.8)
@@ -935,14 +1251,14 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
     // for older Xcode versions.
     func testAsyncStreamWatchForChangesInMDBCollection() async throws {
         // :snippet-start: watch-collection-async-sequence
-        let user = try await app.login(credentials: Credentials.anonymous)
+        let user = try await appClient.login(credentials: Credentials.anonymous)
         // Set up the client, database, and collection.
         let mongoClient = user.mongoClient("mongodb-atlas")
         let database = mongoClient.database(named: "ios")
         let collection = database.collection(withName: "CoffeeDrinks")
         // :remove-start:
         // Populate test data
-        let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 43"]
+        let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 43]
         let objectId = try await collection.insertOne(drink)
         XCTAssertNotNil(objectId) // :remove:
         print("Successfully inserted a document with id: \(objectId)")
@@ -976,14 +1292,17 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
         
         // Updating a document in the collection triggers a change event.
         let queryFilter: Document = ["_id": AnyBSON(objectId) ]
-        let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
-        try await collection.updateOneDocument(filter: queryFilter, update: documentUpdate)
+        let documentUpdate: Document = ["$set": ["containsDairy": true]]
+        let updateResult = try await collection.updateOneDocument(filter: queryFilter, update: documentUpdate)
         sleep(2) // :remove:
         // Cancel the task when you're done watching the stream.
         task.cancel()
         _ = await task.result
         // :snippet-end:
+        let deletedCount = try await collection.deleteOneDocument(filter: queryFilter)
+        XCTAssertEqual(deletedCount, 1)
     }
 #endif
 }
+
 // :replace-end:

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.async-await-insert.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.async-await-insert.swift
@@ -1,5 +1,5 @@
 // This document represents a CoffeeDrink object
-let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 43"]
+let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 43]
 
 do {
     // Use the async collection method to insert the document

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.coffee-drink-model.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.coffee-drink-model.swift
@@ -3,5 +3,5 @@ class CoffeeDrink: Object {
     @Persisted var name: String
     @Persisted var beanRegion: String?
     @Persisted var containsDairy: Bool
-    @Persisted var _partition: String
+    @Persisted var storeNumber: Int
 }

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.delete-one.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.delete-one.swift
@@ -1,4 +1,4 @@
-let queryFilter: Document = ["name": "Mocha", "_partition": "Store 17"]
+let queryFilter: Document = ["name": "Mocha", "storeNumber": 17]
 collection.deleteOneDocument(filter: queryFilter) { deletedResult in
     switch deletedResult {
     case .failure(let error):

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.find-many.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.find-many.swift
@@ -5,10 +5,10 @@ collection.find(filter: queryFilter) { result in
     case .failure(let error):
         print("Call to MongoDB failed: \(error.localizedDescription)")
         return
-    case .success(let documents):
+    case .success(let bsonDocumentArray):
         print("Results: ")
-        for document in documents {
-            print("Coffee drink: \(document)")
+        for bsonDocument in bsonDocumentArray {
+            print("Coffee drink named: \(String(describing: bsonDocument["name"]))")
         }
     }
 }

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.find-one.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.find-one.swift
@@ -1,12 +1,11 @@
-let queryFilter: Document = ["name": "Maple Latte"]
+let queryFilter: Document = ["name": "Colombian Blend"]
 
 collection.findOneDocument(filter: queryFilter) { result in
-
     switch result {
     case .failure(let error):
         print("Did not find matching documents: \(error.localizedDescription)")
         return
     case .success(let document):
-        print("Found a matching document: \(document)")
+        print("Found a matching document: \(String(describing: document))")
     }
 }

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-many.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-many.swift
@@ -1,6 +1,6 @@
-let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 42"]
-let drink2: Document = [ "name": "Maple Latte", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": "true", "_partition": "Store 42"]
-let drink3: Document = [ "name": "Bean of the Day", "beanRegion": "San Marcos, Guatemala", "containsDairy": "false", "_partition": "Store 47"]
+let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
+let drink2: Document = [ "name": "Maple Latte", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": true, "storeNumber": 42]
+let drink3: Document = [ "name": "Bean of the Day", "beanRegion": "San Marcos, Guatemala", "containsDairy": false, "storeNumber": 47]
 
 // Insert the documents into the collection
 collection.insertMany([drink, drink2, drink3]) { result in

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-one.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-one.swift
@@ -1,5 +1,5 @@
 // This document represents a CoffeeDrink object
-let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 43"]
+let drink: Document = [ "name": "Colombian Blend", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 43]
 
 // Insert the document into the collection
 collection.insertOne(drink) { result in

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-sample-data.swift.rst
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-sample-data.swift.rst
@@ -1,7 +1,7 @@
 .. code-block:: swift
-   :emphasize-lines: 1, 4-11, 13, 16, 19
+   :emphasize-lines: 1, 4-9, 11, 14, 17
 
-   app.login(credentials: Credentials.anonymous) { (result) in 
+   appClient.login(credentials: Credentials.anonymous) { (result) in 
        // Remember to dispatch back to the main thread in completion handlers
        // if you want to do anything on the UI.
        DispatchQueue.main.async {
@@ -10,29 +10,28 @@
                print("Login failed: \(error)")
            case .success(let user):
                print("Login as \(user) succeeded!")
-               // Continue below
-           }
-           // mongodb-atlas is the cluster service name
-           let client = app.currentUser!.mongoClient("mongodb-atlas") 
+               // mongodb-atlas is the cluster service name
+               let mongoClient = user.mongoClient("mongodb-atlas") 
 
-           // Select the database
-           let database = client.database(named: "ios") 
+               // Select the database
+               let database = mongoClient.database(named: "ios") 
 
-           // Select the collection
-           let collection = database.collection(withName: "CoffeeDrinks") 
+               // Select the collection
+               let collection = database.collection(withName: "CoffeeDrinks") 
 
-           let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "partition": "Store 42"]
-           let drink2: Document = [ "name": "Maple Latte", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": "true", "partition": "Store 42"]
-           let drink3: Document = [ "name": "Bean of the Day", "beanRegion": "San Marcos, Guatemala", "containsDairy": "false", "partition": "Store 47"]
+               // This document represents a CoffeeDrink object
+               let drink: Document = [ "name": "Colombian Blend", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 43]
 
-           // Insert the documents into the collection
-           collection.insertMany([drink, drink2, drink3]) { result in
-               switch result {
-               case .failure(let error):
-                   print("Call to MongoDB failed: \(error.localizedDescription)")
-                   return
-               case .success(let objectIds):
-                   print("Successfully inserted \(objectIds.count) new documents.")
+               // Insert the document into the collection
+               collection.insertOne(drink) { result in
+                   switch result {
+                   case .failure(let error):
+                       print("Call to MongoDB failed: \(error.localizedDescription)")
+                       return
+                   case .success(let objectId):
+                       // Success returns the objectId for the inserted document
+                       print("Successfully inserted a document with id: \(objectId)")
+                   }
                }
            }
        }

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.update-many.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.update-many.swift
@@ -1,6 +1,6 @@
 let queryFilter: Document = ["name": "Bean of the Day"]
+let documentUpdate: Document = ["$set": ["containsDairy": true]]
 
-let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
 collection.updateManyDocuments(filter: queryFilter, update: documentUpdate) { result in
     switch result {
     case .failure(let error):

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.update-one.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.update-one.swift
@@ -1,5 +1,5 @@
-let queryFilter: Document = ["name": "Bean of the Day", "_partition": "Store 42"]
-let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
+let queryFilter: Document = ["name": "Bean of the Day", "storeNumber": 42]
+let documentUpdate: Document = ["$set": ["containsDairy": true]]
 
 collection.updateOneDocument(filter: queryFilter, update: documentUpdate) { result in
     switch result {

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.upsert.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.upsert.swift
@@ -1,5 +1,5 @@
-let queryFilter: Document = ["name": "Bean of the Day", "_partition": "Store 55"]
-let documentUpdate: Document = ["name": "Bean of the Day", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": "false", "_partition": "Store 55"]
+let queryFilter: Document = ["name": "Bean of the Day", "storeNumber": 55]
+let documentUpdate: Document = ["name": "Bean of the Day", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": false, "storeNumber": 55]
 
 collection.updateOneDocument(filter: queryFilter, update: documentUpdate, upsert: true) { result in
     switch result {
@@ -7,8 +7,8 @@ collection.updateOneDocument(filter: queryFilter, update: documentUpdate, upsert
         print("Failed to update document: \(error.localizedDescription)")
         return
     case .success(let updateResult):
-        if updateResult.objectId != nil {
-            print("Successfully upserted a document with id: \(updateResult.objectId)")
+        if let unwrappedDocumentId = updateResult.documentId {
+            print("Successfully upserted a document with id: \(unwrappedDocumentId)")
         } else {
             print("Did not upsert a document")
         }

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-async-sequence.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-async-sequence.swift
@@ -1,4 +1,4 @@
-let user = try await app.login(credentials: Credentials.anonymous)
+let user = try await appClient.login(credentials: Credentials.anonymous)
 // Set up the client, database, and collection.
 let mongoClient = user.mongoClient("mongodb-atlas")
 let database = mongoClient.database(named: "ios")
@@ -20,8 +20,8 @@ let task = Task {
 
 // Updating a document in the collection triggers a change event.
 let queryFilter: Document = ["_id": AnyBSON(objectId) ]
-let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
-try await collection.updateOneDocument(filter: queryFilter, update: documentUpdate)
+let documentUpdate: Document = ["$set": ["containsDairy": true]]
+let updateResult = try await collection.updateOneDocument(filter: queryFilter, update: documentUpdate)
 // Cancel the task when you're done watching the stream.
 task.cancel()
 _ = await task.result

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-filter.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-filter.swift
@@ -1,4 +1,4 @@
-app.login(credentials: Credentials.anonymous) { (result) in
+appClient.login(credentials: Credentials.anonymous) { (result) in
     DispatchQueue.main.async {
         switch result {
         case .failure(let error):
@@ -9,7 +9,7 @@ app.login(credentials: Credentials.anonymous) { (result) in
         }
         
         // Set up the client, database, and collection.
-        let client = app.currentUser!.mongoClient("mongodb-atlas")
+        let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
         let database = client.database(named: "ios")
         let collection = database.collection(withName: "CoffeeDrinks")
         
@@ -22,7 +22,7 @@ app.login(credentials: Credentials.anonymous) { (result) in
 
         // An update to a relevant document triggers a change event.
         let queryFilter: Document = ["_id": AnyBSON(drinkObjectId) ]
-        let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
+        let documentUpdate: Document = ["$set": ["containsDairy": true]]
 
         collection.updateOneDocument(filter: queryFilter, update: documentUpdate) { result in
             switch result {

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-match.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-match.swift
@@ -1,4 +1,4 @@
-app.login(credentials: Credentials.anonymous) { (result) in
+appClient.login(credentials: Credentials.anonymous) { (result) in
     DispatchQueue.main.async {
         switch result {
         case .failure(let error):
@@ -9,7 +9,7 @@ app.login(credentials: Credentials.anonymous) { (result) in
         }
         
         // Set up the client, database, and collection.
-        let client = app.currentUser!.mongoClient("mongodb-atlas")
+        let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
         let database = client.database(named: "ios")
         let collection = database.collection(withName: "CoffeeDrinks")
         
@@ -17,11 +17,11 @@ app.login(credentials: Credentials.anonymous) { (result) in
         // both of which are optional arguments.
         let queue = DispatchQueue(label: "io.realm.watchQueue")
         let delegate =  MyChangeStreamDelegate()
-        let matchFilter = [ "fullDocument._partition": AnyBSON("Store 42") ]
+        let matchFilter = [ "fullDocument.storeNumber": AnyBSON(42) ]
         let changeStream = collection.watch(matchFilter: matchFilter, delegate: delegate, queue: queue)
         // An update to a relevant document triggers a change event.
         let queryFilter: Document = ["_id": AnyBSON(drinkObjectId) ]
-        let documentUpdate: Document = ["$set": ["containsDairy": "true"]]
+        let documentUpdate: Document = ["$set": ["containsDairy": true]]
 
         collection.updateOneDocument(filter: queryFilter, update: documentUpdate) { result in
             switch result {

--- a/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection.swift
@@ -1,4 +1,4 @@
-app.login(credentials: Credentials.anonymous) { (result) in
+appClient.login(credentials: Credentials.anonymous) { (result) in
     DispatchQueue.main.async {
         switch result {
         case .failure(let error):
@@ -9,7 +9,7 @@ app.login(credentials: Credentials.anonymous) { (result) in
         }
         
         // Set up the client, database, and collection.
-        let client = app.currentUser!.mongoClient("mongodb-atlas")
+        let client = self.appClient.currentUser!.mongoClient("mongodb-atlas")
         let database = client.database(named: "ios")
         let collection = database.collection(withName: "CoffeeDrinks")
         
@@ -20,7 +20,7 @@ app.login(credentials: Credentials.anonymous) { (result) in
         let changeStream = collection.watch(delegate: delegate, queue: queue)
 
         // Adding a document triggers a change event.
-        let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": "false", "_partition": "Store 42"]
+        let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "storeNumber": 42]
         
         collection.insertOne(drink) { result in
             switch result {

--- a/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-add-fields.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-add-fields.swift
@@ -1,4 +1,4 @@
-let pipeline: [Document] = [["$addFields": ["storeNumber": ["$arrayElemAt": [["$split": ["$partition", " "]], 1]]]]]
+let pipeline: [Document] = [["$addFields": ["storeNumber": ["$arrayElemAt": [["$split": ["$store", " "]], 1]]]]]
 
 collection.aggregate(pipeline: pipeline) { result in
     switch result {

--- a/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-group.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-group.swift
@@ -1,4 +1,4 @@
-let pipeline: [Document] = [["$group": ["_id": "$partition", "numItems": ["$sum": 1]]]]
+let pipeline: [Document] = [["$group": ["_id": "$storeNumber", "numItems": ["$sum": 1]]]]
 
 collection.aggregate(pipeline: pipeline) { result in
     switch result {

--- a/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-match.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-match.swift
@@ -1,4 +1,4 @@
-let pipeline: [Document] = [["$match": ["partition": ["$eq": "Store 42"]]]]
+let pipeline: [Document] = [["$match": ["storeNumber": ["$eq": 42]]]]
 
 collection.aggregate(pipeline: pipeline) { result in
     switch result {

--- a/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-project.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-project.swift
@@ -1,4 +1,4 @@
-let pipeline: [Document] = [["$project": ["_id": 0, "name": 1, "storeNumber": ["$arrayElemAt": [["$split": ["$partition", " "]], 1]]]]]
+let pipeline: [Document] = [["$project": ["_id": 0, "name": 1, "storeNumber": ["$arrayElemAt": [["$split": ["$store", " "]], 1]]]]]
 
 collection.aggregate(pipeline: pipeline) { result in
     switch result {

--- a/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.store-document-example.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.store-document-example.swift
@@ -1,0 +1,2 @@
+let drink: Document = [ "name": "Bean of the Day", "beanRegion": "Timbio, Colombia", "containsDairy": false, "store": "Store 42"]
+let drink2: Document = [ "name": "Bean of the Day", "beanRegion": "Yirgacheffe, Ethiopia", "containsDairy": true, "store": "Store 47"]

--- a/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.unwind-test-document.swift
+++ b/source/examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.unwind-test-document.swift
@@ -1,0 +1,11 @@
+let drink: Document = [
+    "name": "Maple Latte",
+    "beanRegion": "Yirgacheffe, Ethiopia",
+    "containsDairy": true,
+    "storeNumber": 42,
+    "featuredInPromotions": [
+        "Spring into Spring",
+        "Tastes of Fall",
+        "Winter Delights"
+    ]
+]

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -114,18 +114,19 @@ Insert a Single Document
 
 You can insert a single document using :swift-sdk:`collection.insertOne() <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE9insertOneyySDySSAC7AnyBSONOSgG_ys6ResultOyAFs5Error_pGctF>`.
 
-This snippet inserts a single document describing a "Bean of the Day" coffee 
+This snippet inserts a single document describing a "Colombian Blend" coffee 
 drink into a :ref:`collection of documents that describe coffee drinks for sale 
 in a group of stores <ios-mongodb-example-dataset>`:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-one.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-one.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully inserted a document with id: objectId(6108...)
+      Successfully inserted a document with id: objectId(64e50cab7765243942cd04ce)
 
 .. _ios-mongodb-insertMany:
 
@@ -138,14 +139,15 @@ This snippet inserts three documents describing coffee drinks into a
 :ref:`collection of documents that describe coffee drinks for sale in a group 
 of stores <ios-mongodb-example-dataset>`:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-many.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.insert-many.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully inserted 3 new documents.
+      Successfully inserted 3 new documents.
 
 .. _ios-mongodb-read-documents:
 
@@ -170,21 +172,23 @@ You can find a single document using :swift-sdk:`collection.findOneDocument() <E
 This snippet finds a single document from a :ref:`collection of documents 
 that describe coffee drinks for sale in a group of stores 
 <ios-mongodb-example-dataset>`, where the document's ``name`` field contains
-the string value "Maple Latte":
+the string value "Colombian Blend":
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.find-one.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.find-one.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Found a matching document: Optional([
-      "name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), 
-      "_id": Optional(RealmSwift.AnyBSON.objectId(60f5...)), 
-      "creamer": Optional(RealmSwift.AnyBSON.string("true")), 
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia"))])
+      Found a matching document: Optional([
+         "name": Optional(RealmSwift.AnyBSON.string("Colombian Blend")), 
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e5014f65796c813bc68274)), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), 
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(false)), 
+         "storeNumber": Optional(RealmSwift.AnyBSON.int64(43))
+      ])
 
 .. _ios-mongodb-findMany:
 
@@ -197,26 +201,17 @@ This snippet finds all documents in a :ref:`collection of documents that
 describe coffee drinks for sale in a group of stores <ios-mongodb-example-dataset>`, 
 where the document's ``name`` field contains the value "Americano":
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.find-many.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.find-many.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Results: 
-   Coffee drink: [
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), 
-      "creamer": Optional(RealmSwift.AnyBSON.string("false")), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), 
-      "_id": Optional(RealmSwift.AnyBSON.objectId(6102...)), 
-      "name": Optional(RealmSwift.AnyBSON.string("Americano"))]
-   Coffee drink: [
-      "creamer": Optional(RealmSwift.AnyBSON.string("false")), 
-      "name": Optional(RealmSwift.AnyBSON.string("Americano")), 
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 47")), 
-      "_id": Optional(RealmSwift.AnyBSON.objectId(6102...)), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("San Marcos, Guatemala"))]
+      Results: 
+      Coffee drink named: Optional(Optional(RealmSwift.AnyBSON.string("Americano")))
+      Coffee drink named: Optional(Optional(RealmSwift.AnyBSON.string("Americano")))
 
 .. _ios-mongodb-findAndSort:
 
@@ -241,26 +236,29 @@ describe coffee drinks for sale in a group of stores <ios-mongodb-example-datase
 where the document's ``name`` field contains the value "Americano", sorted 
 in descending order by the ``beanRegion`` field:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.find-and-sort.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.find-and-sort.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Results: 
-   Coffee drink: [
-      "creamer": Optional(RealmSwift.AnyBSON.string("false")), 
-      "name": Optional(RealmSwift.AnyBSON.string("Americano")), 
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 47")), 
-      "_id": Optional(RealmSwift.AnyBSON.objectId(6102...)), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("San Marcos, Guatemala"))]
-   Coffee drink: [
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), 
-      "creamer": Optional(RealmSwift.AnyBSON.string("false")), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), 
-      "_id": Optional(RealmSwift.AnyBSON.objectId(6102...)), 
-      "name": Optional(RealmSwift.AnyBSON.string("Americano"))]
+      Results: 
+      Coffee drink: [
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e521ed6b124fd047534345)), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("San Marcos, Guatemala")), 
+         "name": Optional(RealmSwift.AnyBSON.string("Americano")), 
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(true)), 
+         "storeNumber": Optional(RealmSwift.AnyBSON.int64(42))
+      ]
+      Coffee drink: [
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e521ed6b124fd047534344)), 
+         "storeNumber": Optional(RealmSwift.AnyBSON.int64(42)), 
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(false)), 
+         "name": Optional(RealmSwift.AnyBSON.string("Americano")), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia"))
+      ]
 
 .. _ios-mongodb-count:
 
@@ -277,14 +275,15 @@ that describe coffee drinks for sale in a group of stores
 <ios-mongodb-example-dataset>`, where the document's ``name`` field contains 
 the value "Bean of the Day":
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.count.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.count.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Found this many documents in the collection matching the filter: 24
+      Found this many documents in the collection matching the filter: 24
 
 .. _ios-mongodb-update-documents:
 
@@ -311,16 +310,17 @@ This snippet updates a single document in a :ref:`collection of documents
 that describe coffee drinks for sale in a group of stores 
 <ios-mongodb-example-dataset>`. This update operation queries for a document
 whose ``name`` field contains the value "Bean of the Day", and sets the
-``containsDairy`` field to "true":
+``containsDairy`` field to ``true``:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.update-one.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.update-one.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully updated a matching document.
+      Successfully updated a matching document.
 
 .. _ios-mongodb-updateMany:
 
@@ -333,16 +333,17 @@ This snippet updates multiple documents in a :ref:`collection of documents
 that describe coffee drinks for sale in a group of stores 
 <ios-mongodb-example-dataset>`. This update operation queries for documents
 where the ``name`` field contains the value "Bean of the Day", and changes the
-``containsDairy`` field to "true":
+``containsDairy`` field to ``true``:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.update-many.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.update-many.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully updated 24 documents.
+      Successfully updated 24 documents.
 
 .. _ios-mongodb-upsert:
 
@@ -359,20 +360,21 @@ that describe coffee drinks for sale in a group of stores
 <ios-mongodb-example-dataset>`. If no document matches the query, it 
 inserts a new document if no document. This operation queries for documents 
 where the ``name`` field has a value of "Bean of the Day", and 
-the ``partition`` field has a value of "Store 55". 
+the ``storeNumber`` field has a value of ``55``. 
 
 Because this snippet sets the ``upsert`` option to ``true``, if no
 document matches the query, MongoDB creates a new document that includes
 both the query and specified updates:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.upsert.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.upsert.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully upserted a document with id: Optional(6108...)
+      Successfully upserted a document with id: 64e523e37765243942eba44a
 
 .. _ios-mongodb-delete-documents:
 
@@ -395,17 +397,18 @@ You can delete a single document from a collection using :swift-sdk:`collection.
 This snippet deletes one document in a :ref:`collection of documents 
 that describe coffee drinks for sale in a group of stores 
 <ios-mongodb-example-dataset>`. This operation queries for a document where
-the ``name`` field has a value of "Mocha" and the ``partition`` field has
-a value of "Store 17", and deletes it.
+the ``name`` field has a value of "Mocha" and the ``storeNumber`` field has
+a value of ``17``, and deletes it.
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.delete-one.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.delete-one.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully deleted a document.
+      Successfully deleted a document.
 
 .. _ios-mongodb-deleteMany:
 
@@ -419,14 +422,15 @@ that describe coffee drinks for sale in a group of stores
 <ios-mongodb-example-dataset>` that match the query for documents
 whose ``name`` field contains the value "Caramel Latte":
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.delete-many.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.delete-many.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully deleted 3 documents.
+      Successfully deleted 3 documents.
 
 .. _swift-mongodb-watch:
 
@@ -458,30 +462,49 @@ or apply a ``$match`` filter to incoming change events with :swift-sdk:`collecti
 
 The ``.watch()`` method can take a :swift-sdk:`ChangeEventDelegate 
 <Protocols/ChangeEventDelegate.html>` to subscribe to changes on a stream.
-
-The following snippet watches for changes to any documents in the
-``CoffeeDrinks`` collection:
-
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection.swift
-   :language: swift
-   :copyable: false
-
-It uses this :swift-sdk:`ChangeEventDelegate <Protocols/ChangeEventDelegate.html>`:
+For example, with this ``ChangeEventDelegate``:
 
 .. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
    :language: swift
    :copyable: false
 
-Running this snippet produces this output:
+This code watches for changes to documents in the ``CoffeeDrinks`` 
+collection:
 
-.. code-block:: console
-   :copyable: false
+.. io-code-block::
 
-   Login as <RLMUser: 0x600003908880> succeeded!
-   Change stream opened: <RLMChangeStream: 0x600000c9a1c0>
-   Change event document received: ["clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-03-30 21:42:44 +0000)), "documentKey": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(642602546207d8b9ce866ec4))])), "_id": Optional(RealmSwift.AnyBSON.document(["_data": Optional(RealmSwift.AnyBSON.string("8264260254000000012B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F69640064642602546207D8B9CE866EC40004"))])), "operationType": Optional(RealmSwift.AnyBSON.string("insert")), "fullDocument": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("false")), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "_id": Optional(RealmSwift.AnyBSON.objectId(642602546207d8b9ce866ec4)), "_partition": Optional(RealmSwift.AnyBSON.string("Store 42")), "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia"))])), "ns": Optional(RealmSwift.AnyBSON.document(["coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks")), "db": Optional(RealmSwift.AnyBSON.string("ios"))]))]
-   Successfully inserted a document with id: objectId(642602546207d8b9ce866ec4)
-   Change stream closed
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection.swift
+      :language: swift
+
+   .. output::
+      :language: console
+
+      Login as <RLMUser: 0x600002dfd1a0> succeeded!
+      Change stream opened: <RLMChangeStream: 0x60000182ab80>
+      Successfully inserted a document with id: objectId(64e525665fef1743dedb5aa6)
+      Change event document received: [
+         "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-08-22 21:15:18 +0000)), 
+         "_id": Optional(RealmSwift.AnyBSON.document([
+            "_data": Optional(RealmSwift.AnyBSON.string(
+               "8264E525660000000B2B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F6964006464E525665FEF1743DEDB5AA60004"
+            ))
+         ])), 
+         "documentKey": Optional(RealmSwift.AnyBSON.document([
+            "_id": Optional(RealmSwift.AnyBSON.objectId(64e525665fef1743dedb5aa6))
+         ])), 
+         "ns": Optional(RealmSwift.AnyBSON.document([
+            "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks")), 
+            "db": Optional(RealmSwift.AnyBSON.string("ios"))
+         ])), 
+         "operationType": Optional(RealmSwift.AnyBSON.string("insert")), 
+         "fullDocument": Optional(RealmSwift.AnyBSON.document([
+            "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), 
+            "storeNumber": Optional(RealmSwift.AnyBSON.int64(42)), 
+            "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), 
+            "_id": Optional(RealmSwift.AnyBSON.objectId(64e525665fef1743dedb5aa6)), 
+            "containsDairy": Optional(RealmSwift.AnyBSON.bool(false))
+         ]))]
+      Change stream closed
 
 .. _swift-mongodb-watch-with-list-of-ids:
 
@@ -494,29 +517,55 @@ passing in their ``_id``. Call :swift-sdk:`collection.watch(filterIds: )
 with an array of ObjectIds to receive only change events that apply to those
 documents.
 
-The following snippet watches for changes to specific documents in the
-``CoffeeDrinks`` collection:
-
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-filter.swift
-   :language: swift
-   :copyable: false
-
-It uses this :swift-sdk:`ChangeEventDelegate <Protocols/ChangeEventDelegate.html>`:
+Consider an example that uses this :swift-sdk:`ChangeEventDelegate 
+<Protocols/ChangeEventDelegate.html>`:
 
 .. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
    :language: swift
    :copyable: false
 
-Running this snippet produces this output:
+The code below uses this delegate to watch for changes to specific
+documents in the ``CoffeeDrinks`` collection:
 
-.. code-block:: console
-   :copyable: false
+.. io-code-block::
 
-   Login as <RLMUser: 0x600003198780> succeeded!
-   Change stream opened: <RLMChangeStream: 0x600000418240>
-   Successfully updated the document
-   Change event document received: ["fullDocument": Optional(RealmSwift.AnyBSON.document(["_partition": Optional(RealmSwift.AnyBSON.string("Store 42")), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), "_id": Optional(RealmSwift.AnyBSON.objectId(6426121ec505cc40eb9f6de2)), "containsDairy": Optional(RealmSwift.AnyBSON.string("true"))])), "_id": Optional(RealmSwift.AnyBSON.document(["_data": Optional(RealmSwift.AnyBSON.string("826426122A000000102B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F696400646426121EC505CC40EB9F6DE20004"))])), "ns": Optional(RealmSwift.AnyBSON.document(["db": Optional(RealmSwift.AnyBSON.string("ios")), "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks"))])), "updateDescription": Optional(RealmSwift.AnyBSON.document(["removedFields": Optional(RealmSwift.AnyBSON.array([])), "updatedFields": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("true"))]))])), "operationType": Optional(RealmSwift.AnyBSON.string("update")), "documentKey": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(6426121ec505cc40eb9f6de2))])), "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-03-30 22:50:18 +0000))]
-   Change stream closed
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-filter.swift
+      :language: swift
+
+   .. output::
+      :language: console
+
+      Login as <RLMUser: 0x60000010eb00> succeeded!
+      Successfully inserted a document with id: objectId(64e525ce7765243942ef0a58)
+      Change stream opened: <RLMChangeStream: 0x6000034946c0>
+      Change event document received: [
+         "fullDocument": Optional(RealmSwift.AnyBSON.document([
+            "containsDairy": Optional(RealmSwift.AnyBSON.bool(true)), 
+            "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), 
+            "_id": Optional(RealmSwift.AnyBSON.objectId(64e525ce7765243942ef0a58)), 
+            "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), 
+            "storeNumber": Optional(RealmSwift.AnyBSON.int64(42))
+         ])), 
+         "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-08-22 21:17:09 +0000)), 
+         "operationType": Optional(RealmSwift.AnyBSON.string("update")), 
+         "documentKey": Optional(RealmSwift.AnyBSON.document([
+            "_id": Optional(RealmSwift.AnyBSON.objectId(64e525ce7765243942ef0a58))
+         ])), 
+         "ns": Optional(RealmSwift.AnyBSON.document([
+            "db": Optional(RealmSwift.AnyBSON.string("ios")), 
+            "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks"))
+         ])), 
+         "updateDescription": Optional(RealmSwift.AnyBSON.document([
+            "removedFields": Optional(RealmSwift.AnyBSON.array([])), 
+            "updatedFields": Optional(RealmSwift.AnyBSON.document([
+               "containsDairy": Optional(RealmSwift.AnyBSON.bool(true))]))
+            ])), 
+         "_id": Optional(RealmSwift.AnyBSON.document([
+            "_data": Optional(RealmSwift.AnyBSON.string(
+               "8264E525D5000000082B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F6964006464E525CE7765243942EF0A580004"
+            ))
+         ]))]
+      Change stream closed
 
 .. _swift-mongodb-watch-with-filter:
 
@@ -532,31 +581,59 @@ used as the query of a :manual:`$match operator
 :ref:`database event <database-events>` that occurs while watching the
 collection.
 
-The following snippet watches for changes to documents in the
-``CoffeeDrink`` collection, but only triggers the provided callback for
-events corresponding to documents belonging to the partition named
-"Store 42":
-
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-match.swift
-   :language: swift
-   :copyable: false
-
-It uses this :swift-sdk:`ChangeEventDelegate <Protocols/ChangeEventDelegate.html>`:
+Consider an example that uses this :swift-sdk:`ChangeEventDelegate 
+<Protocols/ChangeEventDelegate.html>`:
 
 .. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.change-event-delegate.swift
    :language: swift
    :copyable: false
 
-Running this snippet produces this output:
+To use the code below to watch for changes to documents in the
+``CoffeeDrink`` collection, but only trigger the provided callback for
+events corresponding to documents belonging to the ``storeNumber`` named
+``42``:
 
-.. code-block:: console
-   :copyable: false
+.. io-code-block::
 
-   Login as <RLMUser: 0x60000183d7e0> succeeded!
-   Change stream opened: <RLMChangeStream: 0x600002d580c0>
-   Change event document received: ["fullDocument": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(6426e0feedf76ba4a8969b34)), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "_partition": Optional(RealmSwift.AnyBSON.string("Store 42")), "containsDairy": Optional(RealmSwift.AnyBSON.string("true")), "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia"))])), "documentKey": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(6426e0feedf76ba4a8969b34))])), "updateDescription": Optional(RealmSwift.AnyBSON.document(["updatedFields": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("true"))])), "removedFields": Optional(RealmSwift.AnyBSON.array([]))])), "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-03-31 13:33:03 +0000)), "operationType": Optional(RealmSwift.AnyBSON.string("update")), "ns": Optional(RealmSwift.AnyBSON.document(["db": Optional(RealmSwift.AnyBSON.string("ios")), "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks"))])), "_id": Optional(RealmSwift.AnyBSON.document(["_data": Optional(RealmSwift.AnyBSON.string("826426E10F0000000F2B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F696400646426E0FEEDF76BA4A8969B340004"))]))]
-   Successfully updated the document
-   Change stream closed
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-with-match.swift
+      :language: swift
+
+   .. output::
+      :language: text
+
+      Login as <RLMUser: 0x6000026ee640> succeeded!
+      Successfully inserted a document with id: objectId(64e5266731323150716faf13)
+      Change stream opened: <RLMChangeStream: 0x6000013283c0>
+      Change event document received: [
+         "operationType": Optional(RealmSwift.AnyBSON.string("update")), 
+         "updateDescription": Optional(RealmSwift.AnyBSON.document([
+            "removedFields": Optional(RealmSwift.AnyBSON.array([])), 
+            "updatedFields": Optional(RealmSwift.AnyBSON.document([
+               "containsDairy": Optional(RealmSwift.AnyBSON.bool(true))
+            ]))
+         ])), 
+         "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-08-22 21:19:44 +0000)), 
+         "_id": Optional(RealmSwift.AnyBSON.document([
+            "_data": Optional(RealmSwift.AnyBSON.string(
+               "8264E526700000000E2B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F6964006464E5266731323150716FAF130004"
+            ))
+         ])), 
+         "ns": Optional(RealmSwift.AnyBSON.document([
+            "db": Optional(RealmSwift.AnyBSON.string("ios")), 
+            "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks"))
+         ])), 
+         "fullDocument": Optional(RealmSwift.AnyBSON.document([
+            "_id": Optional(RealmSwift.AnyBSON.objectId(64e5266731323150716faf13)), 
+            "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), 
+            "containsDairy": Optional(RealmSwift.AnyBSON.bool(true)), 
+            "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), 
+            "storeNumber": Optional(RealmSwift.AnyBSON.int64(42))
+         ])), 
+         "documentKey": Optional(RealmSwift.AnyBSON.document([
+            "_id": Optional(RealmSwift.AnyBSON.objectId(64e5266731323150716faf13))
+         ]))]
+      Successfully updated the document
+      Change stream closed
 
 
 .. _swift-mongodb-watch-async-sequence:
@@ -583,17 +660,44 @@ to watch a subset of documents in a collection, similar to the examples above.
 The following snippet watches for changes to any documents in the
 ``CoffeeDrinks`` collection as an async sequence:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-async-sequence.swift
-   :language: swift
-   :copyable: false
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccess.snippet.watch-collection-async-sequence.swift
+      :language: swift
 
-.. code-block:: console
-   :copyable: false
+   .. output::
+      :language: text
 
-   Successfully opened change stream
-   Received event: ["_id": Optional(RealmSwift.AnyBSON.document(["_data": Optional(RealmSwift.AnyBSON.string("82642722F9000000052B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F69640064642722F800B264566E25B5CC0004"))])), "updateDescription": Optional(RealmSwift.AnyBSON.document(["updatedFields": Optional(RealmSwift.AnyBSON.document(["containsDairy": Optional(RealmSwift.AnyBSON.string("true"))])), "removedFields": Optional(RealmSwift.AnyBSON.array([]))])), "ns": Optional(RealmSwift.AnyBSON.document(["db": Optional(RealmSwift.AnyBSON.string("ios")), "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks"))])), "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-03-31 18:14:17 +0000)), "fullDocument": Optional(RealmSwift.AnyBSON.document(["beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "_id": Optional(RealmSwift.AnyBSON.objectId(642722f800b264566e25b5cc)), "containsDairy": Optional(RealmSwift.AnyBSON.string("true")), "_partition": Optional(RealmSwift.AnyBSON.string("Store 43"))])), "documentKey": Optional(RealmSwift.AnyBSON.document(["_id": Optional(RealmSwift.AnyBSON.objectId(642722f800b264566e25b5cc))])), "operationType": Optional(RealmSwift.AnyBSON.string("update"))]
+      Successfully opened change stream
+      Received event: [
+         "operationType": Optional(RealmSwift.AnyBSON.string("update")), 
+         "documentKey": Optional(RealmSwift.AnyBSON.document([
+            "_id": Optional(RealmSwift.AnyBSON.objectId(64e526d9850b15debe83ff46))
+         ])), 
+         "ns": Optional(RealmSwift.AnyBSON.document([
+            "coll": Optional(RealmSwift.AnyBSON.string("CoffeeDrinks")), 
+            "db": Optional(RealmSwift.AnyBSON.string("ios"))
+         ])), 
+         "clusterTime": Optional(RealmSwift.AnyBSON.datetime(2023-08-22 21:21:30 +0000)), 
+         "fullDocument": Optional(RealmSwift.AnyBSON.document([
+            "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), 
+            "containsDairy": Optional(RealmSwift.AnyBSON.bool(true)), 
+            "storeNumber": Optional(RealmSwift.AnyBSON.int64(43)), 
+            "_id": Optional(RealmSwift.AnyBSON.objectId(64e526d9850b15debe83ff46)), 
+            "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia"))
+         ])), 
+         "_id": Optional(RealmSwift.AnyBSON.document([
+            "_data": Optional(RealmSwift.AnyBSON.string(
+               "8264E526DA000000092B022C0100296E5A100464816C3449884434A07AC19F4AAFCB8046645F6964006464E526D9850B15DEBE83FF460004"
+               )
+            )
+         ])), 
+         "updateDescription": Optional(RealmSwift.AnyBSON.document([
+            "updatedFields": Optional(RealmSwift.AnyBSON.document([
+               "containsDairy": Optional(RealmSwift.AnyBSON.bool(true))
+            ])), 
+            "removedFields": Optional(RealmSwift.AnyBSON.array([]))
+         ]))]
 
 .. _ios-mongodb-aggregation-pipelines:
 
@@ -624,29 +728,30 @@ documents using standard MongoDB :manual:`query syntax
 </tutorial/query-documents>`:
 
 This ``$match`` stage filters documents to include only those where the 
-``partition`` field has a value equal to "Store 42":
+``storeNumber`` field has a value equal to ``42``:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-match.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-match.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully ran the aggregation: 
-   Coffee drink: [
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), 
-      "creamer": Optional(RealmSwift.AnyBSON.string("false")), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), 
-      "_id": Optional(RealmSwift.AnyBSON.objectId(6102...)), 
-      "name": Optional(RealmSwift.AnyBSON.string("Americano"))]
-   Coffee drink: [
-      "creamer": Optional(RealmSwift.AnyBSON.string("false")), 
-      "name": Optional(RealmSwift.AnyBSON.string("Americano")), 
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), 
-      "_id": Optional(RealmSwift.AnyBSON.objectId(6102...)), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("San Marcos, Guatemala"))]
-   (...more results...)
+      Successfully ran the aggregation:
+      Coffee drink: [
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e53171313231507183e7c2)), 
+         "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), 
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(false)), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), 
+         "storeNumber": Optional(RealmSwift.AnyBSON.int64(42))]
+      Coffee drink: [
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(true)), 
+         "name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia")), 
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e53171313231507183e7c3)), 
+         "storeNumber": Optional(RealmSwift.AnyBSON.int64(42))]
+         (...more results...)
 
 .. _ios-mongodb-aggregate-group:
 
@@ -661,23 +766,22 @@ You can reference a specific document field by prefixing the field name
 with a ``$``.
 
 This ``$group`` stage arranges documents by the value of their
-``partition`` field, which in this case is the store number. It then 
-calculates the number of coffee drink documents that contain that store number
-as the value of the ``partition`` field. In other words, we're calculating
-the number of coffee drinks for each store number. 
+``storeNumber`` field. It then calculates the number of coffee drink 
+documents that contain that store number in the field's value. In other 
+words, we're calculating the number of coffee drinks for each store number. 
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-group.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-group.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully ran the aggregation.
-   ["numItems": Optional(RealmSwift.AnyBSON.int64(6)), "_id": Optional(RealmSwift.AnyBSON.string("Store 43"))]
-   ["numItems": Optional(RealmSwift.AnyBSON.int64(16)), "_id": Optional(RealmSwift.AnyBSON.string("Store 42"))]
-   ["_id": Optional(RealmSwift.AnyBSON.string("Store 47")), "numItems": Optional(RealmSwift.AnyBSON.int64(7))]
-   (...more results...)
+      Successfully ran the aggregation.
+      ["numItems": Optional(RealmSwift.AnyBSON.int64(27)), "_id": Optional(RealmSwift.AnyBSON.int64(42))]
+      ["numItems": Optional(RealmSwift.AnyBSON.int64(44)), "_id": Optional(RealmSwift.AnyBSON.int64(47))]
+      (...more results...)
 
 .. _ios-mongodb-aggregate-project:
 
@@ -705,18 +809,25 @@ vice versa.
    The ``_id`` field is a special case: it is always included in every
    query unless explicitly specified otherwise. For this reason, you
    *can* exclude the ``_id`` field with a ``0`` value while simultaneously
-   including other fields, like ``_partition``, with a ``1``. Only the
+   including other fields, like ``storeNumber``, with a ``1``. Only the
    special case of exclusion of the ``_id`` field allows both exclusion
    and inclusion in one ``$project`` stage.
+
+For this example, assume the ``CoffeeDrink`` document has a ``store``
+field that is a string value containing the word "Store" with a number, 
+such as "Store 42", similar to these documents:
+
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.store-document-example.swift
+   :language: swift
 
 The following ``$project`` stage omits the ``_id`` field, includes
 the ``name`` field, and creates a new field named ``storeNumber``.
 The ``storeNumber`` is generated using two aggregation operators:
 
-1. ``$split`` separates the ``partition`` value into two string
-   segments surrounding the space character. For example, the value
-   "Store 42" split in this way returns an array with two elements:
-   "Store" and "42".
+1. ``$split`` separates the ``store`` string representation into 
+   two string segments surrounding the space character. For example, 
+   the value "Store 42" split in this way returns an array with two 
+   elements: "Store" and "42".
 
 2. ``$arrayElemAt`` selects a specific element from an array based
    on the second argument. In this case, the value ``1`` selects the
@@ -724,18 +835,18 @@ The ``storeNumber`` is generated using two aggregation operators:
    since arrays index from ``0``. For example, the value ["Store", "42"]
    passed to this operation would return a value of "42".
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-project.swift
-   :language: swift
+.. io-code-block::
 
-Running this snippet produces this output:
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-project.swift
+      :language: swift
 
-.. code-block:: text
+   .. output::
+      :language: text
 
-   Successfully ran the aggregation.
-   ["name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), "storeNumber": Optional(RealmSwift.AnyBSON.string("42"))]
-   ["storeNumber": Optional(RealmSwift.AnyBSON.string("42")), "name": Optional(RealmSwift.AnyBSON.string("Americano"))]
-   ["name": Optional(RealmSwift.AnyBSON.string("Americano")), "storeNumber": Optional(RealmSwift.AnyBSON.string("47"))]
-   (...more results...)
+      Successfully ran the aggregation.
+      ["name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "storeNumber": Optional(RealmSwift.AnyBSON.string("42"))]
+      ["storeNumber": Optional(RealmSwift.AnyBSON.string("47")), "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day"))]
+      (...more results...)
 
 .. _ios-mongodb-aggregate-add-fields:
 
@@ -753,22 +864,40 @@ with calculated values using :manual:`aggregation operators
    </reference/operator/aggregation/project/>` but does not allow you to
    include or omit fields.
 
-The following ``$addFields`` stage creates a new field named
-``storeNumber`` where the value is the output of two aggregate operators
-that transform the value of the ``partition`` field.
+For this example, assume the ``CoffeeDrink`` document has a ``store``
+field that is a string value containing the word "Store" with a number, 
+such as "Store 42", similar to these documents:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-add-fields.swift
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.store-document-example.swift
    :language: swift
 
-Running this snippet produces this output:
+The following ``$addFields`` stage creates a new field named
+``storeNumber`` where the value is the output of two aggregate operators
+that transform the value of the ``store`` field.
 
-.. code-block:: text
+.. io-code-block::
 
-   Successfully ran the aggregation.
-   ["storeNumber": Optional(RealmSwift.AnyBSON.string("42")), "creamer": Optional(RealmSwift.AnyBSON.string("true")), "_id": Optional(RealmSwift.AnyBSON.objectId(60f5f39f1eb0f39071acef87)), "name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia")), "partition": Optional(RealmSwift.AnyBSON.string("Store 42"))]
-   ["beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia")), "storeNumber": Optional(RealmSwift.AnyBSON.string("42")), "_id": Optional(RealmSwift.AnyBSON.objectId(6102b91aaa4f3fc37642119e)), "name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), "creamer": Optional(RealmSwift.AnyBSON.string("true")), "partition": Optional(RealmSwift.AnyBSON.string("Store 42"))]
-   ["creamer": Optional(RealmSwift.AnyBSON.string("false")), "_id": Optional(RealmSwift.AnyBSON.objectId(6102f577099eb9b818497908)), "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia")), "storeNumber": Optional(RealmSwift.AnyBSON.string("42")), "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), "name": Optional(RealmSwift.AnyBSON.string("Americano"))]
-   (...more results...)
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-add-fields.swift
+      :language: swift
+
+   .. output::
+      :language: text
+
+      Successfully ran the aggregation.
+      [
+         "storeNumber": Optional(RealmSwift.AnyBSON.string("42")), 
+         "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), 
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e588ff5fef1743de3559aa)), 
+         "store": Optional(RealmSwift.AnyBSON.string("Store 42")), 
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(false)), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia"))]
+      [
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(true)), 
+         "storeNumber": Optional(RealmSwift.AnyBSON.string("47")), 
+         "store": Optional(RealmSwift.AnyBSON.string("Store 47")), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia")), 
+         "name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), 
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e588ff5fef1743de3559ab))]
 
 .. _ios-mongodb-aggregate-unwind:
 
@@ -782,59 +911,49 @@ values from that array. When you unwind an array field,
 MongoDB copies each document once for each element of the array field
 but replaces the array value with the array element in each copy.
 
+Consider this document that includes a ``featuredInPromotions`` array:
+
+.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.unwind-test-document.swift
+   :language: swift
+
 The following ``$unwind`` stage creates a new document for each
 element of the ``items`` array in each document. It also adds a field
 called ``itemIndex`` to each new document that specifies the
 element's position index in the original array:
 
-.. literalinclude:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-unwind.swift
-   :language: swift
+.. io-code-block::
+   
+   .. input:: /examples/generated/code/start/MongoDBRemoteAccessAggregate.snippet.aggregation-unwind.swift
+      :language: swift
 
-Consider this document that includes a ``featuredInPromotions`` array:
+   .. output::
+      :language: text
 
-.. code-block:: text
-
-   _id: 610802b44386a9ed3144447d,
-   name: "Maple Latte",
-   containsDairy:"true",
-   partition:"Store 42",
-   beanRegion: "Yirgacheffe, Ethiopia",
-   featuredInPromotions: [
-      "Spring into Spring",
-      "Tastes of Fall",
-      "Winter Delights"
-   ]
-
-If we apply the example ``$unwind`` stage to this document, the stage outputs
-the following three documents:
-
-.. code-block:: text
-
-   Successfully ran the aggregation.
-   Coffee drink: [
-      "featuredInPromotions": Optional(RealmSwift.AnyBSON.string("Spring into Spring")), 
-      "itemIndex": Optional(RealmSwift.AnyBSON.int64(0)),
-      "name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia")), 
-      "containsDairy": Optional(RealmSwift.AnyBSON.string("true")),  
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), 
-      "_id": Optional(RealmSwift.AnyBSON.objectId(6108...))]
-   Coffee drink: [
-      "featuredInPromotions": Optional(RealmSwift.AnyBSON.string("Tastes of Fall")),
-      "itemIndex": Optional(RealmSwift.AnyBSON.int64(1)),
-      "name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), 
-      "containsDairy": Optional(RealmSwift.AnyBSON.string("true")), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia")), 
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), 
-      "_id": Optional(RealmSwift.AnyBSON.objectId(6108...))]
-   Coffee drink: [
-      "featuredInPromotions": Optional(RealmSwift.AnyBSON.string("Winter Delights")),
-      "itemIndex": Optional(RealmSwift.AnyBSON.int64(2)), 
-      "partition": Optional(RealmSwift.AnyBSON.string("Store 42")), 
-      "containsDairy": Optional(RealmSwift.AnyBSON.string("true")), 
-      "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia")),  
-      "_id": Optional(RealmSwift.AnyBSON.objectId(6108...)), 
-      "name": Optional(RealmSwift.AnyBSON.string("Maple Latte"))]
+      Successfully ran the aggregation.
+      Coffee drink: [
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e58bb4fc901d40e03fde64)), 
+         "storeNumber": Optional(RealmSwift.AnyBSON.int64(42)), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia")), 
+         "featuredInPromotions": Optional(RealmSwift.AnyBSON.string("Spring into Spring")), 
+         "itemIndex": Optional(RealmSwift.AnyBSON.int64(0)), 
+         "name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), 
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(true))]
+      Coffee drink: [
+         "itemIndex": Optional(RealmSwift.AnyBSON.int64(1)), 
+         "name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), 
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e58bb4fc901d40e03fde64)), 
+         "featuredInPromotions": Optional(RealmSwift.AnyBSON.string("Tastes of Fall")), 
+         "storeNumber": Optional(RealmSwift.AnyBSON.int64(42)), 
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(true)), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia"))]
+      Coffee drink: [
+         "name": Optional(RealmSwift.AnyBSON.string("Maple Latte")), 
+         "_id": Optional(RealmSwift.AnyBSON.objectId(64e58bb4fc901d40e03fde64)), 
+         "beanRegion": Optional(RealmSwift.AnyBSON.string("Yirgacheffe, Ethiopia")), 
+         "itemIndex": Optional(RealmSwift.AnyBSON.int64(2)), 
+         "containsDairy": Optional(RealmSwift.AnyBSON.bool(true)), 
+         "storeNumber": Optional(RealmSwift.AnyBSON.int64(42)), 
+         "featuredInPromotions": Optional(RealmSwift.AnyBSON.string("Winter Delights"))]
 
 You could then ``$group`` by the value of ``featuredInPromotions`` and ``$sum`` 
 the number of coffee drinks in each promotion as in the :ref:`group documents 

--- a/source/sdk/swift/app-services/mongodb-remote-access.txt
+++ b/source/sdk/swift/app-services/mongodb-remote-access.txt
@@ -115,8 +115,8 @@ Insert a Single Document
 You can insert a single document using :swift-sdk:`collection.insertOne() <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE9insertOneyySDySSAC7AnyBSONOSgG_ys6ResultOyAFs5Error_pGctF>`.
 
 This snippet inserts a single document describing a "Colombian Blend" coffee 
-drink into a :ref:`collection of documents that describe coffee drinks for sale 
-in a group of stores <ios-mongodb-example-dataset>`:
+drink into a collection of :ref:`documents that describe coffee drinks  
+<ios-mongodb-example-dataset>` for sale in a group of stores:
 
 .. io-code-block::
 
@@ -125,6 +125,7 @@ in a group of stores <ios-mongodb-example-dataset>`:
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully inserted a document with id: objectId(64e50cab7765243942cd04ce)
 
@@ -136,8 +137,8 @@ Insert Multiple Documents
 You can insert multiple documents using :swift-sdk:`collection.insertMany() <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE10insertManyyySaySDySSAC7AnyBSONOSgGG_ys6ResultOySayAFGs5Error_pGctF>`.
 
 This snippet inserts three documents describing coffee drinks into a 
-:ref:`collection of documents that describe coffee drinks for sale in a group 
-of stores <ios-mongodb-example-dataset>`:
+collection of :ref:`documents that describe coffee drinks 
+<ios-mongodb-example-dataset>` for sale in a group of stores:
 
 .. io-code-block::
 
@@ -146,6 +147,7 @@ of stores <ios-mongodb-example-dataset>`:
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully inserted 3 new documents.
 
@@ -169,10 +171,10 @@ Find a Single Document
 
 You can find a single document using :swift-sdk:`collection.findOneDocument() <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE15findOneDocument6filter7options7Combine6FutureCySDySSAC7AnyBSONOSgGSgs5Error_pGAM_So14RLMFindOptionsCtF>`.
 
-This snippet finds a single document from a :ref:`collection of documents 
-that describe coffee drinks for sale in a group of stores 
-<ios-mongodb-example-dataset>`, where the document's ``name`` field contains
-the string value "Colombian Blend":
+This snippet finds a single document from a collection of :ref:`documents 
+that describe coffee drinks <ios-mongodb-example-dataset>` for sale in a 
+group of stores, where the document's ``name`` field contains the string
+value "Colombian Blend":
 
 .. io-code-block::
 
@@ -181,6 +183,7 @@ the string value "Colombian Blend":
 
    .. output::
       :language: text
+      :visible: false
 
       Found a matching document: Optional([
          "name": Optional(RealmSwift.AnyBSON.string("Colombian Blend")), 
@@ -197,9 +200,9 @@ Find Multiple Documents
 
 You can find multiple documents using :swift-sdk:`collection.find() <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE4find6filter7Combine6FutureCySaySDySSAC7AnyBSONOSgGGs5Error_pGAL_tF>`.
 
-This snippet finds all documents in a :ref:`collection of documents that 
-describe coffee drinks for sale in a group of stores <ios-mongodb-example-dataset>`, 
-where the document's ``name`` field contains the value "Americano":
+This snippet finds all documents in a collection of :ref:`documents that 
+describe coffee drinks <ios-mongodb-example-dataset>` for sale in a group 
+of stores, where the document's ``name`` field contains the value "Americano":
 
 .. io-code-block::
 
@@ -208,10 +211,11 @@ where the document's ``name`` field contains the value "Americano":
 
    .. output::
       :language: text
+      :visible: false
 
       Results: 
       Coffee drink named: Optional(Optional(RealmSwift.AnyBSON.string("Americano")))
-      Coffee drink named: Optional(Optional(RealmSwift.AnyBSON.string("Americano")))
+      ... more matching documents ...
 
 .. _ios-mongodb-findAndSort:
 
@@ -231,10 +235,10 @@ or ``-1`` sorts in ascending order.
 You then pass the ``FindOptions`` instance to the ``collection.find()`` method
 when running the query.
 
-This snippet finds all documents in a :ref:`collection of documents that 
-describe coffee drinks for sale in a group of stores <ios-mongodb-example-dataset>`, 
-where the document's ``name`` field contains the value "Americano", sorted 
-in descending order by the ``beanRegion`` field:
+This snippet finds all documents in a collection of :ref:`documents that 
+describe coffee drinks <ios-mongodb-example-dataset>` for sale in a group 
+of stores, where the document's ``name`` field contains the value "Americano", 
+sorted in descending order by the ``beanRegion`` field:
 
 .. io-code-block::
 
@@ -243,6 +247,7 @@ in descending order by the ``beanRegion`` field:
 
    .. output::
       :language: text
+      :visible: false
 
       Results: 
       Coffee drink: [
@@ -259,6 +264,7 @@ in descending order by the ``beanRegion`` field:
          "name": Optional(RealmSwift.AnyBSON.string("Americano")), 
          "beanRegion": Optional(RealmSwift.AnyBSON.string("Timbio, Colombia"))
       ]
+      ... more matching documents, sorted by `beanRegion` ...
 
 .. _ios-mongodb-count:
 
@@ -270,10 +276,10 @@ You can specify an optional query and limit to determine which
 documents to count. If you don't specify a query, the action counts all 
 documents in the collection.
 
-This snippet counts the number of documents in a :ref:`collection of documents 
-that describe coffee drinks for sale in a group of stores 
-<ios-mongodb-example-dataset>`, where the document's ``name`` field contains 
-the value "Bean of the Day":
+This snippet counts the number of documents in a collection of :ref:`documents 
+that describe coffee drinks <ios-mongodb-example-dataset>` for sale in a 
+group of stores, where the document's ``name`` field contains the value 
+"Bean of the Day":
 
 .. io-code-block::
 
@@ -282,6 +288,7 @@ the value "Bean of the Day":
 
    .. output::
       :language: text
+      :visible: false
 
       Found this many documents in the collection matching the filter: 24
 
@@ -306,10 +313,10 @@ Update a Single Document
 You can update a single document using :swift-sdk:`collection.updateOneDocument() 
 <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE17updateOneDocument6filter0E07Combine6FutureCySo15RLMUpdateResultCs5Error_pGSDySSAC7AnyBSONOSgG_AQtF>`.
 
-This snippet updates a single document in a :ref:`collection of documents 
-that describe coffee drinks for sale in a group of stores 
-<ios-mongodb-example-dataset>`. This update operation queries for a document
-whose ``name`` field contains the value "Bean of the Day", and sets the
+This snippet updates a single document in a collection of :ref:`documents 
+that describe coffee drinks <ios-mongodb-example-dataset>` for sale in a 
+group of stores. This update operation queries for a document whose 
+``name`` field contains the value "Bean of the Day", and sets the
 ``containsDairy`` field to ``true``:
 
 .. io-code-block::
@@ -319,6 +326,7 @@ whose ``name`` field contains the value "Bean of the Day", and sets the
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully updated a matching document.
 
@@ -329,10 +337,10 @@ Update Multiple Documents
 
 You can update multiple documents using :swift-sdk:`collection.updateManyDocuments() <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE19updateManyDocuments6filter0E07Combine6FutureCySo15RLMUpdateResultCs5Error_pGSDySSAC7AnyBSONOSgG_AQtF>`.
 
-This snippet updates multiple documents in a :ref:`collection of documents 
-that describe coffee drinks for sale in a group of stores 
-<ios-mongodb-example-dataset>`. This update operation queries for documents
-where the ``name`` field contains the value "Bean of the Day", and changes the
+This snippet updates multiple documents in a collection of :ref:`documents 
+that describe coffee drinks <ios-mongodb-example-dataset>` for sale in a 
+group of stores. This update operation queries for documents where the 
+``name`` field contains the value "Bean of the Day", and changes the
 ``containsDairy`` field to ``true``:
 
 .. io-code-block::
@@ -342,6 +350,7 @@ where the ``name`` field contains the value "Bean of the Day", and changes the
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully updated 24 documents.
 
@@ -355,10 +364,10 @@ you can automatically insert a single new document into the collection
 that matches the update query by setting the ``upsert`` option to
 ``true``.
 
-The following snippet updates a document in a :ref:`collection of documents 
-that describe coffee drinks for sale in a group of stores 
-<ios-mongodb-example-dataset>`. If no document matches the query, it 
-inserts a new document if no document. This operation queries for documents 
+The following snippet updates a document in a collection of :ref:`documents 
+that describe coffee drinks <ios-mongodb-example-dataset>` for sale in a 
+group of stores. If no document matches the query, it inserts a new 
+document if no document. This operation queries for documents 
 where the ``name`` field has a value of "Bean of the Day", and 
 the ``storeNumber`` field has a value of ``55``. 
 
@@ -373,6 +382,7 @@ both the query and specified updates:
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully upserted a document with id: 64e523e37765243942eba44a
 
@@ -394,11 +404,11 @@ Delete a Single Document
 
 You can delete a single document from a collection using :swift-sdk:`collection.deleteOneDocument() <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE17deleteOneDocument6filter7Combine6FutureCySis5Error_pGSDySSAC7AnyBSONOSgG_tF>`.
 
-This snippet deletes one document in a :ref:`collection of documents 
-that describe coffee drinks for sale in a group of stores 
-<ios-mongodb-example-dataset>`. This operation queries for a document where
-the ``name`` field has a value of "Mocha" and the ``storeNumber`` field has
-a value of ``17``, and deletes it.
+This snippet deletes one document in a collection of :ref:`documents 
+that describe coffee drinks <ios-mongodb-example-dataset>` for sale in a 
+group of stores. This operation queries for a document where the ``name`` 
+field has a value of "Mocha" and the ``storeNumber`` field has a value of 
+``17``, and deletes it.
 
 .. io-code-block::
 
@@ -407,6 +417,7 @@ a value of ``17``, and deletes it.
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully deleted a document.
 
@@ -417,10 +428,10 @@ Delete Multiple Documents
 
 You can delete multiple items from a collection using :swift-sdk:`collection.deleteManyDocuments() <Extensions/MongoCollection.html#/s:So18RLMMongoCollectionC10RealmSwiftE19deleteManyDocuments6filter7Combine6FutureCySis5Error_pGSDySSAC7AnyBSONOSgG_tF>`.
 
-This snippet deletes all documents in a :ref:`collection of documents 
-that describe coffee drinks for sale in a group of stores 
-<ios-mongodb-example-dataset>` that match the query for documents
-whose ``name`` field contains the value "Caramel Latte":
+This snippet deletes all documents in a collection of :ref:`documents 
+that describe coffee drinks <ios-mongodb-example-dataset>` for sale in a 
+group of stores that match the query for documents whose ``name`` field 
+contains the value "Caramel Latte":
 
 .. io-code-block::
 
@@ -429,6 +440,7 @@ whose ``name`` field contains the value "Caramel Latte":
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully deleted 3 documents.
 
@@ -478,6 +490,7 @@ collection:
 
    .. output::
       :language: console
+      :visible: false
 
       Login as <RLMUser: 0x600002dfd1a0> succeeded!
       Change stream opened: <RLMChangeStream: 0x60000182ab80>
@@ -534,6 +547,7 @@ documents in the ``CoffeeDrinks`` collection:
 
    .. output::
       :language: console
+      :visible: false
 
       Login as <RLMUser: 0x60000010eb00> succeeded!
       Successfully inserted a document with id: objectId(64e525ce7765243942ef0a58)
@@ -588,10 +602,9 @@ Consider an example that uses this :swift-sdk:`ChangeEventDelegate
    :language: swift
    :copyable: false
 
-To use the code below to watch for changes to documents in the
-``CoffeeDrink`` collection, but only trigger the provided callback for
-events corresponding to documents belonging to the ``storeNumber`` named
-``42``:
+The code below uses this delegate to watch for changes to documents in the
+``CoffeeDrink`` collection. It only triggers the provided callback for
+events whose documents have a ``storeNumber`` value of ``42``:
 
 .. io-code-block::
 
@@ -600,6 +613,7 @@ events corresponding to documents belonging to the ``storeNumber`` named
 
    .. output::
       :language: text
+      :visible: false
 
       Login as <RLMUser: 0x6000026ee640> succeeded!
       Successfully inserted a document with id: objectId(64e5266731323150716faf13)
@@ -667,6 +681,7 @@ The following snippet watches for changes to any documents in the
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully opened change stream
       Received event: [
@@ -737,6 +752,7 @@ This ``$match`` stage filters documents to include only those where the
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully ran the aggregation:
       Coffee drink: [
@@ -777,6 +793,7 @@ words, we're calculating the number of coffee drinks for each store number.
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully ran the aggregation.
       ["numItems": Optional(RealmSwift.AnyBSON.int64(27)), "_id": Optional(RealmSwift.AnyBSON.int64(42))]
@@ -842,6 +859,7 @@ The ``storeNumber`` is generated using two aggregation operators:
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully ran the aggregation.
       ["name": Optional(RealmSwift.AnyBSON.string("Bean of the Day")), "storeNumber": Optional(RealmSwift.AnyBSON.string("42"))]
@@ -882,6 +900,7 @@ that transform the value of the ``store`` field.
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully ran the aggregation.
       [
@@ -928,6 +947,7 @@ element's position index in the original array:
 
    .. output::
       :language: text
+      :visible: false
 
       Successfully ran the aggregation.
       Coffee drink: [


### PR DESCRIPTION
## Pull Request Info

The linked Jira ticket requests fixing some failing tests, but we've got other tickets to remove PBS examples from the docs. Since I'm touching the page anyway, I've switched the PBS examples. While I'm in here, I've added IO code blocks which were not available when this page was created.

### Jira

- https://jira.mongodb.org/browse/DOCSP-32426

### Staged Changes

- [Query MongoDB](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-32426/sdk/swift/app-services/mongodb-remote-access/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
