### PR TITLE
DOCSP-30346: Update Kotlin Delete page

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DataTypesTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DataTypesTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertEquals
 
 
 /*
-** Leaving these here until the Read, Update, and Delete pages are updated
+** Leaving these here until the Read and Update pages are updated
 * to use the new object model and this page can be deleted
 *
 * See the Schema.kt file for the new object model and CreateTest.kt for new tested Create snippets
@@ -66,8 +66,8 @@ class DataTypesTest : RealmTest() {
                 // Modify embedded object properties in a write transaction
                 realm.write {
                     // Fetch the objects
-                    val addressToUpdate = findLatest(address)?: error("Cannot find latest version of embedded object")
-                    val contactToUpdate = findLatest(contact)?: error("Cannot find latest version of parent object")
+                    val addressToUpdate = findLatest(address) ?: error("Cannot find latest version of embedded object")
+                    val contactToUpdate = findLatest(contact) ?: error("Cannot find latest version of parent object")
 
                     // Update a single embedded object property directly
                     addressToUpdate.street = "100 10th St N"
@@ -152,72 +152,5 @@ class DataTypesTest : RealmTest() {
             Realm.deleteRealm(config)
         }
     }
-
-    @Test
-    fun deleteEmbeddedObject() {
-        val realmName = getRandom()
-
-        runBlocking {
-            val config = RealmConfiguration.Builder(setOf(Contact::class, EmbeddedAddress::class))
-                .name(realmName)
-                .build()
-            val realm = Realm.open(config)
-
-            realm.write {
-                val contact1 = copyToRealm(Contact())
-                contact1.apply {
-                    name = "Marvin Monroe"
-                    address = EmbeddedAddress().apply {
-                        street = "123 Fake St"
-                        city = "Some Town"
-                        state = "MA"
-                        postalCode = "12345"
-                    }
-                }
-                val contact2 = copyToRealm(Contact())
-                contact2.apply {
-                    name = "Nick Riviera"
-                    address = EmbeddedAddress().apply {
-                        street = "999 Imaginary Blvd"
-                        city = "Some Town"
-                        state = "FL"
-                        postalCode = "55555"
-                    }
-                }
-            }
-
-            // :snippet-start: delete-embedded-object
-            //  Delete an embedded object directly
-            realm.write {
-                val addressToDelete: EmbeddedAddress =
-                    this.query<EmbeddedAddress>("street == '123 Fake St'").find().first()
-
-                // Delete the embedded object (nullifies the parent property)
-                delete(addressToDelete)
-            }
-
-            // Delete an embedded object through the parent
-            realm.write {
-                val propertyToClear: Contact =
-                    this.query<Contact>("name == 'Nick Riviera'").find().first()
-
-                // Clear the parent property (deletes the embedded object instance)
-                propertyToClear.address = null
-            }
-
-            // Delete parent object (deletes all embedded objects)
-            realm.write {
-                val contactToDelete: Contact =
-                    this.query<Contact>("name == 'Nick Riviera'").find().first()
-                delete(contactToDelete)
-            }
-            // :snippet-end:
-
-            assertEquals(0, realm.query<EmbeddedAddress>().find().size)
-            assertEquals(0, realm.query<Contact>("name == 'Nick Riviera'").find().size)
-
-            realm.close()
-            Realm.deleteRealm(config)
-        }
-    }
 }
+

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DeleteTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DeleteTest.kt
@@ -5,6 +5,7 @@ import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.ext.*
 import io.realm.kotlin.internal.platform.runBlocking
 import io.realm.kotlin.query.RealmResults
+import io.realm.kotlin.types.RealmAny
 import org.mongodb.kbson.ObjectId
 import kotlin.test.*
 
@@ -116,12 +117,11 @@ class DeleteTest: RealmTest() {
             // Open a write transaction
             realm.write {
                 // Query the Frog type and filter by primary key value
-                val frogToDelete: ExampleRealmObject_Frog =
-                    query<ExampleRealmObject_Frog>("_id == $0", PRIMARY_KEY_VALUE).find().first()
+                val frogToDelete: ExampleRealmObject_Frog = query<ExampleRealmObject_Frog>("_id == $0", PRIMARY_KEY_VALUE).find().first()
                 assertEquals(PRIMARY_KEY_VALUE, frogToDelete._id) // :remove:
                 // Pass the query results to delete()
                 delete(frogToDelete)
-                assertFalse(frogToDelete.isValid())
+                assertFalse(frogToDelete.isValid()) // :remove:
                 assertTrue(query<ExampleRealmObject_Frog>().find().size == 6) // :remove:
             }
             // :snippet-end:
@@ -129,8 +129,7 @@ class DeleteTest: RealmTest() {
             // Open a write transaction
             realm.write {
                 // Query by species and limit to 3 results
-                val bullfrogsToDelete: RealmResults<ExampleRealmObject_Frog> =
-                    query<ExampleRealmObject_Frog>("species == 'bullfrog' LIMIT(3)").find()
+                val bullfrogsToDelete: RealmResults<ExampleRealmObject_Frog> = query<ExampleRealmObject_Frog>("species == 'bullfrog' LIMIT(3)").find()
                 // Pass the query results to delete()
                 delete(bullfrogsToDelete)
                 assertTrue(query<ExampleRealmObject_Frog>("species == 'bullfrog'").find().size == 3) // :remove:
@@ -141,6 +140,7 @@ class DeleteTest: RealmTest() {
             realm.write {
                 // Query Frog type with no filter to return all frog objects
                 val frogsLeftInTheRealm = query<ExampleRealmObject_Frog>().find()
+                // Pass the query results to delete()
                 delete(frogsLeftInTheRealm)
                 assertTrue(frogsLeftInTheRealm.size == 0) // :remove:
                 deleteAll() // :remove:
@@ -221,11 +221,11 @@ class DeleteTest: RealmTest() {
                 assertEquals(PRIMARY_KEY_VALUE, parentObject._id) // :remove:
                 assertEquals(2, parentObject.favoritePonds.size)
 
-                // Delete the frog
+                // Delete the frog and all references to ponds
                 delete(parentObject)
                 assertFalse(parentObject.isValid()) // :remove:
 
-                // Confirm all ponds are still in the realm
+                // Confirm pond objects are still in the realm
                 val ponds = query<ExampleRealmList_Pond>().find()
                 assertEquals(2, ponds.size)
                 deleteAll() // :remove:
@@ -367,7 +367,7 @@ class DeleteTest: RealmTest() {
     @Test
     fun deleteRealmDictionaryType() {
         runBlocking {
-            val config = RealmConfiguration.Builder(setOf(RealmDictionary_Frog::class))
+            val config = RealmConfiguration.Builder(setOf(ExampleRealmDictionary_Frog::class))
                 .inMemory()
                 .build()
             val realm = Realm.open(config)
@@ -375,7 +375,7 @@ class DeleteTest: RealmTest() {
 
             realm.write {
                 deleteAll()
-                copyToRealm(RealmDictionary_Frog().apply {
+                copyToRealm(ExampleRealmDictionary_Frog().apply {
                     name = "Kermit"
                     favoritePondsByForest =
                         realmDictionaryOf("Hundred Acre Wood" to "Picnic Pond", "Lothlorien" to "Linya")
@@ -383,7 +383,7 @@ class DeleteTest: RealmTest() {
             }
             // :snippet-start: delete-realm-dictionary
             // Find frogs who have forests with favorite ponds
-            val thisFrog = realm.query<RealmDictionary_Frog>("favoritePondsByForest.@count > 1").find().first()
+            val thisFrog = realm.query<ExampleRealmDictionary_Frog>("favoritePondsByForest.@count > 1").find().first()
             // :remove-start:
             assertEquals(2, thisFrog.favoritePondsByForest.size)
             assertTrue(thisFrog.favoritePondsByForest.containsKey("Hundred Acre Wood"))
@@ -402,7 +402,7 @@ class DeleteTest: RealmTest() {
                 // Remove a key and its value
                 findLatest(thisFrog)?.favoritePondsByForest?.remove("Lothlorien")
                 // :remove-start:
-                val thisFrogUpdated = query<RealmDictionary_Frog>().find().first()
+                val thisFrogUpdated = query<ExampleRealmDictionary_Frog>().find().first()
                 assertFalse(thisFrogUpdated.favoritePondsByForest.containsKey("Lothlorien"))
                 assertTrue(thisFrogUpdated.favoritePondsByForest.containsKey("Hundred Acre Wood"))
                 assertFalse(thisFrogUpdated.favoritePondsByForest.containsValue("Picnic Pond"))
@@ -467,30 +467,33 @@ class DeleteTest: RealmTest() {
                 copyToRealm(business)
             }
             // :snippet-start: delete-embedded-object
+            // Delete an embedded object directly
             realm.write {
-                // Delete an embedded object directly
                 val addressToDelete = query<ExampleRelationship_EmbeddedAddress>("street == $0", "456 Lily Pad Ln").find().first()
                 // Delete the embedded object (nullifies the parent property)
                 delete(addressToDelete)
-
-                // Delete an embedded object through the parent
+                val parent = query<ExampleRelationship_Contact>("name == $0", "Froggy J. Frog").find().first() // :remove:
+                assertNull(parent.address) // :remove:
+            }
+            // Delete an embedded object through the parent
+            realm.write {
                 val propertyToClear = query<ExampleRelationship_Contact>("name == $0", "Kermit").find().first()
                 // Clear the parent property (deletes the embedded object instance)
                 propertyToClear.address = null
                 assertNull(propertyToClear.address) // :remove:
-
-                // Delete the parent object (deletes all embedded objects)
+            }
+            // :snippet-end:
+            // :snippet-start: delete-embedded-object-through-parent
+            // Delete the parent object
+            realm.write {
                 val businessToDelete = query<ExampleRelationship_Business>("name == $0", "Big Frog Corp.").find().first()
-                assertEquals(2, businessToDelete.addresses.size)
+                assertEquals(2, businessToDelete.addresses.size) // :remove:
+                // Delete the parent object (deletes all embedded objects)
                 delete(businessToDelete)
-                assertFalse(businessToDelete.isValid()) // :remove:
+                assertNull(businessToDelete) // :remove:
             }
             // :snippet-end:
             realm.write {
-                val nulledAddress = query<ExampleRelationship_Contact>("name == $0", "Froggy J. Frog").find().first()
-                assertNull(nulledAddress.address)
-                val deletedBusiness = query<ExampleRelationship_Business>("name == $0", "Big Frog Corp.").find().firstOrNull()
-                assertNull(deletedBusiness)
                 deleteAll()
             }
             realm.close()
@@ -518,21 +521,21 @@ class DeleteTest: RealmTest() {
                     name = "Kermit"
                     favoritePonds.addAll(
                         realmListOf(
-                            ExampleRealmList_Pond().apply { name = "Picnic Pond" },
-                            ExampleRealmList_Pond().apply { name = "Big Pond" },
-                            ExampleRealmList_Pond().apply { name = "Small Pond" },
-                            ExampleRealmList_Pond().apply { name = "Huge Pond" },
+                            ExampleRealmList_Pond().apply { name = "1" },
+                            ExampleRealmList_Pond().apply { name = "2" },
+                            ExampleRealmList_Pond().apply { name = "3" },
+                            ExampleRealmList_Pond().apply { name = "4" },
                         )
                     )
                 })
             }
             // :snippet-start: chain-delete-realm-list
             realm.write {
-                // Query for the parent frog object
+                // Query for the parent frog object with ponds
                 val frog = query<ExampleRealmList_Frog>("name == $0", "Kermit").find().first()
                 val ponds = frog.favoritePonds
-                assertEquals(4, ponds.size)
-                // Iterate over the list and delete each pond
+                assertEquals(4, ponds.size) // :remove:
+                // Iterate over the list and delete each pond object
                 if (ponds.isNotEmpty()) {
                     ponds.forEach { pond ->
                         delete(pond)
@@ -545,13 +548,44 @@ class DeleteTest: RealmTest() {
                 }
             }
             // :snippet-end:
+            realm.close()
+        }
+    }
+
+    @Test
+    fun deleteRealmAny() {
+        runBlocking {
+            val config = RealmConfiguration.Builder(setOf(RealmObjectProperties_Frog::class))
+                .inMemory()
+                .build()
+            val realm = Realm.open(config)
+            Log.v("Successfully opened realm: ${realm.configuration.path}")
+
             realm.write {
-                val frogs = query<ExampleRealmList_Frog>().find()
-                Log.v("Frogs: ${frogs.size}")
-                delete(frogs)
-                val ponds = query<ExampleRealmList_Pond>().find()
-                Log.v("Ponds: ${ponds.size}")
-                delete(ponds)
+                deleteAll()
+                copyToRealm(RealmObjectProperties_Frog().apply {
+                    name = "Kermit"
+                    favoriteThings = realmListOf(
+                        RealmAny.create(42),
+                        RealmAny.create("rainbows"),
+                        RealmAny.create(RealmObjectProperties_Frog().apply {
+                            name = "Kermit Jr."
+                        })
+                    )
+                })
+            }
+            // :snippet-start: delete-realmany-property
+            realm.write {
+                val frog = query<RealmObjectProperties_Frog>().find().first()
+                frog.favoriteThings[0] = null
+            }
+            // :snippet-end:
+            realm.write {
+                val frog = query<RealmObjectProperties_Frog>().find().first()
+                assertNull(frog.favoriteThings[0])
+                assertEquals("rainbows", frog.favoriteThings[1]?.asString())
+                assertEquals("Kermit Jr.", frog.favoriteThings[2]?.asRealmObject<RealmObjectProperties_Frog>()?.name)
+                deleteAll()
             }
             realm.close()
         }

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DeleteTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/DeleteTest.kt
@@ -46,14 +46,15 @@ class DeleteTest: RealmTest() {
                 })
             }
             // :snippet-start: fetch-latest-to-delete-object
-            val frozenFrog = realm.query<ExampleRealmObject_Frog>("name == $0", "Kermit").find().first()
-            assertTrue(frozenFrog.isFrozen()) // :remove:
+            val frozenFrog = realm.query<ExampleRealmObject_Frog>("name == $0", "Kermit").find().firstOrNull()
+            frozenFrog?.isFrozen()?.let { assertTrue(it) } // :remove:
 
             // Open a write transaction
             realm.writeBlocking {
                 // Get the live frog object with findLatest(), then delete it
-                findLatest(frozenFrog)?.let { liveFrog ->
-                    delete(liveFrog)
+                if (frozenFrog != null) {
+                    findLatest(frozenFrog)
+                        ?.also { delete(it) }
                 }
             }
             // :snippet-end:
@@ -367,7 +368,7 @@ class DeleteTest: RealmTest() {
     @Test
     fun deleteRealmDictionaryType() {
         runBlocking {
-            val config = RealmConfiguration.Builder(setOf(ExampleRealmDictionary_Frog::class))
+            val config = RealmConfiguration.Builder(setOf(ExampleRealmDictionary_Frog::class, ExampleEmbeddedObject_EmbeddedForest::class))
                 .inMemory()
                 .build()
             val realm = Realm.open(config)
@@ -490,7 +491,6 @@ class DeleteTest: RealmTest() {
                 assertEquals(2, businessToDelete.addresses.size) // :remove:
                 // Delete the parent object (deletes all embedded objects)
                 delete(businessToDelete)
-                assertNull(businessToDelete) // :remove:
             }
             // :snippet-end:
             realm.write {

--- a/source/examples/generated/kotlin/DataTypesTest.snippet.update-embedded-object.kt
+++ b/source/examples/generated/kotlin/DataTypesTest.snippet.update-embedded-object.kt
@@ -1,8 +1,8 @@
 // Modify embedded object properties in a write transaction
 realm.write {
     // Fetch the objects
-    val addressToUpdate = findLatest(address)?: error("Cannot find latest version of embedded object")
-    val contactToUpdate = findLatest(contact)?: error("Cannot find latest version of parent object")
+    val addressToUpdate = findLatest(address) ?: error("Cannot find latest version of embedded object")
+    val contactToUpdate = findLatest(contact) ?: error("Cannot find latest version of parent object")
 
     // Update a single embedded object property directly
     addressToUpdate.street = "100 10th St N"

--- a/source/examples/generated/kotlin/DeleteTest.snippet.chain-delete-realm-list.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.chain-delete-realm-list.kt
@@ -1,9 +1,8 @@
 realm.write {
-    // Query for the parent frog object
+    // Query for the parent frog object with ponds
     val frog = query<Frog>("name == $0", "Kermit").find().first()
     val ponds = frog.favoritePonds
-    assertEquals(4, ponds.size)
-    // Iterate over the list and delete each pond
+    // Iterate over the list and delete each pond object
     if (ponds.isNotEmpty()) {
         ponds.forEach { pond ->
             delete(pond)

--- a/source/examples/generated/kotlin/DeleteTest.snippet.chain-delete-realm-list.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.chain-delete-realm-list.kt
@@ -1,0 +1,17 @@
+realm.write {
+    // Query for the parent frog object
+    val frog = query<Frog>("name == $0", "Kermit").find().first()
+    val ponds = frog.favoritePonds
+    assertEquals(4, ponds.size)
+    // Iterate over the list and delete each pond
+    if (ponds.isNotEmpty()) {
+        ponds.forEach { pond ->
+            delete(pond)
+        }
+    }
+    // Delete the parent frog object
+    val frogToDelete = findLatest(frog)
+    if (frogToDelete != null) {
+        delete(frogToDelete)
+    }
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.clear-set.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.clear-set.kt
@@ -1,2 +1,9 @@
-// Clear all snacks from the set
-snackSet.clear()
+realm.write {
+    val myFrog = realm.query<RealmSet_Frog>("name == $0", "Kermit").find().first()
+    val snackSet = findLatest(myFrog)!!.favoriteSnacks
+    assertEquals(3, snackSet.size)
+
+    // Clear all snacks from the set
+    snackSet.clear()
+    assertEquals(0, snackSet.size)
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-all-realm-object-types.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-all-realm-object-types.kt
@@ -2,5 +2,6 @@
 realm.write {
     // Query Frog type with no filter to return all frog objects
     val frogsLeftInTheRealm = query<Frog>().find()
+    // Pass the query results to delete()
     delete(frogsLeftInTheRealm)
 }

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-all-realm-object-types.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-all-realm-object-types.kt
@@ -1,0 +1,6 @@
+// Open a write transaction
+realm.write {
+    // Query Frog type with no filter to return all frog objects
+    val frogsLeftInTheRealm = query<Frog>().find()
+    delete(frogsLeftInTheRealm)
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-all-realm-objects.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-all-realm-objects.kt
@@ -1,0 +1,5 @@
+// Open a write transaction
+realm.write {
+    // Delete all objects from the realm
+    deleteAll()
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object-through-parent.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object-through-parent.kt
@@ -1,0 +1,6 @@
+// Delete the parent object
+realm.write {
+    val businessToDelete = query<Business>("name == $0", "Big Frog Corp.").find().first()
+    // Delete the parent object (deletes all embedded objects)
+    delete(businessToDelete)
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object.kt
@@ -1,0 +1,16 @@
+realm.write {
+    // Delete an embedded object directly
+    val addressToDelete = query<EmbeddedAddress>("street == $0", "456 Lily Pad Ln").find().first()
+    // Delete the embedded object (nullifies the parent property)
+    delete(addressToDelete)
+
+    // Delete an embedded object through the parent
+    val propertyToClear = query<Contact>("name == $0", "Kermit").find().first()
+    // Clear the parent property (deletes the embedded object instance)
+    propertyToClear.address = null
+
+    // Delete the parent object (deletes all embedded objects)
+    val businessToDelete = query<Business>("name == $0", "Big Frog Corp.").find().first()
+    assertEquals(2, businessToDelete.addresses.size)
+    delete(businessToDelete)
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object.kt
@@ -1,16 +1,12 @@
+// Delete an embedded object directly
 realm.write {
-    // Delete an embedded object directly
     val addressToDelete = query<EmbeddedAddress>("street == $0", "456 Lily Pad Ln").find().first()
     // Delete the embedded object (nullifies the parent property)
     delete(addressToDelete)
-
-    // Delete an embedded object through the parent
+}
+// Delete an embedded object through the parent
+realm.write {
     val propertyToClear = query<Contact>("name == $0", "Kermit").find().first()
     // Clear the parent property (deletes the embedded object instance)
     propertyToClear.address = null
-
-    // Delete the parent object (deletes all embedded objects)
-    val businessToDelete = query<Business>("name == $0", "Big Frog Corp.").find().first()
-    assertEquals(2, businessToDelete.addresses.size)
-    delete(businessToDelete)
 }

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-multiple-realm-objects.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-multiple-realm-objects.kt
@@ -1,8 +1,7 @@
 // Open a write transaction
 realm.write {
     // Query by species and limit to 3 results
-    val bullfrogsToDelete: RealmResults<Frog> =
-        query<Frog>("species == 'bullfrog' LIMIT(3)").find()
+    val bullfrogsToDelete: RealmResults<Frog> = query<Frog>("species == 'bullfrog' LIMIT(3)").find()
     // Pass the query results to delete()
     delete(bullfrogsToDelete)
 }

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-multiple-realm-objects.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-multiple-realm-objects.kt
@@ -1,0 +1,8 @@
+// Open a write transaction
+realm.write {
+    // Query by species and limit to 3 results
+    val bullfrogsToDelete: RealmResults<Frog> =
+        query<Frog>("species == 'bullfrog' LIMIT(3)").find()
+    // Pass the query results to delete()
+    delete(bullfrogsToDelete)
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-one-realm-object.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-one-realm-object.kt
@@ -1,0 +1,9 @@
+// Open a write transaction
+realm.write {
+    // Query the Frog type and filter by primary key value
+    val frogToDelete: Frog =
+        query<Frog>("_id == $0", PRIMARY_KEY_VALUE).find().first()
+    // Pass the query results to delete()
+    delete(frogToDelete)
+    assertFalse(frogToDelete.isValid())
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-one-realm-object.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-one-realm-object.kt
@@ -1,9 +1,7 @@
 // Open a write transaction
 realm.write {
     // Query the Frog type and filter by primary key value
-    val frogToDelete: Frog =
-        query<Frog>("_id == $0", PRIMARY_KEY_VALUE).find().first()
+    val frogToDelete: Frog = query<Frog>("_id == $0", PRIMARY_KEY_VALUE).find().first()
     // Pass the query results to delete()
     delete(frogToDelete)
-    assertFalse(frogToDelete.isValid())
 }

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-realm-dictionary.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-realm-dictionary.kt
@@ -1,5 +1,5 @@
 // Find frogs who have forests with favorite ponds
-val thisFrog = realm.query<RealmDictionary_Frog>("favoritePondsByForest.@count > 1").find().first()
+val thisFrog = realm.query<Frog>("favoritePondsByForest.@count > 1").find().first()
 // Set an optional value for a key to null if the key exists
 if (thisFrog.favoritePondsByForest.containsKey("Hundred Acre Wood")) {
     realm.write {

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-realm-dictionary.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-realm-dictionary.kt
@@ -1,7 +1,5 @@
 // Find frogs who have forests with favorite ponds
-val frogs = realm.query<Frog>().find()
-val frogsWithFavoritePonds = frogs.query("favoritePondsByForest.@count > 1").find()
-val thisFrog = frogsWithFavoritePonds.first()
+val thisFrog = realm.query<RealmDictionary_Frog>("favoritePondsByForest.@count > 1").find().first()
 // Set an optional value for a key to null if the key exists
 if (thisFrog.favoritePondsByForest.containsKey("Hundred Acre Wood")) {
     realm.write {
@@ -11,7 +9,10 @@ if (thisFrog.favoritePondsByForest.containsKey("Hundred Acre Wood")) {
         }
     }
 }
-// Remove a key and its value
 realm.write {
+    // Remove a key and its value
     findLatest(thisFrog)?.favoritePondsByForest?.remove("Lothlorien")
+    // Remove all keys and values
+    findLatest(thisFrog)?.favoritePondsByForest?.clear()
+    assertTrue(thisFrogUpdated.favoritePondsByForest.isEmpty())
 }

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-realm-object-with-related-objects.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-realm-object-with-related-objects.kt
@@ -4,10 +4,10 @@ realm.write {
     val parentObject = query<Frog>("_id == $0", PRIMARY_KEY_VALUE).find().first()
     assertEquals(2, parentObject.favoritePonds.size)
 
-    // Delete the frog
+    // Delete the frog and all references to ponds
     delete(parentObject)
 
-    // Confirm all ponds are still in the realm
+    // Confirm pond objects are still in the realm
     val ponds = query<Pond>().find()
     assertEquals(2, ponds.size)
 }

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-realm-object-with-related-objects.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-realm-object-with-related-objects.kt
@@ -1,0 +1,13 @@
+// Open a write transaction
+realm.write {
+    // Query for the parent frog object with ponds
+    val parentObject = query<Frog>("_id == $0", PRIMARY_KEY_VALUE).find().first()
+    assertEquals(2, parentObject.favoritePonds.size)
+
+    // Delete the frog
+    delete(parentObject)
+
+    // Confirm all ponds are still in the realm
+    val ponds = query<Pond>().find()
+    assertEquals(2, ponds.size)
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.delete-realmany-property.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.delete-realmany-property.kt
@@ -1,0 +1,4 @@
+realm.write {
+    val frog = query<Frog>().find().first()
+    frog.favoriteThings[0] = null
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.fetch-latest-to-delete-object.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.fetch-latest-to-delete-object.kt
@@ -1,9 +1,10 @@
-val frozenFrog = realm.query<Frog>("name == $0", "Kermit").find().first()
+val frozenFrog = realm.query<Frog>("name == $0", "Kermit").find().firstOrNull()
 
 // Open a write transaction
 realm.writeBlocking {
     // Get the live frog object with findLatest(), then delete it
-    findLatest(frozenFrog)?.let { liveFrog ->
-        delete(liveFrog)
+    if (frozenFrog != null) {
+        findLatest(frozenFrog)
+            ?.also { delete(it) }
     }
 }

--- a/source/examples/generated/kotlin/DeleteTest.snippet.fetch-latest-to-delete-object.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.fetch-latest-to-delete-object.kt
@@ -1,0 +1,9 @@
+val frozenFrog = realm.query<Frog>("name == $0", "Kermit").find().first()
+
+// Open a write transaction
+realm.writeBlocking {
+    // Get the live frog object with findLatest(), then delete it
+    findLatest(frozenFrog)?.let { liveFrog ->
+        delete(liveFrog)
+    }
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.list-clear.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.list-clear.kt
@@ -1,0 +1,10 @@
+// Open a write transaction
+realm.write {
+    val forest = query<Forest>("name == $0", "Hundred Acre Wood").find().first()
+    val forestPonds = forest.nearbyPonds
+    assertEquals(5, forestPonds.size)
+
+    // Clear all ponds from the list
+    forestPonds.clear()
+    assertEquals(0, forestPonds.size)
+}

--- a/source/examples/generated/kotlin/DeleteTest.snippet.remove-item-from-set.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.remove-item-from-set.kt
@@ -1,12 +1,16 @@
+// Open a write transaction
 realm.write {
-    val myFrog = realm.query<Frog>("name == $0", "Kermit").find().first()
-    val snackSet = findLatest(myFrog)!!.favoriteSnacks
+    // Query for the parent frog object
+    val myFrog = query<RealmSet_Frog>("name == $0", "Kermit").find().first()
+    val snackSet = myFrog.favoriteSnacks
+    assertEquals(3, snackSet.size)
 
-    // Remove the Flies snack from the set
-    val fliesSnack = snackSet.first { it.name == "Flies" }
-    snackSet.remove(fliesSnack)
+    // Remove one snack from the set
+    snackSet.remove(snackSet.first { it.name == "Flies" })
+    assertEquals(2, snackSet.size)
 
-    // Remove all snacks from the set
+    // Remove the remaining two snacks from the set
     val allSnacks = findLatest(myFrog)!!.favoriteSnacks
     snackSet.removeAll(allSnacks)
+    assertEquals(0, snackSet.size)
 }

--- a/source/examples/generated/kotlin/DeleteTest.snippet.remove-items-from-list.kt
+++ b/source/examples/generated/kotlin/DeleteTest.snippet.remove-items-from-list.kt
@@ -1,0 +1,20 @@
+// Open a write transaction
+realm.write {
+    // Query for the parent forest object
+    val forest = query<Forest>("name == $0", "Hundred Acre Wood").find().first()
+    val forestPonds = forest.nearbyPonds
+    assertEquals(5, forestPonds.size)
+
+    // Remove the first pond in the list
+    val removeFirstPond = forestPonds.first()
+    forestPonds.remove(removeFirstPond)
+    assertEquals(4, forestPonds.size)
+
+    // Remove the pond at index 2 in the list
+    forestPonds.removeAt(2)
+    assertEquals(3, forestPonds.size)
+
+    // Remove the remaining three ponds in the list
+    forestPonds.removeAll(forestPonds)
+    assertEquals(0, forestPonds.size)
+}

--- a/source/sdk/kotlin/realm-database/crud/delete.txt
+++ b/source/sdk/kotlin/realm-database/crud/delete.txt
@@ -7,87 +7,88 @@ Delete Realm Objects - Kotlin SDK
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
-This page describes how to delete managed objects from a local or synced realm 
+This page describes how to delete objects from a local or synced realm 
 using the Kotlin SDK. 
 
 You can choose to delete a single object, multiple objects, or all 
 objects from the realm. After you delete an object, you can no longer access or 
 modify it. If you try to use a deleted object, Realm throws an error.
 
-.. note:: Deleting Objects Does NOT Delete the Realm File
+Deleting objects from a realm *does not* delete the realm file
+or affect the realm schema. It only deletes the object instance from the 
+realm. If you want to delete the realm file itself,
+refer to :ref:`<kotlin-delete-a-realm>`.
 
-   Deleting objects from a realm *does not* delete the realm file
-   or affect the realm schema. It only deletes the object instance from the 
-   realm. If you want to delete the realm file itself,
-   refer to :ref:`<kotlin-delete-a-realm>`.
+Write Transactions
+------------------
 
-.. _kotlin-delete-operations:
+All operations that modify a realm - including delete operations - 
+must be performed inside of a write transaction. Write transactions
+are passed to the realm's 
+`write() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write.html>`__ 
+or 
+`writeBlocking() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write-blocking.html>`__
+method. Within this callback, you can access a 
+`MutableRealm <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/index.html>`__
+instance, and then delete objects within the realm. For more information on 
+write transactions and how Realm handles them, refer to 
+:ref:`<kotlin-write-transactions>`.
 
-Delete Operations
------------------
+.. note:: Write to a Synced Realm
 
-Like :ref:`update <kotlin-update-objects>` operations, which also modify 
-the state of the realm, delete operations require the following:
+   The syntax to delete an object from a realm is the same for a local or
+   a synced realm. However, there are additional considerations that determine
+   whether the delete operation in a synced realm is successful. For more 
+   information, refer to :ref:`<kotlin-write-synced-realm>`.
 
-- You can only perform a delete operation on a ``mutableRealm`` accessed 
-  within a :ref:`write transaction <kotlin-write-transactions>`.
-- You can only delete live objects, which are only accessible inside of a 
-  write transaction. You can convert a frozen object to a 
-  live object in a transaction with `mutableRealm.findLatest()
-  <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/find-latest.html>`__.
-  For more information, refer to :ref:`<kotlin-frozen-architecture>`.
+You can only delete live objects, which are only accessible inside of a 
+write transaction. You can convert a frozen object to a 
+live object in a transaction with `mutableRealm.findLatest()
+<{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/find-latest.html>`__.
 
-  .. example:: Convert Frozen Object Before Deleting
-   
-   .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-an-object.kt
+.. example:: Convert Frozen Object Before Deleting
+
+   .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.fetch-latest-to-delete-object.kt
       :language: kotlin
-
-Realm supports the deletion of one or more ``RealmObject`` or 
-``EmbeddedRealmObject`` instances, a ``RealmList`` or ``RealmSet`` collection, 
-``RealmQuery``, or ``RealmResults`` instances.
-
-Generally, you delete objects from a realm by querying for the one or more 
-objects that you want to delete, and then passing the results to ``delete()``. 
-For more information on querying with the Kotlin SDK, refer to 
-:ref:`<kotlin-read>`.
-
-
-
-
-
-
-You cannot directly add or remove items from a backlinks collection. The collection automatically updates itself when relationships are changed.
 
 Related Objects and References
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Realm supports :ref:`relationships <kotlin-relationships>` between an 
-objects. In general, if you delete an 
-object with a property that references another object,
-Realm only deletes the object reference (or pointer). Realm *does not* 
-delete the instance of the related object for you unless the 
-related object is :ref:`embedded <kotlin-embedded-objects>`. Refer to the 
-:ref:`<kotlin-delete-embedded-object>` section for
-more information.
+When you delete an object that has a :ref:`relationship <kotlin-relationships>` 
+property with another object, Realm *does not* automatically 
+delete the instance of the related object. Instead, Realm only
+deletes the reference to the other object. The referenced object remains in the 
+realm, but it can no longer be queried through the parent property.
 
-If you you want to delete any related objects when you delete a parent object, 
-you can manually perform what we call a **chaining delete**. If you do not 
-delete the related objects yourself, they remain orphaned in your realm. 
-Whether or not this is a problem depends on your application's needs.
+The only exception is if the related object is 
+:ref:`embedded <kotlin-embedded-objects>`. When you delete an object that 
+has a relationship with an ``EmbeddedRealmObject``, Realm automatically 
+deletes the embedded object in a cascading delete. For more information, 
+refer to the :ref:`<kotlin-delete-embedded-objects>` section on this page.
 
-We recommend deleting dependent objects by iterating through the 
+Chaining Deletes with Related Realm Objects
+```````````````````````````````````````````
+
+If you want to delete any related objects when you delete a parent object, 
+we recommend performing a **chaining delete**. A chaining delete consists 
+of manually deleting dependent objects by iterating through the 
 dependencies and deleting them before deleting the parent object.
-Refer to the :ref:`<kotlin-delete-related-objects>` section for more information.
+For more information on chaining deletes, refer to the 
+:ref:`<kotlin-delete-related-objects>` section on this page.
+
+If you do not delete the related objects yourself, they remain 
+orphaned in your realm. Whether or not this is a problem depends on 
+your application's needs.
 
 .. _kotlin-delete-an-object:
 
 Delete Realm Objects
 --------------------
 
-To delete objects from a realm:
+To delete specific objects from a realm:
 
 1. Open a write transaction with `realm.write()
    <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write.html>`__ or
@@ -95,17 +96,17 @@ To delete objects from a realm:
    <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write-blocking.html>`__.
 
 #. Get the live objects by querying the transaction's mutable realm 
-   for the one or more objects that you want to delete using 
+   for the objects that you want to delete using 
    `query() <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-query/query.html>`__:
    
    #. Specify the object type as a type parameter passed to ``query()``.
    #. (Optional) Filter the set of returned objects by specifying a query. 
       If you don't include a query filter, you return all objects of the 
-      specified type.
+      specified type. For more information on querying with the Kotlin SDK, refer to :ref:`<kotlin-read-objects>`.
 
    .. important:: Objects Must Be Live
       
-      You can only delete live objects. If your query occurred outside of the 
+      You can only delete live objects. If your query occurs outside of the 
       write transaction, you must convert the frozen objects 
       to live objects in the transaction with 
       ``mutableRealm.findLatest()``.
@@ -116,7 +117,13 @@ To delete objects from a realm:
    `mutableRealm.delete() <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/delete.html>`__.
 
 #. The specified objects are deleted from the realm and can no longer be accessed 
-   or modified.
+   or modified. If you try to use a deleted object, Realm throws an error.
+   
+   If any deleted objects had a relationship with another object, Realm 
+   only deletes the reference to the other object. The referenced object
+   remains in the realm, but it can no longer be queried through the deleted 
+   parent property. Refer to the :ref:`<kotlin-delete-related-objects>` section
+   for more information.
 
 .. tip:: 
 
@@ -142,18 +149,7 @@ In the following example, we query for a ``Frog`` object named
 "Kermit", and then pass the returned object to ``mutableRealm.delete()`` to 
 delete it from the realm: 
 
-.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-an-object.kt
-   :language: kotlin
-
-If the object has a relationship property with another object, Realm only
-deletes the reference to the other object. The referenced object remains in the 
-realm, but it can no longer be queried through the parent property.
-
-In the following example, we query for a ``Frog`` object contains 
-a ``favoritePond`` property that contains a ``Pond`` object.
-When we delete the ``Frog`` object, the ``Pond`` object remains in the realm:
-
-.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realm-object-with-related-objects.kt
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-one-realm-object.kt
    :language: kotlin
 
 .. _kotlin-delete-multiple-objects:
@@ -162,13 +158,14 @@ Delete Multiple Objects
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 To delete multiple objects at the same time, pass the object type to 
-``query()`` and specify a query that returns the objects that you want to delete.
+``query()`` and specify a query that returns all objects that you want 
+to delete.
 
 In the following example, we query for the first 3 ``Frog`` objects whose 
 ``species`` is "bullfrog", and then pass the results to 
 ``mutableRealm.delete()`` to delete them from the realm: 
 
-.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-an-object.kt
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-multiple-realm-objects.kt
    :language: kotlin
 
 .. _kotlin-delete-all-objects-of-a-type:
@@ -176,14 +173,14 @@ In the following example, we query for the first 3 ``Frog`` objects whose
 Delete All Objects of a Type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To delete all objects of a type from a realm at the same time, pass the 
+To delete all objects of a specific type from a realm at the same time, pass the 
 object type to ``query()`` and leave the query filter empty to return all 
 objects of that type.
 
 In the following example, we query for all ``Frog`` objects, and then pass
 the results to ``mutableRealm.delete()`` to delete them all from the realm:
 
-.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-an-object.kt
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-all-realm-object-types.kt
    :language: kotlin
 
 .. _kotlin-delete-all-objects-in-the-realm:
@@ -196,7 +193,12 @@ for quickly clearing out your realm while prototyping. This does not affect
 the realm schema or any objects that are not managed by the realm.
 
 To delete *all* objects from the realm at the same time, call 
-`mutableRealm.deleteAll() <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/delete-all.html>`__.
+`mutableRealm.deleteAll() <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/delete-all.html>`__. This deletes all objects of all types.
+
+In the following example, we delete all objects from the realm with ``deleteAll()``:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-all-realm-objects.kt
+   :language: kotlin
 
 .. tip:: Use deleteAll() in Development
          
@@ -208,42 +210,38 @@ To delete *all* objects from the realm at the same time, call
 Remove Elements from Collections
 --------------------------------
 
-Realm collection instances that contain Realm objects only store 
-references to those objects. Realm only removes the references to the
-objects. It does not delete the objects themselves.
-
-When you delete an object that contains a collection property such as a 
-``RealmList`` or ``RealmSet``, Realm only deletes the object references. 
-
-To delete the collection elements themselves, you must delete them
-manually.
-
+Realm collection instances that contain objects only store 
+references to those objects. You can remove one or more referenced 
+objects from a collection without deleting the objects themselves.
+The objects that you remove from a collection remain in the realm
+until you manually delete them. Alternatively, deleting a Realm object from a 
+realm also deletes that object from any collection instances that contain 
+the object.
 
 Remove Items from a RealmList
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+You can remove one or more items from a ``RealmList`` at a time:
 
-
-You can delete one or more items from a ``RealmSet`` at a time:
-
-- To remove one item from a ``RealmSet``, pass the element 
-  you want to delete to 
+- To remove one item from the list, pass the element to 
   `list.remove() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#731697687%2FFunctions%2F878332154>`__.
-- To remove multiple items from a ``RealmSet``, pass the 
-  elements you want to delete to
+- To remove one item at a specified index in the list, pass the index to 
+  `list.removeAt() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#-209439875%2FFunctions%2F878332154>`__.
+- To remove multiple items from the list, pass the elements to
   `list.removeAll() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#1522148962%2FFunctions%2F878332154>`__.
 
-  `list.removeAt() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#-1899070414%2FFunctions%2F878332154>`__.
+In the following example, we have a ``Forest`` object with a list of 
+``Pond`` objects. We remove the list elements in a series of operations until the 
+list is empty:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.remove-items-from-list.kt
    :language: kotlin
 
+You can also remove *all* list elements at once by calling
+`list.clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#-35526398%2FFunctions%2F878332154>`__.
 
 In the following example, we have a ``Forest`` object with a list of 
-``Pond`` objects: 
-
-You can also remove all list elements at once by calling
-`list.clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#-35526398%2FFunctions%2F878332154>`__: 
+``Pond`` objects. We remove all list elements with the ``list.clear()`` method:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.list-clear.kt
    :language: kotlin
@@ -251,48 +249,82 @@ You can also remove all list elements at once by calling
 Remove Items from a RealmSet
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:ref:`RealmSet <kotlin-realm-set>` instances that contain Realm objects 
-only store references to those objects, so deleting a Realm object from a 
-realm also deletes that object from any ``RealmSet`` instances that contain 
-the object.
+You can remove one or more items from a ``RealmSet`` at a time:
 
-You can delete one or more items from a ``RealmSet`` at a time:
-
-- To remove one item from a ``RealmSet``, pass the element 
+- To remove one item from the set, pass the element 
   you want to delete to 
   `set.remove() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html#-1503494415%2FFunctions%2F-1651551339>`__.
-- To remove multiple items from a ``RealmSet``, pass the 
+- To remove multiple items from the set, pass the 
   elements you want to delete to
   `set.removeAll() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html#430447804%2FFunctions%2F-1651551339>`__.
+
+In the following example, we have a ``Frog`` object with a set of 
+``Snack`` objects. We remove the set elements in a series of operations until the
+set is empty:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.remove-item-from-set.kt
    :language: kotlin
 
-Alternatively, you can use 
-`set.clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html#-767459876%2FFunctions%2F878332154>`__ 
-to clear all items from a ``RealmSet``: 
+You can also remove *all* set elements at once by calling
+`set.clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html#-767459876%2FFunctions%2F878332154>`__.
+
+In the following example, we have a ``Frog`` object with a set of 
+``Snack`` objects. We remove all set elements with the ``set.clear()`` method:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.clear-set.kt
    :language: kotlin
 
 .. _kotlin-delete-dictionary-keys-values:
 
-Delete Dictionary Keys/Values
+Remove Dictionary Keys/Values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can delete 
-`RealmDictionary <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html>`__ 
-entries in a few ways:
+You can remove ``RealmDictionary`` entries in a few ways:
 
-- Use ``remove()`` to remove the key and the value
-- If the dictionary's value is nullable, you can set the value of the key to ``null`` to keep the key.
-- Use ``clear()`` to remove all keys and values
+- If the dictionary's value is nullable, set the value of the key to ``null`` to keep the key
+- Use `remove() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html#-2016920067%2FFunctions%2F878332154>`__ 
+  to remove the key and the value
+- Use `clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html#1264776610%2FFunctions%2F878332154>`__  
+  to remove all keys and values
+
+In the following example, we have a ``Frog`` object with a dictionary of 
+``String`` values. We remove the dictionary elements in a series of operations 
+until the dictionary is empty:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realm-dictionary.kt
    :language: kotlin
 
+.. _kotlin-delete-related-objects:
+
 Delete Related Objects
 ----------------------
+
+Deleting a parent object *does not* automatically delete any objects that are
+related to it unless the related object is embedded. 
+Instead, Realm only deletes the reference to the related object.
+
+In the following example, we have a ``Frog`` object with a list of 
+``Pond`` objects. After we delete the ``Frog`` object, we confirm that all 
+``Pond`` objects still remain in the realm:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realm-object-with-related-objects.kt
+   :language: kotlin
+
+To delete related objects when you delete a parent object, you must manually
+delete the related objects yourself. We recommend performing a **chaining delete**.
+To perform a chaining delete, you first query for the parent object
+that you want to delete, then iterate through the parent object's
+relationships and delete each related object. Finally, delete the parent
+object itself.
+
+In the following example, we query for a ``Frog`` object named "Kermit", then
+iterate through the object's ``favoritePonds`` property, and delete
+each ``Pond`` object. Then, we delete the ``Frog`` object itself:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.chain-delete-realm-list.kt
+   :language: kotlin
+
+.. _kotlin-delete-embedded-objects:
 
 Delete an Embedded Object
 -------------------------
@@ -305,15 +337,22 @@ Delete an Embedded Object
    parent object, use a regular Realm object with a :ref:`to-one relationship 
    <kotlin-to-one-relationship>` instead.
 
-You can delete an 
-`EmbeddedRealmObject.parent() <{+kotlin-local-prefix+}io.realm.kotlin.ext/parent.html>`__  
-directly or through the parent object. 
+You can delete an embedded object directly:
 
-To delete only an embedded object, you can fetch and delete a specific 
-embedded object or clear the parent's reference to the embedded object, 
-which also deletes the embedded object instance.  
+- Fetch and delete a specific embedded object
+- Clear the parent's reference to the embedded object, which also deletes the embedded object instance.  
 
-Deleting the parent object automatically deletes all of its embedded objects. 
+Alternatively, you can delete the parent object, which automatically deletes all 
+of its embedded objects. 
 
-.. literalinclude:: /examples/generated/kotlin/DataTypesTest.snippet.delete-embedded-object.kt 
+In the following example, we have a ``Contact`` object with an embedded 
+``Address`` object and a ``Business`` object with a list of embedded 
+``Contact`` objects:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object.kt 
     :language: kotlin
+
+.. tip:: Get Embedded Object's Parent
+
+   You can get the unique parent of an embedded object using 
+   `parent() <{+kotlin-local-prefix+}io.realm.kotlin.ext/parent.html>`__.

--- a/source/sdk/kotlin/realm-database/crud/delete.txt
+++ b/source/sdk/kotlin/realm-database/crud/delete.txt
@@ -161,7 +161,7 @@ To delete multiple objects at the same time, pass the object type to
 ``query()`` and specify a query that returns all objects that you want 
 to delete.
 
-In the following example, we query for the first 3 ``Frog`` objects whose 
+In the following example, we query for the first three ``Frog`` objects whose 
 ``species`` is "bullfrog", and then pass the results to 
 ``mutableRealm.delete()`` to delete them from the realm: 
 
@@ -302,7 +302,7 @@ You can remove one or more items from a ``RealmList`` at a time:
 - To remove one item from the list, pass the element to 
   `list.remove() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#731697687%2FFunctions%2F878332154>`__.
 - To remove one item at a specified index in the list, pass the index to 
-  `list.removeAt() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#-209439875%2FFunctions%2F878332154>`__.
+  `list.removeAt() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#1522148962%2FFunctions%2F878332154>`__.
 - To remove multiple items from the list, pass the elements to
   `list.removeAll() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#1522148962%2FFunctions%2F878332154>`__.
 

--- a/source/sdk/kotlin/realm-database/crud/delete.txt
+++ b/source/sdk/kotlin/realm-database/crud/delete.txt
@@ -10,93 +10,246 @@ Delete Realm Objects - Kotlin SDK
    :depth: 1
    :class: singlecol
 
-.. note::
+This page describes how to delete managed objects from a local or synced realm 
+using the Kotlin SDK. 
 
-   You can only delete objects from a realm within a
-   :ref:`write transaction <kotlin-write-transactions>`.
+You can choose to delete a single object, multiple objects, or all 
+objects from the realm. After you delete an object, you can no longer access or 
+modify it. If you try to use a deleted object, Realm throws an error.
 
-To delete a realm file, refer to :ref:`Delete a Realm <kotlin-delete-a-realm>`.
+.. note:: Deleting Objects Does NOT Delete the Realm File
+
+   Deleting objects from a realm *does not* delete the realm file
+   or affect the realm schema. It only deletes the object instance from the 
+   realm. If you want to delete the realm file itself,
+   refer to :ref:`<kotlin-delete-a-realm>`.
+
+.. _kotlin-delete-operations:
+
+Delete Operations
+-----------------
+
+Like :ref:`update <kotlin-update-objects>` operations, which also modify 
+the state of the realm, delete operations require the following:
+
+- You can only perform a delete operation on a ``mutableRealm`` accessed 
+  within a :ref:`write transaction <kotlin-write-transactions>`.
+- You can only delete live objects, which are only accessible inside of a 
+  write transaction. You can convert a frozen object to a 
+  live object in a transaction with `mutableRealm.findLatest()
+  <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/find-latest.html>`__.
+  For more information, refer to :ref:`<kotlin-frozen-architecture>`.
+
+  .. example:: Convert Frozen Object Before Deleting
+   
+   .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-an-object.kt
+      :language: kotlin
+
+Realm supports the deletion of one or more ``RealmObject`` or 
+``EmbeddedRealmObject`` instances, a ``RealmList`` or ``RealmSet`` collection, 
+``RealmQuery``, or ``RealmResults`` instances.
+
+Generally, you delete objects from a realm by querying for the one or more 
+objects that you want to delete, and then passing the results to ``delete()``. 
+For more information on querying with the Kotlin SDK, refer to 
+:ref:`<kotlin-read>`.
+
+
+
+
+
+
+You cannot directly add or remove items from a backlinks collection. The collection automatically updates itself when relationships are changed.
+
+Related Objects and References
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Realm supports :ref:`relationships <kotlin-relationships>` between an 
+objects. In general, if you delete an 
+object with a property that references another object,
+Realm only deletes the object reference (or pointer). Realm *does not* 
+delete the instance of the related object for you unless the 
+related object is :ref:`embedded <kotlin-embedded-objects>`. Refer to the 
+:ref:`<kotlin-delete-embedded-object>` section for
+more information.
+
+If you you want to delete any related objects when you delete a parent object, 
+you can manually perform what we call a **chaining delete**. If you do not 
+delete the related objects yourself, they remain orphaned in your realm. 
+Whether or not this is a problem depends on your application's needs.
+
+We recommend deleting dependent objects by iterating through the 
+dependencies and deleting them before deleting the parent object.
+Refer to the :ref:`<kotlin-delete-related-objects>` section for more information.
 
 .. _kotlin-delete-an-object:
 
-Delete a Single Object
-----------------------
+Delete Realm Objects
+--------------------
 
-To delete an object from a realm:
+To delete objects from a realm:
 
 1. Open a write transaction with `realm.write()
    <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write.html>`__ or
    `realm.writeBlocking()
    <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write-blocking.html>`__.
 
-#. Query the transaction's mutable realm for the object you want to delete
-   with `realm.query()
-   <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-query/query.html>`__.
-   Specify the object type as a type parameter passed to :file:`query()`.
-   Filter the set of returned objects by specifying a query. To ensure
-   your query returns the correct object, filter with unique identifying
-   information such as a primary key value.
+#. Get the live objects by querying the transaction's mutable realm 
+   for the one or more objects that you want to delete using 
+   `query() <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-query/query.html>`__:
+   
+   #. Specify the object type as a type parameter passed to ``query()``.
+   #. (Optional) Filter the set of returned objects by specifying a query. 
+      If you don't include a query filter, you return all objects of the 
+      specified type.
+
+   .. important:: Objects Must Be Live
+      
+      You can only delete live objects. If your query occurred outside of the 
+      write transaction, you must convert the frozen objects 
+      to live objects in the transaction with 
+      ``mutableRealm.findLatest()``.
 
 #. Pass the set of `RealmResults
    <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-results/index.html>`__
-   returned by the query to `mutableRealm.delete() <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/delete.html>`__
+   returned by the query to 
+   `mutableRealm.delete() <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/delete.html>`__.
 
-.. literalinclude:: /examples/generated/kotlin/CRUDTest.snippet.delete-an-object.kt
+#. The specified objects are deleted from the realm and can no longer be accessed 
+   or modified.
+
+.. tip:: 
+
+   You can check whether an object is still valid to use by calling 
+   `isValid() <{+kotlin-local-prefix+}io.realm.kotlin.ext/is-valid.html>`__.
+   Deleted items return ``false``.
+
+.. _kotlin-delete-a-single-object:
+
+Delete a Single Object 
+~~~~~~~~~~~~~~~~~~~~~~
+
+To delete a single ``RealmObject`` object, 
+query for the object type using a filter 
+that returns the specific object that you want to delete.
+
+.. tip:: Use Unique Identifying Information
+
+   We recommend filtering with unique identifying information such as 
+   a primary key value to ensure your query returns the correct object.
+
+In the following example, we query for a ``Frog`` object named
+"Kermit", and then pass the returned object to ``mutableRealm.delete()`` to 
+delete it from the realm: 
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-an-object.kt
+   :language: kotlin
+
+If the object has a relationship property with another object, Realm only
+deletes the reference to the other object. The referenced object remains in the 
+realm, but it can no longer be queried through the parent property.
+
+In the following example, we query for a ``Frog`` object contains 
+a ``favoritePond`` property that contains a ``Pond`` object.
+When we delete the ``Frog`` object, the ``Pond`` object remains in the realm:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realm-object-with-related-objects.kt
    :language: kotlin
 
 .. _kotlin-delete-multiple-objects:
 
 Delete Multiple Objects
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
-To delete multiple objects from a realm at the same time:
+To delete multiple objects at the same time, pass the object type to 
+``query()`` and specify a query that returns the objects that you want to delete.
 
-1. Open a write transaction with `realm.write()
-   <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write.html>`__ or
-   `realm.writeBlocking()
-   <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write-blocking.html>`__.
+In the following example, we query for the first 3 ``Frog`` objects whose 
+``species`` is "bullfrog", and then pass the results to 
+``mutableRealm.delete()`` to delete them from the realm: 
 
-#. Query the transaction's mutable realm for the objects you want to delete
-   with `realm.query()
-   <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-query/query.html>`__.
-   Specify the object type as a type parameter passed to :file:`query()`.
-   Filter the set of returned objects by specifying a query.
-
-#. Delete the set of `RealmResults
-   <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-results/index.html>`__
-   returned by the query with `realmResults.delete()
-   <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/delete.html>`__.
-
-.. literalinclude:: /examples/generated/kotlin/CRUDTest.snippet.delete-multiple-objects.kt
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-an-object.kt
    :language: kotlin
 
 .. _kotlin-delete-all-objects-of-a-type:
 
 Delete All Objects of a Type
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To delete all objects of a type from a realm:
+To delete all objects of a type from a realm at the same time, pass the 
+object type to ``query()`` and leave the query filter empty to return all 
+objects of that type.
 
-1. Open a write transaction with `realm.write()
-   <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write.html>`__ or
-   `realm.writeBlocking()
-   <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write-blocking.html>`__.
+In the following example, we query for all ``Frog`` objects, and then pass
+the results to ``mutableRealm.delete()`` to delete them all from the realm:
 
-#. Query the transaction's mutable realm for all objects of that type
-   with `realm.query()
-   <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-query/query.html>`__.
-   Specify the object type as a type parameter passed to :file:`query()`.
-
-#. Delete the set of `RealmResults
-   <{+kotlin-local-prefix+}io.realm.kotlin.query/-realm-results/index.html>`__
-   returned by the query with `mutableRealm.delete()
-   <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/index.html#-181441016%2FFunctions%2F-1651551339>`__.
-
-.. literalinclude:: /examples/generated/kotlin/CRUDTest.snippet.delete-all-objects-of-a-type.kt
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-an-object.kt
    :language: kotlin
 
-Delete Items from a RealmSet
-----------------------------
+.. _kotlin-delete-all-objects-in-the-realm:
+
+Delete All Objects in a Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Kotlin SDK lets you delete all managed objects of all types, which is useful 
+for quickly clearing out your realm while prototyping. This does not affect
+the realm schema or any objects that are not managed by the realm.
+
+To delete *all* objects from the realm at the same time, call 
+`mutableRealm.deleteAll() <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/delete-all.html>`__.
+
+.. tip:: Use deleteAll() in Development
+         
+   The ``deleteAll()`` method is useful for quickly clearing out 
+   your realm during development. For example, instead of writing 
+   a migration to update objects to a new schema, it may be faster to 
+   delete all, and then re-generate the objects with the app itself.
+
+Remove Elements from Collections
+--------------------------------
+
+Realm collection instances that contain Realm objects only store 
+references to those objects. Realm only removes the references to the
+objects. It does not delete the objects themselves.
+
+When you delete an object that contains a collection property such as a 
+``RealmList`` or ``RealmSet``, Realm only deletes the object references. 
+
+To delete the collection elements themselves, you must delete them
+manually.
+
+
+Remove Items from a RealmList
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+You can delete one or more items from a ``RealmSet`` at a time:
+
+- To remove one item from a ``RealmSet``, pass the element 
+  you want to delete to 
+  `list.remove() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#731697687%2FFunctions%2F878332154>`__.
+- To remove multiple items from a ``RealmSet``, pass the 
+  elements you want to delete to
+  `list.removeAll() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#1522148962%2FFunctions%2F878332154>`__.
+
+  `list.removeAt() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#-1899070414%2FFunctions%2F878332154>`__.
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.remove-items-from-list.kt
+   :language: kotlin
+
+
+In the following example, we have a ``Forest`` object with a list of 
+``Pond`` objects: 
+
+You can also remove all list elements at once by calling
+`list.clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#-35526398%2FFunctions%2F878332154>`__: 
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.list-clear.kt
+   :language: kotlin
+
+Remove Items from a RealmSet
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :ref:`RealmSet <kotlin-realm-set>` instances that contain Realm objects 
 only store references to those objects, so deleting a Realm object from a 
@@ -125,7 +278,7 @@ to clear all items from a ``RealmSet``:
 .. _kotlin-delete-dictionary-keys-values:
 
 Delete Dictionary Keys/Values
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can delete 
 `RealmDictionary <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html>`__ 
@@ -137,6 +290,9 @@ entries in a few ways:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realm-dictionary.kt
    :language: kotlin
+
+Delete Related Objects
+----------------------
 
 Delete an Embedded Object
 -------------------------

--- a/source/sdk/kotlin/realm-database/crud/delete.txt
+++ b/source/sdk/kotlin/realm-database/crud/delete.txt
@@ -22,6 +22,13 @@ or affect the realm schema. It only deletes the object instance from the
 realm. If you want to delete the realm file itself,
 refer to :ref:`<kotlin-delete-a-realm>`.
 
+.. note:: Write to a Synced Realm
+
+   The syntax to delete an object from a realm is the same for a local or
+   a synced realm. However, there are additional considerations that determine
+   whether the delete operation in a synced realm is successful. For more 
+   information, refer to :ref:`<kotlin-write-synced-realm>`.
+
 Write Transactions
 ------------------
 
@@ -36,13 +43,6 @@ method. Within this callback, you can access a
 instance, and then delete objects within the realm. For more information on 
 write transactions and how Realm handles them, refer to 
 :ref:`<kotlin-write-transactions>`.
-
-.. note:: Write to a Synced Realm
-
-   The syntax to delete an object from a realm is the same for a local or
-   a synced realm. However, there are additional considerations that determine
-   whether the delete operation in a synced realm is successful. For more 
-   information, refer to :ref:`<kotlin-write-synced-realm>`.
 
 You can only delete live objects, which are only accessible inside of a 
 write transaction. You can convert a frozen object to a 
@@ -207,6 +207,72 @@ In the following example, we delete all objects from the realm with ``deleteAll(
    a migration to update objects to a new schema, it may be faster to 
    delete all, and then re-generate the objects with the app itself.
 
+Delete Related Objects
+----------------------
+
+Deleting a parent object *does not* automatically delete any objects that are
+related to it unless the related object is embedded. 
+Instead, Realm only deletes the reference to the related object.
+
+In the following example, we have a ``Frog`` object with a list of 
+``Pond`` objects. After we delete the ``Frog`` object, we confirm that all 
+``Pond`` objects still remain in the realm:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realm-object-with-related-objects.kt
+   :language: kotlin
+
+.. _kotlin-delete-related-objects:
+
+Delete an Object and Its Related Objects
+----------------------------------------
+
+To delete related objects when you delete a parent object, you must manually
+delete the related objects yourself. We recommend performing a **chaining delete**.
+To perform a chaining delete, you first query for the parent object
+that you want to delete, then iterate through the parent object's
+relationships and delete each related object. Finally, delete the parent
+object itself.
+
+In the following example, we query for a ``Frog`` object named "Kermit", then
+iterate through the object's ``favoritePonds`` property, and delete
+each ``Pond`` object. Then, we delete the ``Frog`` object itself:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.chain-delete-realm-list.kt
+   :language: kotlin
+
+.. _kotlin-delete-embedded-objects:
+
+Delete an Embedded Object
+-------------------------
+
+.. warning:: Realm Uses Cascading Deletes for Embedded Objects
+
+   When you delete a Realm object, Realm automatically deletes any
+   embedded objects referenced by that object. 
+   If you want the referenced objects to persist after the deletion of the 
+   parent object, use a regular Realm object with a :ref:`to-one relationship 
+   <kotlin-to-one-relationship>` instead.
+
+You can delete an embedded object directly:
+
+- Fetch and delete a specific embedded object
+- Clear the parent's reference to the embedded object, which also deletes the embedded object instance.  
+
+Alternatively, you can delete the parent object, which automatically deletes all 
+of its embedded objects. 
+
+In the following example, we have a ``Contact`` object with an embedded 
+``Address`` object and a ``Business`` object with a list of embedded 
+``Contact`` objects:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object.kt 
+    :language: kotlin
+
+.. tip:: Get Embedded Object's Parent
+
+   You can get the unique parent of an embedded object using 
+   `parent() <{+kotlin-local-prefix+}io.realm.kotlin.ext/parent.html>`__.
+
 Remove Elements from Collections
 --------------------------------
 
@@ -293,66 +359,3 @@ until the dictionary is empty:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realm-dictionary.kt
    :language: kotlin
-
-.. _kotlin-delete-related-objects:
-
-Delete Related Objects
-----------------------
-
-Deleting a parent object *does not* automatically delete any objects that are
-related to it unless the related object is embedded. 
-Instead, Realm only deletes the reference to the related object.
-
-In the following example, we have a ``Frog`` object with a list of 
-``Pond`` objects. After we delete the ``Frog`` object, we confirm that all 
-``Pond`` objects still remain in the realm:
-
-.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realm-object-with-related-objects.kt
-   :language: kotlin
-
-To delete related objects when you delete a parent object, you must manually
-delete the related objects yourself. We recommend performing a **chaining delete**.
-To perform a chaining delete, you first query for the parent object
-that you want to delete, then iterate through the parent object's
-relationships and delete each related object. Finally, delete the parent
-object itself.
-
-In the following example, we query for a ``Frog`` object named "Kermit", then
-iterate through the object's ``favoritePonds`` property, and delete
-each ``Pond`` object. Then, we delete the ``Frog`` object itself:
-
-.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.chain-delete-realm-list.kt
-   :language: kotlin
-
-.. _kotlin-delete-embedded-objects:
-
-Delete an Embedded Object
--------------------------
-
-.. warning:: Realm Uses Cascading Deletes for Embedded Objects
-
-   When you delete a Realm object, Realm automatically deletes any
-   embedded objects referenced by that object. 
-   If you want the referenced objects to persist after the deletion of the 
-   parent object, use a regular Realm object with a :ref:`to-one relationship 
-   <kotlin-to-one-relationship>` instead.
-
-You can delete an embedded object directly:
-
-- Fetch and delete a specific embedded object
-- Clear the parent's reference to the embedded object, which also deletes the embedded object instance.  
-
-Alternatively, you can delete the parent object, which automatically deletes all 
-of its embedded objects. 
-
-In the following example, we have a ``Contact`` object with an embedded 
-``Address`` object and a ``Business`` object with a list of embedded 
-``Contact`` objects:
-
-.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object.kt 
-    :language: kotlin
-
-.. tip:: Get Embedded Object's Parent
-
-   You can get the unique parent of an embedded object using 
-   `parent() <{+kotlin-local-prefix+}io.realm.kotlin.ext/parent.html>`__.

--- a/source/sdk/kotlin/realm-database/crud/delete.txt
+++ b/source/sdk/kotlin/realm-database/crud/delete.txt
@@ -29,18 +29,18 @@ refer to :ref:`<kotlin-delete-a-realm>`.
    whether the delete operation in a synced realm is successful. For more 
    information, refer to :ref:`<kotlin-write-synced-realm>`.
 
-Write Transactions
-------------------
+Delete Operations
+-----------------
 
 All operations that modify a realm - including delete operations - 
-must be performed inside of a write transaction. Write transactions
+must be performed inside of a **write transaction**. Write transactions
 are passed to the realm's 
 `write() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write.html>`__ 
 or 
 `writeBlocking() <{+kotlin-local-prefix+}io.realm.kotlin/-realm/write-blocking.html>`__
 method. Within this callback, you can access a 
 `MutableRealm <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/index.html>`__
-instance, and then delete objects within the realm. For more information on 
+instance and then delete objects within the realm. For more information on 
 write transactions and how Realm handles them, refer to 
 :ref:`<kotlin-write-transactions>`.
 
@@ -66,7 +66,7 @@ realm, but it can no longer be queried through the parent property.
 The only exception is if the related object is 
 :ref:`embedded <kotlin-embedded-objects>`. When you delete an object that 
 has a relationship with an ``EmbeddedRealmObject``, Realm automatically 
-deletes the embedded object in a cascading delete. For more information, 
+deletes the embedded object in a **cascading delete**. For more information, 
 refer to the :ref:`<kotlin-delete-embedded-objects>` section on this page.
 
 Chaining Deletes with Related Realm Objects
@@ -145,8 +145,8 @@ that returns the specific object that you want to delete.
    We recommend filtering with unique identifying information such as 
    a primary key value to ensure your query returns the correct object.
 
-In the following example, we query for a ``Frog`` object named
-"Kermit", and then pass the returned object to ``mutableRealm.delete()`` to 
+In the following example, we query for a ``Frog`` object with a specific 
+primary key, and then pass the returned object to ``mutableRealm.delete()`` to 
 delete it from the realm: 
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-one-realm-object.kt
@@ -224,17 +224,16 @@ In the following example, we have a ``Frog`` object with a list of
 .. _kotlin-delete-related-objects:
 
 Delete an Object and Its Related Objects
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To delete related objects when you delete a parent object, you must manually
-delete the related objects yourself. We recommend performing a **chaining delete**.
-To perform a chaining delete, you first query for the parent object
-that you want to delete, then iterate through the parent object's
-relationships and delete each related object. Finally, delete the parent
-object itself.
+delete the related objects yourself. We recommend chaining deletes: 
+first query for the parent object that you want to delete, then iterate 
+through the parent object's relationships and delete each related object. 
+Finally, delete the parent object itself.
 
 In the following example, we query for a ``Frog`` object named "Kermit", then
-iterate through the object's ``favoritePonds`` property, and delete
+iterate through the object's ``favoritePonds`` property and delete
 each ``Pond`` object. Then, we delete the ``Frog`` object itself:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.chain-delete-realm-list.kt
@@ -243,7 +242,7 @@ each ``Pond`` object. Then, we delete the ``Frog`` object itself:
 .. _kotlin-delete-embedded-objects:
 
 Delete an Embedded Object
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning:: Realm Uses Cascading Deletes for Embedded Objects
 
@@ -253,17 +252,28 @@ Delete an Embedded Object
    parent object, use a regular Realm object with a :ref:`to-one relationship 
    <kotlin-to-one-relationship>` instead.
 
-You can delete an embedded object directly:
+You can delete an embedded object through the parent object in a cascading 
+delete or by deleting the embedded object directly.
 
-- Fetch and delete a specific embedded object
-- Clear the parent's reference to the embedded object, which also deletes the embedded object instance.  
+- To delete the embedded object through the parent object, fetch and delete
+  the parent object. Realm automatically deletes all of its embedded objects
+  from the realm.
+- To delete an embedded object instance directly:
 
-Alternatively, you can delete the parent object, which automatically deletes all 
-of its embedded objects. 
+  - Fetch and delete a specific embedded object.  
+  - Clear the parent's reference to the embedded object, which also 
+    deletes the embedded object instance.  
 
-In the following example, we have a ``Contact`` object with an embedded 
-``Address`` object and a ``Business`` object with a list of embedded 
-``Contact`` objects:
+In the following example, we have a ``Business`` object with a list of 
+embedded ``EmbeddedAddress`` objects. We query for and delete the ``Business`` object, 
+which automatically deletes all of its embedded ``EmbeddedAddress`` objects:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object-through-parent.kt
+   :language: kotlin
+
+In the following example, we have ``Contact`` objects with embedded 
+``EmbeddedAddress`` objects. We delete an ``EmbeddedAddress`` object directly and delete 
+another through the parent object:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-embedded-object.kt 
     :language: kotlin
@@ -296,15 +306,15 @@ You can remove one or more items from a ``RealmList`` at a time:
 - To remove multiple items from the list, pass the elements to
   `list.removeAll() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#1522148962%2FFunctions%2F878332154>`__.
 
+You can also remove *all* list elements at once by calling
+`list.clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#-35526398%2FFunctions%2F878332154>`__.
+
 In the following example, we have a ``Forest`` object with a list of 
 ``Pond`` objects. We remove the list elements in a series of operations until the 
 list is empty:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.remove-items-from-list.kt
    :language: kotlin
-
-You can also remove *all* list elements at once by calling
-`list.clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-list/index.html#-35526398%2FFunctions%2F878332154>`__.
 
 In the following example, we have a ``Forest`` object with a list of 
 ``Pond`` objects. We remove all list elements with the ``list.clear()`` method:
@@ -324,15 +334,15 @@ You can remove one or more items from a ``RealmSet`` at a time:
   elements you want to delete to
   `set.removeAll() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html#430447804%2FFunctions%2F-1651551339>`__.
 
+You can also remove *all* set elements at once by calling
+`set.clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html#-767459876%2FFunctions%2F878332154>`__.
+
 In the following example, we have a ``Frog`` object with a set of 
 ``Snack`` objects. We remove the set elements in a series of operations until the
 set is empty:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.remove-item-from-set.kt
    :language: kotlin
-
-You can also remove *all* set elements at once by calling
-`set.clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-set/index.html#-767459876%2FFunctions%2F878332154>`__.
 
 In the following example, we have a ``Frog`` object with a set of 
 ``Snack`` objects. We remove all set elements with the ``set.clear()`` method:
@@ -347,15 +357,31 @@ Remove Dictionary Keys/Values
 
 You can remove ``RealmDictionary`` entries in a few ways:
 
-- If the dictionary's value is nullable, set the value of the key to ``null`` to keep the key
-- Use `remove() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html#-2016920067%2FFunctions%2F878332154>`__ 
-  to remove the key and the value
-- Use `clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html#1264776610%2FFunctions%2F878332154>`__  
-  to remove all keys and values
+- To remove the value but keep the key, set the key to ``null`` (the 
+  dictionary's value must be nullable)
+- To remove the key and the value, pass the key to 
+  `remove() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html#-2016920067%2FFunctions%2F878332154>`__ 
+
+You can also remove *all* keys and values by calling 
+`clear() <{+kotlin-local-prefix+}io.realm.kotlin.types/-realm-dictionary/index.html#1264776610%2FFunctions%2F878332154>`__.
 
 In the following example, we have a ``Frog`` object with a dictionary of 
 ``String`` values. We remove the dictionary elements in a series of operations 
 until the dictionary is empty:
 
 .. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realm-dictionary.kt
+   :language: kotlin
+
+Delete RealmAny (Mixed) Property Value
+--------------------------------------
+
+Although ``RealmAny`` instances *cannot* store null values, you can 
+delete a ``RealmAny`` property value by assigning ``null`` directly 
+to the property.
+For more information on the ``RealmAny`` data type, refer to :ref:`<kotlin-realmany>`.
+
+In the following example, we have a ``Frog`` object with a list of  
+``RealmAny`` properties, and we clear the first ``RealmAny`` property value:
+
+.. literalinclude:: /examples/generated/kotlin/DeleteTest.snippet.delete-realmany-property.kt
    :language: kotlin

--- a/source/sdk/kotlin/realm-database/frozen-arch.txt
+++ b/source/sdk/kotlin/realm-database/frozen-arch.txt
@@ -20,7 +20,8 @@ you may have used in other Realm SDKs.
 Access a Live Version of Frozen Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to modify objects, they must be live. You can convert a frozen
+In order to :ref:`update <kotlin-update-objects>` or :ref:`delete <kotlin-delete-objects>`
+objects, they must be live. You can convert a frozen
 object to a live object in a transaction with `mutableRealm.findLatest()
 <{+kotlin-local-prefix+}io.realm.kotlin/-mutable-realm/find-latest.html>`__.
 Live objects are only accessible inside of a write transaction within
@@ -33,7 +34,12 @@ write transaction completes.
 
 .. literalinclude:: /examples/generated/kotlin/MigrateFromJavaToKotlinSDKTest.snippet.deletes.kt
    :language: kotlin
-   :copyable: false
+
+.. tip:: 
+
+   You can check if an object is frozen with the 
+   `isFrozen() <{+kotlin-local-prefix+}io.realm.kotlin.ext/is-frozen.html>`__ 
+   method.
 
 Thread-safe Realms
 ------------------
@@ -60,7 +66,7 @@ support change listeners.
 
 .. important:: Flows API Requires Kotlinx Coroutines
 
-   To use the Flows API in your Kotlin Multiplatform project, install the
+   To use the Flows API in your KMP project, install the
    :github:`kotlinx.coroutines <Kotlin/kotlinx.coroutines#multiplatform>`
    library.
 

--- a/source/sdk/kotlin/realm-database/frozen-arch.txt
+++ b/source/sdk/kotlin/realm-database/frozen-arch.txt
@@ -66,7 +66,7 @@ support change listeners.
 
 .. important:: Flows API Requires Kotlinx Coroutines
 
-   To use the Flows API in your KMP project, install the
+   To use the Flows API in your Kotlin Multiplatform project, install the
    :github:`kotlinx.coroutines <Kotlin/kotlinx.coroutines#multiplatform>`
    library.
 


### PR DESCRIPTION
## Pull Request Info

Update existing [Delete](https://www.mongodb.com/docs/realm/sdk/kotlin/realm-database/crud/delete/) page with missing content and updated code examples 

### Jira

- https://jira.mongodb.org/browse/DOCSP-30346

### Staged Changes

- [Delete Realm Objects - Kotlin SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-30346-delete-page/sdk/kotlin/realm-database/crud/delete/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
