### PR TITLE
(DOCSP-33149) Add Data Ingest docs for Flutter

### DIFF
--- a/examples/dart/pubspec.lock
+++ b/examples/dart/pubspec.lock
@@ -437,10 +437,10 @@ packages:
     dependency: transitive
     description:
       name: objectid
-      sha256: "22fa972000d3256f10d06323a9dcbf4b564fb03fdb9024399e3a6c1d9902f914"
+      sha256: fd4a0b9fe07df25c446948b786e7ab2f363b2f461afa78632cab179d7613b9b3
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   package_config:
     dependency: transitive
     description:
@@ -493,26 +493,26 @@ packages:
     dependency: transitive
     description:
       name: realm_common
-      sha256: "2ee6c3d01a70cf3c7cf8d8550cee6f17e55c0184aed53ececdb5b153ea501b57"
+      sha256: "19e368e3e56b033b112472debfcbb276caec25b5ee597ee77bec5138f1f8ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   realm_dart:
     dependency: "direct main"
     description:
       name: realm_dart
-      sha256: "10075650eae7b9a9f31bd7631d7941c0bcc7ebf53870c01f7502456091435b19"
+      sha256: "53b5a9c3e2d8d3c4c0d3ddd902c977cece50ca37df5c3a7e23494f503bc65f0e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   realm_generator:
     dependency: transitive
     description:
       name: realm_generator
-      sha256: "8ccf72fd6aec2fd8a8863fcfd1e9d24d2c054cfcbe0123808a77bede00285d9c"
+      sha256: c22e20208a4e4accdc23262f57478eff92d68788e45e863eddda4fe1a6b825d3
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   rxdart:
     dependency: transitive
     description:
@@ -629,10 +629,10 @@ packages:
     dependency: transitive
     description:
       name: tar
-      sha256: "85ffd53e277f2bac8afa2885e6b195e26937e9c402424c3d88d92fd920b56de9"
+      sha256: "7196d37d26fcf4d523cd0d086b463b66550bae0c29777bf398006827d5e5d453"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
+    version: "1.0.1"
   term_glyph:
     dependency: transitive
     description:

--- a/examples/dart/pubspec.yaml
+++ b/examples/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: "^3.0.2"
 
 dependencies:
-  realm_dart: ^1.4.0
+  realm_dart: ^1.5.0
   path: ^1.8.2
   dart_jsonwebtoken: ^2.4.2
   faker: ^2.0.0

--- a/examples/dart/test/data_ingest.test.dart
+++ b/examples/dart/test/data_ingest.test.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'package:test/test.dart';
+import 'package:realm_dart/realm.dart';
+import './utils.dart';
+part 'data_ingest.test.g.dart';
+
+// :snippet-start: asymmetric-sync-object
+@RealmModel(ObjectType.asymmetricObject)
+class _WeatherSensor {
+  @PrimaryKey()
+  @MapTo("_id")
+  late ObjectId id;
+
+  late String deviceId;
+  late double modtemperatureInFahrenheitel;
+  late double barometricPressureInHg;
+  late double windSpeedInMph;
+}
+// :snippet-end:
+
+void main() {
+  // Because the Flutter/Dart SDK doesn't have a mongoClient yet,
+  // we can't test that asymmetric objects exist in the backend.
+  group('Create asymmetric abject and use Data Ingest', () {
+    const APP_ID = "flutter-flexible-luccm";
+    final appConfig = AppConfiguration(APP_ID);
+    final app = App(appConfig);
+
+    test("Create asymmetric object locally", () async {
+      final credentials = Credentials.anonymous();
+      final currentUser = await app.logIn(credentials);
+      final config = Configuration.flexibleSync(
+          currentUser, [WeatherSensor.schema],
+          path: 'flex.realm');
+      final realm = Realm(config);
+
+      expect(realm.isClosed, false);
+      expect(app.currentUser?.id != null, true);
+
+      realm.syncSession.pause();
+
+      final weatherSensorId = ObjectId();
+
+      // :snippet-start: write-asymmetric-object
+      realm.write(() {
+        realm.ingest(
+            WeatherSensor(weatherSensorId, "WX1278UIT", 66.7, 29.65, 2));
+      });
+      // :snippet-end:
+
+      print(realm.dynamic.find('WeatherSensor', weatherSensorId));
+
+      // Resume sync session and wait for WeatherSensor to be uploaded
+      // and then deleted locally.
+      realm.syncSession.resume();
+      await realm.syncSession.waitForUpload();
+
+      // Check that the Asymmetric object no longer exists locally
+      expect(realm.dynamic.find('WeatherSensor', weatherSensorId), null);
+
+      await cleanUpRealm(realm, app);
+      expect(realm.isClosed, true);
+      expect(app.currentUser, null);
+    });
+  });
+}

