### PR TITLE
(DOCSP-29738): C++: Add Decimal128 to supported types

### DIFF
--- a/examples/cpp/beta/local/CMakeLists.txt
+++ b/examples/cpp/beta/local/CMakeLists.txt
@@ -14,7 +14,11 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
+<<<<<<< HEAD
   GIT_TAG        v0.3.0-preview
+=======
+  GIT_TAG        9ad9588542d71ffaa1168fdb79ebb25dbd264f5e
+>>>>>>> 2dc787e4e (C++: Add Decimal128 to supported types)
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/beta/local/CMakeLists.txt
+++ b/examples/cpp/beta/local/CMakeLists.txt
@@ -14,11 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-<<<<<<< HEAD
   GIT_TAG        v0.3.0-preview
-=======
-  GIT_TAG        9ad9588542d71ffaa1168fdb79ebb25dbd264f5e
->>>>>>> 2dc787e4e (C++: Add Decimal128 to supported types)
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/beta/local/supported-types.cpp
+++ b/examples/cpp/beta/local/supported-types.cpp
@@ -63,6 +63,12 @@ struct Beta_AllTypesObject {
     // :snippet-start: beta-optional-date
     std::optional<std::chrono::time_point<std::chrono::system_clock>> optDateName;
     // :snippet-end:
+    // :snippet-start: beta-required-decimal128
+    realm::decimal128 decimal128Name;
+    // :snippet-end:
+    // :snippet-start: beta-optional-decimal128
+    std::optional<realm::decimal128> optDecimal128Name;
+    // :snippet-end:
     // :snippet-start: beta-required-uuid
     realm::uuid uuidName;
     // :snippet-end:
@@ -88,8 +94,8 @@ struct Beta_AllTypesObject {
 REALM_SCHEMA(Beta_AllTypesObject, boolName, optBoolName, intName, optIntName,
     doubleName, optDoubleName, stringName, optStringName, enumName,
     optEnumName, binaryDataName, optBinaryDataName, dateName, optDateName,
-    uuidName, optUuidName, objectIdName, optObjectIdName, mixedName,
-    mapName, listTypeName
+    decimal128Name, optDecimal128Name, uuidName, optUuidName, objectIdName, 
+    optObjectIdName, mixedName, mapName, listTypeName
 )
 
 // :snippet-start: beta-dog-map-model
@@ -114,6 +120,7 @@ TEST_CASE("Test supported types", "[model][write]") {
         auto date = std::chrono::time_point<std::chrono::system_clock>();
         auto uuid = realm::uuid();
         auto objectId = realm::object_id::generate();
+        auto decimal = realm::decimal128(123.456);
 
         auto allRequiredTypesObject = Beta_AllTypesObject {
             .boolName = true,
@@ -123,6 +130,7 @@ TEST_CASE("Test supported types", "[model][write]") {
             .enumName = Beta_AllTypesObject::Enum::one,
             .binaryDataName = std::vector<uint8_t>{0,1,2},
             .dateName = date,
+            .decimal128Name = decimal,
             .uuidName = uuid,
             .objectIdName = objectId,
             .mixedName = realm::mixed("mixed data"),
@@ -144,6 +152,7 @@ TEST_CASE("Test supported types", "[model][write]") {
         REQUIRE(*specificAllTypeObjects.enumName == Beta_AllTypesObject::Enum::one);
         REQUIRE(specificAllTypeObjects.binaryDataName == std::vector<uint8_t>{0,1,2});
         REQUIRE(specificAllTypeObjects.dateName == date);
+        REQUIRE(specificAllTypeObjects.decimal128Name == decimal);
         REQUIRE(specificAllTypeObjects.uuidName == uuid);
         REQUIRE(specificAllTypeObjects.objectIdName == objectId);
         REQUIRE(*specificAllTypeObjects.mixedName == realm::mixed("mixed data"));
@@ -162,6 +171,8 @@ TEST_CASE("Test supported types", "[model][write]") {
         auto date = std::chrono::time_point<std::chrono::system_clock>();
         auto uuid = realm::uuid();
         auto objectId = realm::object_id::generate();
+        auto decimal = realm::decimal128(123.456);
+        auto decimal2 = realm::decimal128(789.012);
         
         auto allRequiredAndOptionalTypesObject = Beta_AllTypesObject {
             .boolName = true,
@@ -171,6 +182,7 @@ TEST_CASE("Test supported types", "[model][write]") {
             .enumName = Beta_AllTypesObject::Enum::one,
             .binaryDataName = std::vector<uint8_t>{0,1,2},
             .dateName = date,
+            .decimal128Name = decimal,
             .uuidName = uuid,
             .objectIdName = objectId,
             .mixedName = realm::mixed("mixed data"),
@@ -181,6 +193,7 @@ TEST_CASE("Test supported types", "[model][write]") {
             .optDoubleName = 42.42,
             .optStringName = "Maui",
             .optEnumName = Beta_AllTypesObject::Enum::two,
+            .optDecimal128Name = decimal2,
             .optUuidName = uuid,
             .optObjectIdName = objectId,
             .optBinaryDataName = std::vector<uint8_t>{3,4,5},
@@ -200,6 +213,7 @@ TEST_CASE("Test supported types", "[model][write]") {
         REQUIRE(*specificAllTypeObjects.enumName == Beta_AllTypesObject::Enum::one);
         REQUIRE(specificAllTypeObjects.binaryDataName == std::vector<uint8_t>{0,1,2});
         REQUIRE(specificAllTypeObjects.dateName == date);
+        REQUIRE(specificAllTypeObjects.decimal128Name == decimal);
         REQUIRE(specificAllTypeObjects.uuidName == uuid);
         REQUIRE(specificAllTypeObjects.objectIdName == objectId);
         REQUIRE(*specificAllTypeObjects.mixedName == realm::mixed("mixed data"));
@@ -210,6 +224,7 @@ TEST_CASE("Test supported types", "[model][write]") {
         REQUIRE(specificAllTypeObjects.optDoubleName == 42.42);
         REQUIRE(specificAllTypeObjects.optStringName == "Maui");
         REQUIRE(*specificAllTypeObjects.optEnumName == Beta_AllTypesObject::Enum::two);
+        REQUIRE(specificAllTypeObjects.optDecimal128Name == decimal2);
         REQUIRE(specificAllTypeObjects.optUuidName == uuid);
         REQUIRE(specificAllTypeObjects.optObjectIdName == objectId);
         REQUIRE(specificAllTypeObjects.optBinaryDataName == std::vector<uint8_t>({3,4,5}));

--- a/source/examples/generated/cpp/supported-types.snippet.beta-optional-decimal128.cpp
+++ b/source/examples/generated/cpp/supported-types.snippet.beta-optional-decimal128.cpp
@@ -1,0 +1,1 @@
+std::optional<realm::decimal128> optDecimal128Name;

--- a/source/examples/generated/cpp/supported-types.snippet.beta-required-decimal128.cpp
+++ b/source/examples/generated/cpp/supported-types.snippet.beta-required-decimal128.cpp
@@ -1,0 +1,1 @@
+realm::decimal128 decimal128Name;

--- a/source/sdk/cpp/model-data/supported-types.txt
+++ b/source/sdk/cpp/model-data/supported-types.txt
@@ -28,6 +28,8 @@ properties.
    .. tab:: Current
       :tabid: current
 
+      .. versionadded:: 0.2.1 realm::decimal128
+
       .. list-table::
          :header-rows: 1
          :stub-columns: 1
@@ -83,6 +85,13 @@ properties.
                 :language: cpp
                 :copyable: false
            - .. literalinclude:: /examples/generated/cpp/supported-types.snippet.beta-optional-date.cpp
+                :language: cpp
+                :copyable: false
+         * - Decimal128
+           - .. literalinclude:: /examples/generated/cpp/supported-types.snippet.beta-required-decimal128.cpp
+                :language: cpp
+                :copyable: false
+           - .. literalinclude:: /examples/generated/cpp/supported-types.snippet.beta-optional-decimal128.cpp
                 :language: cpp
                 :copyable: false
          * - UUID

--- a/source/sdk/cpp/model-data/supported-types.txt
+++ b/source/sdk/cpp/model-data/supported-types.txt
@@ -28,7 +28,7 @@ properties.
    .. tab:: Current
       :tabid: current
 
-      .. versionadded:: 0.2.1 realm::decimal128
+      .. versionadded:: v0.3.0-preview Adds realm::decimal128
 
       .. list-table::
          :header-rows: 1


### PR DESCRIPTION
## Pull Request Info

This is currently blocked pending the upcoming release of the C++ SDK. DO NOT MERGE until that release.

Before merging:

- [x] Update the commit ref to the release version tag in `CMakeLists.txt`
- [x] Confirm the release version number for the `.. versionadded::` directive

### Jira

- https://jira.mongodb.org/browse/DOCSP-29738

### Staged Changes

- [Supported Types](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-29738/sdk/cpp/model-data/supported-types/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [X] Create Jira ticket for corresponding docs-app-services update(s), if any
- [X] Checked/updated Admin API
- [X] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
