### PR TITLE
(DOCSP-32529): Node.js Data Types: Update JS API reference links for v12

### DIFF
--- a/source/sdk/node/model-data/data-types/collections.txt
+++ b/source/sdk/node/model-data/data-types/collections.txt
@@ -29,7 +29,7 @@ notifications <node-register-a-collection-change-listener>`.
 
 Results
 -------
-A :js-sdk:`Results <Realm.Results.html>` collection represents the
+A :js-sdk:`Results <classes/Results.html>` collection represents the
 lazily-evaluated results of a query operation. Results are immutable:
 you cannot add or remove elements to or from the results collection.
 Results have an associated query that determines their contents.
@@ -42,14 +42,14 @@ Results have an associated query that determines their contents.
 
 Lists
 -----
-A :js-sdk:`List <Realm.List.html>` represents a collection of values of a single 
+A :js-sdk:`List <classes/List.html>` represents a collection of values of a single 
 type. Lists are declared as a property within an 
 :ref:`object model <node-object-schemas>`, and are not associated with a query.
 
 Lists behave like normal JavaScript arrays, except that they 
 can only store values of a single type, which you indicate by setting the 
-:js-sdk:`type <Realm.List.html#type>` property to one of the 
-valid :js-sdk:`property types <Realm.html#~PropertyType>` or to the name of 
+``type`` property to the name of a valid 
+:js-sdk:`property type <types/PropertyTypeName.html>` or to the name of 
 another Realm object type. 
 
 .. literalinclude:: /examples/generated/node/data-types.snippet.node_list.js
@@ -88,7 +88,7 @@ A collection is **not** live when:
   even if you have deleted or modified the collection's objects to exclude them 
   from the filter that produced the results collection.
 
-- the collection is a frozen :js-sdk:`Results.snapshot() <Realm.Collection.html#snapshot>`.
+- the collection is a frozen :js-sdk:`Results.snapshot() <classes/Results.html#snapshot>`.
 
 Combined with :ref:`collection notifications
 <node-change-notifications>`, live collections enable

--- a/source/sdk/node/model-data/data-types/dictionaries.txt
+++ b/source/sdk/node/model-data/data-types/dictionaries.txt
@@ -38,7 +38,7 @@ integers or ``"string{}"`` to specify that dictionary values must be strings.
 Create an Object with a  Dictionary Value
 -----------------------------------------
 Create an object with a dictionary value by running the :js-sdk:`realm.create()
-<Realm.html#create>` method within a write transaction. 
+<classes/Realm-1.html#create>` method within a write transaction. 
 
 .. literalinclude:: /examples/generated/node/data-types.snippet.create-realm-obj-with-dictionary.js
     :language: javascript
@@ -46,7 +46,7 @@ Create an object with a dictionary value by running the :js-sdk:`realm.create()
 Query for Objects with a Dictionary Property
 --------------------------------------------
 To filter a query, run :js-sdk:`collection.filtered()
-<Realm.Collection.html#filtered>` to specify a subset of results based on the
+<classes/OrderedCollection.html#filtered>` to specify a subset of results based on the
 value(s) of one or more object properties. You can specify results based on the value of a 
 dictionary's properties by using :mdn:`bracket-notation <Web/JavaScript/Reference/Operators/Property_accessors>`.
 
@@ -62,9 +62,10 @@ running the query: ``home.@keys = "price"``.
 Add a Listener to a Dictionary
 ------------------------------
 You can add a listener to a dictionary by running the
-:js-sdk:`dictionary.addListener() <Realm.List.html#addListener>` method. The
-``addListener`` method's callback function has two parameters, the changed
-dictionary and an array of changes describing how the dictionary was changed.
+:js-sdk:`dictionary.addListener() <classes/Dictionary.html#addListener>` 
+method. The ``addListener`` method's callback function has two parameters, 
+the changed dictionary and an array of changes describing how the dictionary 
+was changed.
 
 .. note:: 
 

--- a/source/sdk/node/model-data/data-types/field-types.txt
+++ b/source/sdk/node/model-data/data-types/field-types.txt
@@ -26,6 +26,6 @@ Realm supports the following field data types:
 - ``dictionary`` used to manage a collection of unique String keys paired with values. The ``Dictionary`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
 - ``set`` is based on the JavaScript :mdn:`Set <Web/JavaScript/Reference/Global_Objects/Set>` type. ``Realm Set`` is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
 - ``mixed`` is a property type that can hold different data types. The ``Mixed`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
-- ``uuid`` is a universally unique identifier from :js-sdk:`Realm.BSON <Realm.html#.BSON>`. The ``UUID`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
+- ``uuid`` is a universally unique identifier from :js-sdk:`Realm.BSON <modules/BSON.html>`. The ``UUID`` data type is available in the :github:`realm-js@10.5.0 release <realm/realm-js/releases/tag/v10.5.0>`.
 
 .. include:: /includes/map-to-bson-type.rst

--- a/source/sdk/node/model-data/data-types/mixed.txt
+++ b/source/sdk/node/model-data/data-types/mixed.txt
@@ -36,7 +36,7 @@ To :ref:`set a property of your object model
 Create an Object With a Mixed Value
 -----------------------------------
 Create an object with a mixed value by running the :js-sdk:`realm.create()
-<Realm.html#create>` method within a write transaction.
+<classes/Realm-1.html#create>` method within a write transaction.
 
 .. literalinclude:: /examples/generated/node/data-types.snippet.create-objects-with-mixed-values.js
     :language: javascript
@@ -44,9 +44,10 @@ Create an object with a mixed value by running the :js-sdk:`realm.create()
 Query for Objects with a Mixed Value
 ------------------------------------
 Query for objects with a mixed value by running the
-:js-sdk:`Collection.filtered() <Realm.Collection.html#filtered>` method and
-passing in a :ref:`filter <node-filter-queries>` for a non-mixed field. You can
-then print the value of the mixed property or the entire object itself.
+:js-sdk:`Collection.filtered() <classes/OrderedCollection.html#filtered>` 
+method and passing in a :ref:`filter <node-filter-queries>` for a non-mixed 
+field. You can then print the value of the mixed property or the entire 
+object itself.
 
 .. literalinclude:: /examples/generated/node/data-types.snippet.query-objects-with-mixed-values.js
     :language: javascript


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-32529

### Staged Changes

- [Collections](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-32529/sdk/node/model-data/data-types/collections/)
- [Dictionaries](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-32529/sdk/node/model-data/data-types/dictionaries/)
- [Field Types](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-32529/sdk/node/model-data/data-types/field-types/)
- [Mixed](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-32529/sdk/node/model-data/data-types/mixed/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
