### PR TITLE
Revert "DOCSP-32483 programmatic tagging script for realm repo"

### DIFF
--- a/source/facets.toml
+++ b/source/facets.toml
@@ -1,3 +1,0 @@
-[[facets]]
-category = "target_product"
-value = "realm"

--- a/source/sdk/dotnet/facets.toml
+++ b/source/sdk/dotnet/facets.toml
@@ -1,7 +1,0 @@
-[[facets.sub_facets]]
-category = "sub_product"
-value = "dotnet"
-
-[[facets]]
-category = "programming_language"
-value = "csharp"

--- a/source/sdk/flutter/facets.toml
+++ b/source/sdk/flutter/facets.toml
@@ -1,7 +1,0 @@
-[[facets]]
-category = "programming_language"
-value = "dart"
-
-[[facets.sub_facets]]
-category = "sub_product"
-value = "flutter"

--- a/source/sdk/java/facets.toml
+++ b/source/sdk/java/facets.toml
@@ -1,6 +1,0 @@
-[[facets]]
-category = "programming_language"
-value = "java"
-[[facets]]
-category = "programming_language"
-value = "kotlin"

--- a/source/sdk/kotlin/facets.toml
+++ b/source/sdk/kotlin/facets.toml
@@ -1,3 +1,0 @@
-[[facets]]
-category = "programming_language"
-value = "kotlin"

--- a/source/sdk/node/facets.toml
+++ b/source/sdk/node/facets.toml
@@ -1,7 +1,0 @@
-[[facets]]
-category = "programming_language"
-value = "javascript/typescript"
-
-[[facets.sub_facets]]
-category = "sub_product"
-value = "node"

--- a/source/sdk/react-native/facets.toml
+++ b/source/sdk/react-native/facets.toml
@@ -1,7 +1,0 @@
-[[facets]]
-category = "programming_language"
-value = "javascript/typescript"
-
-[[facets.sub_facets]]
-category = "sub_product"
-value = "react-native"

--- a/source/sdk/swift/facets.toml
+++ b/source/sdk/swift/facets.toml
@@ -1,6 +1,0 @@
-[[facets]]
-category = "programming_language"
-value = "objective-c"
-[[facets]]
-category = "programming_language"
-value = "swift"

--- a/source/web/facets.toml
+++ b/source/web/facets.toml
@@ -1,7 +1,0 @@
-[[facets]]
-category = "programming_language"
-value = "javascript/typescript"
-
-[[facets.sub_facets]]
-category = "sub_product"
-value = "web"


### PR DESCRIPTION
Reverts mongodb/docs-realm#2982

Currently, Snooty is unable to build docs-realm with an error that platform theorizes is related to this file: https://github.com/mongodb/docs-realm/pull/2982/files#diff-59b2cb232ab8f22d89bc70df42f016b1489393983e4791fa811cb0f60534e23a

Reverting this to enable docs-realm to build again - we can try again with a fresh run once the script has been tweaked.