### PR TITLE
DOCSP-30339: Convert Manage Realm Files landing page

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1262,3 +1262,7 @@ raw: ${prefix}/sdk/swift/sync/sync-realm-open-legacy -> ${base}/sdk/swift/sync/c
 
 raw: ${prefix}/sdk/swift/sync/sync-progress -> ${base}/sdk/swift/sync/sync-session/
 raw: ${prefix}/sdk/swift/sync/network-connection -> ${base}/sdk/swift/sync/sync-session/
+
+# DOCSP-30339: Move Configure & Open a Realm page up a level 
+
+raw: ${prefix}/sdk/kotlin/realm-database/realm-files/open-and-close-a-realm -> ${base}/sdk/kotlin/realm-database/open-and-close-a-realm/

--- a/config/redirects
+++ b/config/redirects
@@ -1027,10 +1027,6 @@ raw: ${prefix}/sdk/dotnet/advanced-guides -> ${base}/sdk/dotnet/
 raw: ${prefix}/sdk/dotnet/advanced-guides/debugging -> ${base}/sdk/dotnet/
 raw: ${prefix}/sdk/dotnet/advanced-guides/testing -> ${base}/sdk/dotnet/
 
-# Kotlin Realm Files IA Improvements
-
-raw: ${prefix}/sdk/kotlin/realm-database/open-and-close-a-realm -> ${base}/sdk/kotlin/realm-database/realm-files/open-and-close-a-realm
-
 # Realm React Guidance (https://jira.mongodb.org/browse/DOCSP-23395)
 
 raw: ${prefix}/sdk/react-native/realm-database/open-and-close-a-realm -> ${base}/sdk/react-native/realm-files/configure-a-realm/

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/OpenARealmTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/OpenARealmTest.kt
@@ -12,99 +12,202 @@ import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.PrimaryKey
 import org.mongodb.kbson.ObjectId
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 // :replace-start: {
 //   "terms": {