--- a/examples/dart/test/data_ingest.test.g.dart
+++ b/examples/dart/test/data_ingest.test.g.dart
@@ -1,0 +1,82 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'data_ingest.test.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+class WeatherSensor extends _WeatherSensor
+    with RealmEntity, RealmObjectBase, AsymmetricObject {
+  WeatherSensor(
+    ObjectId id,
+    String deviceId,
+    double modtemperatureInFahrenheitel,
+    double barometricPressureInHg,
+    double windSpeedInMph,
+  ) {
+    RealmObjectBase.set(this, '_id', id);
+    RealmObjectBase.set(this, 'deviceId', deviceId);
+    RealmObjectBase.set(
+        this, 'modtemperatureInFahrenheitel', modtemperatureInFahrenheitel);
+    RealmObjectBase.set(this, 'barometricPressureInHg', barometricPressureInHg);
+    RealmObjectBase.set(this, 'windSpeedInMph', windSpeedInMph);
+  }
+
+  WeatherSensor._();
+
+  @override
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
+  @override
+  set id(ObjectId value) => RealmObjectBase.set(this, '_id', value);
+
+  @override
+  String get deviceId =>
+      RealmObjectBase.get<String>(this, 'deviceId') as String;
+  @override
+  set deviceId(String value) => RealmObjectBase.set(this, 'deviceId', value);
+
+  @override
+  double get modtemperatureInFahrenheitel =>
+      RealmObjectBase.get<double>(this, 'modtemperatureInFahrenheitel')
+          as double;
+  @override
+  set modtemperatureInFahrenheitel(double value) =>
+      RealmObjectBase.set(this, 'modtemperatureInFahrenheitel', value);
+
+  @override
+  double get barometricPressureInHg =>
+      RealmObjectBase.get<double>(this, 'barometricPressureInHg') as double;
+  @override
+  set barometricPressureInHg(double value) =>
+      RealmObjectBase.set(this, 'barometricPressureInHg', value);
+
+  @override
+  double get windSpeedInMph =>
+      RealmObjectBase.get<double>(this, 'windSpeedInMph') as double;
+  @override
+  set windSpeedInMph(double value) =>
+      RealmObjectBase.set(this, 'windSpeedInMph', value);
+
+  @override
+  Stream<RealmObjectChanges<WeatherSensor>> get changes =>
+      RealmObjectBase.getChanges<WeatherSensor>(this);
+
+  @override
+  WeatherSensor freeze() => RealmObjectBase.freezeObject<WeatherSensor>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(WeatherSensor._);
+    return const SchemaObject(
+        ObjectType.asymmetricObject, WeatherSensor, 'WeatherSensor', [
+      SchemaProperty('id', RealmPropertyType.objectid,
+          mapTo: '_id', primaryKey: true),
+      SchemaProperty('deviceId', RealmPropertyType.string),
+      SchemaProperty('modtemperatureInFahrenheitel', RealmPropertyType.double),
+      SchemaProperty('barometricPressureInHg', RealmPropertyType.double),
+      SchemaProperty('windSpeedInMph', RealmPropertyType.double),
+    ]);
+  }
+}

--- a/examples/dart/test_sdk_example/pubspec.lock
+++ b/examples/dart/test_sdk_example/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: cancellation_token
-      sha256: "44891ef71d605bc59ef7974c403630d8e8506fcd897a29c3e38466ef69e5c4eb"
+      sha256: ad95acf9d4b2f3563e25dc937f63587e46a70ce534e910b65d10e115490f1027
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "2.0.1"
   characters:
     dependency: transitive
     description:
@@ -367,10 +367,10 @@ packages:
     dependency: transitive
     description:
       name: objectid
-      sha256: "22fa972000d3256f10d06323a9dcbf4b564fb03fdb9024399e3a6c1d9902f914"
+      sha256: fd4a0b9fe07df25c446948b786e7ab2f363b2f461afa78632cab179d7613b9b3
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   package_config:
     dependency: transitive
     description:
@@ -415,26 +415,26 @@ packages:
     dependency: "direct main"
     description:
       name: realm
-      sha256: "818bd06d65cf736dab3e41111a9f641d129083a6056788544ea6a94697fbac2e"
+      sha256: "8f15e65cd17e5d9dab34e08dbfcd0ae57c48ac3a78ded1eebc0eabd6010157a6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   realm_common:
     dependency: transitive
     description:
       name: realm_common
