### PR TITLE
DOCSP-32919: Update Kotlin FTS doc with prefix search

### DIFF
--- a/source/examples/generated/kotlin/ReadTest.snippet.kotlin-fts-property.kt
+++ b/source/examples/generated/kotlin/ReadTest.snippet.kotlin-fts-property.kt
@@ -1,9 +1,5 @@
-class Book() : RealmObject {
-    @PrimaryKey
-    var _id: ObjectId = ObjectId() // Primary key
-
+class Book : RealmObject {
     var name: String = ""
-
     @FullText // Marks the property with FTS
     var genre: String = ""
 }

--- a/source/examples/generated/kotlin/ReadTest.snippet.kotlin-fts-query.kt
+++ b/source/examples/generated/kotlin/ReadTest.snippet.kotlin-fts-query.kt
@@ -1,5 +1,11 @@
-// Find all the books with science fiction as the genre
-var scienceFiction = realmFts.query<Book>("genre TEXT $0", "science fiction").find()
+// Find all books with "science fiction" as the genre
+val scienceFiction =
+    realm.query<Book>("genre TEXT $0", "science fiction").find()
 
-// Find all the books with fiction but not science in the genre
-var fictionNotScience = realmFts.query<Book>("genre TEXT $0", "fiction -science").find()
+// Find all books with "fiction" but not "science" in the genre
+val fictionNotScience =
+    realm.query<Book>("genre TEXT $0", "fiction -science").find()
+
+// Find all books with "sci-" and "fi-" prefixes in the genre
+val sciFi =
+    realm.query<Book>("genre TEXT $0", "sci* fi*").find()

--- a/source/sdk/kotlin/realm-database/crud/read.txt
+++ b/source/sdk/kotlin/realm-database/crud/read.txt
@@ -126,32 +126,36 @@ Filter with Full-Text Search
 
 You can use Realm Query Language (RQL) to query on properties that 
 have :ref:`Full-Text Search Indexes <kotlin-fts-index>` (FTS) on them.
-To query these properties, use the ``TEXT`` predicate in your query.
+To query these properties, use the ``TEXT`` predicate.
 
-Exclude results for a word by placing the ``-`` character
-in front of the word. For example, a search for ``fiction -science`` would 
-include all search results for ``fiction`` excluding those that include the
-word ``science``.
+Words in the query are converted to tokens by a tokenizer using the 
+following rules:
+
+- Tokens can only consist of characters from ASCII and the Latin-1 
+  supplement (western languages). All other characters are considered whitespace. 
+- Words split by a hyphen (``-``), for example ``full-text``, are split into 
+  two tokens. 
+- Tokens are diacritics- and case-insensitive. 
+
+You can search for an entire word or phrase or limit your results with the 
+following characters: 
+
+- Exclude results for a word by placing the ``-`` character
+  in front of the word. For example, ``fiction -science`` would 
+  include all search results for ``fiction`` and exclude those that include the
+  word ``science``.
+- In Kotlin SDK version 1.11.0 and later, you can specify prefixes 
+  by placing the ``*`` character at the end of a word. 
+  For example, ``fict*`` would include all search results for 
+  ``fiction`` and ``fictitious``. (The Kotlin SDK does *not* currently 
+  support suffix searches.)
 
 In the following example, we query the ``Book.genre`` field:
 
 .. literalinclude:: /examples/generated/kotlin/ReadTest.snippet.kotlin-fts-query.kt
   :language: kotlin
 
-Full-Text Search Tokenizer Details
-``````````````````````````````````
-
-Full-Text Search (FTS) indexes support:
-
-- Boolean match word searches, not searches for relevance. 
-- Tokens are diacritics- and case-insensitive.
-- Tokens can only consist of characters from ASCII and the Latin-1 supplement (western languages). 
-- All other characters are considered whitespace. Words split by a hyphen 
-  (``-``) like ``full-text`` are split into two tokens. 
-
-For more information on features of the FTS index, see the API reference for 
-the `@FullText <{+kotlin-local-prefix+}io.realm.kotlin.types.annotations/
--full-text/index.html>`__ index annotation. 
+Note that FTS only supports Boolean matches and not relevance-based matches.
 
 .. _kotlin-sort-queries:
 

--- a/source/sdk/kotlin/realm-database/crud/read.txt
+++ b/source/sdk/kotlin/realm-database/crud/read.txt
@@ -125,7 +125,7 @@ Filter with Full-Text Search
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use Realm Query Language (RQL) to query on properties that 
-have :ref:`Full-Text Search Indexes <kotlin-fts-index>` (FTS) on them.
+have :ref:`Full-Text Search Indexes <kotlin-fts-index>` (FTS) on them. FTS supports Boolean matches and not relevance-based matches.
 To query these properties, use the ``TEXT`` predicate.
 
 Words in the query are converted to tokens by a tokenizer using the 
@@ -154,8 +154,6 @@ In the following example, we query the ``Book.genre`` field:
 
 .. literalinclude:: /examples/generated/kotlin/ReadTest.snippet.kotlin-fts-query.kt
   :language: kotlin
-
-Note that FTS only supports Boolean matches and not relevance-based matches.
 
 .. _kotlin-sort-queries:
 

--- a/source/sdk/kotlin/realm-database/schemas/property-annotations.txt
+++ b/source/sdk/kotlin/realm-database/schemas/property-annotations.txt
@@ -213,14 +213,11 @@ Full-Text Search Indexes
 ------------------------
 
 In addition to standard indexes, Realm also supports Full-Text Search 
-(FTS) indexes on ``string`` properties. While you can query a string 
+(FTS) indexes on ``String`` properties. While you can query a string 
 field with or without a standard index, an FTS index enables searching 
 for multiple words and phrases and excluding others.
 
-For more information on querying full-text indexes, see 
-:ref:`Filter with Full Text Search <kotlin-filter-fts>`.
-
-To create a FTS index on a property, use the `@FullText
+To create an FTS index on a ``String`` property, use the `@FullText
 <{+kotlin-local-prefix+}io.realm.kotlin.types.annotations
 /-full-text/index.html>`__ annotation. This enables full-text queries
 on the property. In the following example, we mark the ``genre`` 
@@ -228,18 +225,23 @@ property with the FTS annotation:
 
 .. literalinclude:: /examples/generated/kotlin/ReadTest.snippet.kotlin-fts-property.kt
   :language: kotlin
-  :emphasize-lines: 7-8
+  :emphasize-lines: 3-4
 
-You cannot combine `@Index 
-<{+kotlin-local-prefix+}io.realm.kotlin.types.annotations
-/-index/index.html>`__ and `@FullText
-<{+kotlin-local-prefix+}io.realm.kotlin.types.annotations
-/-full-text/index.html>`__ on the same property.
+Note the following constraints on FTS indexes:
+
+- You can only annotate ``String`` properties with ``@FullText``.
+- FTS indexes can't be combined with standard indexes. You *cannot* annotate 
+  the same property with `@Index 
+  <{+kotlin-local-prefix+}io.realm.kotlin.types.annotations/-index/index.html>`__ 
+  and `@FullText
+  <{+kotlin-local-prefix+}io.realm.kotlin.types.annotations/-full-text/index.html>`__.
 
 .. note:: Character Limitations for Full-Text Search Indexes
 
   For Full-Text Search (FTS) indexes, only ASCII and Latin-1 alphanumerical 
-  chars are included in the index (most western languages). See the `@FullText 
-  <{+kotlin-local-prefix+}io.realm.kotlin.types.annotations/
-  -full-text/index.html>`__ for more information on current FTS index constraints.
+  chars (most western languages) are included in the index. 
+  
+  Indexes are diacritics- and case-insensitive.
 
+For more information on querying full-text indexes, refer to 
+:ref:`Filter with Full Text Search <kotlin-filter-fts>`.


### PR DESCRIPTION
## Pull Request Info

Update FTS documentation to include support for prefix searches (requires Kotlin v1.11.0 and later)

### Jira

- https://jira.mongodb.org/browse/DOCSP-32919

### Staged Changes

- [Read - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-32919-fts-prefix/sdk/kotlin/realm-database/crud/read/#filter-with-full-text-search) - updated section
- [Property Annotations](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-32919-fts-prefix/sdk/kotlin/realm-database/schemas/property-annotations/#full-text-search-indexes) - updated section

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
