### PR TITLE
DOCS-33261: Add note that Java SDK is in Maintenance Mode

### DIFF
--- a/source/includes/note-java-maintenance-mode.rst
+++ b/source/includes/note-java-maintenance-mode.rst
@@ -1,7 +1,7 @@
 .. note:: Java SDK in Maintenance Mode
 
-   The Java SDK is in best-effort maintenance mode and no longer receives 
-   new development or non-critical bug fixes. To develop your app with new 
+   The Java SDK is in best-effort maintenance mode and **no longer receives 
+   new development or non-critical bug fixes**. To develop your app with new 
    features, use the :ref:`Kotlin SDK <kotlin-intro>`. You can use the Java SDK 
    with the Kotlin SDK in the same project. 
    

--- a/source/includes/note-java-maintenance-mode.rst
+++ b/source/includes/note-java-maintenance-mode.rst
@@ -1,0 +1,8 @@
+.. note:: Java SDK in Maintenance Mode
+
+   The Java SDK is in best-effort maintenance mode and no longer receives 
+   new development or non-critical bug fixes. To develop your app with new 
+   features, use the :ref:`Kotlin SDK <kotlin-intro>`. You can use the Java SDK 
+   with the Kotlin SDK in the same project. 
+   
+   Learn more about how to :ref:`<kotlin-migrate-from-java-sdk-to-kotlin-sdk>`. 

--- a/source/sdk/java.txt
+++ b/source/sdk/java.txt
@@ -38,11 +38,20 @@ Realm Java SDK
    :depth: 2
    :class: singlecol
 
-.. include:: /includes/note-java-maintenance-mode.rst
 
 Use the Realm Java SDK to develop Android apps in Java or Kotlin. To develop
 multiplatform apps using Kotlin Multiplatform (KMP), refer to the
 :ref:`Realm Kotlin SDK <kotlin-intro>`.
+
+.. note:: Java SDK in Maintenance Mode
+
+   The Java SDK is in best-effort maintenance mode and no longer receives 
+   new development or non-critical bug fixes. To develop your app with new 
+   features, use the :ref:`Kotlin SDK <kotlin-intro>`. You can use the Java SDK 
+   with the Kotlin SDK in the same project. 
+   
+   Learn more about how to :ref:`<kotlin-migrate-from-java-sdk-to-kotlin-sdk>`. 
+
 
 .. kicker:: What You Can Do
 

--- a/source/sdk/java.txt
+++ b/source/sdk/java.txt
@@ -43,15 +43,15 @@ Use the Realm Java SDK to develop Android apps in Java or Kotlin. To develop
 multiplatform apps using Kotlin Multiplatform (KMP), refer to the
 :ref:`Realm Kotlin SDK <kotlin-intro>`.
 
-.. note:: Java SDK in Maintenance Mode
+SDK in Maintenance Mode
+-----------------------
 
-   The Java SDK is in best-effort maintenance mode and no longer receives 
-   new development or non-critical bug fixes. To develop your app with new 
-   features, use the :ref:`Kotlin SDK <kotlin-intro>`. You can use the Java SDK 
-   with the Kotlin SDK in the same project. 
-   
-   Learn more about how to :ref:`<kotlin-migrate-from-java-sdk-to-kotlin-sdk>`. 
+This SDK is in best-effort maintenance mode and **no longer receives 
+new development or non-critical bug fixes**. To develop your app with new 
+features, use the :ref:`Kotlin SDK <kotlin-intro>`. You can use the Java SDK 
+with the Kotlin SDK.
 
+Learn more about how to :ref:`<kotlin-migrate-from-java-sdk-to-kotlin-sdk>`. 
 
 .. kicker:: What You Can Do
 

--- a/source/sdk/java.txt
+++ b/source/sdk/java.txt
@@ -43,9 +43,15 @@ Use the Realm Java SDK to develop Android apps in Java or Kotlin. To develop
 multiplatform apps using Kotlin Multiplatform (KMP), refer to the
 :ref:`Realm Kotlin SDK <kotlin-intro>`.
 
-.. container::
+SDK in Maintenance Mode
+-----------------------
 
-   .. include:: /includes/note-java-maintenance-mode.rst 
+This SDK is in best-effort maintenance mode and **no longer receives 
+new development or non-critical bug fixes**. To develop your app with new 
+features, use the :ref:`Kotlin SDK <kotlin-intro>`. You can use the Java SDK 
+with the Kotlin SDK.
+
+Learn more about how to :ref:`<kotlin-migrate-from-java-sdk-to-kotlin-sdk>`. 
 
 .. kicker:: What You Can Do
 

--- a/source/sdk/java.txt
+++ b/source/sdk/java.txt
@@ -38,6 +38,8 @@ Realm Java SDK
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/note-java-maintenance-mode.rst
+
 Use the Realm Java SDK to develop Android apps in Java or Kotlin. To develop
 multiplatform apps using Kotlin Multiplatform (KMP), refer to the
 :ref:`Realm Kotlin SDK <kotlin-intro>`.

--- a/source/sdk/java.txt
+++ b/source/sdk/java.txt
@@ -43,15 +43,9 @@ Use the Realm Java SDK to develop Android apps in Java or Kotlin. To develop
 multiplatform apps using Kotlin Multiplatform (KMP), refer to the
 :ref:`Realm Kotlin SDK <kotlin-intro>`.
 
-SDK in Maintenance Mode
------------------------
+.. container::
 
-This SDK is in best-effort maintenance mode and **no longer receives 
-new development or non-critical bug fixes**. To develop your app with new 
-features, use the :ref:`Kotlin SDK <kotlin-intro>`. You can use the Java SDK 
-with the Kotlin SDK.
-
-Learn more about how to :ref:`<kotlin-migrate-from-java-sdk-to-kotlin-sdk>`. 
+   .. include:: /includes/note-java-maintenance-mode.rst 
 
 .. kicker:: What You Can Do
 

--- a/source/sdk/java/install.txt
+++ b/source/sdk/java/install.txt
@@ -10,11 +10,19 @@ Install Realm - Java SDK
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/note-java-maintenance-mode.rst 
+
 Overview
 --------
 
-This page details how to install Realm in your project
+This page details how to install Realm using the Java SDK in your project
 and get started.
+
+You can use multiple SDKs in your project. Because the Java SDK is no longer
+receiving new development, this is useful if you want to 
+use new features in your app. For example, you can add Atlas 
+Device Sync's :ref:`Data Ingest <optimize-data-ingest>` feature to your 
+app using the Kotlin SDK while continuing to use Java for everything else.  
 
 Prerequisites
 -------------


### PR DESCRIPTION
## Pull Request Info

Indicate to users that the Java SDK is in a best-effort maintenance mode and no longer receiving any new features.

And, per [Slack convo](https://mongodb.slack.com/archives/CL9JSLTGE/p1698666451443479), confirm you can use other SDKs in a Java project.

### Jira

- https://jira.mongodb.org/browse/DOCSP-33261

### Staged Changes

- [Java SDK landing](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-33261-java-sdk-guidance/sdk/java/)
- [Install - Java SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-33261-java-sdk-guidance/sdk/java/install/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