-      sha256: b7fefe203362d9afc21094fdc1d97c9ada95c25f80fc5c352a0dd3f3cbf34625
+      sha256: "19e368e3e56b033b112472debfcbb276caec25b5ee597ee77bec5138f1f8ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   realm_generator:
     dependency: transitive
     description:
       name: realm_generator
-      sha256: "22a3b16b3f1830af221d7b07c847e85a44873a82d8b90f67bdd81cc4a2b64f2a"
+      sha256: c22e20208a4e4accdc23262f57478eff92d68788e45e863eddda4fe1a6b825d3
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   sane_uuid:
     dependency: transitive
     description:
@@ -516,10 +516,10 @@ packages:
     dependency: transitive
     description:
       name: tar
-      sha256: "85ffd53e277f2bac8afa2885e6b195e26937e9c402424c3d88d92fd920b56de9"
+      sha256: "7196d37d26fcf4d523cd0d086b463b66550bae0c29777bf398006827d5e5d453"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
+    version: "1.0.1"
   term_glyph:
     dependency: transitive
     description:

--- a/examples/dart/test_sdk_example/pubspec.yaml
+++ b/examples/dart/test_sdk_example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -32,11 +32,10 @@ dependencies:
   flutter:
     sdk: flutter
 
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  realm: ^1.3.0
+  realm: ^1.5.0
 
 dev_dependencies:
   flutter_test:
@@ -54,7 +53,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.
@@ -66,10 +64,10 @@ flutter:
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware
+  # https://docs.flutter.dev/ui/assets/assets-and-images#resolution-aware
 
   # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
+  # https://docs.flutter.dev/ui/assets/assets-and-images#from-packages
 
   # To add custom fonts to your application, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
@@ -89,4 +87,4 @@ flutter:
   #         weight: 700
   #
   # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages
+  # see https://docs.flutter.dev/cookbook/design/fonts#from-packages

--- a/source/examples/generated/flutter/data_ingest.test.snippet.asymmetric-sync-object.dart
+++ b/source/examples/generated/flutter/data_ingest.test.snippet.asymmetric-sync-object.dart
@@ -1,0 +1,11 @@
+@RealmModel(ObjectType.asymmetricObject)
+class _WeatherSensor {
+  @PrimaryKey()
+  @MapTo("_id")
+  late ObjectId id;
+
+  late String deviceId;
+  late double modtemperatureInFahrenheitel;
+  late double barometricPressureInHg;
+  late double windSpeedInMph;
+}

--- a/source/examples/generated/flutter/data_ingest.test.snippet.write-asymmetric-object.dart
+++ b/source/examples/generated/flutter/data_ingest.test.snippet.write-asymmetric-object.dart
@@ -1,0 +1,4 @@
+realm.write(() {
+  realm.ingest(
+      WeatherSensor(weatherSensorId, "WX1278UIT", 66.7, 29.65, 2));
+});

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -316,15 +316,15 @@ Cleaning the generator cache can be useful when debugging.
 .. _flutter-define-an-asymmetric-object:
 
 Define an Asymmetric Object
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 .. versionadded:: 1.5.0
 
-To define an asymmetric object, you must use Flexible Sync. When you define your
-asymmetric object, pass ``ObjectType.asymmetricObject`` to ``@RealmModel()``.
+Asymmetric objects require Flexible Sync. To define an asymmetric object, pass
+``ObjectType.asymmetricObject`` to ``@RealmModel()``.
 
 .. literalinclude:: /examples/generated/flutter/data_ingest.test.snippet.asymmetric-sync-object.dart
-   :language: dart   
+   :language: dart
 
 .. note:: Attempting to Read Asymmetric Objects
 

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -325,11 +325,12 @@ Asymmetric objects require Flexible Sync. To define an asymmetric object, pass
 
 .. literalinclude:: /examples/generated/flutter/data_ingest.test.snippet.asymmetric-sync-object.dart
    :language: dart
+   :emphasize-lines: 1
 
 .. note:: Attempting to Read Asymmetric Objects
 
