### PR TITLE
C++: Add generated Set snippet to the supported types table

### DIFF
--- a/examples/cpp/beta/local/supported-types.cpp
+++ b/examples/cpp/beta/local/supported-types.cpp
@@ -91,7 +91,7 @@ struct Beta_AllTypesObject {
     std::vector<SomeType> listTypeName;
     // :snippet-end:
     // :snippet-start: beta-required-set
-    std::set<std::string> setTypeName;
+    std::set<SomeType> setTypeName;
     // :snippet-end:
 };
 REALM_SCHEMA(Beta_AllTypesObject, boolName, optBoolName, intName, optIntName,

--- a/source/examples/generated/cpp/supported-types.snippet.beta-required-set.cpp
+++ b/source/examples/generated/cpp/supported-types.snippet.beta-required-set.cpp
@@ -1,1 +1,1 @@
-std::set<std::string> setTypeName;
+std::set<SomeType> setTypeName;

--- a/source/sdk/cpp/model-data/supported-types.txt
+++ b/source/sdk/cpp/model-data/supported-types.txt
@@ -123,6 +123,11 @@ properties.
                 :language: cpp
                 :copyable: false
            - N/A
+         * - Set
+           - .. literalinclude:: /examples/generated/cpp/supported-types.snippet.beta-required-set.cpp
+                :language: cpp
+                :copyable: false
+           - N/A
          * - User-defined Object
            - N/A
            - .. code-block:: cpp


### PR DESCRIPTION
## Pull Request Info

Noticed this quick fix while I was putting together release notes.

### Staged Changes

- [Supported Types](https://preview-mongodbdacharyc.gatsbyjs.io/realm/fix-missed-set-code-snippet/sdk/cpp/model-data/supported-types/)

### Reminder Checklist

If your PR modifies the docs, you might need to also update some corresponding
pages. Check if completed or N/A.

- [x] Create Jira ticket for corresponding docs-app-services update(s), if any
- [x] Checked/updated Admin API
- [x] Checked/updated CLI reference

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
