### PR TITLE
DOCSP-33430: Rename KMM refs to KMP

### DIFF
--- a/source/example-projects.txt
+++ b/source/example-projects.txt
@@ -101,7 +101,7 @@ Check out these supplementary projects to build on the power of Realm with Atlas
     - Build a Flutter app with a pre-initialized realm file that is shipped with the app. 
     - - `Flutter <https://github.com/realm/realm-dart-samples/tree/main/bundled_realm>`__
 
-  * - Realm Kotlin Multiplatform Mobile (KMM) Sample
+  * - Realm Kotlin Multiplatform (KMP) Sample
     - Build a simple multiplatform calculator app.
     - - `Kotlin <https://github.com/realm/realm-kotlin-samples/tree/main/Intro>`__
 
@@ -110,7 +110,7 @@ Check out these supplementary projects to build on the power of Realm with Atlas
       and Realm, combined with a platform specific UI using Jetpack Compose and SwiftUI.
     - - `Kotlin <https://github.com/realm/realm-kotlin-samples/tree/main/Bookshelf>`__
 
-  * - Kotlin Multiplatform Demo
+  * - Kotlin Multiplatform (KMP) Demo
     - Build a multiplatform demo running on Android/iOS/macOS and JVM with Compose Desktop.
     - - `Kotlin <https://github.com/realm/realm-kotlin-samples/tree/main/MultiplatformDemo>`__
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -82,7 +82,7 @@ and platforms. Each SDK is language-idiomatic and includes:
       :icon: /images/icons/kotlin_sdk.svg
       :icon-alt: Kotlin SDK icon
 
-      Build cross-platform applications for Android, iOS, and macOS with Kotlin Multiplatform Mobile. Realm data maps directly to the classes in your app.
+      Build cross-platform applications for Android, iOS, and macOS with Kotlin Multiplatform (KMP). Realm data maps directly to the classes in your app.
 
    .. card::
       :headline: .NET SDK

--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -65,7 +65,7 @@ and platforms. Each SDK is language-idiomatic and includes:
       :icon: /images/icons/kotlin_sdk.svg
       :icon-alt: Kotlin SDK icon
 
-      Build cross-platform applications for Android, iOS, and macOS with Kotlin Multiplatform Mobile. Realm data maps directly to the classes in your app.
+      Build cross-platform applications for Android, iOS, and macOS with Kotlin Multiplatform (KMP). Realm data maps directly to the classes in your app.
 
    .. card::
       :headline: Web SDK

--- a/source/sdk/java.txt
+++ b/source/sdk/java.txt
@@ -39,7 +39,7 @@ Realm Java SDK
    :class: singlecol
 
 Use the Realm Java SDK to develop Android apps in Java or Kotlin. To develop
-multiplatform apps using Kotlin Multiplatform Mobile, refer to the
+multiplatform apps using Kotlin Multiplatform (KMP), refer to the
 :ref:`Realm Kotlin SDK <kotlin-intro>`.
 
 .. kicker:: What You Can Do

--- a/source/sdk/kotlin.txt
+++ b/source/sdk/kotlin.txt
@@ -24,7 +24,7 @@ Realm Kotlin SDK
    Migrate from Java SDK to Kotlin SDK </sdk/kotlin/migrate-from-java-sdk-to-kotlin-sdk>
 
 Use the Realm Kotlin SDK to develop Android or iOS apps
-using the Android platform or Kotlin Multiplatform Mobile (KMM).
+using the Android platform or Kotlin Multiplatform (KMP).
    
 .. kicker:: Learning Paths
 

--- a/source/sdk/kotlin/install.txt
+++ b/source/sdk/kotlin/install.txt
@@ -15,7 +15,7 @@ The Kotlin SDK supports two platforms, each with its own installation
 method:
 
 - :ref:`Android <kotlin-install-android>`
-- :ref:`Kotlin Multiplatform <kotlin-install-kotlin-multiplatform>`
+- :ref:`Kotlin Multiplatform (KMP) <kotlin-install-kotlin-multiplatform>`
 
 Prerequisites
 -------------
@@ -28,17 +28,18 @@ meets the following prerequisites:
 - Kotlin Plugin for Android Studio, version 1.6.10 or higher.
 - An Android Virtual Device (AVD) using a supported CPU architecture.
 
-Additionally, Kotlin Multiplatform (KMM) projects require the following:
+Additionally, Kotlin Multiplatform (KMP) for mobile projects require the following:
 
 - `Kotlin Multiplatform Mobile (KMM) Plugin
   <https://kotlinlang.org/docs/mobile/kmm-plugin-releases.html#release-details>`__
   for Android Studio, version 0.3.1 or higher.
-- A KMM App created using the "KMM Application" template in Android
-  Studio. Follow the instructions in the `KMM documentation
+- A Kotlin Multiplatform (KMP) App created using the "Kotlin Multiplatform App" 
+  template in Android Studio. Follow the instructions in the 
+  `Kotlin Multiplatform documentation 
   <https://kotlinlang.org/docs/mobile/create-first-app.html>`__.
 
