### PR TITLE
(DOCSP-33260): Swift: Asymmetric objects can now link to non-embedded types

### DIFF
--- a/source/sdk/swift/model-data/object-models.txt
+++ b/source/sdk/swift/model-data/object-models.txt
@@ -516,9 +516,9 @@ Define an asymmetric object by inheriting from :swift-sdk:`AsymmetricObject
 .. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
    :language: swift
 
-.. versionchanged:: 10.42.4 AsymmetricObjects can link to non-embedded objects.
+.. versionchanged:: 10.42.4 Asymmetric objects can link to non-embedded objects.
 
-``AsymmetricObjects`` broadly support the same property types as ``Object``, 
+``AsymmetricObject`` broadly supports the same property types as ``Object``, 
 with a few exceptions:
 
 - Asymmetric objects can only link to embedded objects

--- a/source/sdk/swift/model-data/object-models.txt
+++ b/source/sdk/swift/model-data/object-models.txt
@@ -516,12 +516,16 @@ Define an asymmetric object by inheriting from :swift-sdk:`AsymmetricObject
 .. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
    :language: swift
 
+.. versionchanged:: 10.42.4 AsymmetricObjects can link to non-embedded objects.
+
 ``AsymmetricObjects`` broadly support the same property types as ``Object``, 
 with a few exceptions:
 
 - Asymmetric objects can only link to embedded objects
-   - ``Object`` and ``List<Object>`` properties are not supported 
-   - ``EmbeddedObject`` and ``List<EmbeddedObject>`` are supported
+   - ``Object`` and ``List<Object>`` properties are not supported in Swift SDK
+     versions 10.42.3 and earlier. In Swift SDK versions 10.42.4 and later,
+     asymmetric objects can link to non-embedded objects.
+   - ``EmbeddedObject`` and ``List<EmbeddedObject>`` are supported.
 
 You cannot link to an ``AsymmetricObject`` from within an ``Object``. Doing so 
 throws an error.

--- a/source/sdk/swift/sync/stream-data-to-atlas.txt
+++ b/source/sdk/swift/sync/stream-data-to-atlas.txt
@@ -31,8 +31,7 @@ Sync Data Unidirectionally from a Client Application
       .. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
          :language: swift
 
-      For more information on how to define an AsymmetricObject, including
-      limitations when linking to other object types, see: 
+      For more information on how to define an AsymmetricObject, see: 
       :ref:`Define an AsymmetricObject <swift-define-asymmetric-object>`.
 
    .. step:: Connect and Authenticate with an App Services App

--- a/source/sdk/swift/sync/stream-data-to-atlas.txt
+++ b/source/sdk/swift/sync/stream-data-to-atlas.txt
@@ -31,7 +31,7 @@ Sync Data Unidirectionally from a Client Application
       .. literalinclude:: /examples/generated/code/start/AsymmetricSync.snippet.asymmetric-model.swift
          :language: swift
 
-      For more information on how to define an AsymmetricObject, see: 
+      For more information on how to define an ``AsymmetricObject``, see: 
       :ref:`Define an AsymmetricObject <swift-define-asymmetric-object>`.
 
    .. step:: Connect and Authenticate with an App Services App


### PR DESCRIPTION
## Pull Request Info

### Jira

- https://jira.mongodb.org/browse/DOCSP-33260

### Staged Changes

- [Define a Realm Object Model](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-33260/sdk/swift/model-data/object-models/#define-an-asymmetric-object)
- [Stream Data to Atlas](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-33260/sdk/swift/sync/stream-data-to-atlas/#sync-data-unidirectionally-from-a-client-application)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
