### PR TITLE
(DOCSP-32291): C++: Open a realm overload now takes a db::config

### DIFF
--- a/examples/cpp/beta/local/CMakeLists.txt
+++ b/examples/cpp/beta/local/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        650a7fd6d9038e1c7ea02e201f8626b2573886a3 
+  GIT_TAG        v0.3.0-preview
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/beta/local/CMakeLists.txt
+++ b/examples/cpp/beta/local/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        v0.2.0-preview 
+  GIT_TAG        650a7fd6d9038e1c7ea02e201f8626b2573886a3 
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/beta/local/crud.cpp
+++ b/examples/cpp/beta/local/crud.cpp
@@ -223,7 +223,7 @@ TEST_CASE("Beta embedded object example", "[write]") {
         mongoDB.contactDetails->emailAddress = "info@example.com";
     });
     
-    std::cout << "New email address: " << mongoDB.contactDetails->emailAddress.value() << "\n";
+    std::cout << "New email address: " << mongoDB.contactDetails->emailAddress.detach() << "\n";
     // :snippet-end:
     REQUIRE(mongoDB.contactDetails->emailAddress == "info@example.com");
     // :snippet-start: beta-overwrite-embedded-object
@@ -294,7 +294,8 @@ TEST_CASE("Pass a subset of classes to a realm", "[write]") {
     std::cout << "dog: " << dog.name << "\n";
 
     // :snippet-start: beta-realm-specify-classes
-    auto realm = realm::experimental::open<Beta_Dog>(path);
+    auto config = realm::db_config();
+    auto realm = realm::experimental::open<Beta_Dog>(std::move(config));
     // :snippet-end:
 
     auto managedDog = realm.write([&] {
@@ -345,7 +346,7 @@ TEST_CASE("update a dog", "[write][update]") {
         REQUIRE(maui.age == static_cast<long long>(1));
         // :remove-end:
 
-        std::cout << "Dog " << maui.name.value() << " is " << maui.age.value() << " years old\n";
+        std::cout << "Dog " << maui.name.detach() << " is " << maui.age.detach() << " years old\n";
         
         // Assign a new value to a member of the object in a write transaction
         int64_t newAge = 2;

--- a/source/examples/generated/cpp/crud.snippet.beta-realm-specify-classes.cpp
+++ b/source/examples/generated/cpp/crud.snippet.beta-realm-specify-classes.cpp
@@ -1,1 +1,2 @@
-auto realm = realm::experimental::open<Dog>(path);
+auto config = realm::db_config();
+auto realm = realm::experimental::open<Dog>(std::move(config));

--- a/source/examples/generated/cpp/crud.snippet.beta-update-an-object.cpp
+++ b/source/examples/generated/cpp/crud.snippet.beta-update-an-object.cpp
@@ -8,7 +8,7 @@ CHECK(dogsNamedMaui.size() >= 1);
 // Access an object in the results set.
 auto maui = dogsNamedMaui[0];
 
-std::cout << "Dog " << maui.name.value() << " is " << maui.age.value() << " years old\n";
+std::cout << "Dog " << maui.name.detach() << " is " << maui.age.detach() << " years old\n";
 
 // Assign a new value to a member of the object in a write transaction
 int64_t newAge = 2;

--- a/source/examples/generated/cpp/crud.snippet.beta-update-embedded-object.cpp
+++ b/source/examples/generated/cpp/crud.snippet.beta-update-embedded-object.cpp
@@ -8,4 +8,4 @@ realm.write([&] {
     mongoDB.contactDetails->emailAddress = "info@example.com";
 });
 
-std::cout << "New email address: " << mongoDB.contactDetails->emailAddress.value() << "\n";
+std::cout << "New email address: " << mongoDB.contactDetails->emailAddress.detach() << "\n";

--- a/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
@@ -132,13 +132,6 @@ in the current directory.
       .. literalinclude:: /examples/generated/cpp/crud.snippet.beta-open-realm.cpp
          :language: cpp
 
-      However, if you want the realm to manage only a subset of classes, you
-      can specify those models by passing them into the template parameter list
-      of the ``realm::experimental::open()`` function.
-
-      .. literalinclude:: /examples/generated/cpp/crud.snippet.beta-realm-specify-classes.cpp
-         :language: cpp
-
       .. include:: /includes/tip-cpp-beta-experimental-features.rst
 
    .. tab:: Deprecated
@@ -234,3 +227,41 @@ To open a synced realm:
    you must pass the ``filesDir.path`` to the ``path`` parameter in the 
    :cpp-sdk:`db_config <structrealm_1_1internal_1_1bridge_1_1realm_1_1config.html>` 
    constructor. For more information, refer to: :ref:`cpp-build-android-app`.
+
+.. _cpp-provide-subset-of-classes-to-realm:
+
+Provide a Subset of Classes to a Realm
+--------------------------------------
+
+.. tip:: Operating with Low Memory Constraints
+   
+   Some applications have tight constraints on their memory footprints. 
+   To optimize your data model for low-memory environments, open the 
+   realm with a subset of classes.
+
+.. tabs::
+
+   .. tab:: Current
+      :tabid: current
+
+      By default, the C++ SDK automatically adds all object types that have a
+      :ref:`cpp-object-schema` in your executable to your 
+      :ref:`cpp-realm-schema`. 
+
+      However, if you want the realm to manage only a subset of classes, you
+      can specify those models by passing them into the template parameter list
+      of the ``realm::experimental::open()`` function.
+
+      .. literalinclude:: /examples/generated/cpp/crud.snippet.beta-realm-specify-classes.cpp
+         :language: cpp
+
+      .. include:: /includes/tip-cpp-beta-experimental-features.rst
+
+   .. tab:: Deprecated
+      :tabid: deprecated
+
+      When opening a realm, you must specify which models are available by passing 
+      the models into the template parameter list of the ``realm::open()`` function.
+
+      .. literalinclude:: /examples/generated/cpp/open-realm.snippet.open-default-realm.cpp
+         :language: cpp

--- a/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
@@ -228,16 +228,16 @@ To open a synced realm:
    :cpp-sdk:`db_config <structrealm_1_1internal_1_1bridge_1_1realm_1_1config.html>` 
    constructor. For more information, refer to: :ref:`cpp-build-android-app`.
 
-.. _cpp-provide-subset-of-classes-to-realm:
+.. _cpp-provide-subset-of-models-to-realm:
 
-Provide a Subset of Classes to a Realm
---------------------------------------
+Provide a Subset of Models to a Realm
+-------------------------------------
 
 .. tip:: Operating with Low Memory Constraints
    
    Some applications have tight constraints on their memory footprints. 
-   To optimize your data model for low-memory environments, open the 
-   realm with a subset of classes.
+   To optimize your realm memory usage for low-memory environments, open the 
+   realm with a subset of models.
 
 .. tabs::
 
@@ -248,7 +248,7 @@ Provide a Subset of Classes to a Realm
       :ref:`cpp-object-schema` in your executable to your 
       :ref:`cpp-realm-schema`. 
 
-      However, if you want the realm to manage only a subset of classes, you
+      However, if you want the realm to manage only a subset of models, you
       can specify those models by passing them into the template parameter list
       of the ``realm::experimental::open()`` function.
 

--- a/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
@@ -136,8 +136,6 @@ in the current directory.
       can specify those models by passing them into the template parameter list
       of the ``realm::experimental::open()`` function.
 
-      This method currently requires a string path, and does not accept a ``db_config``.
-
       .. literalinclude:: /examples/generated/cpp/crud.snippet.beta-realm-specify-classes.cpp
          :language: cpp
 


### PR DESCRIPTION
## Pull Request Info

In updating to the current version of the C++ SDK, I also had to change `value()` to `detach()` as it has been renamed.

Prior to merging:

- [x] Update CMakeLists.txt `GIT_TAG` for C++ SDK to the release version instead of using a commit hash

### Jira

- https://jira.mongodb.org/browse/DOCSP-32291

### Staged Changes

- [Configure & Open a Realm](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-32291/sdk/cpp/realm-files/configure-and-open-a-realm/#provide-a-subset-of-classes-to-a-realm): New "Provide a Subset of Classes to a Realm" section

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