-For more details on setting up your KMM environment, refer to the `official Kotlin
-Multiplatform documentation
+For more details on setting up your KMP environment, refer to the `official Kotlin
+Kotlin Multiplatform for mobile documentation
 <https://kotlinlang.org/docs/multiplatform-mobile-setup.html>`__. To verify your
 environment setup, follow Kotlin's `guide to checking your
 environment
@@ -46,7 +47,7 @@ environment
 
 .. tip:: Kotlin Plugin Version
 
-   The Kotlin Multiplatform ecosystem frequently changes. If you experience
+   The Kotlin Multiplatform (KMP) ecosystem frequently changes. If you experience
    any issues installing the SDK, check your Kotlin Plugin version, since
    outdated plugins can lead to difficult to debug errors. To see which
    versions of the Kotlin Plugin are compatible with the SDK, see the
@@ -109,8 +110,8 @@ Installation
                   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:{+kotlinx-coroutines-version+}' // If using coroutines with the SDK
                }
 
-         .. tab:: Kotlin Multiplatform (KMM)
-            :tabid: kmm
+         .. tab:: Kotlin Multiplatform (KMP)
+            :tabid: kmp
 
             Add the following to your app-level Gradle build file, typically
             found at :file:`<project>/app/build.gradle`:
@@ -180,7 +181,7 @@ Installation
 Supported Target Environments
 -----------------------------
 
-Kotlin Multiplatform supports a `wide range of application environments
+Kotlin Multiplatform (KMP) supports a `wide range of application environments
 <https://kotlinlang.org/docs/multiplatform-dsl-reference.html#targets>`__.
 
 Supported Environments

--- a/source/sdk/kotlin/quick-start.txt
+++ b/source/sdk/kotlin/quick-start.txt
@@ -18,12 +18,12 @@ illustrates how to get Atlas Device Sync integrated into your application.
 Before you begin, ensure you have installed
 the Kotlin SDK for your platform. 
 
-- :ref:`Install for Kotlin Multiplatform <kotlin-install-kotlin-multiplatform>`
+- :ref:`Install for Kotlin Multiplatform (KMP) <kotlin-install-kotlin-multiplatform>`
 - :ref:`Install for Android <kotlin-install-android>`
 
-.. note:: Using this Quick Start with KMM 
+.. note:: Using this Quick Start with KMP  
 
-   If you're running this project in a fresh KMM template project, you can
+   If you're running this project in a fresh Kotlin Multiplatform (KMP) template project, you can
    copy and paste the following snippets into the :file:`Greeting.greeting()` method in the
    :file:`commonMain` module.
 

--- a/source/sdk/kotlin/realm-database/frozen-arch.txt
+++ b/source/sdk/kotlin/realm-database/frozen-arch.txt
@@ -60,7 +60,7 @@ support change listeners.
 
 .. important:: Flows API Requires Kotlinx Coroutines
 
-   To use the Flows API in your KMM project, install the
+   To use the Flows API in your Kotlin Multiplatform project, install the
    :github:`kotlinx.coroutines <Kotlin/kotlinx.coroutines#multiplatform>`
    library.
 

--- a/source/sdk/kotlin/users/authenticate-users.txt
+++ b/source/sdk/kotlin/users/authenticate-users.txt
@@ -293,7 +293,7 @@ code implements this flow, starting with a method call to
    official :google:`Google Sign-In for Android Integration Guide
    <identity/sign-in/android/start-integrating>`.
 
-KMM supports many environments, but this example shows sign-in on
+Kotlin Multiplatform (KMP) supports many environments, but this example shows sign-in on
 the Android platform. For information about signing into a Google
 account on Apple platforms, refer to the :ref:`Swift SDK Example <ios-login-google>`.
 
@@ -327,7 +327,7 @@ to `app.login()
 
 .. include:: /includes/note-facebook-profile-picture-url.rst
 
-KMM supports many environments, but this example shows sign-in on
+Kotlin Multiplatform (KMP) supports many environments, but this example shows sign-in on
 the Android platform. For information about signing into a Facebook
 account on Apple platforms, refer to the
 :ref:`Swift SDK Example <ios-login-facebook>`.
@@ -352,7 +352,7 @@ to `app.login()
 .. literalinclude:: /examples/generated/kotlin/AuthenticationTest.snippet.apple-authentication.kt
    :language: kotlin
 
-KMM supports many environments, but this example shows sign-in on
+Kotlin Multiplatform (KMP) supports many environments, but this example shows sign-in on
 the Android platform. For information about signing in with Apple
 on Apple platforms, see the :ref:`Swift SDK Example <ios-login-apple>`.
 


### PR DESCRIPTION
## Pull Request Info

Per [JetBrains](https://blog.jetbrains.com/kotlin/2023/07/update-on-the-name-of-kotlin-multiplatform/): `Kotlin Multiplatform Mobile (KMM)` is deprecated and should be replaced with From now on, `Kotlin Multiplatform (KMP)`

### Jira

- https://jira.mongodb.org/browse/DOCSP-33430

### Staged Changes

https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-33430-KMM-to-KMP/sdk/kotlin/install/

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