+//     "TMP_PATH": "\"my-directory-path\"",
 //     "local2": "local",
 //     "yourFlexAppId": "YOUR_APP_ID"
 //   }
 // }
 
 class OpenARealmTest: RealmTest() {
-
-    class Toad: RealmObject {
+    // :snippet-start: open-realm-object-schemas
+    class Frog : RealmObject {
         @PrimaryKey
         var _id: ObjectId = ObjectId()
         var name: String = ""
     }
+
+    class Person : RealmObject {
+        @PrimaryKey
+        var _id: ObjectId = ObjectId()
+        var name: String = ""
+    }
+    // :snippet-end:
+
     @Test
-    fun openAndCloseARealmTest() {
+    fun openAndCloseDefaultRealmTest() {
         runBlocking {
-            // :snippet-start: open-a-realm
-            val config = RealmConfiguration.Builder(setOf(Toad::class))
-                // :remove-start:
-                .directory("/tmp/") // default location for jvm is... in the project root
-                // :remove-end:
-                .build()
+            // :snippet-start: open-a-default-realm
+            // Creates a realm with default configuration values
+            val config = RealmConfiguration.create(
+                // Pass object classes for the realm schema
+                schema = setOf(Frog::class, Person::class)
+            )
+
+            // Open the realm with the configuration object
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.name}")
+
+            // ... use the open realm ...
             // :snippet-end:
+            assertEquals("default.realm", config.name)
+            assertTrue(config.schema.contains(Frog::class))
             // :snippet-start: close-a-realm
             realm.close()
             // :snippet-end:
+            assertTrue(realm.isClosed())
+            Realm.deleteRealm(config)
         }
     }
+
+    @Test
+    fun openConfiguredRealmTest() {
+        runBlocking {
+            val myEncryptionKey = getEncryptionKey()
+            // :snippet-start: open-a-realm
+            // Create a realm configuration with configuration builder
+            // and pass all optional arguments
+            val config = RealmConfiguration.Builder(
+                schema = setOf(Frog::class, Person::class)
+            )
+                .name("myRealmName.realm")
+                .directory(TMP_PATH)
+                .encryptionKey(myEncryptionKey)
+                .build()
+
+            // Open the realm with the configuration object
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.name}")
+
+            // ... use the open realm ...
+            // :snippet-end:
+            // :snippet-start: find-realm-path
+            val realmPath = realm.configuration.path
+            Log.v("Realm path: $realmPath")
+            // :snippet-end:
+            assertTrue(realmPath.contains("tmp"))
+            assertEquals(myEncryptionKey, config.encryptionKey)
+            assertEquals("myRealmName", config.name)
+            realm.close()
+            assertTrue(realm.isClosed())
+            Realm.deleteRealm(config)
+        }
+    }
+
     @Test
     fun deleteRealmIfMigrationNeeded() {
-        val REALM_NAME = getRandom()
         runBlocking {
             // :snippet-start: delete-realm-if-migration-needed
-            val config = RealmConfiguration.Builder(setOf(Toad::class))
-                // :remove-start:
-                .name(REALM_NAME)
-                // :remove-end:
+            val config = RealmConfiguration.Builder(
+                schema = setOf(Frog::class)
+            )
                 .deleteRealmIfMigrationNeeded()
                 .build()
             val realm = Realm.open(config)
             Log.v("Successfully opened realm: ${realm.configuration.name}")
             // :snippet-end:
+            assertTrue(config.deleteRealmIfMigrationNeeded)
+            realm.close()
+            assertTrue(realm.isClosed())
+            Realm.deleteRealm(config)
         }
     }
+
     @Test
-    fun onAnInMemoryRealm() {
+    fun openAnInMemoryRealmTest() {
         runBlocking {
             // :snippet-start: open-an-in-memory-realm
-            val config = RealmConfiguration.Builder(setOf(Toad::class))
+            // Create the in-memory realm configuration
+            val config = RealmConfiguration.Builder(
+                schema = setOf(Frog::class, Person::class)
+            )
                 .inMemory()
                 .build()
 
+            // Open the realm with the configuration object
             val realm = Realm.open(config)
-            Log.v("Successfully opened an in memory realm")
+            Log.v("Successfully opened an in-memory realm")
+
+            // ... use the open realm ...
             // :snippet-end:
+            assertTrue(config.inMemory)
             realm.close()
+            assertTrue(realm.isClosed())
+            Realm.deleteRealm(config)
+        }
+    }
+
+    @Test
+    fun initialDataCallbackTest() {
+        runBlocking {
+            // :snippet-start: initial-data-callback
+            val config = RealmConfiguration.Builder(
+                schema = setOf(Frog::class, Person::class)
+            )
+                .initialData {
+                    copyToRealm(Frog().apply { name = "Kermit" })
+                    copyToRealm(Person().apply { name = "Jim Henson" })
+                }
+                .inMemory() // :remove:
+                .build()
+
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.name}")
+
+            // Opened realm includes the initial data
+            val initialFrog = realm.query<Frog>().find().first()
+            val initialPerson = realm.query<Person>().find().first()
+            Log.v("Realm initialized with: ${initialFrog.name} and ${initialPerson.name}")
+            // :snippet-end:
+            assertEquals(1, realm.query<Frog>().find().size)
+            assertEquals("Kermit", initialFrog.name)
+            assertEquals(1, realm.query<Person>().find().size)
+            assertEquals("Jim Henson", initialPerson.name)
+            realm.close()
+            assertTrue(realm.isClosed())
+            Realm.deleteRealm(config)
         }
     }
 
     @Test
     fun syncToLocalRealm() {
+        val credentials = Credentials.anonymous(reuseExisting = false)
         // :snippet-start: sync-to-local-realm
         // Instantiate the synced realm with your App ID
         val app = App.create(yourFlexAppId)
 
         runBlocking {
-            val user = app.login(Credentials.anonymous())
+            val user = app.login(credentials)
             // Create the synced realm configuration
-            val syncConfig = SyncConfiguration.Builder(user, setOf(Toad::class))
+            val syncConfig = SyncConfiguration.Builder(user, setOf(Frog::class))
                 .initialSubscriptions { realm ->
-                    add(realm.query<Toad>(),"subscription name")
+                    add(realm.query<Frog>(),"all-frogs")
                 }
                 .build()
 
             // Open the synced realm and add data to it
             val syncRealm = Realm.open(syncConfig)
-            Log.v("Successfully opened realm: ${syncRealm.configuration}")
+            Log.v("Successfully opened realm: ${syncRealm.configuration.name}")
 
             syncRealm.write {
-                this.copyToRealm(Toad().apply {
+                this.copyToRealm(Frog().apply {
                     name = "Kermit"
                 })
             }
             // Wait for write to sync
             syncRealm.syncSession.uploadAllLocalChanges(30.seconds)
+            // :remove-start:
+            val syncFrog = syncRealm.query<Frog>().find().first()
+            assertEquals("Kermit", syncFrog.name)
+            // :remove-end:
 
             // Create the local realm
-            val localConfig = RealmConfiguration.Builder(setOf(Toad::class))
+            val localConfig = RealmConfiguration.Builder(setOf(Frog::class))
                 .name("local.realm")
                 .build()
             // Copy data from synced realm to the new realm
@@ -115,13 +218,19 @@ class OpenARealmTest: RealmTest() {
             // Open the new local realm
             val localRealm = Realm.open(localConfig)
 
-            // Copied Toad object is available in the new realm
-            val toad: Toad =
-                localRealm.query<Toad>().find().first()
-            Log.v("Copied Toad: ${toad.name}")
+            // Copied Frog object is available in the new realm
+            val frog = localRealm.query<Frog>().find().first()
+            Log.v("Copied Frog: ${frog.name}")
+            assertEquals("Kermit", frog.name) // :remove:
 
             localRealm.close()
-            Realm.deleteRealm(localConfig) // :remove:
+            // :remove-start:
+            assertTrue(syncRealm.isClosed())
+            assertTrue(localRealm.isClosed())
+            app.close()
+            Realm.deleteRealm(localConfig)
+            //Realm.deleteRealm(syncConfig) // [RLM_ERR_DELETE_OPENED_REALM]: Cannot delete files of an open Realm
+            // :remove-end:
         }
         // :snippet-end:
     }
@@ -130,21 +239,27 @@ class OpenARealmTest: RealmTest() {
         // :snippet-start: in-memory-to-local-realm
         runBlocking {
             // Create the in-memory realm
-            val inMemoryConfig = RealmConfiguration.Builder(setOf(Toad::class))
+            val inMemoryConfig = RealmConfiguration.Builder(setOf(Frog::class))
                 .name("inMemory.realm")
                 .inMemory()
                 .build()
 
             // Open the realm and add data to it
             val inMemoryRealm = Realm.open(inMemoryConfig)
+            assertTrue(inMemoryRealm.configuration.inMemory) // :remove:
+
             inMemoryRealm.write {
-                this.copyToRealm(Toad().apply {
+                this.copyToRealm(Frog().apply {
                     name = "Kermit"
                 })
             }
+            // :remove-start:
+            val inMemoryFrog = inMemoryRealm.query<Frog>().find().first()
+            assertEquals("Kermit", inMemoryFrog.name)
+            // :remove-end:
 
             // Create the local realm
-            val localConfig = RealmConfiguration.Builder(setOf(Toad::class))
+            val localConfig = RealmConfiguration.Builder(setOf(Frog::class))
                 .name("local2.realm")
                 .build()
             // Copy data from `inMemoryRealm` to the new realm
@@ -155,23 +270,28 @@ class OpenARealmTest: RealmTest() {
             // Open the new local realm
             val localRealm = Realm.open(localConfig)
 
-            // Copied Toad object is available in the new realm
-            val toad: Toad =
-                localRealm.query<Toad>().find().first()
-            Log.v("Copied Toad: ${toad.name}")
+            // Copied Frog object is available in the new realm
+            val frog = localRealm.query<Frog>().find().first()
+            Log.v("Copied Frog: ${frog.name}")
+            assertEquals("Kermit", frog.name) // :remove:
 
             localRealm.close()
-            Realm.deleteRealm(inMemoryConfig) // :remove:
-            Realm.deleteRealm(localConfig) // :remove:
+            // :remove-start:
+            assertTrue(inMemoryRealm.isClosed())
+            assertTrue(localRealm.isClosed())
+            Realm.deleteRealm(inMemoryConfig)
+            Realm.deleteRealm(localConfig)
+            // :remove-end:
         }
         // :snippet-end:
     }
     @Test
     fun unencryptedToEncryptedRealm() {
+        val encryptionKey = getEncryptionKey()
         // :snippet-start: unencrypted-to-encrypted-realm
         runBlocking {
             // Create the unencrypted realm
-            val unencryptedConfig = RealmConfiguration.Builder(setOf(Toad::class))
+            val unencryptedConfig = RealmConfiguration.Builder(setOf(Frog::class))
                 .name("unencrypted.realm")
                 .build()
 
@@ -179,7 +299,7 @@ class OpenARealmTest: RealmTest() {
             val unencryptedRealm = Realm.open(unencryptedConfig)
 
             unencryptedRealm.write {
-                this.copyToRealm(Toad().apply {
+                this.copyToRealm(Frog().apply {
                     name = "Kermit"
                 })
             }
@@ -187,9 +307,9 @@ class OpenARealmTest: RealmTest() {
             // ... Generate encryption key ...
 
             // Create the encrypted realm
-            val encryptedConfig = RealmConfiguration.Builder(setOf(Toad::class))
+            val encryptedConfig = RealmConfiguration.Builder(setOf(Frog::class))
                 .name("encrypted.realm")
-                .encryptionKey(getEncryptionKey())
+                .encryptionKey(encryptionKey)
                 .build()
 
             // Copy data from `unencryptedRealm` to the new realm
@@ -202,16 +322,22 @@ class OpenARealmTest: RealmTest() {
             // Open the new encrypted realm
             val encryptedRealm = Realm.open(encryptedConfig)
 
-            // Copied Toad object is available in the new realm
-            val toad: Toad =
-                encryptedRealm.query<Toad>().find().first()
-            Log.v("Copied Toad: ${toad.name}")
-
+            // Copied Frog object is available in the new realm
+            val frog = encryptedRealm.query<Frog>().find().first()
+            Log.v("Copied Frog: ${frog.name}")
+            // :remove-start:
+            assertEquals("Kermit", frog.name)
+            assertEquals(encryptionKey, encryptedRealm.configuration.encryptionKey)
+            // :remove-end:
             encryptedRealm.close()
-            Realm.deleteRealm(unencryptedConfig) // :remove:
-            Realm.deleteRealm(encryptedConfig) // :remove:
+            // :remove-start:
+            assertTrue(encryptedRealm.isClosed())
+            assertTrue(unencryptedRealm.isClosed())
+            Realm.deleteRealm(unencryptedConfig)
+            Realm.deleteRealm(encryptedConfig)
+            // :remove-end:
         }
         // :snippet-end:
     }
 }
-        // :replace-end:
+ // :replace-end:

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/OpenARealmTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/OpenARealmTest.kt
@@ -92,7 +92,7 @@ class OpenARealmTest: RealmTest() {
             // :snippet-end:
             assertTrue(realmPath.contains("tmp"))
             assertEquals(myEncryptionKey, config.encryptionKey)
-            assertEquals("myRealmName", config.name)
+            assertEquals("myRealmName.realm", config.name)
             realm.close()
             assertTrue(realm.isClosed())
             Realm.deleteRealm(config)

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/OpenARealmTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/OpenARealmTest.kt
@@ -329,6 +329,7 @@ class OpenARealmTest: RealmTest() {
             assertEquals("Kermit", frog.name)
             assertEquals(encryptionKey, encryptedRealm.configuration.encryptionKey)
             // :remove-end:
+
             encryptedRealm.close()
             // :remove-start:
             assertTrue(encryptedRealm.isClosed())

--- a/snooty.toml
+++ b/snooty.toml
@@ -52,7 +52,6 @@ toc_landing_pages = [
   "/sdk/kotlin/users",
   "/sdk/kotlin/realm-database",
   "/sdk/kotlin/realm-database/schemas",
-  "/sdk/kotlin/realm-database/realm-files",
   "/sdk/kotlin/realm-database/write-transactions",
   "/sdk/kotlin/sync",
   "/sdk/web",

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.delete-realm-if-migration-needed.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.delete-realm-if-migration-needed.kt
@@ -1,4 +1,6 @@
-val config = RealmConfiguration.Builder(setOf(Toad::class))
+val config = RealmConfiguration.Builder(
+    schema = setOf(Frog::class)
+)
     .deleteRealmIfMigrationNeeded()
     .build()
 val realm = Realm.open(config)

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.find-realm-path.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.find-realm-path.kt
@@ -1,0 +1,2 @@
+val realmPath = realm.configuration.path
+Log.v("Realm path: $realmPath")

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.in-memory-to-local-realm.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.in-memory-to-local-realm.kt
@@ -1,20 +1,21 @@
 runBlocking {
     // Create the in-memory realm
-    val inMemoryConfig = RealmConfiguration.Builder(setOf(Toad::class))
+    val inMemoryConfig = RealmConfiguration.Builder(setOf(Frog::class))
         .name("inMemory.realm")
         .inMemory()
         .build()
 
     // Open the realm and add data to it
     val inMemoryRealm = Realm.open(inMemoryConfig)
+
     inMemoryRealm.write {
-        this.copyToRealm(Toad().apply {
+        this.copyToRealm(Frog().apply {
             name = "Kermit"
         })
     }
 
     // Create the local realm
-    val localConfig = RealmConfiguration.Builder(setOf(Toad::class))
+    val localConfig = RealmConfiguration.Builder(setOf(Frog::class))
         .name("local.realm")
         .build()
     // Copy data from `inMemoryRealm` to the new realm
@@ -25,10 +26,9 @@ runBlocking {
     // Open the new local realm
     val localRealm = Realm.open(localConfig)
 
-    // Copied Toad object is available in the new realm
-    val toad: Toad =
-        localRealm.query<Toad>().find().first()
-    Log.v("Copied Toad: ${toad.name}")
+    // Copied Frog object is available in the new realm
+    val frog = localRealm.query<Frog>().find().first()
+    Log.v("Copied Frog: ${frog.name}")
 
     localRealm.close()
 }

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.initial-data-callback.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.initial-data-callback.kt
@@ -1,0 +1,16 @@
+val config = RealmConfiguration.Builder(
+    schema = setOf(Frog::class, Person::class)
+)
+    .initialData {
+        copyToRealm(Frog().apply { name = "Kermit" })
+        copyToRealm(Person().apply { name = "Jim Henson" })
+    }
+    .build()
+
+val realm = Realm.open(config)
+Log.v("Successfully opened realm: ${realm.configuration.name}")
+
+// Opened realm includes the initial data
+val initialFrog = realm.query<Frog>().find().first()
+val initialPerson = realm.query<Person>().find().first()
+Log.v("Realm initialized with: ${initialFrog.name} and ${initialPerson.name}")

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.open-a-default-realm.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.open-a-default-realm.kt
@@ -1,0 +1,11 @@
+// Creates a realm with default configuration values
+val config = RealmConfiguration.create(
+    // Pass object classes for the realm schema
+    schema = setOf(Frog::class, Person::class)
+)
+
+// Open the realm with the configuration object
+val realm = Realm.open(config)
+Log.v("Successfully opened realm: ${realm.configuration.name}")
+
+// ... use the open realm ...

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.open-a-realm.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.open-a-realm.kt
@@ -1,4 +1,15 @@
-val config = RealmConfiguration.Builder(setOf(Toad::class))
+// Create a realm configuration with configuration builder
+// and pass all optional arguments
+val config = RealmConfiguration.Builder(
+    schema = setOf(Frog::class, Person::class)
+)
+    .name("myRealmName.realm")
+    .directory("my-directory-path")
+    .encryptionKey(myEncryptionKey)
     .build()
+
+// Open the realm with the configuration object
 val realm = Realm.open(config)
 Log.v("Successfully opened realm: ${realm.configuration.name}")
+
+// ... use the open realm ...

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.open-an-in-memory-realm.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.open-an-in-memory-realm.kt
@@ -1,6 +1,12 @@
-val config = RealmConfiguration.Builder(setOf(Toad::class))
+// Create the in-memory realm configuration
+val config = RealmConfiguration.Builder(
+    schema = setOf(Frog::class, Person::class)
+)
     .inMemory()
     .build()
 
+// Open the realm with the configuration object
 val realm = Realm.open(config)
-Log.v("Successfully opened an in memory realm")
+Log.v("Successfully opened an in-memory realm")
+
+// ... use the open realm ...

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.open-realm-object-schemas.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.open-realm-object-schemas.kt
@@ -1,0 +1,11 @@
+class Frog : RealmObject {
+    @PrimaryKey
+    var _id: ObjectId = ObjectId()
+    var name: String = ""
+}
+
+class Person : RealmObject {
+    @PrimaryKey
+    var _id: ObjectId = ObjectId()
+    var name: String = ""
+}

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.sync-to-local-realm.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.sync-to-local-realm.kt
@@ -2,20 +2,20 @@
 val app = App.create(YOUR_APP_ID)
 
 runBlocking {
-    val user = app.login(Credentials.anonymous())
+    val user = app.login(credentials)
     // Create the synced realm configuration
-    val syncConfig = SyncConfiguration.Builder(user, setOf(Toad::class))
+    val syncConfig = SyncConfiguration.Builder(user, setOf(Frog::class))
         .initialSubscriptions { realm ->
-            add(realm.query<Toad>(),"subscription name")
+            add(realm.query<Frog>(),"all-frogs")
         }
         .build()
 
     // Open the synced realm and add data to it
     val syncRealm = Realm.open(syncConfig)
-    Log.v("Successfully opened realm: ${syncRealm.configuration}")
+    Log.v("Successfully opened realm: ${syncRealm.configuration.name}")
 
     syncRealm.write {
-        this.copyToRealm(Toad().apply {
+        this.copyToRealm(Frog().apply {
             name = "Kermit"
         })
     }
@@ -23,7 +23,7 @@ runBlocking {
     syncRealm.syncSession.uploadAllLocalChanges(30.seconds)
 
     // Create the local realm
-    val localConfig = RealmConfiguration.Builder(setOf(Toad::class))
+    val localConfig = RealmConfiguration.Builder(setOf(Frog::class))
         .name("local.realm")
         .build()
     // Copy data from synced realm to the new realm
@@ -34,10 +34,9 @@ runBlocking {
     // Open the new local realm
     val localRealm = Realm.open(localConfig)
 
-    // Copied Toad object is available in the new realm
-    val toad: Toad =
-        localRealm.query<Toad>().find().first()
-    Log.v("Copied Toad: ${toad.name}")
+    // Copied Frog object is available in the new realm
+    val frog = localRealm.query<Frog>().find().first()
+    Log.v("Copied Frog: ${frog.name}")
 
     localRealm.close()
 }

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.unencrypted-to-encrypted-realm.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.unencrypted-to-encrypted-realm.kt
@@ -34,5 +34,6 @@ runBlocking {
     // Copied Frog object is available in the new realm
     val frog = encryptedRealm.query<Frog>().find().first()
     Log.v("Copied Frog: ${frog.name}")
+
     encryptedRealm.close()
 }

--- a/source/examples/generated/kotlin/OpenARealmTest.snippet.unencrypted-to-encrypted-realm.kt
+++ b/source/examples/generated/kotlin/OpenARealmTest.snippet.unencrypted-to-encrypted-realm.kt
@@ -1,6 +1,6 @@
 runBlocking {
     // Create the unencrypted realm
-    val unencryptedConfig = RealmConfiguration.Builder(setOf(Toad::class))
+    val unencryptedConfig = RealmConfiguration.Builder(setOf(Frog::class))
         .name("unencrypted.realm")
         .build()
 
@@ -8,7 +8,7 @@ runBlocking {
     val unencryptedRealm = Realm.open(unencryptedConfig)
 
     unencryptedRealm.write {
-        this.copyToRealm(Toad().apply {
+        this.copyToRealm(Frog().apply {
             name = "Kermit"
         })
     }
@@ -16,9 +16,9 @@ runBlocking {
     // ... Generate encryption key ...
 
     // Create the encrypted realm
-    val encryptedConfig = RealmConfiguration.Builder(setOf(Toad::class))
+    val encryptedConfig = RealmConfiguration.Builder(setOf(Frog::class))
         .name("encrypted.realm")
-        .encryptionKey(getEncryptionKey())
+        .encryptionKey(encryptionKey)
         .build()
 
     // Copy data from `unencryptedRealm` to the new realm
@@ -31,10 +31,8 @@ runBlocking {
     // Open the new encrypted realm
     val encryptedRealm = Realm.open(encryptedConfig)
 
-    // Copied Toad object is available in the new realm
-    val toad: Toad =
-        encryptedRealm.query<Toad>().find().first()
-    Log.v("Copied Toad: ${toad.name}")
-
+    // Copied Frog object is available in the new realm
+    val frog = encryptedRealm.query<Frog>().find().first()
+    Log.v("Copied Frog: ${frog.name}")
     encryptedRealm.close()
 }

--- a/source/sdk/kotlin/realm-database.txt
+++ b/source/sdk/kotlin/realm-database.txt
@@ -10,8 +10,9 @@ Realm - Kotlin SDK
    
    Frozen Architecture </sdk/kotlin/realm-database/frozen-arch> 
    Model Data </sdk/kotlin/realm-database/schemas>
-   Manage Realm Files </sdk/kotlin/realm-database/realm-files>
+   Configure & Open a Realm </sdk/kotlin/realm-database/open-and-close-a-realm>
    Read & Write Data </sdk/kotlin/realm-database/write-transactions>
+   Manage Realm Files </sdk/kotlin/realm-database/realm-files>
    React to Changes </sdk/kotlin/realm-database/react-to-changes>
    Serialization </sdk/kotlin/realm-database/serialization>
    Handle Realm Errors </sdk/kotlin/realm-database/errors>

--- a/source/sdk/kotlin/realm-database/open-and-close-a-realm.txt
+++ b/source/sdk/kotlin/realm-database/open-and-close-a-realm.txt
@@ -133,6 +133,13 @@ Then, pass the resulting ``RealmConfiguration`` to `Realm.open()
    :language: kotlin
    :emphasize-lines: 5
 
+.. note:: In-Memory Realms are Not Persisted
+
+  Because in-memory realms are not persisted, ensure you have at least one open 
+  instance of the realm for as long as you want to access the data. After you 
+  :ref:`close <kotlin-close-a-realm>` the last instance of an in-memory realm, 
+  the data is no longer available.
+
 Customize a Realm Configuration
 -------------------------------
 

--- a/source/sdk/kotlin/realm-database/open-and-close-a-realm.txt
+++ b/source/sdk/kotlin/realm-database/open-and-close-a-realm.txt
@@ -10,8 +10,8 @@ Configure & Open a Realm - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-This page describes realm files and how to open and close a realm that only 
-persists data locally. To open a realm that synchronizes data with Atlas 
+This page describes realm files and how to configure, open, and close a realm 
+that only persists data locally. To open a realm that synchronizes data with Atlas 
 using Device Sync, refer to :ref:`Open a Synced Realm 
 <kotlin-open-a-synced-realm>`.
 
@@ -146,6 +146,9 @@ specifics of the realm that you would like to open, including:
   :ref:`making schema changes <kotlin-change-object-model>`
 - Flagging whether Realm should :ref:`delete the realm file 
   <kotlin-delete-to-avoid-migration>` if a migration is required
+
+For more information on specific configuration implementations, refer to 
+:ref:`<kotlin-manage-realm-files>`.
 
 To configure a realm with non-default values, create the ``RealmConfiguration`` 
 through `RealmConfiguration.Builder.build() 

--- a/source/sdk/kotlin/realm-database/realm-files.txt
+++ b/source/sdk/kotlin/realm-database/realm-files.txt
@@ -1,5 +1,3 @@
-.. _kotlin-realm-files:
-
 ===============================
 Manage Realm Files - Kotlin SDK
 ===============================
@@ -12,43 +10,3 @@ Manage Realm Files - Kotlin SDK
    Delete a Realm </sdk/kotlin/realm-database/realm-files/delete-a-realm>
    Encrypt a Realm </sdk/kotlin/realm-database/realm-files/encrypt-a-realm>
    Bundle a Realm </sdk/kotlin/realm-database/realm-files/bundle-a-realm>
-
-.. contents:: On this page
-   :local:
-   :backlinks: none
-   :depth: 2
-   :class: singlecol
-
-A **realm** is the core data structure used to organize data in
-Realm. A realm is a collection of the objects that you use
-in your application, called Realm objects, as well as additional metadata
-that describe the objects. To learn how to define a Realm object, see
-:ref:`Define a Realm Object Schema <flutter-define-realm-object-schema>`.
-
-When you :ref:`open a realm <kotlin-open-and-close-a-realm>`, you can include configuration that specifies additional details
-about how to configure the realm file. This includes things like:
-
-- Pass a file path or in-memory identifier to customize how the realm is stored on device
-- Provide a logged-in user and Sync details to use Sync with the realm
-- Specify the realm use only a subset of your app's classes
-- Whether and when to compact a realm to reduce its file size
-- Pass an encryption key to encrypt a realm
-- Provide a schema version or migration block when making schema changes
-
-.. _kotlin-realm-file:
-
-Realm Files
------------
-
-Realm stores a binary encoded version of every object and type in a
-realm in a single ``.realm`` file. The file is located at a specific
-path that you can define when you open the realm.
-You can open, view, and edit the contents of these files with
-:ref:`realm-studio`.
-
-Realm also creates additional files for each realm.
-To learn more about these files, see :ref:`Realm Internals
-<kotlin-realm-database-internals>`. Deleting these files has important implications.
-
-For more information about deleting ``.realm`` or auxiliary files, refer to
-:ref:`Delete a Realm <kotlin-delete-a-realm>`.

--- a/source/sdk/kotlin/realm-database/realm-files.txt
+++ b/source/sdk/kotlin/realm-database/realm-files.txt
@@ -1,3 +1,5 @@
+.. _kotlin-manage-realm-files:
+
 ===============================
 Manage Realm Files - Kotlin SDK
 ===============================
@@ -5,8 +7,12 @@ Manage Realm Files - Kotlin SDK
 .. toctree::
    :titlesonly:
    
-   Configure & Open a Realm </sdk/kotlin/realm-database/realm-files/open-and-close-a-realm>
    Reduce Realm File Size </sdk/kotlin/realm-database/realm-files/compact-realm>
    Delete a Realm </sdk/kotlin/realm-database/realm-files/delete-a-realm>
    Encrypt a Realm </sdk/kotlin/realm-database/realm-files/encrypt-a-realm>
    Bundle a Realm </sdk/kotlin/realm-database/realm-files/bundle-a-realm>
+
+- :ref:`Reduce Realm File Size <kotlin-compact-realm>`
+- :ref:`Delete a Realm <kotlin-delete-a-realm>`
+- :ref:`Encrypt a Realm <kotlin-encrypt-a-realm>`
+- :ref:`Bundle a Realm <kotlin-bundle-a-realm>`

--- a/source/sdk/kotlin/realm-database/realm-files/delete-a-realm.txt
+++ b/source/sdk/kotlin/realm-database/realm-files/delete-a-realm.txt
@@ -47,3 +47,7 @@ schema instead of writing migration blocks for development or test data.
 
 .. literalinclude:: /examples/generated/kotlin/OpenARealmTest.snippet.delete-realm-if-migration-needed.kt
    :language: kotlin
+
+.. important:: Do Not Use ``deleteRealmIfMigrationNeeded`` in Production
+
+   Never release an app to production with this flag set to ``true``.

--- a/source/sdk/kotlin/realm-database/realm-files/open-and-close-a-realm.txt
+++ b/source/sdk/kotlin/realm-database/realm-files/open-and-close-a-realm.txt
@@ -10,74 +10,189 @@ Configure & Open a Realm - Kotlin SDK
    :depth: 2
    :class: singlecol
 
-.. note:: Automatic Compaction of Realm File Size
+This page describes realm files and how to open and close a realm that only 
+persists data locally. To open a realm that synchronizes data with Atlas 
+using Device Sync, refer to :ref:`Open a Synced Realm 
+<kotlin-open-a-synced-realm>`.
 
-  .. versionadded:: 1.6.0
+.. _kotlin-realm-files:
+.. _kotlin-realm-file:
 
-  Realm automatically compacts files in the background by continuously 
-  reallocating data in the file and removing unused file space. Realm will 
-  automatically compact the file only when the file is not being accessed.
+Realm Files
+-----------
+
+A **realm** is the core data structure used to organize data in
+Realm. Each realm is a collection of Realm objects: the objects 
+that you use in your application as well as additional metadata that 
+describe those objects. Learn how to :ref:`<kotlin-define-object-model>`.
+
+Realm stores a binary-encoded version of every object and type in a realm 
+in a single ``.realm`` file. When you open a realm, Realm creates the 
+``.realm`` file if it doesn't already exist. The file is located at a specific 
+path, which you can define when you open the realm. Realm also creates 
+additional auxiliary files for each realm, such as lock and management files. 
+To learn more about these files, refer to :ref:`<kotlin-realm-database-internals>`. 
+Note that deleting these files has important implications.
+For more information about deleting ``.realm`` or auxiliary files, refer to
+:ref:`Delete a Realm <kotlin-delete-a-realm>`.
+
+.. tip:: Work with Realm Files in Realm Studio
+  
+  You can open, view, and edit the contents of realm files with :ref:`realm-studio`.
+
+If you don't want to create a ``.realm`` file or its associated auxiliary 
+files, you can open an in-memory realm.
+Refer to the :ref:`<kotlin-open-an-in-memory-realm>` section for 
+more information.
+
+.. _kotlin-open-a-realm:
 
 Open a Realm
 ------------
 
-Use 
-`RealmConfiguration <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__ 
-to control the specifics of your realm that you would like to open.
+To open a realm, create a `RealmConfiguration 
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__ 
+object that defines the details of a realm. Then, pass the resulting 
+``RealmConfiguration`` to `Realm.open()
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__.
 
-When you open the realm, you must provide a list of 
-:ref:`object schemas <kotlin-define-a-new-object-type>` as 
-an argument. 
+You can open a realm with default configuration values or you can build a 
+``RealmConfiguration`` with additional configuration options. However, you 
+*must* pass a `schema 
+<{+kotlin-local-prefix+}io.realm.kotlin/-configuration/schema.html>`__
+parameter that includes all :ref:`object classes <kotlin-define-a-new-object-type>`
+that you want to use in the realm. 
 
-.. include:: /includes/realm-schema.rst
+After you open the realm with the desired configuration, you can 
+:ref:`read and write data <kotlin-read-write-data>` based on your defined schema.
 
-.. _kotlin-open-a-realm:
+The examples on this page refer to the following Realm objects:
 
-Open a Local-Only Realm
-~~~~~~~~~~~~~~~~~~~~~~~
-
-To open a realm that only persists data locally, create a
-`RealmConfiguration <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__ with
-`RealmConfiguration.Builder <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-builder/index.html>`__
-and pass the resulting :file:`RealmConfiguration` to
-`Realm.open() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__:
-
-.. literalinclude:: /examples/generated/kotlin/OpenARealmTest.snippet.open-a-realm.kt
+.. literalinclude:: /examples/generated/kotlin/OpenARealmTest.snippet.open-realm-object-schemas.kt
    :language: kotlin
+
+Open a Default Realm
+~~~~~~~~~~~~~~~~~~~~
+
+To open a realm with default configuration values, use the 
+`RealmConfiguration.create() 
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-companion/create.html>`__.
+method. You only need to define a set of object classes as the realm schema. 
+Then, pass the ``RealmConfiguration`` to `Realm.open()
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__.
+
+The following example opens a ``default.realm`` file at the default path with 
+a schema that includes the ``Frog`` and ``Person`` classes:
+
+.. literalinclude:: /examples/generated/kotlin/OpenARealmTest.snippet.open-a-default-realm.kt
+   :language: kotlin
+
+Default File Location
+`````````````````````
+
+If you don't define a directory for the realm file, the default app storage 
+location for the platform is used. You can find the default directory for your 
+platform with the following:
+
+- Android: ``Context.getFiles()``
+- JVM: ``System.getProperty("user.dir")``
+- macOS: ``platform.Foundation.NSFileManager.defaultManager.currentDirectoryPath``
+- iOS: 
+  
+  .. code-block::
+
+    NSFileManager.defaultManager.URLForDirectory(
+       NSDocumentDirectory,
+       NSUserDomainMask,
+       null,
+       true,
+       null
+    )
 
 .. _kotlin-open-an-in-memory-realm:
 
 Open an In-Memory Realm
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-To open a realm that runs entirely in memory without being written to a file,
-create a `RealmConfiguration <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html>`__
-using the `inMemory <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/index.html#1296212310%2FProperties%2F-1651551339>`__
-property with `RealmConfiguration.Builder <{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-builder/index.html>`__.
-Then  pass the resulting :file:`RealmConfiguration` to `Realm.open() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__:
+You can open a realm entirely in memory, which does not create a 
+``.realm`` file or its associated auxiliary files. Instead, the SDK stores 
+objects in memory while the realm is open, and then discards the data 
+when all instances are closed.
+
+To open a realm that runs without being written to a file, build a 
+``RealmConfiguration`` with the 
+`RealmConfiguration.Builder 
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-builder/index.html>`__
+using the `inMemory 
+<{+kotlin-local-prefix+}io.realm.kotlin/-configuration/in-memory.html>`__
+property.
+Then, pass the resulting ``RealmConfiguration`` to `Realm.open() 
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__:
 
 .. literalinclude:: /examples/generated/kotlin/OpenARealmTest.snippet.open-an-in-memory-realm.kt
    :language: kotlin
+   :emphasize-lines: 5
 
-Open a Synced Realm
-~~~~~~~~~~~~~~~~~~~
+Customize a Realm Configuration
+-------------------------------
 
-To open a realm that synchronizes data with Atlas using Device Sync,
-refer to :ref:`Open a Synced Realm <kotlin-open-a-synced-realm>`.
+You can add optional arguments to the ``RealmConfiguration`` to control the 
+specifics of the realm that you would like to open, including:
+
+- Defining a custom file name and file path 
+- Passing an encryption key to :ref:`encrypt a realm <kotlin-encrypt-a-realm>`
+- :ref:`Compacting a realm <kotlin-compact-realm>` to reduce its file size
+- Specifying a schema version or migration block when 
+  :ref:`making schema changes <kotlin-change-object-model>`
+- Flagging whether Realm should :ref:`delete the realm file 
+  <kotlin-delete-to-avoid-migration>` if a migration is required
+
+To configure a realm with non-default values, create the ``RealmConfiguration`` 
+through `RealmConfiguration.Builder.build() 
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm-configuration/-builder/index.html>`__ 
+and pass any properties you want to set. Then, pass the resulting 
+``RealmConfiguration`` to `Realm.open() 
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm/-companion/open.html>`__. 
+
+In the following example, the ``RealmConfiguration`` specifies a custom 
+name and directory ("my-directory-path/myRealmName.realm") and encryption key:
+
+.. literalinclude:: /examples/generated/kotlin/OpenARealmTest.snippet.open-a-realm.kt
+   :language: kotlin
+
+Add Initial Data to Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can add initial data to a realm by using an `initialDataCallback 
+<+kotlin-local-prefix+}io.realm.kotlin/-configuration/initial-data-callback.html>`__.
+The callback is triggered when the realm is opened for the first time. 
+
+.. literalinclude:: /examples/generated/kotlin/OpenARealmTest.snippet.initial-data-callback.kt
+   :language: kotlin
+   :emphasize-lines: 4-7
+
+Find a Realm File Path
+----------------------
+
+To find the file path for a ``.realm`` file, use the `realm.configuration.path 
+<{+kotlin-local-prefix+}io.realm.kotlin/-configuration/path.html>`__ property:
+
+.. literalinclude:: /examples/generated/kotlin/OpenARealmTest.snippet.find-realm-path.kt
+   :language: kotlin
 
 .. _kotlin-close-a-realm:
 
 Close a Realm
 -------------
 
-You close a realm with `realm.close() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/close.html>`__.
-The :file:`close()` method blocks until all write transactions on the
-realm have completed.
+You close a realm with `realm.close() 
+<{+kotlin-local-prefix+}io.realm.kotlin/-realm/close.html>`__. This method 
+blocks until all write transactions on the realm have completed.
 
 .. literalinclude:: /examples/generated/kotlin/OpenARealmTest.snippet.close-a-realm.kt
    :language: kotlin
 
-.. warning::
+.. warning:: Close Realms to Prevent Memory Leaks
 
   It's important to close your realm instance to free resources. Failing to close
   realms can lead to an ``OutOfMemoryError``. 
@@ -120,7 +235,7 @@ Some additional considerations to keep in mind while using
 
 - The destination file cannot already exist.
 - Copying a realm is not allowed within a write transaction or during
-  a :ref:`migration<kotlin-migrations>`.
+  a :ref:`migration <kotlin-migrations>`.
 - When using :ref:`Device Sync <sync>`, you must sync all local changes with the
   server before the copy is written. This ensures that the file can 
   be used as a starting point for a newly installed application. 


### PR DESCRIPTION
## Pull Request Info

- Convert existing [Manage Realm Files](https://www.mongodb.com/docs/realm/sdk/kotlin/realm-database/realm-files/) page to container
- Move relevant info to existing [Configure & Open a Realm](https://www.mongodb.com/docs/realm/sdk/kotlin/realm-database/realm-files/open-and-close-a-realm/) page
- Update examples 
- Move Configure & Open a Realm page out of Manage Realm Files container 

### Jira

- https://jira.mongodb.org/browse/DOCSP-30339

### Staged Changes

- [Configure & Open a Realm - Kotlin SDK](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/docsp-30339-manage-realm-files/sdk/kotlin/realm-database/realm-files/open-and-close-a-realm/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
