### PR TITLE
DOCSP-33313 Manual Compaction Example Fix

### DIFF
--- a/examples/dotnet/Examples/Compact.cs
+++ b/examples/dotnet/Examples/Compact.cs
@@ -26,7 +26,7 @@ namespace Examples
 
                     var oneHundredMB = 100 * 1024 * 1024;
 
-                    return (totalBytes > (double)oneHundredMB) ||
+                    return (totalBytes > (double)oneHundredMB) &&
                         ((double)usedBytes / totalBytes < 0.5);
                 }
             };

--- a/examples/dotnet/Examples/Compact.cs
+++ b/examples/dotnet/Examples/Compact.cs
@@ -21,7 +21,7 @@ namespace Examples
                      * the realm file
                      */
 
-                    // Compact if the file is over 100MB in size or more
+                    // Compact if the file is over 100MB in size or less
                     // than 50% 'used'
 
                     var oneHundredMB = 100 * 1024 * 1024;

--- a/examples/dotnet/Examples/Compact.cs
+++ b/examples/dotnet/Examples/Compact.cs
@@ -21,7 +21,7 @@ namespace Examples
                      * the realm file
                      */
 
-                    // Compact if the file is over 100MB in size or less
+                    // Compact if the file is over 100MB in size and less
                     // than 50% 'used'
 
                     var oneHundredMB = 100 * 1024 * 1024;

--- a/examples/dotnet/Examples/Compact.cs
+++ b/examples/dotnet/Examples/Compact.cs
@@ -27,7 +27,7 @@ namespace Examples
                     var oneHundredMB = 100 * 1024 * 1024;
 
                     return (totalBytes > (double)oneHundredMB) ||
-                        ((double)usedBytes / totalBytes > 0.5);
+                        ((double)usedBytes / totalBytes < 0.5);
                 }
             };
             var realm = await Realm.GetInstanceAsync(config);

--- a/source/examples/generated/dotnet/Compact.snippet.config-compact.cs
+++ b/source/examples/generated/dotnet/Compact.snippet.config-compact.cs
@@ -13,7 +13,7 @@ config = new RealmConfiguration()
 
         var oneHundredMB = 100 * 1024 * 1024;
 
-        return (totalBytes > (double)oneHundredMB) ||
+        return (totalBytes > (double)oneHundredMB) &&
             ((double)usedBytes / totalBytes < 0.5);
     }
 };

--- a/source/examples/generated/dotnet/Compact.snippet.config-compact.cs
+++ b/source/examples/generated/dotnet/Compact.snippet.config-compact.cs
@@ -8,7 +8,7 @@ config = new RealmConfiguration()
          * the realm file
          */
 
-        // Compact if the file is over 100MB in size or more
+        // Compact if the file is over 100MB in size or less
         // than 50% 'used'
 
         var oneHundredMB = 100 * 1024 * 1024;

--- a/source/examples/generated/dotnet/Compact.snippet.config-compact.cs
+++ b/source/examples/generated/dotnet/Compact.snippet.config-compact.cs
@@ -8,7 +8,7 @@ config = new RealmConfiguration()
          * the realm file
          */
 
-        // Compact if the file is over 100MB in size or less
+        // Compact if the file is over 100MB in size and less
         // than 50% 'used'
 
         var oneHundredMB = 100 * 1024 * 1024;

--- a/source/examples/generated/dotnet/Compact.snippet.config-compact.cs
+++ b/source/examples/generated/dotnet/Compact.snippet.config-compact.cs
@@ -14,7 +14,7 @@ config = new RealmConfiguration()
         var oneHundredMB = 100 * 1024 * 1024;
 
         return (totalBytes > (double)oneHundredMB) ||
-            ((double)usedBytes / totalBytes > 0.5);
+            ((double)usedBytes / totalBytes < 0.5);
     }
 };
 var realm = await Realm.GetInstanceAsync(config);

--- a/source/sdk/dotnet/realm-files/compact-realm.txt
+++ b/source/sdk/dotnet/realm-files/compact-realm.txt
@@ -80,7 +80,7 @@ These calculations might look like this in your delegate:
     * and the amount of bytes currently used to be less than 50% of the
     * total realm file size */
    return (totalBytes > (double)maxFileSize) ||
-      ((double)usedBytes / totalBytes > 0.5);
+      ((double)usedBytes / totalBytes < 0.5);
 
 Experiment with conditions to find the right balance of how often to 
 compact realm files in your application.