-   Asymmetric objects cannot be read. If you attempt to query an asymmetric
-   object, you will get the following error: "Error: You cannot query an
+   Asymmetric objects can't be read. If you attempt to query an asymmetric
+   object, you will get the following error: "Error: You can't query an
    asymmetric class.".
 
 To learn more about Data Ingest, read :ref:`Stream Data to Atlas 

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -333,5 +333,5 @@ Asymmetric objects require Flexible Sync. To define an asymmetric object, pass
    object, you will get the following error: "Error: You can't query an
    asymmetric class.".
 
-To learn more about Data Ingest, read :ref:`Stream Data to Atlas 
-<flutter-stream-data-to-atlas>`
+To learn more about Data Ingest, refer to :ref:`Stream Data to Atlas 
+<flutter-stream-data-to-atlas>`.

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -312,3 +312,25 @@ Cleaning the generator cache can be useful when debugging.
       .. code-block::
 
          dart run realm_dart generate --clean
+
+.. _flutter-define-an-asymmetric-object:
+
+Define an Asymmetric Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.5.0
+
+To define an asymmetric object, you must use Flexible Sync. When you define your
+asymmetric object, pass ``ObjectType.asymmetricObject`` to ``@RealmModel()``.
+
+.. literalinclude:: /examples/generated/flutter/data_ingest.test.snippet.asymmetric-sync-object.dart
+   :language: dart   
+
+.. note:: Attempting to Read Asymmetric Objects
+
+   Asymmetric objects cannot be read. If you attempt to query an asymmetric
+   object, you will get the following error: "Error: You cannot query an
+   asymmetric class.".
+
+To learn more about Data Ingest, read :ref:`Stream Data to Atlas 
+<flutter-stream-data-to-atlas>`

--- a/source/sdk/flutter/sync.txt
+++ b/source/sdk/flutter/sync.txt
@@ -15,6 +15,7 @@ Device Sync - Flutter SDK
    Sync Multiple Processes </sdk/flutter/sync/sync-multiple-processes>
    Handle Sync Errors </sdk/flutter/sync/handle-sync-errors>
    Set Sync Log Level </sdk/flutter/sync/log-level>
+   Stream Data to Atlas </sdk/flutter/sync/stream-data-to-atlas>
 
 .. contents:: On this page
    :local:

--- a/source/sdk/flutter/sync/stream-data-to-atlas.txt
+++ b/source/sdk/flutter/sync/stream-data-to-atlas.txt
@@ -19,12 +19,13 @@ Sync Data Unidirectionally from a Client Application
 
    .. step:: Define an Asymmetric Object
 
-      To define an asymmetric object, you must use Flexible Sync. When you
-      define your asymmetric object, pass ``ObjectType.asymmetricObject`` to
+      Data Ingest and asymmetric objects require Flexible Sync. To define an
+      asymmetric object, pass ``ObjectType.asymmetricObject`` to
       ``@RealmModel()``.
 
       .. literalinclude:: /examples/generated/flutter/data_ingest.test.snippet.asymmetric-sync-object.dart
-         :language: dart 
+         :language: dart
+         :emphasize-lines: 1
 
       For more information on how to define an asymmetric object, refer to 
       :ref:`Define an Asymmetric Object <flutter-define-an-asymmetric-object>`.
@@ -32,18 +33,14 @@ Sync Data Unidirectionally from a Client Application
    .. step:: Connect and Authenticate with an App Services App
 
       To stream data from the client to your backend App, you must 
-      :ref:`connect to an App Services backend <flutter-connect-to-backend>`.
+      :ref:`connect to an App Services backend <flutter-connect-to-backend>` and
+      :ref:`authenticate a user <flutter-authenticate>`.
       
       .. literalinclude:: /examples/generated/flutter/app_services_test.snippet.access-app-client.dart
          :language: dart
-      
-      You must also :ref:`authenticate a user <flutter-authenticate>`.
 
       .. literalinclude:: /examples/generated/flutter/authenticate_users_test.snippet.anonymous-credentials.dart
          :language: dart
-
-      Data Ingest is a feature of Flexible Sync, so the App you connect 
-      to must use :ref:`Flexible Sync <flexible-sync>`.
 
    .. step:: Open a Realm
 
@@ -56,7 +53,7 @@ Sync Data Unidirectionally from a Client Application
       Unlike bi-directional Sync, Data Ingest does not use a 
       :ref:`Flexible Sync subscription <flutter-flexible-sync-manage-subscriptions>`.
          
-      You cannot query an asymmetric object or persist it in a local
+      You can't query an asymmetric object or persist it in a local
       realm, so asymmetric objects are incompatible with bi-directional
       Flexible Sync, Partition-Based Sync, and local Realm use.
 
@@ -68,7 +65,7 @@ Sync Data Unidirectionally from a Client Application
       .. literalinclude:: /examples/generated/flutter/data_ingest.test.snippet.write-asymmetric-object.dart
          :language: dart 
          
-      You cannot read asymmetric objects. Once created, they sync to the App 
+      You can't read asymmetric objects. Once created, they sync to the App 
       Services backend and the linked Atlas database.
 
       Atlas Device Sync completely manages the lifecycle of this data. 

--- a/source/sdk/flutter/sync/stream-data-to-atlas.txt
+++ b/source/sdk/flutter/sync/stream-data-to-atlas.txt
@@ -63,7 +63,7 @@ Sync Data Unidirectionally from a Client Application
    .. step:: Create Asymmetric Objects
 
       Once you have an open Realm, you can create an asymmetric object inside
-      a write transaction.
+      a write transaction. Pass your object data to ``realm.ingest``.
             
       .. literalinclude:: /examples/generated/flutter/data_ingest.test.snippet.write-asymmetric-object.dart
          :language: dart 

--- a/source/sdk/flutter/sync/stream-data-to-atlas.txt
+++ b/source/sdk/flutter/sync/stream-data-to-atlas.txt
@@ -1,0 +1,76 @@
+.. _flutter-stream-data-to-atlas:
+
+==================================
+Stream Data to Atlas - Flutter SDK
+==================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/data-ingest-overview.rst
+
+Sync Data Unidirectionally from a Client Application
+----------------------------------------------------
+
+.. procedure::
+
+   .. step:: Define an Asymmetric Object
+
+      To define an asymmetric object, you must use Flexible Sync. When you
+      define your asymmetric object, pass ``ObjectType.asymmetricObject`` to
+      ``@RealmModel()``.
+
+      .. literalinclude:: /examples/generated/flutter/data_ingest.test.snippet.asymmetric-sync-object.dart
+         :language: dart 
+
+      For more information on how to define an asymmetric object, refer to 
+      :ref:`Define an Asymmetric Object <flutter-define-an-asymmetric-object>`.
+
+   .. step:: Connect and Authenticate with an App Services App
+
+      To stream data from the client to your backend App, you must 
+      :ref:`connect to an App Services backend <flutter-connect-to-backend>`.
+      
+      .. literalinclude:: /examples/generated/flutter/app_services_test.snippet.access-app-client.dart
+         :language: dart
+      
+      You must also :ref:`authenticate a user <flutter-authenticate>`.
+
+      .. literalinclude:: /examples/generated/flutter/authenticate_users_test.snippet.anonymous-credentials.dart
+         :language: dart
+
+      Data Ingest is a feature of Flexible Sync, so the App you connect 
+      to must use :ref:`Flexible Sync <flexible-sync>`.
+
+   .. step:: Open a Realm
+
+      After you have an authenticated user, open a :ref:`synced realm 
+      <flutter-open-synced-realm>`.
+
+      .. literalinclude:: /examples/generated/flutter/open_flexible_sync_realm_test.snippet.open-flexible-sync-realm.dart
+         :language: dart
+
+      Unlike bi-directional Sync, Data Ingest does not use a 
+      :ref:`Flexible Sync subscription <flutter-flexible-sync-manage-subscriptions>`.
+         
+      You cannot query an asymmetric object or persist it in a local
+      realm, so asymmetric objects are incompatible with bi-directional
+      Flexible Sync, Partition-Based Sync, and local Realm use.
+
+   .. step:: Create Asymmetric Objects
+
+      Once you have an open Realm, you can create an asymmetric object inside
+      a write transaction.
+            
+      .. literalinclude:: /examples/generated/flutter/data_ingest.test.snippet.write-asymmetric-object.dart
+         :language: dart 
+         
+      You cannot read asymmetric objects. Once created, they sync to the App 
+      Services backend and the linked Atlas database.
+
+      Atlas Device Sync completely manages the lifecycle of this data. 
+      It is maintained on the device until Data Ingest synchronization is 
+      complete, and then removed from the device.


### PR DESCRIPTION
## Pull Request Info

This PR adds docs and tests for Data Ingest. Note that the Flutter SDK doesn't have a mongoClient yet. It's not really feasible to test that asymmetric objects make it to the backend without the mongoClient. However, we can test that the write occurs and the object is deleted after it's synced.

### Jira

- https://jira.mongodb.org/browse/DOCSP-33149

### Staged Changes

- [Stream Data to Atlas](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-33149/sdk/flutter/sync/stream-data-to-atlas/). New page.
- [Define a Realm Object Schema](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/DOCSP-33149/sdk/flutter/realm-database/model-data/define-realm-object-schema/#define-an-asymmetric-object). New section for defining an asymmetric object.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT5G5snnQTWgTYB60srJ4j_mry27nCnine685JRnPjF_tokRZuoBX9YQiKz0QgvlAevFTE&usqp=CAU)
