### PR TITLE
(DOCSP-30341 & DOCSP-31759): Revamp Kotlin Supported Types page

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DataTypes.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DataTypes.kt
@@ -1,5 +1,4 @@
 package com.mongodb.realm.realmkmmapp
-
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.ext.*
@@ -9,12 +8,9 @@ import io.realm.kotlin.types.*
 import org.mongodb.kbson.Decimal128
 import org.mongodb.kbson.ObjectId
 import kotlin.test.*
-
-
 class CustomObjectType : RealmObject {
     var uuid: RealmUUID = RealmUUID.random()
 }
-
 class AnotherCustomObjectType : RealmObject {
     var uuid: RealmUUID = RealmUUID.random()
     // :snippet-start: realm-object-optional
@@ -71,7 +67,6 @@ class EnumObject : RealmObject {
         }
 }
 // :snippet-end:
-
 class KotlinSupportedTypes : RealmObject {
     // :snippet-start: bool-required
     var boolReq: Boolean = false
@@ -128,7 +123,6 @@ class KotlinSupportedTypes : RealmObject {
     var charOpt: Char? = null
     // :snippet-end:
 }
-
 class BSONSupportedTypes : RealmObject {
     // :snippet-start: decimal128-required
     var decimal128Req: Decimal128 = Decimal128("123.456")
@@ -143,7 +137,6 @@ class BSONSupportedTypes : RealmObject {
     var objectIdOpt: ObjectId? = null
     // :snippet-end:
 }
-
 class RealmSupportedTypes : RealmObject {
     // :snippet-start: realmInstant-required
     var realmInstantReq: RealmInstant = RealmInstant.now()
@@ -177,27 +170,22 @@ class RealmSupportedTypes : RealmObject {
     var uuidOpt: RealmUUID? = null
     // :snippet-end:
 }
-
 class SupportedDataTypesTest : RealmTest() {
-
     @Test
-    fun populateEnumPropertiesDefaultsTest() {
+    fun populateEnumPropertiesTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(EnumObject::class))
                 .inMemory()
                 .build()
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.path}")
-
             val enumObject1 = EnumObject().apply {
                 name = "MyEnum"
                 stateEnum = EnumClass.IN_PROGRESS
             }
-
             val enumObject2 = EnumObject().apply {
                 name = "MyOtherEnum"
             }
-
             realm.write {
                 copyToRealm(enumObject1)
                 copyToRealm(enumObject2)
@@ -213,21 +201,17 @@ class SupportedDataTypesTest : RealmTest() {
             realm.close()
         }
     }
-
     @Test
-    fun populateKotlinPropertiesDefaultsTest() {
+    fun populateKotlinDefaultPropertiesTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(KotlinSupportedTypes::class))
                 .inMemory()
                 .build()
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.path}")
-
             val kotlinSupportedTypes = KotlinSupportedTypes().apply{}
-
             realm.write {
                 copyToRealm(kotlinSupportedTypes)
-
                 val kotlinSupportedTypesResult = query<KotlinSupportedTypes>().find().first()
                 assertFalse(kotlinSupportedTypesResult.boolReq)
                 assertNull(kotlinSupportedTypesResult.boolOpt)
@@ -252,7 +236,6 @@ class SupportedDataTypesTest : RealmTest() {
             realm.close()
         }
     }
-
     @Test
     fun populateKotlinPropertiesWithValuesTest() {
         runBlocking {
@@ -261,7 +244,6 @@ class SupportedDataTypesTest : RealmTest() {
                 .build()
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.path}")
-
             val kotlinSupportedTypes = KotlinSupportedTypes().apply {
                 boolReq = true
                 boolOpt = false
@@ -304,7 +286,6 @@ class SupportedDataTypesTest : RealmTest() {
             assertEquals(12, kotlinSupportedTypesResult.byteOpt!!)
             assertEquals('a', kotlinSupportedTypesResult.charReq)
             assertEquals('b', kotlinSupportedTypesResult.charOpt!!)
-
             realm.write {
                 val kotlinSupportedTypes = query<KotlinSupportedTypes>().find().first()
                 delete(kotlinSupportedTypes)
@@ -312,18 +293,15 @@ class SupportedDataTypesTest : RealmTest() {
             realm.close()
         }
     }
-
     @Test
-    fun populateBSONPropertiesDefaultsTest() {
+    fun populateBSONDefaultPropertiesTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(BSONSupportedTypes::class, EmbeddedObjectType::class))
                 .inMemory()
                 .build()
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.path}")
-
             val bsonSupportedTypes = BSONSupportedTypes().apply {}
-
             realm.write {
                 copyToRealm(bsonSupportedTypes)
                 val bsonSupportedTypesResult = query<BSONSupportedTypes>().find().first()
@@ -337,7 +315,6 @@ class SupportedDataTypesTest : RealmTest() {
             realm.close()
         }
     }
-
     @Test
     fun populateBSONPropertiesWithValuesTest() {
         runBlocking {
@@ -346,10 +323,8 @@ class SupportedDataTypesTest : RealmTest() {
                 .build()
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.path}")
-
             val oidReq = ObjectId()
             val oidOpt = ObjectId()
-
             val bsonSupportedTypes = BSONSupportedTypes().apply{
                 decimal128Req = Decimal128("111.222")
                 decimal128Opt = Decimal128("222.333")
@@ -364,7 +339,6 @@ class SupportedDataTypesTest : RealmTest() {
             assertEquals(Decimal128("222.333"), bsonSupportedTypesResult.decimal128Opt)
             assertEquals(oidReq, bsonSupportedTypesResult.objectIdReq)
             assertEquals(oidOpt, bsonSupportedTypesResult.objectIdOpt)
-
             realm.write {
                 val bsonSupportedTypes = query<BSONSupportedTypes>().find().first()
                 delete(bsonSupportedTypes)
@@ -372,18 +346,15 @@ class SupportedDataTypesTest : RealmTest() {
             realm.close()
         }
     }
-
     @Test
-    fun populateRealmPropertiesDefaultsTest() {
+    fun populateRealmDefaultPropertiesTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(RealmSupportedTypes::class, CustomObjectType::class))
                 .inMemory()
                 .build()
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.path}")
-
             val realmSupportedTypes = RealmSupportedTypes().apply {}
-
             realm.write {
                 copyToRealm(realmSupportedTypes)
 
@@ -403,7 +374,6 @@ class SupportedDataTypesTest : RealmTest() {
             realm.close()
         }
     }
-
     @Test
     fun populateRealmPropertiesWithValuesTest() {
         runBlocking {
@@ -412,7 +382,6 @@ class SupportedDataTypesTest : RealmTest() {
                 .build()
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.path}")
-
             // :snippet-start: create-uuid
             val uuid1 = RealmUUID.from("46423f1b-ce3e-4a7e-812f-004cf9c42d76")
             val uuid2 = RealmUUID.random()
@@ -421,7 +390,6 @@ class SupportedDataTypesTest : RealmTest() {
             val date2 = RealmInstant.from(1, 0)
             val int1 = MutableRealmInt.create(1)
             val int2 = MutableRealmInt.create(2)
-
             val realmSupportedTypes = RealmSupportedTypes().apply {
                 realmInstantReq = date1
                 realmInstantOpt = date2
@@ -434,11 +402,9 @@ class SupportedDataTypesTest : RealmTest() {
                 uuidReq = uuid1
                 uuidOpt = uuid2
             }
-
             realm.write {
                 copyToRealm(realmSupportedTypes)
             }
-
             val realmSupportedTypesResult = realm.query<RealmSupportedTypes>().find().first()
             val customObjectTypeResult = realm.query<CustomObjectType>().find().first()
             assertEquals(date1, realmSupportedTypesResult.realmInstantReq)
@@ -455,7 +421,6 @@ class SupportedDataTypesTest : RealmTest() {
             assertEquals(uuid1, realmSupportedTypesResult.uuidReq)
             assertEquals(uuid2, realmSupportedTypesResult.uuidOpt)
             assertEquals(uuid1, customObjectTypeResult.uuid)
-
             realm.write {
                 val realmSupportedTypes = query<RealmSupportedTypes>().find().first()
                 val customObjectType = query<CustomObjectType>().find().first()
@@ -464,18 +429,15 @@ class SupportedDataTypesTest : RealmTest() {
             }
             realm.close()
         }
-
     }
-
     @Test
-    fun populateRealmObjectPropertiesDefaultsTest() {
+    fun populateRealmObjectDefaultPropertiesTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(EmbeddedObjectType::class, EmbeddedChildType::class, AnotherCustomObjectType::class, CustomObjectType::class, ParentObjectType::class, ChildObjectType::class))
                 .inMemory()
                 .build()
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.path}")
-
             val anotherCustomObjectType = AnotherCustomObjectType().apply {
             }
 
@@ -497,9 +459,9 @@ class SupportedDataTypesTest : RealmTest() {
                 assertEquals("11111111-1111-1111-1111-111111111111", parentResult.children.first().uuid.toString())
                 delete(parentResult)
             }
+            realm.close()
         }
     }
-
     @Test
     fun populateRealmObjectPropertiesWithValuesTest() {
         runBlocking {
@@ -509,12 +471,10 @@ class SupportedDataTypesTest : RealmTest() {
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.path}")
 
-            val customObjectType = CustomObjectType().apply {
-                uuid = RealmUUID.from("00000000-0000-0000-0000-000000000000")
-            }
-
             val anotherCustomObjectType = AnotherCustomObjectType().apply {
-                realmObjectPropertyOpt = customObjectType
+                realmObjectPropertyOpt = CustomObjectType().apply {
+                    uuid = RealmUUID.from("00000000-0000-0000-0000-000000000000")
+                }
                 embeddedProperty = EmbeddedObjectType().apply {uuid = RealmUUID.from("11111111-1111-1111-1111-111111111111")}
 
             }
@@ -529,5 +489,4 @@ class SupportedDataTypesTest : RealmTest() {
             realm.close()
         }
     }
-
 }

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DataTypes.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DataTypes.kt
@@ -1,0 +1,479 @@
+package com.mongodb.realm.realmkmmapp
+
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
+import io.realm.kotlin.ext.*
+import io.realm.kotlin.internal.platform.runBlocking
+import io.realm.kotlin.query.RealmResults
+import io.realm.kotlin.types.*
+import org.mongodb.kbson.Decimal128
+import org.mongodb.kbson.ObjectId
+import kotlin.test.*
+
+
+class CustomObjectType : RealmObject {
+    var uuid: RealmUUID = RealmUUID.random()
+    // var embeddedProperty1: EmbeddedObjectType = EmbeddedObjectType() //Property 'CustomObjectType.embeddedProperty' of type 'object' must be nullable.
+    // :snippet-start: embedded-object-optional
+    var embeddedProperty: EmbeddedObjectType? = null
+    // :snippet-end:
+    //var embeddedProperties: RealmList<EmbeddedObjectType> = null // [Realm] Error in field embeddedProperties - RealmList does not support nullable realm objects element types.
+}
+
+class AnotherCustomObjectType : RealmObject {
+    var uuid: RealmUUID = RealmUUID.random()
+   // var realmObjectProperty: CustomObjectType = CustomObjectType() // Property 'AnotherCustomObjectType.realmObjectProperty' of type 'object' must be nullable.
+    // :snippet-start: realm-object-optional
+    var realmObjectPropertyOptional: CustomObjectType? = null
+    // :snippet-end:
+}
+
+class EmbeddedObjectType : EmbeddedRealmObject {
+    var uuid: RealmUUID = RealmUUID.random()
+}
+
+class ParentObjectType : RealmObject {
+    var uuid: RealmUUID = RealmUUID.random() // :remove:
+    var children: RealmList<ChildObjectType> = realmListOf()
+    var embeddedChildren: RealmList<EmbeddedChildObjectType> = realmListOf()
+}
+
+class ChildObjectType : RealmObject {
+    var uuid: RealmUUID = RealmUUID.from("11111111-1111-1111-1111-111111111111")
+    // :snippet-start: backlinks-realm-object
+    val child: RealmResults<ParentObjectType> by backlinks(ParentObjectType::children)
+    // :snippet-end:
+}
+
+class EmbeddedChildObjectType : EmbeddedRealmObject {
+    var uuid: RealmUUID = RealmUUID.from("22222222-2222-2222-2222-222222222222")
+    // :snippet-start: backlinks-embedded-object
+    val child: ParentObjectType by backlinks(ParentObjectType::embeddedChildren)
+    // :snippet-end:
+}
+
+class KotlinSupportedTypes : RealmObject {
+    // :snippet-start: bool-required
+    var boolReq: Boolean = false
+    // :snippet-end:
+    // :snippet-start: bool-optional
+    var boolOpt: Boolean? = null
+    // :snippet-end:
+    // :snippet-start: int-required
+    var intReq: Int = 0
+    // :snippet-end:
+    // :snippet-start: int-optional
+    var intOpt: Int? = null
+    // :snippet-end:
+    // :snippet-start: long-required
+    var longReq: Long = 0L
+    // :snippet-end:
+    // :snippet-start: long-optional
+    var longOpt: Long? = null
+    // :snippet-end:
+    // :snippet-start: float-required
+    var floatReq: Float = 0.0f
+    // :snippet-end:
+    // :snippet-start: float-optional
+    var floatOpt: Float? = null
+    // :snippet-end:
+    // :snippet-start: double-required
+    var doubleReq: Double = 0.0
+    // :snippet-end:
+    // :snippet-start: double-optional
+    var doubleOpt: Double? = null
+    // :snippet-end:
+    // :snippet-start: short-required
+    var shortReq: Short = 0
+    // :snippet-end:
+    // :snippet-start: short-optional
+    var shortOpt: Short? = null
+    // :snippet-end:
+    // :snippet-start: string-required
+    var stringReq: String = ""
+    // :snippet-end:
+    // :snippet-start: string-optional
+    var stringOpt: String? = null
+    // :snippet-end:
+    // :snippet-start: byte-required
+    var byteReq: Byte = 0
+    // :snippet-end:
+    // :snippet-start: byte-optional
+    var byteOpt: Byte? = null
+    // :snippet-end:
+    // :snippet-start: char-required
+    var charReq: Char = 'a'
+    // :snippet-end:
+    // :snippet-start: char-optional
+    var charOpt: Char? = null
+    // :snippet-end:
+    //var enumReq: MyEnum = MyEnum.ONE //[Realm] Realm does not support persisting properties of this type. Mark the field with `@Ignore` to suppress this error.
+    // var enumOpt: MyEnum? = null //[Realm] Realm does not support persisting properties of this type. Mark the field with `@Ignore` to suppress this error.
+}
+
+class BSONSupportedTypes : RealmObject {
+    // :snippet-start: decimal128-required
+    var decimal128Req: Decimal128 = Decimal128("123.456")
+    // :snippet-end:
+    // :snippet-start: decimal128-optional
+    var decimal128Opt: Decimal128? = null
+    // :snippet-end:
+    // :snippet-start: objectId-required
+    var objectIdReq: ObjectId = ObjectId()
+    // :snippet-end:
+    // :snippet-start: objectId-optional
+    var objectIdOpt: ObjectId? = null
+    // :snippet-end:
+}
+
+class RealmSupportedTypes : RealmObject {
+
+    // :snippet-start: realmInstant-required
+    var realmInstantReq: RealmInstant = RealmInstant.now()
+    // :snippet-end:
+    // :snippet-start: realmInstant-optional
+    var realmInstantOpt: RealmInstant? = null
+    // :snippet-end:
+    // :snippet-start: mutableRealmInt-required
+    var mutableRealmIntReq: MutableRealmInt =
+        MutableRealmInt.create(0)
+    // :snippet-end:
+    // :snippet-start: mutableRealmInt-optional
+    var mutableRealmIntOpt: MutableRealmInt? = null
+    // :snippet-end:
+    // :snippet-start: list-required
+    var listReq: RealmList<CustomObjectType> = realmListOf()
+    // :snippet-end:
+   // var listOpt: RealmList<CustomObjectType?> = realmListOf() // [Realm] Error in field listOpt - RealmList does not support nullable realm objects element types.
+   // var listOpt: RealmList<String>? = null // [Realm] Error in field listOpt - a RealmList field cannot be marked as nullable.
+    var listOpt1: RealmList<String?> = realmListOf()
+   // var listOpt2: RealmList<CustomObjectType>? = null //null cannot be cast to non-null type io.realm.kotlin.types.RealmList<*>
+    var listOpt3: RealmList<CustomObjectType>? = realmListOf()
+    var listOpt4: RealmList<EmbeddedObjectType>? = realmListOf()
+    //var listOpt5: RealmList<EmbeddedObjectType?> = realmListOf() // [Realm] Error in field listOpt5 - RealmList does not support nullable realm objects element types.
+    // :snippet-start: set-required
+    var setReq: RealmSet<String> = realmSetOf()
+    // :snippet-end:
+    //var setOpt: RealmSet<String>? = null // [Realm] Error in field setOpt - a RealmSet field cannot be marked as nullable.
+    //  val mapReq: RealmMap<String, String> = mapOf("foo" to "bar")
+    // var mapOpt: RealmMap<String, String>? = null //[Realm] Realm does not support persisting properties of this type. Mark the field with `@Ignore` to suppress this error.
+    // :snippet-start: dictionary-required
+    var dictionaryReq: RealmDictionary<String> = realmDictionaryOf()
+    // :snippet-end:
+    // var dictionaryOpt: RealmDictionary<String>? = null //[Realm] Error in field dictionaryOpt - a RealmDictionary field cannot be marked as nullable.
+    var dictionaryOpt: RealmDictionary<String?> = realmDictionaryOf()
+    // :snippet-start: realmAny-optional
+    var realmAnyOpt: RealmAny? = RealmAny.create("foo")
+    // :snippet-end:
+    // :snippet-start: uuid-required
+    var uuidReq: RealmUUID = RealmUUID.random()
+    // :snippet-end:
+    // :snippet-start: uuid-optional
+    var uuidOpt: RealmUUID? = null
+    // :snippet-end:
+}
+
+class SupportedDataTypesTest : RealmTest() {
+
+    @Test
+    fun populateKotlinPropertiesTest() {
+        runBlocking {
+            val config = RealmConfiguration.Builder(setOf(KotlinSupportedTypes::class))
+                .inMemory()
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.path}")
+
+            val kotlinSupportedTypes = KotlinSupportedTypes().apply{}
+
+
+            realm.write {
+                copyToRealm(kotlinSupportedTypes)
+
+                val kotlinSupportedTypesResult = query<KotlinSupportedTypes>().find().first()
+                assertFalse(kotlinSupportedTypesResult.boolReq)
+                assertNull(kotlinSupportedTypesResult.boolOpt)
+                assertEquals(0, kotlinSupportedTypesResult.intReq)
+                assertNull(kotlinSupportedTypesResult.intOpt)
+                assertEquals(0L, kotlinSupportedTypesResult.longReq)
+                assertNull(kotlinSupportedTypesResult.longOpt)
+                assertEquals(0.0f, kotlinSupportedTypesResult.floatReq)
+                assertNull(kotlinSupportedTypesResult.floatOpt)
+                assertEquals(0.0, kotlinSupportedTypesResult.doubleReq)
+                assertNull(kotlinSupportedTypesResult.doubleOpt)
+                assertEquals(0, kotlinSupportedTypesResult.shortReq)
+                assertNull(kotlinSupportedTypesResult.shortOpt)
+                assertEquals("", kotlinSupportedTypesResult.stringReq)
+                assertNull(kotlinSupportedTypesResult.stringOpt)
+                assertEquals(0, kotlinSupportedTypesResult.byteReq)
+                assertNull(kotlinSupportedTypesResult.byteOpt)
+                assertEquals('a', kotlinSupportedTypesResult.charReq)
+                assertNull(kotlinSupportedTypesResult.charOpt)
+                delete(kotlinSupportedTypesResult)
+            }
+            realm.close()
+        }
+    }
+
+    @Test
+    fun populateKotlinPropertiesWithValuesTest() {
+        runBlocking {
+            val config = RealmConfiguration.Builder(setOf(KotlinSupportedTypes::class))
+                .inMemory()
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.path}")
+
+            val kotlinSupportedTypes = KotlinSupportedTypes().apply {
+                boolReq = true
+                boolOpt = false
+                intReq = 1
+                intOpt = 2
+                longReq = 3L
+                longOpt = 4L
+                floatReq = 5.0f
+                floatOpt = 6.0f
+                doubleReq = 7.0
+                doubleOpt = 8.0
+                shortReq = 9
+                shortOpt = 10
+                stringReq = "string1"
+                stringOpt = "string2"
+                byteReq = 11
+                byteOpt = 12
+                charReq = 'a'
+                charOpt = 'b'
+            }
+            realm.write {
+                copyToRealm(kotlinSupportedTypes)
+            }
+            val kotlinSupportedTypesResult = realm.query<KotlinSupportedTypes>().find().first()
+            assertTrue(kotlinSupportedTypesResult.boolReq)
+            assertFalse(kotlinSupportedTypesResult.boolOpt!!)
+            assertEquals(1, kotlinSupportedTypesResult.intReq)
+            assertEquals(2, kotlinSupportedTypesResult.intOpt!!)
+            assertEquals(3L, kotlinSupportedTypesResult.longReq)
+            assertEquals(4L, kotlinSupportedTypesResult.longOpt!!)
+            assertEquals(5.0f, kotlinSupportedTypesResult.floatReq)
+            assertEquals(6.0f, kotlinSupportedTypesResult.floatOpt!!)
+            assertEquals(7.0, kotlinSupportedTypesResult.doubleReq)
+            assertEquals(8.0, kotlinSupportedTypesResult.doubleOpt!!)
+            assertEquals(9, kotlinSupportedTypesResult.shortReq)
+            assertEquals(10, kotlinSupportedTypesResult.shortOpt!!)
+            assertEquals("string1", kotlinSupportedTypesResult.stringReq)
+            assertEquals("string2", kotlinSupportedTypesResult.stringOpt!!)
+            assertEquals(11, kotlinSupportedTypesResult.byteReq)
+            assertEquals(12, kotlinSupportedTypesResult.byteOpt!!)
+            assertEquals('a', kotlinSupportedTypesResult.charReq)
+            assertEquals('b', kotlinSupportedTypesResult.charOpt!!)
+
+            realm.write {
+                val kotlinSupportedTypes = query<KotlinSupportedTypes>().find().first()
+                delete(kotlinSupportedTypes)
+            }
+            realm.close()
+        }
+    }
+
+    @Test
+    fun populateBSONPropertiesTest() {
+        runBlocking {
+            val config = RealmConfiguration.Builder(setOf(BSONSupportedTypes::class))
+                .inMemory()
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.path}")
+
+            val bsonSupportedTypes = BSONSupportedTypes().apply {}
+
+            realm.write {
+                copyToRealm(bsonSupportedTypes)
+                val bsonSupportedTypesResult = query<BSONSupportedTypes>().find().first()
+                assertEquals(Decimal128("123.456"), bsonSupportedTypesResult.decimal128Req)
+                assertNull(bsonSupportedTypesResult.decimal128Opt)
+                assertNotNull(bsonSupportedTypesResult.objectIdReq)
+                assertNull(bsonSupportedTypesResult.objectIdOpt)
+                delete(bsonSupportedTypesResult)
+            }
+            realm.close()
+        }
+    }
+
+    @Test
+    fun populateBSONPropertiesWithValuesTest() {
+        runBlocking {
+            val config = RealmConfiguration.Builder(setOf(BSONSupportedTypes::class))
+                .inMemory()
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.path}")
+
+            val oidReq = ObjectId()
+            val oidOpt = ObjectId()
+
+            val bsonSupportedTypes = BSONSupportedTypes().apply{
+                decimal128Req = Decimal128("111.222")
+                decimal128Opt = Decimal128("789.012")
+                objectIdReq = oidReq
+                objectIdOpt = oidOpt
+            }
+            realm.write {
+                copyToRealm(bsonSupportedTypes)
+            }
+            val bsonSupportedTypesResult = realm.query<BSONSupportedTypes>().find().first()
+            assertEquals(Decimal128("111.222"), bsonSupportedTypesResult.decimal128Req)
+            assertEquals(Decimal128("789.012"), bsonSupportedTypesResult.decimal128Opt)
+            assertEquals(oidReq, bsonSupportedTypesResult.objectIdReq)
+            assertEquals(oidOpt, bsonSupportedTypesResult.objectIdOpt)
+
+            realm.write {
+                val bsonSupportedTypes = query<BSONSupportedTypes>().find().first()
+                delete(bsonSupportedTypes)
+            }
+            realm.close()
+        }
+    }
+
+    @Test
+    fun populateRealmPropertiesTest() {
+        runBlocking {
+            val config = RealmConfiguration.Builder(setOf(RealmSupportedTypes::class, CustomObjectType::class, AnotherCustomObjectType::class, EmbeddedObjectType::class))
+                .inMemory()
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.path}")
+
+            val realmSupportedTypes = RealmSupportedTypes().apply {}
+            val customObjectType = AnotherCustomObjectType().apply {}
+
+            realm.write {
+                copyToRealm(realmSupportedTypes)
+                copyToRealm(customObjectType)
+
+                val realmSupportedTypesResult = query<RealmSupportedTypes>().find().first()
+                val customObjectTypeResult = query<AnotherCustomObjectType>().find().first()
+                assertNotNull(realmSupportedTypesResult.realmInstantReq)
+                assertNull(realmSupportedTypesResult.realmInstantOpt)
+                assertEquals(0, realmSupportedTypesResult.mutableRealmIntReq.get())
+                assertNull(realmSupportedTypesResult.mutableRealmIntOpt)
+                assertEquals(0, realmSupportedTypesResult.listReq.size)
+                assertEquals(0, realmSupportedTypesResult.setReq.size)
+                assertEquals(0, realmSupportedTypesResult.dictionaryReq.size)
+                realmSupportedTypesResult.realmAnyReq?.let { assertEquals("foo", it.asString()) }
+                assertNull(realmSupportedTypesResult.realmAnyOpt)
+                assertNotNull(realmSupportedTypesResult.uuidReq)
+                assertNull(realmSupportedTypesResult.uuidOpt)
+                assertNotNull(customObjectTypeResult.uuid)
+                assertNull(customObjectTypeResult.realmObjectPropertyOptional)
+                delete(realmSupportedTypesResult)
+                delete(customObjectTypeResult)
+            }
+            realm.close()
+        }
+    }
+
+    @Test
+    fun populateRealmPropertiesWithValuesTest() {
+        runBlocking {
+            val config = RealmConfiguration.Builder(setOf(RealmSupportedTypes::class, CustomObjectType::class, AnotherCustomObjectType::class, EmbeddedObjectType::class))
+                .inMemory()
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.path}")
+
+            // :snippet-start: create-uuid
+            val uuid1 = RealmUUID.from("46423f1b-ce3e-4a7e-812f-004cf9c42d76")
+            val uuid2 = RealmUUID.random()
+            // :snippet-end:
+            val date1 = RealmInstant.from(0, 1)
+            val date2 = RealmInstant.from(1, 0)
+            val int1 = MutableRealmInt.create(1)
+            val int2 = MutableRealmInt.create(2)
+
+            val realmSupportedTypes = RealmSupportedTypes().apply {
+                realmInstantReq = date1
+                realmInstantOpt = date2
+                mutableRealmIntReq = int1
+                mutableRealmIntOpt = int2
+                listReq.add(CustomObjectType().apply {
+                    uuid = uuid1
+                    embeddedProperty = EmbeddedObjectType().apply { uuid = uuid2 } })
+                setReq.add("hello")
+                dictionaryReq["bing"] = "bong"
+                realmAnyOpt = RealmAny.create(123)
+                uuidReq = uuid1
+                uuidOpt = uuid2
+            }
+            val customObjectType = CustomObjectType().apply {
+                uuid = uuid1
+                embeddedProperty = EmbeddedObjectType().apply { uuid = uuid1 }
+            }
+
+            val anotherCustomObjectType = AnotherCustomObjectType().apply {
+                uuid = uuid2
+                realmObjectPropertyOptional = customObjectType
+            }
+
+            realm.write {
+                copyToRealm(realmSupportedTypes)
+                copyToRealm(anotherCustomObjectType)
+            }
+
+            val realmSupportedTypesResult = realm.query<RealmSupportedTypes>().find().first()
+            val customObjectTypeResult = realm.query<CustomObjectType>().find().first()
+            assertEquals(date1, realmSupportedTypesResult.realmInstantReq)
+            assertEquals(date2, realmSupportedTypesResult.realmInstantOpt)
+            assertEquals(1, realmSupportedTypesResult.mutableRealmIntReq.get())
+            assertEquals(2, realmSupportedTypesResult.mutableRealmIntOpt!!.get())
+            assertEquals(1, realmSupportedTypesResult.listReq.size)
+            assertEquals(uuid2, realmSupportedTypesResult.listReq.first().embeddedProperty?.uuid)
+            assertEquals(uuid1, realmSupportedTypesResult.listReq.first().uuid)
+            assertEquals(1, realmSupportedTypesResult.setReq.size)
+            assertEquals("hello", realmSupportedTypesResult.setReq.first())
+            assertEquals(1, realmSupportedTypesResult.dictionaryReq.size)
+            assertEquals("bong", realmSupportedTypesResult.dictionaryReq["bing"])
+            assertEquals(123, realmSupportedTypesResult.realmAnyOpt!!.asInt())
+            assertEquals(uuid1, realmSupportedTypesResult.uuidReq)
+            assertEquals(uuid2, realmSupportedTypesResult.uuidOpt)
+            assertEquals(uuid1, customObjectTypeResult.uuid)
+            assertEquals(uuid2, anotherCustomObjectType.uuid)
+
+            realm.write {
+                val realmSupportedTypes = query<RealmSupportedTypes>().find().first()
+                val customObjectType = query<CustomObjectType>().find().first()
+                delete(realmSupportedTypes)
+                delete(customObjectType)
+            }
+            realm.close()
+        }
+
+    }
+
+    @Test
+    fun populateRelationshipPropertiesTest() {
+        runBlocking {
+            val config = RealmConfiguration.Builder(setOf(EmbeddedObjectType::class, ParentObjectType::class, ChildObjectType::class, EmbeddedChildObjectType::class))
+                .inMemory()
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.path}")
+
+            val parent = ParentObjectType().apply {
+                children.add(ChildObjectType().apply {})
+                embeddedChildren.add(EmbeddedChildObjectType().apply {})
+            }
+
+            realm.write {
+                copyToRealm(parent)
+                val parentResult = query<ParentObjectType>().find().first()
+
+                assertEquals(1, parentResult.children.size)
+                assertEquals("11111111-1111-1111-1111-111111111111", parentResult.children.first().uuid.toString())
+                assertEquals(1, parentResult.embeddedChildren.size)
+                assertEquals("22222222-2222-2222-2222-222222222222", parentResult.embeddedChildren.first().uuid.toString())
+                delete(parentResult)
+            }
+        }
+    }
+
+}

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DataTypes.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DataTypes.kt
@@ -181,7 +181,7 @@ class RealmSupportedTypes : RealmObject {
 class SupportedDataTypesTest : RealmTest() {
 
     @Test
-    fun populateEnumPropertiesTest() {
+    fun populateEnumPropertiesDefaultsTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(EnumObject::class))
                 .inMemory()
@@ -215,7 +215,7 @@ class SupportedDataTypesTest : RealmTest() {
     }
 
     @Test
-    fun populateKotlinPropertiesTest() {
+    fun populateKotlinPropertiesDefaultsTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(KotlinSupportedTypes::class))
                 .inMemory()
@@ -314,7 +314,7 @@ class SupportedDataTypesTest : RealmTest() {
     }
 
     @Test
-    fun populateBSONPropertiesTest() {
+    fun populateBSONPropertiesDefaultsTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(BSONSupportedTypes::class, EmbeddedObjectType::class))
                 .inMemory()
@@ -374,7 +374,7 @@ class SupportedDataTypesTest : RealmTest() {
     }
 
     @Test
-    fun populateRealmPropertiesTest() {
+    fun populateRealmPropertiesDefaultsTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(RealmSupportedTypes::class, CustomObjectType::class))
                 .inMemory()
@@ -468,7 +468,7 @@ class SupportedDataTypesTest : RealmTest() {
     }
 
     @Test
-    fun populateRealmObjectPropertiesTest() {
+    fun populateRealmObjectPropertiesDefaultsTest() {
         runBlocking {
             val config = RealmConfiguration.Builder(setOf(EmbeddedObjectType::class, EmbeddedChildType::class, AnotherCustomObjectType::class, CustomObjectType::class, ParentObjectType::class, ChildObjectType::class))
                 .inMemory()

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/SchemaTest.kt
@@ -74,12 +74,10 @@ class Snack2 : RealmObject {
     var name: String? = null
 }
 
-// :snippet-start: uuid
 class Cat: RealmObject {
     @PrimaryKey
     var _id: RealmUUID = RealmUUID.random()
 }
-// :snippet-end:
 
 // :snippet-start: example-schema
 class Car : RealmObject {
@@ -196,21 +194,17 @@ class SchemaTest: RealmTest() {
                 delete(cats)
             }
 
-            // :snippet-start: create-uuid-random
             realm.write {
                 this.copyToRealm(Cat().apply {
                     _id = RealmUUID.random()
                 })
             }
-            // :snippet-end:
 
-            // :snippet-start: create-uuid-from-string
             realm.write {
                 this.copyToRealm(Cat().apply {
                     _id = RealmUUID.from("46423f1b-ce3e-4a7e-812f-004cf9c42d76")
                 })
             }
-            // :snippet-end:
 
             realm.close()
         }

--- a/source/examples/generated/kotlin/DataTypes.snippet.backlinks-embedded-object.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.backlinks-embedded-object.kt
@@ -1,0 +1,1 @@
+val child: ParentObjectType by backlinks(ParentObjectType::embeddedChildren)

--- a/source/examples/generated/kotlin/DataTypes.snippet.backlinks-embedded-object.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.backlinks-embedded-object.kt
@@ -1,1 +1,1 @@
-val child: ParentObjectType by backlinks(ParentObjectType::embeddedChildren)
+val embeddedChild: ParentObjectType by backlinks(ParentObjectType::embeddedChildren)

--- a/source/examples/generated/kotlin/DataTypes.snippet.backlinks-parent-object.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.backlinks-parent-object.kt
@@ -1,0 +1,3 @@
+var children: RealmSet<ChildObjectType> = realmSetOf()
+var embeddedChildren: RealmList<EmbeddedChildType> = realmListOf() // RealmSets cannot contain embedded objects
+var embeddedChildrenDictionary: RealmDictionary<EmbeddedChildType?> = realmDictionaryOf()

--- a/source/examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
@@ -1,0 +1,1 @@
+val child: RealmResults<ParentObjectType> by backlinks(ParentObjectType::children)

--- a/source/examples/generated/kotlin/DataTypes.snippet.bool-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.bool-optional.kt
@@ -1,0 +1,1 @@
+var boolOpt: Boolean? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.bool-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.bool-required.kt
@@ -1,0 +1,1 @@
+var boolReq: Boolean = false

--- a/source/examples/generated/kotlin/DataTypes.snippet.byte-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.byte-optional.kt
@@ -1,0 +1,1 @@
+var byteOpt: Byte? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.byte-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.byte-required.kt
@@ -1,0 +1,1 @@
+var byteReq: Byte = 0

--- a/source/examples/generated/kotlin/DataTypes.snippet.char-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.char-optional.kt
@@ -1,0 +1,1 @@
+var charOpt: Char? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.char-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.char-required.kt
@@ -1,0 +1,1 @@
+var charReq: Char = 'a'

--- a/source/examples/generated/kotlin/DataTypes.snippet.create-uuid.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.create-uuid.kt
@@ -1,0 +1,2 @@
+val uuid1 = RealmUUID.from("46423f1b-ce3e-4a7e-812f-004cf9c42d76")
+val uuid2 = RealmUUID.random()

--- a/source/examples/generated/kotlin/DataTypes.snippet.decimal128-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.decimal128-optional.kt
@@ -1,0 +1,1 @@
+var decimal128Opt: Decimal128? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.decimal128-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.decimal128-required.kt
@@ -1,0 +1,1 @@
+var decimal128Req: Decimal128 = Decimal128("123.456")

--- a/source/examples/generated/kotlin/DataTypes.snippet.dictionary-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.dictionary-required.kt
@@ -1,0 +1,1 @@
+var dictionaryReq: RealmDictionary<String> = realmDictionaryOf()

--- a/source/examples/generated/kotlin/DataTypes.snippet.double-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.double-optional.kt
@@ -1,0 +1,1 @@
+var doubleOpt: Double? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.double-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.double-required.kt
@@ -1,0 +1,1 @@
+var doubleReq: Double = 0.0

--- a/source/examples/generated/kotlin/DataTypes.snippet.embedded-object-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.embedded-object-optional.kt
@@ -1,0 +1,1 @@
+var embeddedProperty: EmbeddedObjectType? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.enum-workaround.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.enum-workaround.kt
@@ -1,0 +1,15 @@
+enum class EnumClass(var state: String) {
+    NOT_STARTED("NOT_STARTED"),
+    IN_PROGRESS("IN_PROGRESS"),
+    COMPLETE("COMPLETE")
+}
+
+class EnumObject : RealmObject {
+    var name: String? = null
+    private var state: String = EnumClass.NOT_STARTED.state
+    var stateEnum: EnumClass
+        get() = EnumClass.valueOf(state)
+        set(value) {
+            state = value.state
+        }
+}

--- a/source/examples/generated/kotlin/DataTypes.snippet.float-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.float-optional.kt
@@ -1,0 +1,1 @@
+var floatOpt: Float? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.float-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.float-required.kt
@@ -1,0 +1,1 @@
+var floatReq: Float = 0.0f

--- a/source/examples/generated/kotlin/DataTypes.snippet.int-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.int-optional.kt
@@ -1,0 +1,1 @@
+var intOpt: Int? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.int-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.int-required.kt
@@ -1,0 +1,1 @@
+var intReq: Int = 0

--- a/source/examples/generated/kotlin/DataTypes.snippet.list-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.list-required.kt
@@ -1,2 +1,1 @@
-var listReq: RealmList<CustomObjectType> =
-    realmListOf()
+var listReq: RealmList<CustomObjectType> = realmListOf()

--- a/source/examples/generated/kotlin/DataTypes.snippet.list-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.list-required.kt
@@ -1,0 +1,2 @@
+var listReq: RealmList<CustomObjectType> =
+    realmListOf()

--- a/source/examples/generated/kotlin/DataTypes.snippet.long-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.long-optional.kt
@@ -1,0 +1,1 @@
+var longOpt: Long? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.long-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.long-required.kt
@@ -1,0 +1,1 @@
+var longReq: Long = 0L

--- a/source/examples/generated/kotlin/DataTypes.snippet.mutableRealmInt-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.mutableRealmInt-optional.kt
@@ -1,0 +1,1 @@
+var mutableRealmIntOpt: MutableRealmInt? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.mutableRealmInt-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.mutableRealmInt-required.kt
@@ -1,0 +1,2 @@
+var mutableRealmIntReq: MutableRealmInt =
+    MutableRealmInt.create(0)

--- a/source/examples/generated/kotlin/DataTypes.snippet.mutableRealmInt-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.mutableRealmInt-required.kt
@@ -1,2 +1,1 @@
-var mutableRealmIntReq: MutableRealmInt =
-    MutableRealmInt.create(0)
+var mutableRealmIntReq: MutableRealmInt = MutableRealmInt.create(0)

--- a/source/examples/generated/kotlin/DataTypes.snippet.objectId-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.objectId-optional.kt
@@ -1,0 +1,1 @@
+var objectIdOpt: ObjectId? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.objectId-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.objectId-required.kt
@@ -1,0 +1,1 @@
+var objectIdReq: ObjectId = ObjectId()

--- a/source/examples/generated/kotlin/DataTypes.snippet.realm-object-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.realm-object-optional.kt
@@ -1,0 +1,1 @@
+var realmObjectPropertyOptional: CustomObjectType? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.realm-object-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.realm-object-optional.kt
@@ -1,1 +1,1 @@
-var realmObjectPropertyOptional: CustomObjectType? = null
+var realmObjectPropertyOpt: CustomObjectType? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.realmAny-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.realmAny-optional.kt
@@ -1,0 +1,1 @@
+var realmAnyOpt: RealmAny? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.realmAny-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.realmAny-optional.kt
@@ -1,1 +1,1 @@
-var realmAnyOpt: RealmAny? = null
+var realmAnyOpt: RealmAny? = RealmAny.create("foo")

--- a/source/examples/generated/kotlin/DataTypes.snippet.realmInstant-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.realmInstant-optional.kt
@@ -1,0 +1,1 @@
+var realmInstantOpt: RealmInstant? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.realmInstant-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.realmInstant-required.kt
@@ -1,0 +1,1 @@
+var realmInstantReq: RealmInstant = RealmInstant.now()

--- a/source/examples/generated/kotlin/DataTypes.snippet.set-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.set-required.kt
@@ -1,0 +1,1 @@
+var setReq: RealmSet<String> = realmSetOf()

--- a/source/examples/generated/kotlin/DataTypes.snippet.short-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.short-optional.kt
@@ -1,0 +1,1 @@
+var shortOpt: Short? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.short-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.short-required.kt
@@ -1,0 +1,1 @@
+var shortReq: Short = 0

--- a/source/examples/generated/kotlin/DataTypes.snippet.string-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.string-optional.kt
@@ -1,0 +1,1 @@
+var stringOpt: String? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.string-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.string-required.kt
@@ -1,0 +1,1 @@
+var stringReq: String = ""

--- a/source/examples/generated/kotlin/DataTypes.snippet.uuid-optional.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.uuid-optional.kt
@@ -1,0 +1,1 @@
+var uuidOpt: RealmUUID? = null

--- a/source/examples/generated/kotlin/DataTypes.snippet.uuid-required.kt
+++ b/source/examples/generated/kotlin/DataTypes.snippet.uuid-required.kt
@@ -1,0 +1,1 @@
+var uuidReq: RealmUUID = RealmUUID.random()

--- a/source/examples/generated/kotlin/SchemaTest.snippet.create-uuid-from-string.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.create-uuid-from-string.kt
@@ -1,5 +1,0 @@
-realm.write {
-    this.copyToRealm(Cat().apply {
-        _id = RealmUUID.from("46423f1b-ce3e-4a7e-812f-004cf9c42d76")
-    })
-}

--- a/source/examples/generated/kotlin/SchemaTest.snippet.create-uuid-random.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.create-uuid-random.kt
@@ -1,5 +1,0 @@
-realm.write {
-    this.copyToRealm(Cat().apply {
-        _id = RealmUUID.random()
-    })
-}

--- a/source/examples/generated/kotlin/SchemaTest.snippet.uuid.kt
+++ b/source/examples/generated/kotlin/SchemaTest.snippet.uuid.kt
@@ -1,4 +1,0 @@
-class Cat: RealmObject {
-    @PrimaryKey
-    var _id: RealmUUID = RealmUUID.random()
-}

--- a/source/sdk/kotlin/realm-database/crud/create.txt
+++ b/source/sdk/kotlin/realm-database/crud/create.txt
@@ -50,11 +50,13 @@ To persist a new object to a realm:
    You can also upsert into a realm using specific criteria. See 
    :ref:`Upsert a Realm Object <kotlin-upsert-an-object>`.
 
+.. _kotlin-create-a-collection:
+
 Create a Collection
 -------------------
 
 You can create collections of items using 
-``RealmList``, ``RealmSet``, and ``RealmMap`` types.
+``RealmList``, ``RealmSet``, and ``RealmDictionary`` types.
 
 You can also register a notification handler to listen for changes to a 
 collection. For more information, see 

--- a/source/sdk/kotlin/realm-database/crud/update.txt
+++ b/source/sdk/kotlin/realm-database/crud/update.txt
@@ -40,6 +40,13 @@ To modify an object stored within a realm:
 .. literalinclude:: /examples/generated/kotlin/CRUDTest.snippet.modify-an-object.kt
    :language: kotlin
 
+.. note:: Updating Strings or Byte arrays
+
+   Because Realm operates on fields as a whole, it's not possible
+   to directly update individual elements of strings or byte arrays. Instead,
+   you'll need to read the whole field, make your modification to individual
+   elements, and then write the entire field back again in a transaction block.
+
 Update a Dictionary Property
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/sdk/kotlin/realm-database/schemas/define-realm-object-model.txt
+++ b/source/sdk/kotlin/realm-database/schemas/define-realm-object-model.txt
@@ -50,22 +50,24 @@ Realm Schema
 
 .. include:: /includes/realm-schema.rst
 
+Property Types
+~~~~~~~~~~~~~~
+
+The Kotlin SDK supports Kotlin data types, a limited subset of BSON types,
+UUID, and Realm-specific types.
+
+To learn more about the available property types, refer to the
+:ref:`Supported Types <kotlin-supported-types>` page.
+
 Property Annotations
 ~~~~~~~~~~~~~~~~~~~~
 
 Annotations add functionality to properties in your Realm object models.  
-You can use annotations for things like marking a property as nullable, setting a primary key, ignoring a property, and more. 
+You can use annotations for things like marking a property as nullable, 
+setting a primary key, ignoring a property, and more. 
 
-To learn more about the available property annotations, refer to :ref:`Property Annotations <kotlin-property-annotations>`.
-
-Relationship Properties
-~~~~~~~~~~~~~~~~~~~~~~~
-
-You can define relationships between Realm objects in your schema. 
-The Realm Kotlin SDK supports to-one relationships, to-many relationships, 
-inverse relationships, and embedding objects within other objects. 
-
-To learn more about how to define relationships in your Realm object schema, refer to :ref:`Relationships <kotlin-relationships>`.
+To learn more about the available property annotations, refer to 
+:ref:`Property Annotations <kotlin-property-annotations>`.
 
 .. _kotlin-define-a-new-object-type:
 
@@ -97,12 +99,53 @@ when you :ref:`open the realm <kotlin-open-a-realm>`.
   :language: kotlin
   :emphasize-lines: 2
 
+Define a Relationship Property
+------------------------------
+
+You can define relationships between Realm objects in your schema. 
+The Realm Kotlin SDK supports to-one relationships, to-many relationships, 
+inverse relationships, and embedding objects within other objects. 
+
+For more information, refer to the :ref:`Relationships <kotlin-relationships>` 
+page.
+
+Define an Inverse Relationship Property
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can define a backlink property as a `BacklinksDelegate 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-backlinks-delegate/index.html>`__ 
+or `EmbeddedBacklinksDelegate 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-backlinks-delegate/index.html>`__ 
+to the parent object using the ``backlinks()`` method.
+
+- A ``BacklinksDelegate<T>`` property is defined as a `RealmResults 
+  <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-results/index.html>`__ list 
+  of the parent ``RealmObject`` type:
+
+  .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
+     :language: kotlin
+
+- An ``EmbeddedBacklinksDelegate<T>`` property is defined as the parent 
+  ``RealmObject`` type:
+
+  .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-embedded-object.kt
+     :language: kotlin
+
+You then reference the backlinks in collections in the parent ``RealmObject``:
+
+.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-parent-object.kt
+   :language: kotlin
+
+.. todo add link to Create when page is updated
 
 Define a Collection 
 -------------------
 
 You can define collections of items using 
-``RealmList``, ``RealmSet``, and ``RealmMap`` types.
+``RealmList``, ``RealmSet``, and ``RealmDictionary`` types.
+
+For more information on the collection types used in the Kotlin SDK, 
+refer to :ref:`Collection Types <kotlin-collection-types>`.
 
 .. _kotlin-define-realm-set-type:
 
@@ -132,7 +175,8 @@ In the following example, we define a ``Frog`` schema with a
 Define a RealmDictionary/RealmMap
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To define a :ref:`RealmDictionary <kotlin-realm-dictionary>`, specify its type within the schema as ``RealmDictionary<T>``, where T is any Realm :ref:`primitive type 
+To define a :ref:`RealmDictionary <kotlin-realm-dictionary>`, specify its type 
+within the schema as ``RealmDictionary<T>``, where T is any Realm :ref:`primitive type 
 <kotlin-supported-types>`, a ``RealmObject``, or an ``EmbeddedRealmObject``. 
 If a ``RealmDictionary``'s value is a ``RealmObject``
 or ``EmbeddedRealmObject``, the value must be declared nullable.

--- a/source/sdk/kotlin/realm-database/schemas/relationships.txt
+++ b/source/sdk/kotlin/realm-database/schemas/relationships.txt
@@ -1,4 +1,5 @@
 .. _kotlin-relationships:
+.. _kotlin-reference-realm-object:
 
 ==========================
 Relationships - Kotlin SDK
@@ -94,6 +95,8 @@ many-to-many and a one-to-many relationship is up to your application.
    <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html>`__. For
    instance, if a "Sushi" object has many "Fish" objects, you must specify the
    "Sushi.fishes" as a ``RealmList`` or ``RealmSet`` of ``Fish`` objects.
+
+.. _kotlin-inverse-relationships:
 
 Inverse Relationships
 ---------------------

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -193,6 +193,10 @@ your object model.
      - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.embedded-object-optional.kt
          :language: kotlin
 
+The Kotlin SDK does not natively support user-defined enumeration properties. 
+See the :ref:`Enums <kotlin-enums>` section for more information on how to 
+use enums in your Realm objects.
+
 
 Unique Identifiers
 ------------------
@@ -257,9 +261,9 @@ supports ``increment`` and ``decrement`` methods that implement a
 This ensures that numeric updates can be executed regardless of order to 
 converge to the same value.
 
-``MutableRealmInteger`` fields are backed by traditional numeric types, 
+``MutableRealmInt`` fields are backed by traditional numeric types, 
 so no migration is required when changing a field from ``Byte``, ``Short``, 
-``Int``, or ``Long`` to ``MutableRealmInteger``
+``Int``, or ``Long`` to ``MutableRealmInt``
 
 A ``MutableRealmInt`` property: 
 
@@ -291,23 +295,13 @@ RealmAny (Mixed)
 ----------------
 
 `RealmAny <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-any/index.html>`__ 
-represents a non-nullable mixed data type. You can use ``RealmAny`` to hold the 
-following data types: 
+represents a non-nullable mixed data type. You can use ``RealmAny`` to hold 
+any supported Kotlin data types, supported BSON types, and the following
+Realm-specific types: 
 
-- Boolean
-- Byte 
-- ByteArray
-- Char
-- Float
-- Double
-- Decimal128
-- Int
-- ObjectID 
 - RealmInstant
 - RealmObject
 - RealmUUID
-- Short
-- String
 
 Additionally, ``RealmAny`` values can be sorted (from lowest to highest): 
 
@@ -481,8 +475,8 @@ or `EmbeddedBacklinksDelegate
 A ``BacklinksDelegate<T>`` property is defined as a ``RealmResults<T>`` list 
 of ``RealmObjects`` :
 
-You can store backlinks for to-many relationships in RealmLists, RealmSets, or 
-RealmDictionaries
+You can store backlinks for to-many relationships in ``RealmLists``, ``RealmSets``, or 
+``RealmDictionaries``
 
 .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
    :language: kotlin
@@ -520,4 +514,19 @@ See :ref:`Embedded Objects <kotlin-embedded-objects>` for more information.
 
 .. Geospatial Types
 .. ----------------
+
+.. _kotlin-enums:
+
+Enums
+-----
+
+The Kotlin SDK does not natively support enumerations, or enums. To use 
+enums in a Realm object class, define a field with a type matching the 
+underlying data type of your enum. 
+
+Then, create getters and setters for the field that convert the field 
+value between the underlying value and the enum type.
+
+.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.enum-workaround.kt
+   :language: kotlin
 

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -415,7 +415,8 @@ containing distinct values of:
 - any of the :ref:`supported Kotlin data types <kotlin-types-table>`
 - any of the :ref:`supported BSON types <kotlin-bson-types-table>`
 - a `RealmObject 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+  <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+
 You cannot use ``EmbeddedRealmObject`` elements in a ``RealmSet``.
 
 ``RealmSet<E>`` is a non-null type, where:
@@ -472,6 +473,7 @@ type represents a custom object that you can use as a property.
 
 ``RealmObject`` properties:  
 
+- must be declared nullable
 - can be used as elements in collections 
 - can be held as a ``RealmAny`` value
 - *cannot* be used as a :ref:`primary key <kotlin-primary-keys>`

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -13,7 +13,7 @@ Supported Types - Kotlin SDK
 
 This page describes the supported data types that you can use to define 
 properties in your object model. For more information on how to define 
-your object model, see :ref:`Define an Object Model <kotlin-define-object-model>`.
+your object model, refer to :ref:`Define an Object Model <kotlin-define-object-model>`.
 
 .. include:: /includes/map-to-bson-type.rst
 
@@ -30,9 +30,9 @@ identifiers, timestamps, counters, and collections.
 
 The Kotlin SDK does *not* natively support:  
 
-- user-defined enumeration properties. See the :ref:`Enums <kotlin-enums>` 
+- user-defined enumeration properties. Refer to the :ref:`Enums <kotlin-enums>` 
   section for more information on how to use enums in your Realm objects.
-- Kotlin's built-in ``Date`` or ``Instant``. See the 
+- Kotlin's built-in ``Date`` or ``Instant``. Refer to the 
   :ref:`RealmInstant <kotlin-timestamps>` section for more information on 
   how to use timestamps in your Realm objects.
 
@@ -221,8 +221,7 @@ ObjectId
 
 ``ObjectId`` is a MongoDB-specific BSON type. It is a 
 12-byte, globally unique value that you can use as an identifier for objects. 
-
-An ``ObjectId`` is nullable, :ref:`indexable <kotlin-indices>`, and can 
+It is nullable, :ref:`indexable <kotlin-indices>`, and can 
 be used as a :ref:`primary key <kotlin-primary-keys>`.
 
 You can initialize an ``ObjectId`` using ``ObjectId()``.
@@ -317,14 +316,15 @@ RealmAny (Mixed)
 
 `RealmAny <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-any/index.html>`__ 
 represents a non-nullable mixed data type. It behaves like the value type 
-that it contains. You can use ``RealmAny`` to hold 
-any :ref:`supported Kotlin data types <kotlin-types-table>`, 
-:ref:`supported BSON types <kotlin-bson-types-table>`, and the following
-Realm-specific types: 
+that it contains. ``RealmAny`` can hold:
 
-- RealmInstant
-- RealmUUID
-- RealmObject (holds a reference to the object, not a copy of it)
+- :ref:`supported Kotlin data types <kotlin-types-table>` 
+- :ref:`supported BSON types <kotlin-bson-types-table>`
+- the following Realm-specific types: 
+
+  - RealmInstant
+  - RealmUUID
+  - RealmObject (holds a reference to the object, not a copy of it)
 
 ``RealmAny`` *cannot* hold ``EmbeddedRealmObject`` types, 
 collection types (``RealmList``, ``RealmSet``, ``RealmDictionary``), 
@@ -361,12 +361,12 @@ same type) and are backed by their corresponding built-in Kotlin classes.
 User-created collections are unmanaged until they are copied to the realm 
 and can contain both managed and unmanaged objects. Unmanaged collections 
 behave like their corresponding Kotlin classes and are not persisted to the realm.
-See :ref:`Managed vs. Unmanaged Objects <kotlin-managed-vs-unmanaged-objects>`
+Refer to :ref:`Managed vs. Unmanaged Objects <kotlin-managed-vs-unmanaged-objects>`
 for more information.
 
 Collection types are non-null. When you define a collection property, you must 
 initialize it. 
-See also :ref:`Create a Collection <kotlin-create-a-collection>`. 
+Learn how to :ref:`Create a Collection <kotlin-create-a-collection>`. 
 
 .. _kotlin-realm-list:
 
@@ -381,11 +381,14 @@ behave like Kotlin's `MutableList
 <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-mutable-list/>`__.
 
 A ``RealmList`` represents a :ref:`to-many relationship <kotlin-to-many-relationship>` 
-containing any of the :ref:`supported Kotlin data types <kotlin-types-table>` or 
-:ref:`supported BSON types <kotlin-bson-types-table>`, a 
-`RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__, 
-or an `EmbeddedRealmObject 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
+containing: 
+
+- any of the :ref:`supported Kotlin data types <kotlin-types-table>` 
+- any of the :ref:`supported BSON types <kotlin-bson-types-table>`
+- a `RealmObject 
+  <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+- an `EmbeddedRealmObject 
+  <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__
 
 ``RealmList<E>`` is a non-null type, where: 
 
@@ -407,10 +410,12 @@ like Kotlin's `MutableSet
 <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-mutable-set/>`__. 
 
 A ``RealmSet`` represents a :ref:`to-many relationship <kotlin-to-many-relationship>` 
-containing distinct values of any of the 
-:ref:`supported Kotlin data types <kotlin-types-table>`,
-:ref:`supported BSON types <kotlin-bson-types-table>`, or a `RealmObject 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
+containing distinct values of: 
+
+- any of the :ref:`supported Kotlin data types <kotlin-types-table>`
+- any of the :ref:`supported BSON types <kotlin-bson-types-table>`
+- a `RealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
 You cannot use ``EmbeddedRealmObject`` elements in a ``RealmSet``.
 
 ``RealmSet<E>`` is a non-null type, where:
@@ -435,11 +440,13 @@ is a specialized ``RealmMap`` that accepts a ``String`` key and non-string value
 like Kotlin's `LinkedHashMap 
 <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-linked-hash-map/>`__.
 
-``RealmDictionary`` values can be any of the :ref:`supported Kotlin data types 
-<kotlin-types-table>` or :ref:`supported BSON types <kotlin-bson-types-table>`, 
-a `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
-or an `EmbeddedRealmObject 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
+``RealmDictionary`` values can be: 
+
+- any of the :ref:`supported Kotlin data types <kotlin-types-table>`
+- any of the :ref:`supported BSON types <kotlin-bson-types-table>`
+- a `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+- an `EmbeddedRealmObject 
+  <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__
 
 ``RealmDictionary<K, V>`` is a non-null type, where: 
 
@@ -453,52 +460,45 @@ or an `EmbeddedRealmObject
 RealmObjects as Properties
 --------------------------
 
-You can use 
-`RealmObjects <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__ 
-and any subclasses as properties in your object model.
+You can use ``RealmObject`` and any subclasses as properties in your 
+object model.
+
+RealmObjects
+~~~~~~~~~~~~
+
+A `RealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+type represents a custom object that you can use as a property.
 
 ``RealmObject`` properties:  
 
 - can be used as elements in collections 
+- can be held as a ``RealmAny`` value
 - *cannot* be used as a :ref:`primary key <kotlin-primary-keys>`
 
 You can also reference one or more Realm objects from another through 
 to-one and to-many relationships. 
-For more information, see the :ref:`Relationships <kotlin-relationships>` page.
+For more information, refer to the :ref:`Relationships <kotlin-relationships>` 
+page.
 
 Backlinks
 ~~~~~~~~~
 
-A backlink represents an :ref:`inverse <kotlin-inverse-relationships>`, 
-to-many relationship between a ``RealmObject`` and one or more ``RealmObject`` 
-or between a ``RealmObject`` and an ``EmbeddedRealmObject``. 
-Backlinks cannot be null.
+A backlink represents an inverse, to-many relationship between a 
+``RealmObject`` and one or more ``RealmObject`` or between a ``RealmObject`` 
+and an ``EmbeddedRealmObject``. Backlinks cannot be null.
 
-You can define a backlink property as a `BacklinksDelegate 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-backlinks-delegate/index.html>`__ 
-or `EmbeddedBacklinksDelegate 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-backlinks-delegate/index.html>`__ 
-to the parent object using the ``backlinks()`` method.
+Backlinks implement: 
 
-- A ``BacklinksDelegate<T>`` property is defined as a `RealmResults 
-  <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-results/index.html>`__ list 
-  of the parent ``RealmObject`` type:
+- the `BacklinksDelegate 
+  <{+kotlin-local-prefix+}io.realm.kotlin.types/-backlinks-delegate/index.html>`__ 
+  type for ``RealmObject`` backlinks
+- the `EmbeddedBacklinksDelegate 
+  <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-backlinks-delegate/index.html>`__ 
+  type for ``EmbeddedRealmObject`` backlinks
 
-  .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
-     :language: kotlin
-
-- An ``EmbeddedBacklinksDelegate<T>`` property is defined as the parent 
-  ``RealmObject`` type:
-
-  .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-embedded-object.kt
-     :language: kotlin
-
-You then reference the backlinks in collections in the parent ``RealmObject``:
-
-.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-parent-object.kt
-   :language: kotlin
-
-.. todo add link to Create when page is updated
+For more information, refer to :ref:`Inverse Relationships 
+<kotlin-inverse-relationships>`.
 
 .. _kotlin-embedded-objects-as-properties:
 
@@ -517,7 +517,7 @@ is a special type of ``RealmObject``.
 - *cannot* be used as a :ref:`primary key <kotlin-primary-keys>` 
 - can be recursively referenced as an optional property in its own definition
 
-See :ref:`Embedded Objects <kotlin-embedded-objects>` for more information.
+For more information, refer to :ref:`Embedded Objects <kotlin-embedded-objects>`.
 
 .. Geospatial Types
 .. ----------------

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -1,8 +1,9 @@
 .. _kotlin-supported-types:
+.. _kotlin-additional-types:
 
-=======================
-Data Types - Kotlin SDK
-=======================
+============================
+Supported Types - Kotlin SDK
+============================
 
 .. contents:: On this page
    :local:
@@ -11,81 +12,205 @@ Data Types - Kotlin SDK
    :class: singlecol
 
 
-The Kotlin SDK supports Kotlin data types, a limited subset of
-`BSON <https://bsonspec.org/>`__ types, and :wikipedia:`UUID <Universally_unique_identifier>`.
+The Kotlin SDK supports `Kotlin types 
+<https://kotlinlang.org/docs/basic-types.html>`__, a limited subset of
+`BSON <https://bsonspec.org/>`__ types, and 
+:wikipedia:`UUID <Universally_unique_identifier>`.
 
-.. include:: /includes/map-to-bson-type.rst
+Additionally, the Kotlin SDK offers Realm-specific types, including types 
+that you can use for unique identifiers, timestamps, counters, and collections.
 
 .. _kotlin-data-types:
 
-Supported Types
----------------
+Supported Data Types List
+-------------------------
 
-Realm supports the following field data types:
+The Realm Kotlin SDK supports the following Kotlin data types, 
+MongoDB BSON types, and Realm-specific types.
 
-- ``String``
-- ``Byte``
-- ``Char``
-- ``Short``
-- ``Int``
-- ``MutableRealmInt``, which behaves like a ``Long`` but also supports ``increment`` 
-  and ``decrement`` methods that implement a conflict-free replicated data type.  
-  For more information, see `MutableRealmInt <{+kotlin-local-prefix+}io.realm.kotlin.types/-mutable-realm-int/index.html>`__.   
-- ``Long``
-- ``Boolean``
-- ``Double``
-- ``Float``
-- ``Decimal128``
-- ``ObjectId``
-- ``RealmAny``, which represents a polymorphic Realm value. For more 
-  information, see `RealmAny <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-any/index.html>`__.  
-- ``RealmInstant``
-- ``RealmUUID``
-- Any ``RealmObject`` subclass
-- ``RealmList<T>``, where T is any of the supported data types or a   
-  `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
-  Lists of ``RealmObject`` cannot have null elements. 
-  All other types of ``RealmList<T>`` can be nullable (``RealmList<T?>``).
-- ``RealmSet<T>``, where T is any of the supported data types or a
-  `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
-  Sets of ``RealmObject`` cannot have null elements. 
-  All other types of ``RealmSet<T>`` can be nullable (``RealmSet<T?>``).
-- ``RealmDictionary<T>``, where T is any type of Realm primitive nullable or 
-  non-nullable value (``RealmDictionary<T?>``), a
-  `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__,
-  or an `EmbeddedRealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
-  Dictionaries of ``RealmObject`` and ``EmbeddedRealmObject`` must be declared nullable. 
-- ``BacklinksDelegate<T>``, a `backlinks <{+kotlin-local-prefix+}io.realm.kotlin.ext/backlinks.html>`__
-  delegate used to define an inverse relationship between 
-  `RealmObjects <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__. 
+You can use these types to define your object model 
+properties.
 
-Realm stores all non-decimal numeric types as ``Long`` values.
-Similarly, Realm stores all decimal numeric types as ``Double``
-values.
+.. include:: /includes/map-to-bson-type.rst
 
-Realm does not support fields with modifiers ``final`` and
-``volatile``, though you can use fields with those modifiers if you
-:ref:`ignore <kotlin-ignore>` them. If you choose to provide custom
-constructors, you must 
-:ref:`declare a public constructor with no arguments <kotlin-single-primary-constructor>`.
+.. list-table:: 
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 20 40 40
 
-Updating Strings and Byte Arrays
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * - Kotlin Data Type
+     - Required
+     - Optional
+   * - ``String``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``Byte``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``Short``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``Int``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``Long``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``Float``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``Double``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``Boolean``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``Char``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
 
-Since Realm operates on fields as a whole, it's not possible
-to directly update individual elements of strings or byte arrays. Instead,
-you'll need to read the whole field, make your modification to individual
-elements, and then write the entire field back again in a transaction block.
+.. list-table:: 
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 20 40 40
+
+   * - MongoDB BSON Type
+     - Required
+     - Optional
+   * - :ref:`ObjectId <kotlin-objectid>`
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``Decimal128``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+
+.. list-table:: 
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 20 40 40
+
+   * - Realm-Specific Type
+     - Required
+     - Optional
+   * - :ref:`RealmUUID <kotlin-uuid>`
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - :ref:`RealmInstant <kotlin-timestamps>`
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - :ref:`RealmAny <kotlin-realmany>`
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - :ref:`MutableRealmInt <kotlin-mutablerealmint>`
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``RealmObject``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``EmbeddedRealmObject``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``BacklinksDelegate<T>``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``EmbeddedBacklinksDelegate<T>``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``RealmList<T>``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``RealmSet<T>``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``RealmMap<T>``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+   * - ``RealmDictionary<T>``
+     - ``var name: String = "John"``
+     - ``var name: String? = null``
+
+
+.. note:: Numeric Types
+   
+   Realm stores all non-decimal numeric types as ``Long`` values.
+   Similarly, Realm stores all decimal numeric types as ``Double``
+   values.
+
+Unique Identifiers
+------------------
+
+
+.. _kotlin-objectid:
+
+ObjectId
+~~~~~~~~
+
+.. important:: 
+
+   In Realm Kotlin SDK version 1.5.0 and newer, `io.realm.kotlin.types.ObjectId <{+kotlin-local-prefix+}/io.realm.kotlin.types/-object-id/index.html>`__ is deprecated. You must import ``ObjectId`` from :github:`org.mongodb.kbson.ObjectId <mongodb/kbson>` instead.
+
+``ObjectId`` is a MongoDB-specific 12-byte unique value that you 
+can use as an identifier for objects. 
+
+An ``ObjectId`` is :ref:`indexable <kotlin-indices>` 
+and can be used as a :ref:`primary key <kotlin-primary-keys>`.
+
+.. _kotlin-uuid:
+
+RealmUUID
+~~~~~~~~~
+
+``UUID`` (Universal Unique Identifier) is a 16-byte :wikipedia:`unique value
+<Universally_unique_identifier>` that you can use as an identifier for
+objects. It is :ref:`indexable <kotlin-indices>` and can be used as a 
+:ref:`primary key <kotlin-primary-keys>`. 
+
+Realm creates UUIDs with the `RealmUUID <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/index.html>`__ type that:
+
+- conform to `RFC 4122 version 4 <https://www.rfc-editor.org/info/rfc4122>`_
+- are created with random bytes
+
+You can generate a random ``RealmUUID`` using `RealmUUID.random() 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/-companion/random.html>`__ 
+or pass a UUID-formatted string to `RealmUUID.from() 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/-companion/from.html>`__.
+
+.. include:: /includes/note-using-uuid-instead-of-objectid.rst
+
+.. _kotlin-mutablerealmint:
+
+MutableRealmInt (Counter)
+-------------------------
+
+The Kotlin SDK offers `MutableRealmInt 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-mutable-realm-int/index.html>`__ 
+as a special integer type that you can use as a logical counter to accurately 
+synchronize numeric changes across multiple distributed clients using 
+Device Sync. 
+
+``MutableRealmInt`` behaves like a ``Long`` but also 
+supports ``increment`` and ``decrement`` methods that implement a 
+:wikipedia:`conflict-free replicated data type <Conflict-free_replicated_data_type>`. This ensures that numeric updates
+can be executed regardless of order to converge to the same value.
+
+``MutableRealmInteger`` fields are backed by traditional numeric types, 
+so no migration is required when changing a field from ``Byte``, ``Short``, 
+``Integer`` or ``Long`` to ``MutableRealmInteger``
+
+A ``MutableRealmInt`` *cannot*: 
+- be used as a :ref:`primary key <kotlin-primary-keys>`
+- store null values, but it can be declared nullable (``MutableRealmInt?``)
 
 .. _kotlin-timestamps:
 
-Timestamps
-~~~~~~~~~~
+RealmInstant (Timestamp)
+------------------------
 
-You cannot store Kotlin's built-in ``Date`` or ``Instant`` types in Realm
-Database. Instead, use the
-`RealmInstant <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-instant/index.html>`__
-type, which stores time information as a UNIX epoch timestamp.
+You cannot store Kotlin's built-in ``Date`` or ``Instant`` types in Realm. 
+
+Instead, the Kotlin SDK uses the `RealmInstant 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-instant/index.html>`__ 
+type to store time information as a UNIX epoch timestamp.
 
 If you need timestamp data in a form other than ``RealmInstant``, you
 can add conversion code to your model class based on the following
@@ -94,27 +219,65 @@ example:
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.timestamp-workaround.kt
    :language: kotlin
 
-.. _kotlin-reference-realm-object:
+.. _kotlin-realmany:
 
-Reference Realm Objects
------------------------
+RealmAny (Mixed)
+----------------
 
-You can also reference one or more Realm objects from another. Learn more in the
-:ref:`relationship properties documentation <kotlin-relationships>`.
+The `RealmAny 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-any/index.html>`__ is a
+mixed data type that represents a polymorphic Realm value. 
+
+You can use the ``RealmAny`` type to create
+Realm object fields that can contain any of several
+underlying types. You can store multiple ``RealmAny`` 
+instances in ``RealmList``, ``RealmDictionary``, or 
+``RealmSet`` fields. To change the value of a 
+``RealmAny`` field, assign a new ``RealmAny`` instance
+with a different underlying value.
+
+``RealmAny``: 
+- are :ref:`indexable <kotlin-indices>`
+- *cannot* be used as a :ref:`primary key <kotlin-primary-keys>`
+- *cannot* store null values, but they *must* be declared nullable (``RealmAny?``)
+- *cannot* store an ``EmbeddedRealmObject`` 
+
+.. tip:: Handle Polymorphism with Conditional Expressions
+
+   Because you must know the stored type to extract its value, we 
+   recommend using a ``when`` expression to handle the 
+   ``RealmAny`` type and its possible inner value class.
 
 .. _kotlin-collections:
 
-Collections
------------
+Collection Types
+----------------
 
-A Realm collection contains zero or more instances of a
-:ref:`Realm supported data type <kotlin-data-types>`.
-In a Realm collection, all objects in a collection are of the same type.
+Realm collections can contain zero or more instances of a supported data type.
+Within a Realm collection, all objects are of the same type.
+   
+- 
+- ``RealmSet<T>``
+- ``RealmMap<T>``
+- ``RealmDictionary<T>``
+
+.. _kotlin-realm-list:
+
+RealmLists
+~~~~~~~~~~
+
+
+
+``RealmList<T>``, where T is any of the supported data types or a   
+`RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
+Lists of ``RealmObject`` cannot have null elements. 
+
+All other types of ``RealmList<T>`` can be nullable (``RealmList<T?>``).
 
 .. _kotlin-realm-set:
 
-RealmSet
-~~~~~~~~
+RealmSets
+~~~~~~~~~
 
 A `RealmSet() 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html>`__  
@@ -128,78 +291,60 @@ interface, so it works just like the built-in ``HashSet`` class,
 except managed ``RealmSet`` instances persist their contents to a
 realm. 
 
+, where T is any of the supported data types or a
+`RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
+Sets of ``RealmObject`` cannot have null elements. 
+
+All other types of ``RealmSet<T>`` can be nullable (``RealmSet<T?>``).
+
 .. _kotlin-realm-dictionary:
 
-RealmMap/RealmDictionary
-~~~~~~~~~~~~~~~~~~~~~~~~
+RealmMap/RealmDictionaries
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A `RealmDictionary 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html>`__ 
 is a specialized 
 `RealmMap <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-map/index.html>`__ 
 where every key is a string. A ``RealmMap`` is an associative array that 
-contains  key-value pairs with unique keys. 
+contains key-value pairs with unique keys. 
 
-.. _kotlin-additional-types:
+, where T is any type of Realm primitive nullable or 
+non-nullable value (``RealmDictionary<T?>``), a
+`RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__,
+or an `EmbeddedRealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
+Dictionaries of ``RealmObject`` and ``EmbeddedRealmObject`` must be declared nullable.
 
-Additional Supported Data Types
--------------------------------
 
-.. _kotlin-objectid:
+.. _kotlin-reference-realm-object:
 
-ObjectId
-~~~~~~~~
+RealmObjects
+------------
 
-.. note:: Importing ``ObjectId`` in the Realm Kotlin SDK ``version 1.5.x`` or Higher
+You can also reference one or more Realm objects from another. 
+Learn more in the
+:ref:`Relationships <kotlin-relationships>` page.
 
-   With the :github:`Realm Kotlin Kotlin version 1.5.0
-   <realm/realm-kotlin/blob/main/CHANGELOG.md#150-2022-11-11>` you must import
-   ``ObjectId`` from :github:`org.mongodb.kbson.ObjectId <mongodb/kbson>`. If
-   you were using an older SDK version and wish to upgrade, replace your old
-   import statements as `io.realm.kotlin.types.ObjectId
-   <{+kotlin-local-prefix+}io.realm.kotlin.types/#-1137254501%2FClasslikes%2F-1651551339>`__
-   has been deprecated. 
 
-``ObjectId`` is a MongoDB-specific 12-byte unique value which you can use as an
-identifier for objects. ``ObjectId`` is :ref:`indexable <kotlin-indices>` 
-and can be used as a :ref:`primary key <kotlin-primary-keys>`. 
 
-To define a property as an ObjectId, set its type as ``ObjectId`` in
-your :ref:`object model <kotlin-define-object-model>`.
+Backlinks
+~~~~~~~~~
 
-.. _kotlin-uuid:
+``BacklinksDelegate<T>``, a `backlinks <{+kotlin-local-prefix+}io.realm.kotlin.ext/backlinks.html>`__
+delegate used to define an inverse relationship between 
+`RealmObjects <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
 
-UUID
-~~~~
 
-``UUID`` (Universal Unique Identifier) is a 16-byte :wikipedia:`unique value
-<Universally_unique_identifier>`. You can use ``UUID`` as an identifier for
-objects. ``UUID`` is :ref:`indexable <kotlin-indices>` and can be used as a 
-:ref:`primary key <kotlin-primary-keys>`. 
+EmbeddedRealmObject
+~~~~~~~~~~~~~~~~~~~
 
-Realm creates UUIDs with the `RealmUUID <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/index.html>`__ type that:
 
-- conform to `RFC 4122 version 4 <https://www.rfc-editor.org/info/rfc4122>`_
-- are created with random bytes
 
-.. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.uuid.kt
-   :language: kotlin
-   :copyable: false
 
-.. include:: /includes/note-using-uuid-instead-of-objectid.rst
+AsymmetricRealmObject
+~~~~~~~~~~~~~~~~~~~~~
 
-Create a UUID from a String
-```````````````````````````
 
-To generate a new ``RealmUUID`` from a UUID formatted string, pass the string to `RealmUUID.from() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/-companion/from.html>`__:
+.. Geospatial Types
+.. ----------------
 
-.. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.create-uuid-from-string.kt
-   :language: kotlin
-
-Create a Random UUID
-````````````````````
-
-To generate a random ``RealmUUID``, call `RealmUUID.random() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/-companion/random.html>`__:
-
-.. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.create-uuid-random.kt
-   :language: kotlin

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -11,33 +11,42 @@ Supported Types - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-The Kotlin SDK supports `Kotlin types 
-<https://kotlinlang.org/docs/basic-types.html>`__, a limited subset of
-`BSON <https://bsonspec.org/>`__ types, and 
-:wikipedia:`UUID <Universally_unique_identifier>`.
-Additionally, the Kotlin SDK offers Realm-specific types, including types 
-that you can use for unique identifiers, timestamps, counters, and collections.
+This page describes the supported data types that you can use to define 
+properties in your object model. For more information on how to define 
+your object model, see :ref:`Define an Object Model <kotlin-define-object-model>`.
+
+.. include:: /includes/map-to-bson-type.rst
 
 .. _kotlin-data-types:
 
 Supported Data Types List
 -------------------------
 
-The Realm Kotlin SDK supports the following Kotlin data types, 
-MongoDB BSON types, and Realm-specific types.
-You can use these types to define your object model properties.
-For more information, see :ref:`Define an Object Model <kotlin-define-object-model>`.
+The Kotlin SDK supports the following `Kotlin types 
+<https://kotlinlang.org/docs/basic-types.html>`__,
+`BSON <https://bsonspec.org/>`__ types, and 
+Realm-specific types, which you can use for unique 
+identifiers, timestamps, counters, and collections.
 
-.. include:: /includes/map-to-bson-type.rst
+The Kotlin SDK does *not* natively support:  
+
+- user-defined enumeration properties. See the :ref:`Enums <kotlin-enums>` 
+  section for more information on how to use enums in your Realm objects.
+- Kotlin's built-in ``Date`` or ``Instant``. See the 
+  :ref:`RealmInstant <kotlin-timestamps>` section for more information on 
+  how to use timestamps in your Realm objects.
+
+.. note:: 
+   
+   Realm stores all non-decimal numeric types as ``Long`` 
+   values and all decimal numeric types as ``Double`` values.
+
+.. _kotlin-types-table:
 
 **Kotlin Data Types**
 
 The following table lists the supported Kotlin data types and examples of 
 how to declare them as required or optional properties in your object model.
-
-Note that Realm stores all non-decimal numeric types as ``Long`` 
-values. Similarly, Realm stores all decimal numeric types as 
-``Double`` values.
 
 .. list-table:: 
    :header-rows: 1
@@ -102,6 +111,8 @@ values. Similarly, Realm stores all decimal numeric types as
      - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.char-optional.kt
          :language: kotlin
 
+.. _kotlin-bson-types-table:
+
 **MongoDB BSON Types**
 
 The following table lists the supported MongoDB BSON data types and examples 
@@ -130,10 +141,12 @@ To use these types, you must import them from the
      - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.decimal128-optional.kt
          :language: kotlin
 
+.. _kotlin-realm-specific-types-table:
+
 **Realm-Specific Types**
 
 The following table lists the supported Realm-specific data types and 
-examples of how oto declare them as required or optional properties in 
+examples of how to declare them as required or optional properties in 
 your object model.
 
 .. list-table:: 
@@ -193,20 +206,28 @@ your object model.
      - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.embedded-object-optional.kt
          :language: kotlin
 
-The Kotlin SDK does not natively support user-defined enumeration properties. 
-See the :ref:`Enums <kotlin-enums>` section for more information on how to 
-use enums in your Realm objects.
-
-
 Unique Identifiers
 ------------------
+
+The Kotlin SDK supports :wikipedia:`UUID <Universally_unique_identifier>` 
+and ``ObjectId`` as unique identifiers for Realm objects. 
+
+.. include:: /includes/note-using-uuid-instead-of-objectid.rst
 
 .. _kotlin-objectid:
 
 ObjectId
 ~~~~~~~~
 
-.. important:: 
+``ObjectId`` is a MongoDB-specific BSON type. It is a 
+12-byte, globally unique value that you can use as an identifier for objects. 
+
+An ``ObjectId`` is nullable, :ref:`indexable <kotlin-indices>`, and can 
+be used as a :ref:`primary key <kotlin-primary-keys>`.
+
+You can initialize an ``ObjectId`` using ``ObjectId()``.
+
+.. important:: io.realm.kotlin.types.ObjectId Deprecated in v1.5.0
 
    In Realm Kotlin SDK version 1.5.0 and newer, 
    `io.realm.kotlin.types.ObjectId 
@@ -214,26 +235,19 @@ ObjectId
    is deprecated. You must import ``ObjectId`` from 
    :github:`org.mongodb.kbson.ObjectId <mongodb/kbson>` instead.
 
-``ObjectId`` is a MongoDB-specific 12-byte globally unique value that you 
-can use as an identifier for objects. An ``ObjectId`` is :ref:`indexable 
-<kotlin-indices>` and can be used as a :ref:`primary key <kotlin-primary-keys>`.
-
 .. _kotlin-uuid:
 
 RealmUUID
 ~~~~~~~~~
 
-``UUID`` (Universal Unique Identifier) is a 16-byte :wikipedia:`unique value
-<Universally_unique_identifier>` that you can use as an identifier for
-objects. It is :ref:`indexable <kotlin-indices>` and can be used as a 
-:ref:`primary key <kotlin-primary-keys>`. 
+``UUID`` (Universal Unique Identifier) is a 16-byte unique value 
+that you can use as an identifier for objects. It is nullable, 
+:ref:`indexable <kotlin-indices>`, and can be used as a :ref:`primary key <kotlin-primary-keys>`. 
 
 Realm creates UUIDs with the `RealmUUID 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/index.html>`__ 
-type that:
-
-- conform to `RFC 4122 version 4 <https://www.rfc-editor.org/info/rfc4122>`_
-- are created with random bytes
+type that conform to `RFC 4122 version 4 <https://www.rfc-editor.org/info/rfc4122>`_ 
+and are created with random bytes. 
 
 You can generate a random ``RealmUUID`` using `RealmUUID.random() 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/-companion/random.html>`__ 
@@ -242,8 +256,6 @@ or pass a UUID-formatted string to `RealmUUID.from()
 
 .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.create-uuid.kt
    :language: kotlin
-
-.. include:: /includes/note-using-uuid-instead-of-objectid.rst
 
 .. _kotlin-mutablerealmint:
 
@@ -254,22 +266,28 @@ The Kotlin SDK offers `MutableRealmInt
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-mutable-realm-int/index.html>`__ 
 as a special integer type that you can use as a logical counter to accurately 
 synchronize numeric changes across multiple distributed clients. 
-
-``MutableRealmInt`` behaves like a ``Long`` but also 
-supports ``increment`` and ``decrement`` methods that implement a 
+It behaves like a ``Long`` but also supports ``increment`` and ``decrement`` 
+methods that implement a 
 :wikipedia:`conflict-free replicated data type <Conflict-free_replicated_data_type>`. 
 This ensures that numeric updates can be executed regardless of order to 
 converge to the same value.
-
-``MutableRealmInt`` fields are backed by traditional numeric types, 
-so no migration is required when changing a field from ``Byte``, ``Short``, 
-``Int``, or ``Long`` to ``MutableRealmInt``
 
 A ``MutableRealmInt`` property: 
 
 - *cannot* be used as a :ref:`primary key <kotlin-primary-keys>`
 - *cannot* store null values, but it can be declared nullable 
   (``MutableRealmInt?``)
+
+Additionally, ``MutableRealmInt`` fields: 
+
+- are backed by Kotlin's 
+  `numeric types <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-number/>`__, 
+  so no migration is required when changing a numeric field to ``MutableRealmInt``.
+- can use operators and infix functions similar to those provided by ``Long``. 
+  However, note that any operations *other than* ``set``, ``increment``, and 
+  ``decrement`` do not mutate the instance on which they are executed. Instead,
+  they create a new, unmanaged ``MutableRealmInt`` instance with the updated 
+  value.
 
 .. _kotlin-timestamps:
 
@@ -280,11 +298,14 @@ You cannot store Kotlin's built-in ``Date`` or ``Instant`` types in Realm.
 
 Instead, the Kotlin SDK uses the `RealmInstant 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-instant/index.html>`__ 
-type to store time information as a UNIX epoch timestamp.
+type to store time information as a :wikipedia:`Unix epoch <Unix_time>` 
+timestamp.
 
 If you need timestamp data in a form other than ``RealmInstant``, you
 can add conversion code to your model class based on the following
 example:
+
+.. is this still a good workaround example?
 
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.timestamp-workaround.kt
    :language: kotlin
@@ -295,29 +316,19 @@ RealmAny (Mixed)
 ----------------
 
 `RealmAny <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-any/index.html>`__ 
-represents a non-nullable mixed data type. You can use ``RealmAny`` to hold 
-any supported Kotlin data types, supported BSON types, and the following
+represents a non-nullable mixed data type. It behaves like the value type 
+that it contains. You can use ``RealmAny`` to hold 
+any :ref:`supported Kotlin data types <kotlin-types-table>`, 
+:ref:`supported BSON types <kotlin-bson-types-table>`, and the following
 Realm-specific types: 
 
 - RealmInstant
-- RealmObject
 - RealmUUID
+- RealmObject (holds a reference to the object, not a copy of it)
 
-Additionally, ``RealmAny`` values can be sorted (from lowest to highest): 
-
-#. Boolean
-#. Byte, Short, Int, Long, Float, Double, Decimal128
-#. ByteArray, String
-#. Date
-#. ObjectId
-#. UUID
-#. RealmObject
-
-You can store multiple ``RealmAny`` instances in ``RealmList``, 
-``RealmDictionary``, or ``RealmSet`` fields. 
-
-To change the value of a ``RealmAny`` field, assign a new ``RealmAny`` 
-instance with a different underlying value.
+``RealmAny`` *cannot* hold ``EmbeddedRealmObject`` types, 
+collection types (``RealmList``, ``RealmSet``, ``RealmDictionary``), 
+or another ``RealmAny``. 
 
 .. Link to Create page once example is added
 
@@ -326,8 +337,9 @@ instance with a different underlying value.
 - are :ref:`indexable <kotlin-indices>` but *cannot* be used as a 
   :ref:`primary key <kotlin-primary-keys>`
 - must be declared nullable (``RealmAny?``), but *cannot* store null values
-- can be aggregated. Results are based on the sort order, and the output 
-  type will be a ``RealmAny`` instance containing the corresponding value type.
+
+You can store multiple ``RealmAny`` instances in ``RealmList``, 
+``RealmDictionary``, or ``RealmSet`` fields.  
 
 .. tip:: Handle Polymorphism with Conditional Expressions
 
@@ -335,7 +347,7 @@ instance with a different underlying value.
    recommend using a ``when`` expression to handle the 
    ``RealmAny`` type and its possible inner value class.
 
-.. _kotlin-collections:
+.. _kotlin-collection-types:
 
 Collection Types
 ----------------
@@ -343,9 +355,17 @@ Collection Types
 The Kotlin SDK offers several collection types that you can use as 
 properties in your data model. A collection is an object 
 that contains zero or more instances of one supported data type. 
-Realm collections are homogenous: all objects in a collection are of the 
-same type.
+Realm collections are homogenous (all objects in a collection are of the 
+same type) and are backed by their corresponding built-in Kotlin classes.
 
+User-created collections are unmanaged until they are copied to the realm 
+and can contain both managed and unmanaged objects. Unmanaged collections 
+behave like their corresponding Kotlin classes and are not persisted to the realm.
+See :ref:`Managed vs. Unmanaged Objects <kotlin-managed-vs-unmanaged-objects>`
+for more information.
+
+Collection types are non-null. When you define a collection property, you must 
+initialize it. 
 See also :ref:`Create a Collection <kotlin-create-a-collection>`. 
 
 .. _kotlin-realm-list:
@@ -353,102 +373,89 @@ See also :ref:`Create a Collection <kotlin-create-a-collection>`.
 RealmLists
 ~~~~~~~~~~
 
-A `RealmList <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html>`__
-represents a :ref:`to-many relationship <kotlin-to-many-relationship>` 
-containing any of the supported data types, a `RealmObject 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+The `RealmList <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html>`__
+type implements Kotlin's 
+`List <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/>`__ 
+interface. :ref:`Unmanaged <kotlin-managed-vs-unmanaged-objects>` lists 
+behave like Kotlin's `MutableList 
+<https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-mutable-list/>`__.
+
+A ``RealmList`` represents a :ref:`to-many relationship <kotlin-to-many-relationship>` 
+containing any of the :ref:`supported Kotlin data types <kotlin-types-table>` or 
+:ref:`supported BSON types <kotlin-bson-types-table>`, a 
+`RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__, 
 or an `EmbeddedRealmObject 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
 
-``RealmList`` implements Kotlin's `List <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/>`__ 
-interface. Unmanaged lists are backed by an  built-in ``List`` class,
-except managed ``RealmList`` instances persist their contents to a
-realm. See :ref:`Managed vs. Unmanaged Objects <kotlin-managed-vs-unmanaged-objects>`
-for more information.
-
 ``RealmList<E>`` is a non-null type, where: 
 
-- Lists of ``RealmObject`` or ``EmbeddedRealmObject`` elements *cannot* 
+- lists of ``RealmObject`` or ``EmbeddedRealmObject`` elements *cannot* 
   be nullable
-- Lists of any other supported elements can be nullable (``RealmList<E?>``)
+- lists of any other supported elements can be nullable (``RealmList<E?>``)
 
 .. _kotlin-realm-set:
 
 RealmSets
 ~~~~~~~~~
 
-A `RealmSet 
+The `RealmSet 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html>`__   
-represents a :ref:`to-many relationship <kotlin-to-many-relationship>` 
-containing distinct values of any of the supported data types, a `RealmObject 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
-or an `EmbeddedRealmObject 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
-
-``RealmSet`` implements Kotlin's 
+type implements Kotlin's 
 `Set <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/>`__ 
-interface, so it works exactly like the built-in ``HashSet`` class,
-except managed ``RealmSet`` instances persist their contents to a
-realm. See :ref:`Managed vs. Unmanaged Objects <kotlin-managed-vs-unmanaged-objects>`
-for more information.
+interface. :ref:`Unmanaged <kotlin-managed-vs-unmanaged-objects>` sets behave 
+like Kotlin's `MutableSet 
+<https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-mutable-set/>`__. 
+
+A ``RealmSet`` represents a :ref:`to-many relationship <kotlin-to-many-relationship>` 
+containing distinct values of any of the 
+:ref:`supported Kotlin data types <kotlin-types-table>`,
+:ref:`supported BSON types <kotlin-bson-types-table>`, or a `RealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
+You cannot use ``EmbeddedRealmObject`` elements in a ``RealmSet``.
 
 ``RealmSet<E>`` is a non-null type, where:
 
-- Sets of ``RealmObject`` or ``EmbeddedRealmObject`` elements *cannot* be nullable
-- Sets of any other supported elements can be nullable (``RealmSet<E?>``)
+- sets of ``RealmObject`` elements *cannot* be nullable
+- sets of any other supported elements can be nullable (``RealmSet<E?>``)
 
 .. _kotlin-realm-dictionary:
 
 RealmMap/RealmDictionaries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A `RealmMap <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-map/index.html>`__  
-is an associative array that contains key-value pairs with unique keys. `RealmDictionary 
+The `RealmMap <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-map/index.html>`__ 
+type implements Kotlin's `Map 
+<https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/>`__ 
+interface and is an associative array that contains key-value ``String`` pairs 
+with unique keys. 
+`RealmDictionary 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html>`__ 
-is a specialized ``RealmMap`` where every key is a string and values can 
-be any of the supported data types, a `RealmObject
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+is a specialized ``RealmMap`` that accepts a ``String`` key and non-string values.
+:ref:`Unmanaged <kotlin-managed-vs-unmanaged-objects>` dictionaries behave 
+like Kotlin's `LinkedHashMap 
+<https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-linked-hash-map/>`__.
+
+``RealmDictionary`` values can be any of the :ref:`supported Kotlin data types 
+<kotlin-types-table>` or :ref:`supported BSON types <kotlin-bson-types-table>`, 
+a `RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
 or an `EmbeddedRealmObject 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
 
-``RealmDictionary`` implements Kotlin's `Map 
-<https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/>`__ 
-interface, so it works exactly like the built-in ``LinkedHashMap`` class,
-except managed ``RealmDictionary`` instances persist their contents to a
-realm. See :ref:`Managed vs. Unmanaged Objects <kotlin-managed-vs-unmanaged-objects>`
-for more information.
-
 ``RealmDictionary<K, V>`` is a non-null type, where: 
 
-- Keys must be strings
-- Dictionaries of ``RealmObject`` or ``EmbeddedRealmObject`` values *must* 
-  be nullable (``RealmDictionary<K, V?>``)
-- Dictionaries of any other supported elements can be nullable (``RealmDictionary<K, V?>``)
-
-RealmResults
-~~~~~~~~~~~~
-
-`RealmResults 
-<{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-results/index.html>`__ 
-represents the lazily evaluated results of a ``RealmQuery``. Results are 
-immutable: you cannot add or remove elements on the results collection. 
-Instead, the associated query determines their contents.
-
-``RealmResults<E>`` implements Kotlin's `List 
-<https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/>`__ 
-and behaves in similar ways.
-
-An inverse, to-many relationship property is a ``RealmResults`` list: 
-
-.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
-   :language: kotlin
+- keys must be strings
+- ``RealmObject`` or ``EmbeddedRealmObject`` values *must* be nullable 
+  (``RealmDictionary<K, V?>``)
+- any other supported element values can be nullable 
 
 .. _kotlin-realm-objects-as-properties:
 
 RealmObjects as Properties
 --------------------------
 
-You can use `RealmObjects <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__ and any subclasses as properties in your object model.
+You can use 
+`RealmObjects <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__ 
+and any subclasses as properties in your object model.
 
 ``RealmObject`` properties:  
 
@@ -462,30 +469,36 @@ For more information, see the :ref:`Relationships <kotlin-relationships>` page.
 Backlinks
 ~~~~~~~~~
 
-A backlink represents an :ref:`inverse relationship <kotlin-inverse-relationships>`
-between a ``RealmObject`` and one or more ``RealmObject`` or between a 
-``RealmObject`` and an ``EmbeddedRealmObject``. Backlinks cannot be null.
+A backlink represents an :ref:`inverse <kotlin-inverse-relationships>`, 
+to-many relationship between a ``RealmObject`` and one or more ``RealmObject`` 
+or between a ``RealmObject`` and an ``EmbeddedRealmObject``. 
+Backlinks cannot be null.
 
 You can define a backlink property as a `BacklinksDelegate 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-backlinks-delegate/index.html>`__ 
 or `EmbeddedBacklinksDelegate 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-backlinks-delegate/index.html>`__ to the parent object using the ``backlinks()`` method.
- 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-backlinks-delegate/index.html>`__ 
+to the parent object using the ``backlinks()`` method.
 
-A ``BacklinksDelegate<T>`` property is defined as a ``RealmResults<T>`` list 
-of ``RealmObjects`` :
+- A ``BacklinksDelegate<T>`` property is defined as a `RealmResults 
+  <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-results/index.html>`__ list 
+  of the parent ``RealmObject`` type:
 
-You can store backlinks for to-many relationships in ``RealmLists``, ``RealmSets``, or 
-``RealmDictionaries``
+  .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
+     :language: kotlin
 
-.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
+- An ``EmbeddedBacklinksDelegate<T>`` property is defined as the parent 
+  ``RealmObject`` type:
+
+  .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-embedded-object.kt
+     :language: kotlin
+
+You then reference the backlinks in collections in the parent ``RealmObject``:
+
+.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-parent-object.kt
    :language: kotlin
 
-An ``EmbeddedBacklinksDelegate<T>`` property is defined as an object that 
-links:
-
-.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-embedded-object.kt
-   :language: kotlin
+.. todo add link to Create when page is updated
 
 .. _kotlin-embedded-objects-as-properties:
 
@@ -494,23 +507,17 @@ EmbeddedRealmObject
 
 An `EmbeddedRealmObject 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__
-is a special type of `RealmObject 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__. 
+is a special type of ``RealmObject``. 
 
 ``EmbeddedRealmObject`` properties: 
 
 - must be nullable objects within the parent object 
-- *cannot* be nullable elements within a list or set  
+- must be nullable values within a dictionary
+- *cannot* be nullable elements within a list 
 - *cannot* be used as a :ref:`primary key <kotlin-primary-keys>` 
+- can be recursively referenced as an optional property in its own definition
 
 See :ref:`Embedded Objects <kotlin-embedded-objects>` for more information.
-
-.. tip:: Embedded Object Types are Reusable and Composable
-
-   You can use the same embedded object type in multiple parent object types, and
-   you can embed objects inside other embedded objects. You can even
-   recursively reference an embedded object type as an optional property in its
-   own definition.
 
 .. Geospatial Types
 .. ----------------
@@ -529,4 +536,3 @@ value between the underlying value and the enum type.
 
 .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.enum-workaround.kt
    :language: kotlin
-

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -36,6 +36,9 @@ The Kotlin SDK does *not* natively support:
   :ref:`RealmInstant <kotlin-timestamps>` section for more information on 
   how to use timestamps in your Realm objects.
 
+Additionally, the Kotlin SDK does not currently support abstract properties.
+Kotlin properties *must* be initialized. 
+
 .. note:: 
    
    Realm stores all non-decimal numeric types as ``Long`` 
@@ -304,8 +307,6 @@ If you need timestamp data in a form other than ``RealmInstant``, you
 can add conversion code to your model class based on the following
 example:
 
-.. is this still a good workaround example?
-
 .. literalinclude:: /examples/generated/kotlin/SchemaTest.snippet.timestamp-workaround.kt
    :language: kotlin
 
@@ -329,8 +330,6 @@ that it contains. ``RealmAny`` can hold:
 ``RealmAny`` *cannot* hold ``EmbeddedRealmObject`` types, 
 collection types (``RealmList``, ``RealmSet``, ``RealmDictionary``), 
 or another ``RealmAny``. 
-
-.. Link to Create page once example is added
 
 ``RealmAny`` properties: 
 
@@ -461,8 +460,14 @@ like Kotlin's `LinkedHashMap
 RealmObjects as Properties
 --------------------------
 
-You can use ``RealmObject`` and any subclasses as properties in your 
-object model.
+You can use ``RealmObject`` and any subclasses, *except* 
+``AsymmetricRealmObject`` as properties in your object model.
+
+.. important:: 
+
+    ``AsymmetricRealmObject`` *cannot* be used as properties. 
+    For more information, refer to :ref:`Asymmetric Objects 
+    <kotlin-asymmetric-objects>`. 
 
 RealmObjects
 ~~~~~~~~~~~~
@@ -518,6 +523,7 @@ is a special type of ``RealmObject``.
 - *cannot* be nullable elements within a list 
 - *cannot* be used as a :ref:`primary key <kotlin-primary-keys>` 
 - can be recursively referenced as an optional property in its own definition
+- can be properties within an asymmetric object
 
 For more information, refer to :ref:`Embedded Objects <kotlin-embedded-objects>`.
 

--- a/source/sdk/kotlin/realm-database/schemas/supported-types.txt
+++ b/source/sdk/kotlin/realm-database/schemas/supported-types.txt
@@ -11,12 +11,10 @@ Supported Types - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-
 The Kotlin SDK supports `Kotlin types 
 <https://kotlinlang.org/docs/basic-types.html>`__, a limited subset of
 `BSON <https://bsonspec.org/>`__ types, and 
 :wikipedia:`UUID <Universally_unique_identifier>`.
-
 Additionally, the Kotlin SDK offers Realm-specific types, including types 
 that you can use for unique identifiers, timestamps, counters, and collections.
 
@@ -27,11 +25,19 @@ Supported Data Types List
 
 The Realm Kotlin SDK supports the following Kotlin data types, 
 MongoDB BSON types, and Realm-specific types.
-
-You can use these types to define your object model 
-properties.
+You can use these types to define your object model properties.
+For more information, see :ref:`Define an Object Model <kotlin-define-object-model>`.
 
 .. include:: /includes/map-to-bson-type.rst
+
+**Kotlin Data Types**
+
+The following table lists the supported Kotlin data types and examples of 
+how to declare them as required or optional properties in your object model.
+
+Note that Realm stores all non-decimal numeric types as ``Long`` 
+values. Similarly, Realm stores all decimal numeric types as 
+``Double`` values.
 
 .. list-table:: 
    :header-rows: 1
@@ -41,33 +47,67 @@ properties.
    * - Kotlin Data Type
      - Required
      - Optional
+
    * - ``String``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.string-required.kt
+         :language: kotlin     
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.string-optional.kt
+         :language: kotlin
+
    * - ``Byte``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.byte-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.byte-optional.kt
+         :language: kotlin
+
    * - ``Short``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.short-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.short-optional.kt
+         :language: kotlin
+
    * - ``Int``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.int-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.int-optional.kt
+         :language: kotlin
+
    * - ``Long``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.long-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.long-optional.kt
+         :language: kotlin
+
    * - ``Float``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.float-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.float-optional.kt
+         :language: kotlin
+
    * - ``Double``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.double-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.double-optional.kt
+         :language: kotlin
+
    * - ``Boolean``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.bool-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.bool-optional.kt
+         :language: kotlin
+
    * - ``Char``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.char-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.char-optional.kt
+         :language: kotlin
+
+**MongoDB BSON Types**
+
+The following table lists the supported MongoDB BSON data types and examples 
+of how to declare them as required or optional properties in your object model.
+To use these types, you must import them from the 
+:github:`org.mongodb.kbson <mongodb/kbson>` package.
 
 .. list-table:: 
    :header-rows: 1
@@ -77,12 +117,24 @@ properties.
    * - MongoDB BSON Type
      - Required
      - Optional
+
    * - :ref:`ObjectId <kotlin-objectid>`
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.objectId-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.objectId-optional.kt
+         :language: kotlin
+
    * - ``Decimal128``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.decimal128-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.decimal128-optional.kt
+         :language: kotlin
+
+**Realm-Specific Types**
+
+The following table lists the supported Realm-specific data types and 
+examples of how oto declare them as required or optional properties in 
+your object model.
 
 .. list-table:: 
    :header-rows: 1
@@ -92,53 +144,58 @@ properties.
    * - Realm-Specific Type
      - Required
      - Optional
+
    * - :ref:`RealmUUID <kotlin-uuid>`
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.uuid-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.uuid-optional.kt
+         :language: kotlin
+
    * - :ref:`RealmInstant <kotlin-timestamps>`
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.realmInstant-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.realmInstant-optional.kt
+         :language: kotlin
+
    * - :ref:`RealmAny <kotlin-realmany>`
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     -       N/A
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.realmAny-optional.kt
+         :language: kotlin
+
    * - :ref:`MutableRealmInt <kotlin-mutablerealmint>`
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
-   * - ``RealmObject``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
-   * - ``EmbeddedRealmObject``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
-   * - ``BacklinksDelegate<T>``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
-   * - ``EmbeddedBacklinksDelegate<T>``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
-   * - ``RealmList<T>``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
-   * - ``RealmSet<T>``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
-   * - ``RealmMap<T>``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
-   * - ``RealmDictionary<T>``
-     - ``var name: String = "John"``
-     - ``var name: String? = null``
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.mutableRealmInt-required.kt
+         :language: kotlin
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.mutableRealmInt-optional.kt
+         :language: kotlin
 
+   * - :ref:`RealmList <kotlin-realm-list>`
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.list-required.kt
+         :language: kotlin
+     -       N/A
 
-.. note:: Numeric Types
-   
-   Realm stores all non-decimal numeric types as ``Long`` values.
-   Similarly, Realm stores all decimal numeric types as ``Double``
-   values.
+   * - :ref:`RealmSet <kotlin-realm-set>`
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.set-required.kt
+         :language: kotlin
+     -       N/A
+
+   * - :ref:`RealmDictionary <kotlin-realm-dictionary>`
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.dictionary-required.kt
+         :language: kotlin
+     -       N/A
+
+   * - :ref:`RealmObject <kotlin-realm-objects-as-properties>`
+     -       N/A
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.realm-object-optional.kt
+         :language: kotlin
+
+   * - :ref:`EmbeddedRealmObject <kotlin-embedded-objects-as-properties>`
+     -       N/A
+     - .. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.embedded-object-optional.kt
+         :language: kotlin
+
 
 Unique Identifiers
 ------------------
-
 
 .. _kotlin-objectid:
 
@@ -147,13 +204,15 @@ ObjectId
 
 .. important:: 
 
-   In Realm Kotlin SDK version 1.5.0 and newer, `io.realm.kotlin.types.ObjectId <{+kotlin-local-prefix+}/io.realm.kotlin.types/-object-id/index.html>`__ is deprecated. You must import ``ObjectId`` from :github:`org.mongodb.kbson.ObjectId <mongodb/kbson>` instead.
+   In Realm Kotlin SDK version 1.5.0 and newer, 
+   `io.realm.kotlin.types.ObjectId 
+   <{+kotlin-local-prefix+}/io.realm.kotlin.types/-object-id/index.html>`__ 
+   is deprecated. You must import ``ObjectId`` from 
+   :github:`org.mongodb.kbson.ObjectId <mongodb/kbson>` instead.
 
-``ObjectId`` is a MongoDB-specific 12-byte unique value that you 
-can use as an identifier for objects. 
-
-An ``ObjectId`` is :ref:`indexable <kotlin-indices>` 
-and can be used as a :ref:`primary key <kotlin-primary-keys>`.
+``ObjectId`` is a MongoDB-specific 12-byte globally unique value that you 
+can use as an identifier for objects. An ``ObjectId`` is :ref:`indexable 
+<kotlin-indices>` and can be used as a :ref:`primary key <kotlin-primary-keys>`.
 
 .. _kotlin-uuid:
 
@@ -165,7 +224,9 @@ RealmUUID
 objects. It is :ref:`indexable <kotlin-indices>` and can be used as a 
 :ref:`primary key <kotlin-primary-keys>`. 
 
-Realm creates UUIDs with the `RealmUUID <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/index.html>`__ type that:
+Realm creates UUIDs with the `RealmUUID 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/index.html>`__ 
+type that:
 
 - conform to `RFC 4122 version 4 <https://www.rfc-editor.org/info/rfc4122>`_
 - are created with random bytes
@@ -173,7 +234,10 @@ Realm creates UUIDs with the `RealmUUID <{+kotlin-local-prefix+}io.realm.kotlin.
 You can generate a random ``RealmUUID`` using `RealmUUID.random() 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/-companion/random.html>`__ 
 or pass a UUID-formatted string to `RealmUUID.from() 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/-companion/from.html>`__.
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-u-u-i-d/-companion/from.html>`__:
+
+.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.create-uuid.kt
+   :language: kotlin
 
 .. include:: /includes/note-using-uuid-instead-of-objectid.rst
 
@@ -185,21 +249,23 @@ MutableRealmInt (Counter)
 The Kotlin SDK offers `MutableRealmInt 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-mutable-realm-int/index.html>`__ 
 as a special integer type that you can use as a logical counter to accurately 
-synchronize numeric changes across multiple distributed clients using 
-Device Sync. 
+synchronize numeric changes across multiple distributed clients. 
 
 ``MutableRealmInt`` behaves like a ``Long`` but also 
 supports ``increment`` and ``decrement`` methods that implement a 
-:wikipedia:`conflict-free replicated data type <Conflict-free_replicated_data_type>`. This ensures that numeric updates
-can be executed regardless of order to converge to the same value.
+:wikipedia:`conflict-free replicated data type <Conflict-free_replicated_data_type>`. 
+This ensures that numeric updates can be executed regardless of order to 
+converge to the same value.
 
 ``MutableRealmInteger`` fields are backed by traditional numeric types, 
 so no migration is required when changing a field from ``Byte``, ``Short``, 
-``Integer`` or ``Long`` to ``MutableRealmInteger``
+``Int``, or ``Long`` to ``MutableRealmInteger``
 
-A ``MutableRealmInt`` *cannot*: 
-- be used as a :ref:`primary key <kotlin-primary-keys>`
-- store null values, but it can be declared nullable (``MutableRealmInt?``)
+A ``MutableRealmInt`` property: 
+
+- *cannot* be used as a :ref:`primary key <kotlin-primary-keys>`
+- *cannot* store null values, but it can be declared nullable 
+  (``MutableRealmInt?``)
 
 .. _kotlin-timestamps:
 
@@ -224,23 +290,50 @@ example:
 RealmAny (Mixed)
 ----------------
 
-The `RealmAny 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-any/index.html>`__ is a
-mixed data type that represents a polymorphic Realm value. 
+`RealmAny <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-any/index.html>`__ 
+represents a non-nullable mixed data type. You can use ``RealmAny`` to hold the 
+following data types: 
 
-You can use the ``RealmAny`` type to create
-Realm object fields that can contain any of several
-underlying types. You can store multiple ``RealmAny`` 
-instances in ``RealmList``, ``RealmDictionary``, or 
-``RealmSet`` fields. To change the value of a 
-``RealmAny`` field, assign a new ``RealmAny`` instance
-with a different underlying value.
+- Boolean
+- Byte 
+- ByteArray
+- Char
+- Float
+- Double
+- Decimal128
+- Int
+- ObjectID 
+- RealmInstant
+- RealmObject
+- RealmUUID
+- Short
+- String
 
-``RealmAny``: 
-- are :ref:`indexable <kotlin-indices>`
-- *cannot* be used as a :ref:`primary key <kotlin-primary-keys>`
-- *cannot* store null values, but they *must* be declared nullable (``RealmAny?``)
-- *cannot* store an ``EmbeddedRealmObject`` 
+Additionally, ``RealmAny`` values can be sorted (from lowest to highest): 
+
+#. Boolean
+#. Byte, Short, Int, Long, Float, Double, Decimal128
+#. ByteArray, String
+#. Date
+#. ObjectId
+#. UUID
+#. RealmObject
+
+You can store multiple ``RealmAny`` instances in ``RealmList``, 
+``RealmDictionary``, or ``RealmSet`` fields. 
+
+To change the value of a ``RealmAny`` field, assign a new ``RealmAny`` 
+instance with a different underlying value.
+
+.. Link to Create page once example is added
+
+``RealmAny`` properties: 
+
+- are :ref:`indexable <kotlin-indices>` but *cannot* be used as a 
+  :ref:`primary key <kotlin-primary-keys>`
+- must be declared nullable (``RealmAny?``), but *cannot* store null values
+- can be aggregated. Results are based on the sort order, and the output 
+  type will be a ``RealmAny`` instance containing the corresponding value type.
 
 .. tip:: Handle Polymorphism with Conditional Expressions
 
@@ -253,97 +346,177 @@ with a different underlying value.
 Collection Types
 ----------------
 
-Realm collections can contain zero or more instances of a supported data type.
-Within a Realm collection, all objects are of the same type.
-   
-- 
-- ``RealmSet<T>``
-- ``RealmMap<T>``
-- ``RealmDictionary<T>``
+The Kotlin SDK offers several collection types that you can use as 
+properties in your data model. A collection is an object 
+that contains zero or more instances of one supported data type. 
+Realm collections are homogenous: all objects in a collection are of the 
+same type.
+
+See also :ref:`Create a Collection <kotlin-create-a-collection>`. 
 
 .. _kotlin-realm-list:
 
 RealmLists
 ~~~~~~~~~~
 
+A `RealmList <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html>`__
+represents a :ref:`to-many relationship <kotlin-to-many-relationship>` 
+containing any of the supported data types, a `RealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+or an `EmbeddedRealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
 
+``RealmList`` implements Kotlin's `List <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/>`__ 
+interface. Unmanaged lists are backed by an  built-in ``List`` class,
+except managed ``RealmList`` instances persist their contents to a
+realm. See :ref:`Managed vs. Unmanaged Objects <kotlin-managed-vs-unmanaged-objects>`
+for more information.
 
-``RealmList<T>``, where T is any of the supported data types or a   
-`RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
-Lists of ``RealmObject`` cannot have null elements. 
+``RealmList<E>`` is a non-null type, where: 
 
-All other types of ``RealmList<T>`` can be nullable (``RealmList<T?>``).
+- Lists of ``RealmObject`` or ``EmbeddedRealmObject`` elements *cannot* 
+  be nullable
+- Lists of any other supported elements can be nullable (``RealmList<E?>``)
 
 .. _kotlin-realm-set:
 
 RealmSets
 ~~~~~~~~~
 
-A `RealmSet() 
-<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html>`__  
-collection represents a 
-:ref:`to-many relationship <kotlin-to-many-relationship>` containing 
-distinct values. 
+A `RealmSet 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html>`__   
+represents a :ref:`to-many relationship <kotlin-to-many-relationship>` 
+containing distinct values of any of the supported data types, a `RealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+or an `EmbeddedRealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
 
 ``RealmSet`` implements Kotlin's 
 `Set <https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/>`__ 
-interface, so it works just like the built-in ``HashSet`` class,
+interface, so it works exactly like the built-in ``HashSet`` class,
 except managed ``RealmSet`` instances persist their contents to a
-realm. 
+realm. See :ref:`Managed vs. Unmanaged Objects <kotlin-managed-vs-unmanaged-objects>`
+for more information.
 
-, where T is any of the supported data types or a
-`RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
-Sets of ``RealmObject`` cannot have null elements. 
+``RealmSet<E>`` is a non-null type, where:
 
-All other types of ``RealmSet<T>`` can be nullable (``RealmSet<T?>``).
+- Sets of ``RealmObject`` or ``EmbeddedRealmObject`` elements *cannot* be nullable
+- Sets of any other supported elements can be nullable (``RealmSet<E?>``)
 
 .. _kotlin-realm-dictionary:
 
 RealmMap/RealmDictionaries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A `RealmDictionary 
+A `RealmMap <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-map/index.html>`__  
+is an associative array that contains key-value pairs with unique keys. `RealmDictionary 
 <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html>`__ 
-is a specialized 
-`RealmMap <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-map/index.html>`__ 
-where every key is a string. A ``RealmMap`` is an associative array that 
-contains key-value pairs with unique keys. 
+is a specialized ``RealmMap`` where every key is a string and values can 
+be any of the supported data types, a `RealmObject
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__
+or an `EmbeddedRealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
 
-, where T is any type of Realm primitive nullable or 
-non-nullable value (``RealmDictionary<T?>``), a
-`RealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__,
-or an `EmbeddedRealmObject <{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__.
-Dictionaries of ``RealmObject`` and ``EmbeddedRealmObject`` must be declared nullable.
+``RealmDictionary`` implements Kotlin's `Map 
+<https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/>`__ 
+interface, so it works exactly like the built-in ``LinkedHashMap`` class,
+except managed ``RealmDictionary`` instances persist their contents to a
+realm. See :ref:`Managed vs. Unmanaged Objects <kotlin-managed-vs-unmanaged-objects>`
+for more information.
 
+``RealmDictionary<K, V>`` is a non-null type, where: 
 
-.. _kotlin-reference-realm-object:
+- Keys must be strings
+- Dictionaries of ``RealmObject`` or ``EmbeddedRealmObject`` values *must* 
+  be nullable (``RealmDictionary<K, V?>``)
+- Dictionaries of any other supported elements can be nullable (``RealmDictionary<K, V?>``)
 
-RealmObjects
-------------
+RealmResults
+~~~~~~~~~~~~
 
-You can also reference one or more Realm objects from another. 
-Learn more in the
-:ref:`Relationships <kotlin-relationships>` page.
+`RealmResults 
+<{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-results/index.html>`__ 
+represents the lazily evaluated results of a ``RealmQuery``. Results are 
+immutable: you cannot add or remove elements on the results collection. 
+Instead, the associated query determines their contents.
 
+``RealmResults<E>`` implements Kotlin's `List 
+<https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/>`__ 
+and behaves in similar ways.
 
+An inverse, to-many relationship property is a ``RealmResults`` list: 
+
+.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
+   :language: kotlin
+
+.. _kotlin-realm-objects-as-properties:
+
+RealmObjects as Properties
+--------------------------
+
+You can use `RealmObjects <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__ and any subclasses as properties in your object model.
+
+``RealmObject`` properties:  
+
+- can be used as elements in collections 
+- *cannot* be used as a :ref:`primary key <kotlin-primary-keys>`
+
+You can also reference one or more Realm objects from another through 
+to-one and to-many relationships. 
+For more information, see the :ref:`Relationships <kotlin-relationships>` page.
 
 Backlinks
 ~~~~~~~~~
 
-``BacklinksDelegate<T>``, a `backlinks <{+kotlin-local-prefix+}io.realm.kotlin.ext/backlinks.html>`__
-delegate used to define an inverse relationship between 
-`RealmObjects <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__.
+A backlink represents an :ref:`inverse relationship <kotlin-inverse-relationships>`
+between a ``RealmObject`` and one or more ``RealmObject`` or between a 
+``RealmObject`` and an ``EmbeddedRealmObject``. Backlinks cannot be null.
 
+You can define a backlink property as a `BacklinksDelegate 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-backlinks-delegate/index.html>`__ 
+or `EmbeddedBacklinksDelegate 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-backlinks-delegate/index.html>`__ to the parent object using the ``backlinks()`` method.
+ 
+
+A ``BacklinksDelegate<T>`` property is defined as a ``RealmResults<T>`` list 
+of ``RealmObjects`` :
+
+You can store backlinks for to-many relationships in RealmLists, RealmSets, or 
+RealmDictionaries
+
+.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-realm-object.kt
+   :language: kotlin
+
+An ``EmbeddedBacklinksDelegate<T>`` property is defined as an object that 
+links:
+
+.. literalinclude:: /examples/generated/kotlin/DataTypes.snippet.backlinks-embedded-object.kt
+   :language: kotlin
+
+.. _kotlin-embedded-objects-as-properties:
 
 EmbeddedRealmObject
 ~~~~~~~~~~~~~~~~~~~
 
+An `EmbeddedRealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-embedded-realm-object/index.html>`__
+is a special type of `RealmObject 
+<{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-object/index.html>`__. 
 
+``EmbeddedRealmObject`` properties: 
 
+- must be nullable objects within the parent object 
+- *cannot* be nullable elements within a list or set  
+- *cannot* be used as a :ref:`primary key <kotlin-primary-keys>` 
 
-AsymmetricRealmObject
-~~~~~~~~~~~~~~~~~~~~~
+See :ref:`Embedded Objects <kotlin-embedded-objects>` for more information.
 
+.. tip:: Embedded Object Types are Reusable and Composable
+
+   You can use the same embedded object type in multiple parent object types, and
+   you can embed objects inside other embedded objects. You can even
+   recursively reference an embedded object type as an optional property in its
+   own definition.
 
 .. Geospatial Types
 .. ----------------

--- a/source/sdk/kotlin/realm-database/write-transactions.txt
+++ b/source/sdk/kotlin/realm-database/write-transactions.txt
@@ -61,6 +61,8 @@ commits it or cancels it:
   the transaction causes an error, all changes are discarded
   (or "rolled back").
 
+.. _kotlin-managed-vs-unmanaged-objects:
+
 Managed vs. Unmanaged Objects
 -----------------------------
 


### PR DESCRIPTION
## Pull Request Info

- Add "cheatsheet" tables that include all types (similar to [Swift](https://www.mongodb.com/docs/realm/sdk/swift/model-data/supported-types/#supported-property-types)) 
- Generate snippets for cheatsheet examples
- Document Realm specific types 

> NOTE: Supporting info will be added to relevant Define, CRUD, Relationships, etc. pages when those pages are updated (e.g. how to create and update a RealmAny property)

### Jira

- https://jira.mongodb.org/browse/DOCSP-30341
- https://jira.mongodb.org/browse/DOCSP-31759

### Staged Changes

- [Supported Types](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-30341-update-data-types-page/sdk/kotlin/realm-database/schemas/supported-types/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