--- a/source/sdk/dotnet/realm-files/compact-realm.txt
+++ b/source/sdk/dotnet/realm-files/compact-realm.txt
@@ -77,9 +77,9 @@ These calculations might look like this in your delegate:
    var maxFileSize = 20 * 1024 * 1024;
 
    /* Check for the realm file size to be greater than the max file size, 
-    * and the amount of bytes currently used to be less than 50% of the
+    * or the amount of bytes currently used to be less than 50% of the
     * total realm file size */
-   return (totalBytes > (double)maxFileSize) ||
+   return (totalBytes > (double)maxFileSize) &&
       ((double)usedBytes / totalBytes < 0.5);
 
 Experiment with conditions to find the right balance of how often to 

--- a/source/sdk/node/realm-files/compact-realm.txt
+++ b/source/sdk/node/realm-files/compact-realm.txt
@@ -84,9 +84,9 @@ These calculations might look like this:
    const maxFileSize = 20 * 1024 * 1024;
 
    /* Check for the realm file size to be greater than the max file size, 
-    * and the amount of bytes currently used to be less than 50% of the
+    * or the amount of bytes currently used to be less than 50% of the
     * total realm file size */
-   return (totalBytes > (double)maxFileSize) ||
+   return (totalBytes > (double)maxFileSize) &&
       ((double)usedBytes / totalBytes < 0.5);
 
 Experiment with conditions to find the right balance of how often to 

--- a/source/sdk/node/realm-files/compact-realm.txt
+++ b/source/sdk/node/realm-files/compact-realm.txt
@@ -87,7 +87,7 @@ These calculations might look like this:
     * and the amount of bytes currently used to be less than 50% of the
     * total realm file size */
    return (totalBytes > (double)maxFileSize) ||
-      ((double)usedBytes / totalBytes > 0.5);
+      ((double)usedBytes / totalBytes < 0.5);
 
 Experiment with conditions to find the right balance of how often to 
 compact realm files in your application.

--- a/source/sdk/node/realm-files/compact-realm.txt
+++ b/source/sdk/node/realm-files/compact-realm.txt
@@ -84,7 +84,7 @@ These calculations might look like this:
    const maxFileSize = 20 * 1024 * 1024;
 
    /* Check for the realm file size to be greater than the max file size, 
-    * or the amount of bytes currently used to be less than 50% of the
+    * and the amount of bytes currently used to be less than 50% of the
     * total realm file size */
    return (totalBytes > (double)maxFileSize) &&
       ((double)usedBytes / totalBytes < 0.5);

--- a/source/sdk/react-native/realm-files/compact-realm.txt
+++ b/source/sdk/react-native/realm-files/compact-realm.txt
@@ -86,7 +86,7 @@ These calculations might look like this:
     * and the amount of bytes currently used to be less than 50% of the
     * total realm file size */
    return (totalBytes > (double)maxFileSize) ||
-      ((double)usedBytes / totalBytes > 0.5);
+      ((double)usedBytes / totalBytes < 0.5);
 
 Experiment with conditions to find the right balance of how often to 
 compact realm files in your application.

--- a/source/sdk/react-native/realm-files/compact-realm.txt
+++ b/source/sdk/react-native/realm-files/compact-realm.txt
@@ -85,7 +85,7 @@ These calculations might look like this:
    /* Check for the realm file size to be greater than the max file size, 
     * and the amount of bytes currently used to be less than 50% of the
     * total realm file size */
-   return (totalBytes > (double)maxFileSize) ||
+   return (totalBytes > (double)maxFileSize) &&
       ((double)usedBytes / totalBytes < 0.5);
 
 Experiment with conditions to find the right balance of how often to 


### PR DESCRIPTION
## Pull Request Info

Made sure file compacted when used bytes was _less than_ 50% of total bytes in examples for the Node.js, .NET, and React Native SDKs.

### Jira

- https://jira.mongodb.org/browse/DOCSP-33313

### Staged Changes

- [Reduce Realm File Size - .NET](https://preview-mongodblindseymoore.gatsbyjs.io/realm/DOCSP-33313/sdk/dotnet/realm-files/compact-realm/#realm-configuration-file)
- [Reduce Realm File Size - Node.js](https://preview-mongodblindseymoore.gatsbyjs.io/realm/DOCSP-33313/sdk/node/realm-files/compact-realm/#tips-for-manually-compacting-a-realm)
- [Reduce Realm File Size - React Native](https://preview-mongodblindseymoore.gatsbyjs.io/realm/DOCSP-33313/sdk/react-native/realm-files/compact-realm/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [ ] Create Jira ticket for corresponding docs-app-services update(s), if any
- [ ] Checked/updated Admin API
- [ ] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
