### PR TITLE
(DOCSP-33535) React Native: Update more user authentication examples

### DIFF
--- a/examples/react-native/v12/TestApp/App.tsx
+++ b/examples/react-native/v12/TestApp/App.tsx
@@ -78,10 +78,14 @@ function App(): JSX.Element {
           name="Authentication"
           component={AuthenticationScreen}
         />
-        <Drawer.Screen
-          name="Encryption"
-          component={() => <EncryptMetadata encryptionKey={encryptionKey} />}
-        />
+        <Drawer.Screen name="Encryption">
+          {props => (
+            <EncryptMetadata
+              {...props}
+              encryptionKey={encryptionKey}
+            />
+          )}
+        </Drawer.Screen>
       </Drawer.Navigator>
     </NavigationContainer>
   );

--- a/examples/react-native/v12/TestApp/babel.config.cjs
+++ b/examples/react-native/v12/TestApp/babel.config.cjs
@@ -4,5 +4,8 @@ module.exports = {
     'module:metro-react-native-babel-preset',
     '@babel/preset-typescript',
   ],
-  plugins: ['react-native-reanimated/plugin'],
+  plugins: [
+    'react-native-reanimated/plugin',
+    '@babel/plugin-transform-react-jsx',
+  ],
 };

--- a/examples/react-native/v12/TestApp/package-lock.json
+++ b/examples/react-native/v12/TestApp/package-lock.json
@@ -43,7 +43,7 @@
         "@typescript-eslint/eslint-plugin": "^5.37.0",
         "@typescript-eslint/parser": "^5.62.0",
         "babel-jest": "^29.2.1",
-        "babel-plugin-module-resolver": "^4.1.0",
+        "babel-plugin-module-resolver": "^5.0.0",
         "eslint": "^8.19.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -5624,19 +5624,59 @@
       }
     },
     "node_modules/babel-plugin-module-resolver": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
-      "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
+      "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
       "dev": true,
       "dependencies": {
-        "find-babel-config": "^1.2.0",
-        "glob": "^7.1.6",
+        "find-babel-config": "^2.0.0",
+        "glob": "^8.0.3",
         "pkg-up": "^3.1.0",
-        "reselect": "^4.0.0",
-        "resolve": "^1.13.1"
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.1"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 16"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -7901,25 +7941,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/find-babel-config": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.0.0.tgz",
+      "integrity": "sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==",
       "dev": true,
       "dependencies": {
-        "json5": "^0.5.1",
-        "path-exists": "^3.0.0"
+        "json5": "^2.1.1",
+        "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/find-babel-config/node_modules/json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
+    "node_modules/find-babel-config/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-cache-dir": {

--- a/examples/react-native/v12/TestApp/package.json
+++ b/examples/react-native/v12/TestApp/package.json
@@ -48,7 +48,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.62.0",
     "babel-jest": "^29.2.1",
-    "babel-plugin-module-resolver": "^4.1.0",
+    "babel-plugin-module-resolver": "^5.0.0",
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^5.0.0",

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/Login.test.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/Login.test.tsx
@@ -4,10 +4,6 @@ import {BSON} from 'realm';
 import {LoginExample} from './RealmWrapper';
 import {render, screen, userEvent} from '@testing-library/react-native';
 
-// TODO: Figure out why the UI isn't lining up. Authentication succeeds
-// in App Services, but we're not seeing the right UI in this test.
-// Simulator shows the correct things.
-
 describe('Log in with App Services auth providers', () => {
   // Make sure the same user isn't persisted across tests.
   beforeEach(async () => {

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/Login.test.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/Login.test.tsx
@@ -2,33 +2,35 @@ import 'react-native';
 import React from 'react';
 import {BSON} from 'realm';
 import {LoginExample} from './RealmWrapper';
-import {render, screen, userEvent} from '@testing-library/react-native';
+import {
+  render,
+  screen,
+  userEvent,
+  act,
+  cleanup,
+} from '@testing-library/react-native';
+
+/*
+  -- Note about user state --
+  I tried to ensure that every time <LoginExample /> is
+  rendered that it was in its default state - with no
+  logged-in user. Setting this up in a `beforeEach` or
+  `afterEach` was flaky. So, I instead made sure to log
+  the user out at the end of every test.
+*/
+
+// Use promise hack to wait for network operations.
+// Can't await @realm/react hooks, so this helps
+// sequence events.
+const delay = async (duration: number) => {
+  await act(async () => {
+    await new Promise(r => setTimeout(r, duration));
+  });
+};
 
 describe('Log in with App Services auth providers', () => {
-  // Make sure the same user isn't persisted across tests.
-  beforeEach(async () => {
-    render(<LoginExample />);
-
-    const user = userEvent.setup();
-
-    await new Promise(r => setTimeout(r, 250));
-
-    // Log user out
-    const logOutButton = screen.queryByText('Log out', {
-      exact: false,
-    });
-
-    if (logOutButton) {
-      await user.press(logOutButton);
-      await new Promise(r => setTimeout(r, 250));
-    }
-
-    // <Login> component should render because there's no authenthicated user
-    const newLoginAnonymousButton =
-      await screen.findByTestId('log-in-anonymous');
-    expect(newLoginAnonymousButton).toBeInTheDocument;
-
-    screen.unmount();
+  afterEach(async () => {
+    cleanup();
   });
 
   test('anonymous auth provider', async () => {
@@ -36,10 +38,12 @@ describe('Log in with App Services auth providers', () => {
 
     const user = userEvent.setup();
 
+    // const firstLogoutButton = await screen.findByTestId('log-out');
+    // await user.press(firstLogoutButton);
+    // await delay(1000);
+
     const loginAnonymousButton = await screen.findByTestId('log-in-anonymous');
     await user.press(loginAnonymousButton);
-
-    await new Promise(r => setTimeout(r, 500));
 
     // <UserInformation> component should render now that
     // user is logged in.
@@ -50,127 +54,143 @@ describe('Log in with App Services auth providers', () => {
 
     // Ensure user is logged out.
     const logOutButton = await screen.findByTestId('log-out');
-    user.press(logOutButton);
-    await new Promise(r => setTimeout(r, 250));
+    await user.press(logOutButton);
+    await delay(250);
   });
 
-  // test('email/password auth provider', async () => {
-  //   render(<LoginExample />);
+  test('email/password auth provider', async () => {
+    render(<LoginExample />);
 
-  //   // Set up user and user information
-  //   const user = userEvent.setup();
-  //   const userEmail = `${new BSON.UUID()}@example.com`;
-  //   const userPassword = 'v3ryv3rySECRET';
+    // Set up user and user information
+    const user = userEvent.setup();
+    const userEmail = `${new BSON.UUID()}@example.com`;
+    const userPassword = 'v3ryv3rySECRET';
 
-  //   // Get interactive UI nodes
-  //   const emailInput = await screen.findByTestId('email-input');
-  //   const passwordInput = await screen.findByTestId('password-input');
-  //   const registerButton = await screen.findByTestId('register-button');
-  //   const logInButton = await screen.findByTestId('log-in');
+    // Get interactive UI nodes
+    const emailInput = await screen.findByTestId('email-input');
+    const passwordInput = await screen.findByTestId('password-input');
+    const registerButton = await screen.findByTestId('register-button');
 
-  //   // Register user with email and password
-  //   await user.type(emailInput, userEmail);
-  //   await user.type(passwordInput, userPassword);
-  //   await user.press(registerButton);
+    // Enter account info
+    await user.type(emailInput, userEmail);
+    await user.type(passwordInput, userPassword);
+    // Register user with email and password and log in
+    await user.press(registerButton);
 
-  //   // Use promise hack to wait for app services to
-  //   // finish registration process. Can't await register
-  //   // with new hooks. Essentially, delays the next part
-  //   // of the test by 1 second.
-  //   await new Promise(r => setTimeout(r, 500));
+    // Wait for registration to traverse the network and finish.
+    await delay(500);
 
-  //   // Log new user in
-  //   await user.press(logInButton);
+    // <UserInformation> component should render now that
+    // user is logged in
+    const userStateNode = await screen.findByText('User state:', {
+      exact: false,
+    });
+    expect(userStateNode.children[1]).toBe('LoggedIn');
 
-  //   // <UserInformation> component should render now that
-  //   // user is logged in
-  //   const userStateNode = await screen.findByText('User state:', {
-  //     exact: false,
-  //   });
-  //   expect(userStateNode.children[1]).toBe('LoggedIn');
+    const renderedUserEmail = await screen.findByText('Email:', {
+      exact: false,
+    });
+    expect(renderedUserEmail.children[1]).toBe(userEmail);
 
-  //   const renderedUserEmail = await screen.findByText('Email:', {
-  //     exact: false,
-  //   });
-  //   expect(renderedUserEmail.children[1]).toBe(userEmail);
-  // });
+    // Log user out
+    const logOutButton = await screen.findByTestId('log-out');
+    await user.press(logOutButton);
+    await delay(250);
+  });
 
-  // test('send reset password email', async () => {
-  //   render(<LoginExample />);
+  test('send reset password email', async () => {
+    render(<LoginExample />);
 
-  //   // Set up user and user information
-  //   const user = userEvent.setup();
-  //   const userEmail = `${new BSON.UUID()}@example.com`;
-  //   const userPassword = 'v3ryv3rySECRET';
+    // Set up user and user information
+    const user = userEvent.setup();
+    const userEmail = `${new BSON.UUID()}@example.com`;
+    const userPassword = 'v3ryv3rySECRET';
 
-  //   // Get interactive UI nodes
-  //   const emailInput = await screen.findByTestId('email-input');
-  //   const passwordInput = await screen.findByTestId('password-input');
-  //   const registerButton = await screen.findByTestId('register-button');
-  //   const sendResetPasswordEmailButton =
-  //     await screen.findByTestId('send-reset-email');
+    // Get interactive UI nodes
+    const emailInput = await screen.findByTestId('email-input');
+    const passwordInput = await screen.findByTestId('password-input');
+    const registerButton = await screen.findByTestId('register-button');
 
-  //   // Register user with email and password
-  //   await user.type(emailInput, userEmail);
-  //   await user.type(passwordInput, userPassword);
-  //   await user.press(registerButton);
+    // Register user with email and password
+    await user.type(emailInput, userEmail);
+    await user.type(passwordInput, userPassword);
+    await user.press(registerButton);
 
-  //   // Send reset password email. This should fail, as the
-  //   // backend isn't configured for it.
-  //   user.press(sendResetPasswordEmailButton);
+    // Wait for registration to traverse the network and finish.
+    await delay(500);
 
-  //   await new Promise(r => setTimeout(r, 500));
+    // Log user out to take us back to <LoginExample />
+    const logoutButton = await screen.findByTestId('log-out');
+    await user.press(logoutButton);
+    await delay(250);
 
-  //   // Match rendered error message with what we expect
-  //   const renderedErrorMessage = await screen.findByTestId(
-  //     'send-reset-email-error',
-  //     {
-  //       exact: false,
-  //     },
-  //   );
+    const rerenderedEmailInput = await screen.findByTestId('email-input');
+    const sendResetPasswordEmailButton =
+      await screen.findByTestId('send-reset-email');
 
-  //   expect(renderedErrorMessage.children[0]).toContain(
-  //     'please use reset password via function',
-  //   );
-  // });
+    await user.type(rerenderedEmailInput, userEmail);
+    // Send reset password email. This should fail, as the
+    // backend isn't configured for it.
+    user.press(sendResetPasswordEmailButton);
 
-  // test('reset password', async () => {
-  //   render(<LoginExample />);
+    // Match rendered error message with what we expect
+    const renderedErrorMessage = await screen.findByTestId(
+      'send-reset-email-error',
+      {
+        exact: false,
+      },
+    );
 
-  //   // Set up user and user information
-  //   const user = userEvent.setup();
-  //   const userEmail = `${new BSON.UUID()}@example.com`;
-  //   const userPassword = 'v3ryv3rySECRET';
-  //   const newPassword = 'superv3rySECRET';
+    expect(renderedErrorMessage.children[0]).toContain(
+      'please use reset password via function',
+    );
+  });
 
-  //   // Get interactive UI nodes
-  //   const emailInput = await screen.findByTestId('email-input');
-  //   const passwordInput = await screen.findByTestId('password-input');
-  //   const registerButton = await screen.findByTestId('register-button');
-  //   const resetPasswordButton = await screen.findByTestId('reset-password');
+  test('reset password', async () => {
+    render(<LoginExample />);
 
-  //   // Register user with email and password
-  //   await user.type(emailInput, userEmail);
-  //   await user.type(passwordInput, userPassword);
-  //   await user.press(registerButton);
+    // Set up user and user information
+    const user = userEvent.setup();
+    const userEmail = `${new BSON.UUID()}@example.com`;
+    const userPassword = 'v3ryv3rySECRET';
+    const newPassword = 'superv3rySECRET';
 
-  //   await user.type(passwordInput, newPassword);
+    // Get interactive UI nodes
+    const emailInput = await screen.findByTestId('email-input');
+    const passwordInput = await screen.findByTestId('password-input');
+    const registerButton = await screen.findByTestId('register-button');
 
-  //   // Call `performResetPassword()`. The component has
-  //   // fake `token` and `tokenId` values already. This
-  //   // should fail, as the backend isn't configured for it.
-  //   user.press(resetPasswordButton);
+    // Register user with email and password
+    await user.type(emailInput, userEmail);
+    await user.type(passwordInput, userPassword);
+    await user.press(registerButton);
 
-  //   // Match rendered error message with what we expect
-  //   const renderedErrorMessage = await screen.findByTestId(
-  //     'password-reset-error',
-  //     {
-  //       exact: false,
-  //     },
-  //   );
+    // Wait for registration to traverse the network and finish.
+    await delay(500);
 
-  //   expect(renderedErrorMessage.children[0]).toContain('invalid token data');
-  // });
+    // Log user out to take us back to <LoginExample />
+    const logoutButton = await screen.findByTestId('log-out');
+    await user.press(logoutButton);
+    await delay(250);
+
+    const rerenderdPasswordInput = await screen.findByTestId('password-input');
+    const resetPasswordButton = await screen.findByTestId('reset-password');
+
+    // Enter new password
+    await user.type(rerenderdPasswordInput, newPassword);
+
+    // Call `performResetPassword()`. The component has
+    // fake `token` and `tokenId` values already. This
+    // should fail, as the backend isn't configured for it.
+    user.press(resetPasswordButton);
+
+    // Match rendered error message with what we expect
+    const renderedErrorMessage = await screen.findByTestId(
+      'password-reset-error',
+    );
+
+    expect(renderedErrorMessage.children[0]).toContain('invalid token data');
+  });
 
   test('custom JWT provider', async () => {
     render(<LoginExample />);
@@ -180,6 +200,7 @@ describe('Log in with App Services auth providers', () => {
     // Log in anonymously so we can access App Services functions
     const loginAnonymousButton = await screen.findByTestId('log-in-anonymous');
     await user.press(loginAnonymousButton);
+    await delay(250);
 
     // <UserInformation> component should render now that
     // user is logged in.
@@ -191,16 +212,21 @@ describe('Log in with App Services auth providers', () => {
     // Log in with JWT
     const loginWithJWTButton = await screen.findByTestId('log-in-jwt');
     await user.press(loginWithJWTButton);
-
-    await new Promise(r => setTimeout(r, 500));
+    await delay(400);
 
     const userIdNode = await screen.findByTestId('user-id');
     expect(userIdNode.children[1]).toBe('custom-jwt-user');
 
-    // Ensure user is logged out.
-    const logOutButton = await screen.findByTestId('log-out');
-    user.press(logOutButton);
-    await new Promise(r => setTimeout(r, 250));
+    // @realm/react seems to stack logins? We need to log
+    // out the JWT user, then log out the anonymous user
+    // to get back to <LoginExample />.
+    const logoutJWTButton = await screen.findByTestId('log-out');
+    await user.press(logoutJWTButton);
+    await delay(350);
+
+    const logoutButton = await screen.findByTestId('log-out');
+    await user.press(logoutButton);
+    await delay(250);
   });
 
   test('custom function auth provider', async () => {
@@ -235,8 +261,30 @@ describe('Log in with App Services auth providers', () => {
     expect(userIdNode).toBeInTheDocument;
 
     // Ensure user is logged out.
-    const logOutButton = await screen.findByTestId('log-out');
-    user.press(logOutButton);
-    await new Promise(r => setTimeout(r, 250));
+    const logoutButton = await screen.findByTestId('log-out');
+    await user.press(logoutButton);
+    await delay(250);
+  });
+
+  test('refresh access token', async () => {
+    render(<LoginExample />);
+
+    const user = userEvent.setup();
+
+    const loginAnonymousButton = await screen.findByTestId('log-in-anonymous');
+    await user.press(loginAnonymousButton);
+    await delay(250);
+
+    // <UserInformation> component should render now that
+    // user is logged in.
+    const userStateNode = await screen.findByText('User state:', {
+      exact: false,
+    });
+    expect(userStateNode.children[1]).toBe('LoggedIn');
+
+    // Ensure user is logged out.
+    const logoutButton = await screen.findByTestId('log-out');
+    await user.press(logoutButton);
+    await delay(250);
   });
 });

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/Login.test.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/Login.test.tsx
@@ -11,6 +11,8 @@ describe('Log in with App Services auth providers', () => {
 
     const user = userEvent.setup();
 
+    await new Promise(r => setTimeout(r, 250));
+
     // Log user out
     const logOutButton = screen.queryByText('Log out', {
       exact: false,
@@ -21,7 +23,7 @@ describe('Log in with App Services auth providers', () => {
       await new Promise(r => setTimeout(r, 250));
     }
 
-    // <Login> component should render because there's no auth'd user
+    // <Login> component should render because there's no authenthicated user
     const newLoginAnonymousButton =
       await screen.findByTestId('log-in-anonymous');
     expect(newLoginAnonymousButton).toBeInTheDocument;
@@ -45,128 +47,130 @@ describe('Log in with App Services auth providers', () => {
       exact: false,
     });
     expect(userStateNode.children[1]).toBe('LoggedIn');
+
+    // Ensure user is logged out.
+    const logOutButton = await screen.findByTestId('log-out');
+    user.press(logOutButton);
+    await new Promise(r => setTimeout(r, 250));
   });
 
-  test('email/password auth provider', async () => {
-    render(<LoginExample />);
+  // test('email/password auth provider', async () => {
+  //   render(<LoginExample />);
 
-    console.debug(screen.toJSON());
-    console.debug(screen.debug);
+  //   // Set up user and user information
+  //   const user = userEvent.setup();
+  //   const userEmail = `${new BSON.UUID()}@example.com`;
+  //   const userPassword = 'v3ryv3rySECRET';
 
-    // Set up user and user information
-    const user = userEvent.setup();
-    const userEmail = `${new BSON.UUID()}@example.com`;
-    const userPassword = 'v3ryv3rySECRET';
+  //   // Get interactive UI nodes
+  //   const emailInput = await screen.findByTestId('email-input');
+  //   const passwordInput = await screen.findByTestId('password-input');
+  //   const registerButton = await screen.findByTestId('register-button');
+  //   const logInButton = await screen.findByTestId('log-in');
 
-    // Get interactive UI nodes
-    const emailInput = await screen.findByTestId('email-input');
-    const passwordInput = await screen.findByTestId('password-input');
-    const registerButton = await screen.findByTestId('register-button');
-    const logInButton = await screen.findByTestId('log-in');
+  //   // Register user with email and password
+  //   await user.type(emailInput, userEmail);
+  //   await user.type(passwordInput, userPassword);
+  //   await user.press(registerButton);
 
-    // Register user with email and password
-    await user.type(emailInput, userEmail);
-    await user.type(passwordInput, userPassword);
-    await user.press(registerButton);
+  //   // Use promise hack to wait for app services to
+  //   // finish registration process. Can't await register
+  //   // with new hooks. Essentially, delays the next part
+  //   // of the test by 1 second.
+  //   await new Promise(r => setTimeout(r, 500));
 
-    // Use promise hack to wait for app services to
-    // finish registration process. Can't await register
-    // with new hooks. Essentially, delays the next part
-    // of the test by 1 second.
-    await new Promise(r => setTimeout(r, 500));
+  //   // Log new user in
+  //   await user.press(logInButton);
 
-    // Log new user in
-    await user.press(logInButton);
+  //   // <UserInformation> component should render now that
+  //   // user is logged in
+  //   const userStateNode = await screen.findByText('User state:', {
+  //     exact: false,
+  //   });
+  //   expect(userStateNode.children[1]).toBe('LoggedIn');
 
-    // <UserInformation> component should render now that
-    // user is logged in
-    const userStateNode = await screen.findByText('User state:', {
-      exact: false,
-    });
-    expect(userStateNode.children[1]).toBe('LoggedIn');
+  //   const renderedUserEmail = await screen.findByText('Email:', {
+  //     exact: false,
+  //   });
+  //   expect(renderedUserEmail.children[1]).toBe(userEmail);
+  // });
 
-    const renderedUserEmail = await screen.findByText('Email:', {
-      exact: false,
-    });
-    expect(renderedUserEmail.children[1]).toBe(userEmail);
-  });
+  // test('send reset password email', async () => {
+  //   render(<LoginExample />);
 
-  test('send reset password email', async () => {
-    render(<LoginExample />);
+  //   // Set up user and user information
+  //   const user = userEvent.setup();
+  //   const userEmail = `${new BSON.UUID()}@example.com`;
+  //   const userPassword = 'v3ryv3rySECRET';
 
-    // Set up user and user information
-    const user = userEvent.setup();
-    const userEmail = `${new BSON.UUID()}@example.com`;
-    const userPassword = 'v3ryv3rySECRET';
+  //   // Get interactive UI nodes
+  //   const emailInput = await screen.findByTestId('email-input');
+  //   const passwordInput = await screen.findByTestId('password-input');
+  //   const registerButton = await screen.findByTestId('register-button');
+  //   const sendResetPasswordEmailButton =
+  //     await screen.findByTestId('send-reset-email');
 
-    // Get interactive UI nodes
-    const emailInput = await screen.findByTestId('email-input');
-    const passwordInput = await screen.findByTestId('password-input');
-    const registerButton = await screen.findByTestId('register-button');
-    const sendResetPasswordEmailButton =
-      await screen.findByTestId('send-reset-email');
+  //   // Register user with email and password
+  //   await user.type(emailInput, userEmail);
+  //   await user.type(passwordInput, userPassword);
+  //   await user.press(registerButton);
 
-    // Register user with email and password
-    await user.type(emailInput, userEmail);
-    await user.type(passwordInput, userPassword);
-    await user.press(registerButton);
+  //   // Send reset password email. This should fail, as the
+  //   // backend isn't configured for it.
+  //   user.press(sendResetPasswordEmailButton);
 
-    // Send reset password email. This should fail, as the
-    // backend isn't configured for it.
-    user.press(sendResetPasswordEmailButton);
+  //   await new Promise(r => setTimeout(r, 500));
 
-    await new Promise(r => setTimeout(r, 500));
+  //   // Match rendered error message with what we expect
+  //   const renderedErrorMessage = await screen.findByTestId(
+  //     'send-reset-email-error',
+  //     {
+  //       exact: false,
+  //     },
+  //   );
 
-    // Match rendered error message with what we expect
-    const renderedErrorMessage = await screen.findByTestId(
-      'send-reset-email-error',
-      {
-        exact: false,
-      },
-    );
+  //   expect(renderedErrorMessage.children[0]).toContain(
+  //     'please use reset password via function',
+  //   );
+  // });
 
-    expect(renderedErrorMessage.children[0]).toContain(
-      'please use reset password via function',
-    );
-  });
+  // test('reset password', async () => {
+  //   render(<LoginExample />);
 
-  test('reset password', async () => {
-    render(<LoginExample />);
+  //   // Set up user and user information
+  //   const user = userEvent.setup();
+  //   const userEmail = `${new BSON.UUID()}@example.com`;
+  //   const userPassword = 'v3ryv3rySECRET';
+  //   const newPassword = 'superv3rySECRET';
 
-    // Set up user and user information
-    const user = userEvent.setup();
-    const userEmail = `${new BSON.UUID()}@example.com`;
-    const userPassword = 'v3ryv3rySECRET';
-    const newPassword = 'superv3rySECRET';
+  //   // Get interactive UI nodes
+  //   const emailInput = await screen.findByTestId('email-input');
+  //   const passwordInput = await screen.findByTestId('password-input');
+  //   const registerButton = await screen.findByTestId('register-button');
+  //   const resetPasswordButton = await screen.findByTestId('reset-password');
 
-    // Get interactive UI nodes
-    const emailInput = await screen.findByTestId('email-input');
-    const passwordInput = await screen.findByTestId('password-input');
-    const registerButton = await screen.findByTestId('register-button');
-    const resetPasswordButton = await screen.findByTestId('reset-password');
+  //   // Register user with email and password
+  //   await user.type(emailInput, userEmail);
+  //   await user.type(passwordInput, userPassword);
+  //   await user.press(registerButton);
 
-    // Register user with email and password
-    await user.type(emailInput, userEmail);
-    await user.type(passwordInput, userPassword);
-    await user.press(registerButton);
+  //   await user.type(passwordInput, newPassword);
 
-    await user.type(passwordInput, newPassword);
+  //   // Call `performResetPassword()`. The component has
+  //   // fake `token` and `tokenId` values already. This
+  //   // should fail, as the backend isn't configured for it.
+  //   user.press(resetPasswordButton);
 
-    // Call `performResetPassword()`. The component has
-    // fake `token` and `tokenId` values already. This
-    // should fail, as the backend isn't configured for it.
-    user.press(resetPasswordButton);
+  //   // Match rendered error message with what we expect
+  //   const renderedErrorMessage = await screen.findByTestId(
+  //     'password-reset-error',
+  //     {
+  //       exact: false,
+  //     },
+  //   );
 
-    // Match rendered error message with what we expect
-    const renderedErrorMessage = await screen.findByTestId(
-      'password-reset-error',
-      {
-        exact: false,
-      },
-    );
-
-    expect(renderedErrorMessage.children[0]).toContain('invalid token data');
-  });
+  //   expect(renderedErrorMessage.children[0]).toContain('invalid token data');
+  // });
 
   test('custom JWT provider', async () => {
     render(<LoginExample />);
@@ -192,5 +196,47 @@ describe('Log in with App Services auth providers', () => {
 
     const userIdNode = await screen.findByTestId('user-id');
     expect(userIdNode.children[1]).toBe('custom-jwt-user');
+
+    // Ensure user is logged out.
+    const logOutButton = await screen.findByTestId('log-out');
+    user.press(logOutButton);
+    await new Promise(r => setTimeout(r, 250));
+  });
+
+  test('custom function auth provider', async () => {
+    render(<LoginExample />);
+
+    // Set up user and user information
+    const user = userEvent.setup();
+    const userEmail = `${new BSON.UUID()}@example.com`;
+    const userPassword = 'v3ryv3rySECRET';
+
+    // Get interactive UI nodes
+    const emailInput = await screen.findByTestId('email-input-function');
+    const passwordInput = await screen.findByTestId('password-input-function');
+    const logInButton = await screen.findByTestId('log-in-function');
+
+    // Enter user email and password
+    await user.type(emailInput, userEmail);
+    await user.type(passwordInput, userPassword);
+
+    // Log user in, passing email and password to
+    // custom function provider.
+    await user.press(logInButton);
+
+    // <UserInformation> component should render now that
+    // user is logged in
+    const userStateNode = await screen.findByText('User state:', {
+      exact: false,
+    });
+    expect(userStateNode.children[1]).toBe('LoggedIn');
+
+    const userIdNode = await screen.findByTestId('user-id');
+    expect(userIdNode).toBeInTheDocument;
+
+    // Ensure user is logged out.
+    const logOutButton = await screen.findByTestId('log-out');
+    user.press(logOutButton);
+    await new Promise(r => setTimeout(r, 250));
   });
 });

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/Login.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/Login.tsx
@@ -6,6 +6,7 @@ import {StyleSheet} from 'react-native';
 import {AuthError} from '@realm/react';
 import {LoginWithEmail} from './LoginWithEmail';
 import {LogInWithAnonymous} from './LoginWithAnonymous';
+import {LogInWithFunction} from './LoginWithFunction';
 // :remove-end:
 
 // :snippet-start: user-provider-fallback
@@ -43,8 +44,6 @@ export const LogIn = () => {
           {/* The following login options will be added
               In future PRs. */}
           {/* <LoginWithApiKey /> */}
-          {/* <LoginWithJwt /> */}
-          {/* <LoginWithFunction /> */}
           {/* <LoginOffline /> */}
           {/* <LoginWithGoogle /> */}
           {/* <LoginWithFacebook /> */}
@@ -53,6 +52,8 @@ export const LogIn = () => {
       </View>
 
       <LoginWithEmail />
+
+      <LogInWithFunction />
       {/* :remove-end: */}
     </View>
   );

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/LoginWithEmail.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/LoginWithEmail.tsx
@@ -23,7 +23,7 @@ export const LoginWithEmail = () => {
 
       <View>
         <TextInput
-          testID="email-input" 
+          testID="email-input"
           style={styles.textInput} // :remove:
           onChangeText={setEmail}
           value={email}
@@ -39,8 +39,15 @@ export const LoginWithEmail = () => {
       </View>
 
       <View style={styles.buttonGroup}>
-        <Button testID="log-in" title="Log in" onPress={performLogin} />
-        <RegisterButton email={email} password={password} />
+        <Button
+          testID="log-in"
+          title="Log in"
+          onPress={performLogin}
+        />
+        <RegisterButton
+          email={email}
+          password={password}
+        />
         <SendResetPasswordEmailButton email={email} />
         <ResetPasswordButton
           password={password}
@@ -164,8 +171,8 @@ const ResetPasswordButton = ({
         title="Reset password"
         onPress={performPasswordReset}
       />
-      {/* We expect an error because password resets through
-      email is disabled in this app's configuration. */}
+      {/* We expect an error because we don't have
+          a valid token to reset with. */}
       {errorMessage && (
         <Text testID="password-reset-error">{errorMessage}</Text>
       )}

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/LoginWithFunction.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/LoginWithFunction.tsx
@@ -1,0 +1,76 @@
+import React, {useState} from 'react';
+import {useAuth} from '@realm/react';
+import {StyleSheet, View, TextInput} from 'react-native';
+
+import {Button} from '../../utility-components/Button';
+
+// :snippet-start: login-function
+export const LogInWithFunction = () => {
+  const {logInWithFunction, result} = useAuth();
+  // :remove-start:
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  // :remove-end:
+
+  const performFunctionLogin = async (email: string, password: string) => {
+    // Pass arbitrary information to the Atlas function configured
+    // for your App's Custom Function provider.
+    logInWithFunction({email, password});
+  };
+
+  // Handle `result`...
+  // :remove-start:
+  return (
+    <View style={styles.section}>
+      <View>
+        <TextInput
+          testID="email-input-function"
+          style={styles.textInput}
+          onChangeText={setEmail}
+          value={email}
+          placeholder="email..."
+        />
+        <TextInput
+          testID="password-input-function"
+          style={styles.textInput}
+          onChangeText={setPassword}
+          value={password}
+          placeholder="password..."
+        />
+      </View>
+
+      <View style={styles.buttonGroup}>
+        <Button
+          testID="log-in-function"
+          title="Log in with function"
+          onPress={() => {
+            performFunctionLogin(email, password);
+          }}
+        />
+      </View>
+    </View>
+  );
+  // :remove-end:
+};
+// :snippet-end:
+
+const styles = StyleSheet.create({
+  section: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    marginTop: 8,
+    paddingVertical: 12,
+    width: '100%',
+  },
+  textInput: {
+    backgroundColor: '#C5CAE9',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    marginVertical: 5,
+  },
+  buttonGroup: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginVertical: 12,
+    paddingVertical: 8,
+    justifyContent: 'center',
+  },
+});

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/LoginWithJwt.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/LoginWithJwt.tsx
@@ -12,10 +12,8 @@ export const LogInWithJWT = () => {
 
   const performJWTLogin = async () => {
     // Get a JWT from a provider. In this case, from
-    // an App Services Function.
-    const token = (await await anonymousUser.callFunction(
-      'generateJWT',
-    )) as string;
+    // an App Services Function called "generateJWT".
+    const token = (await anonymousUser.functions.generateJWT()) as string;
 
     logInWithJWT(token);
   };

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/LoginWithJwt.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/LoginWithJwt.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {useAuth, useUser} from '@realm/react';
+
+import {Button} from '../../utility-components/Button';
+
+// :snippet-start: login-jwt
+export const LogInWithJWT = () => {
+  const {logInWithJWT, result} = useAuth();
+  // Get the current anonymous user so we can call
+  // an App Services Function later.
+  const anonymousUser = useUser();
+
+  const performJWTLogin = async () => {
+    // Get a JWT from a provider. In this case, from
+    // an App Services Function.
+    const token = (await await anonymousUser.callFunction(
+      'generateJWT',
+    )) as string;
+
+    logInWithJWT(token);
+  };
+
+  // Handle `result`...
+  // :remove-start:
+  return (
+    <Button
+      testID="log-in-jwt"
+      title="Log in with JWT"
+      onPress={performJWTLogin}
+    />
+  );
+  // :remove-end:
+};
+// :snippet-end:

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/RealmWrapper.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/RealmWrapper.tsx
@@ -5,7 +5,7 @@ import {AppProvider, UserProvider} from '@realm/react';
 // Fallback log in component that's defined in another file.
 import {LogIn} from './Login';
 // :remove-start:
-import {View, Text, FlatList, StyleSheet} from 'react-native';
+import {View, Text, FlatList, StyleSheet, ScrollView} from 'react-native';
 import {useUser, useAuth, useApp} from '@realm/react';
 import {APP_ID} from '../../../../appServicesConfig';
 import {Button} from '../../utility-components/Button';
@@ -14,19 +14,24 @@ import {LogInWithJWT} from './LoginWithJwt';
 
 export const LoginExample = () => {
   return (
-    <AppProvider id={APP_ID}>
-      {/* If there is no authenticated user, mount the
+    <ScrollView>
+      <AppProvider id={APP_ID}>
+        {/* If there is no authenticated user, mount the
          `fallback` component. When user successfully
           authenticates, the app unmounts the `fallback`
           component (in this case, the `LogIn` component). */}
-      <UserProvider fallback={LogIn}>
-        {/* Components inside UserProvider have access
+        <UserProvider fallback={LogIn}>
+          {/* Components inside UserProvider have access
             to the user. These components only mount if
             there's an authenticated user. */}
-        <UserInformation />
-        <LogInWithJWT />
-      </UserProvider>
-    </AppProvider>
+          <UserInformation />
+          {/* JWT log in component needs to be here, as we
+            need an anonymous user to call an app services
+            function. */}
+          <LogInWithJWT />
+        </UserProvider>
+      </AppProvider>
+    </ScrollView>
   );
 };
 // :snippet-end:

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/RealmWrapper.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/RealmWrapper.tsx
@@ -5,6 +5,7 @@ import {AppProvider, UserProvider} from '@realm/react';
 // Fallback log in component that's defined in another file.
 import {LogIn} from './Login';
 // :remove-start:
+import {useState} from 'react';
 import {View, Text, FlatList, StyleSheet, ScrollView} from 'react-native';
 import {useUser, useAuth, useApp} from '@realm/react';
 import {APP_ID} from '../../../../appServicesConfig';
@@ -25,10 +26,13 @@ export const LoginExample = () => {
             to the user. These components only mount if
             there's an authenticated user. */}
           <UserInformation />
+          {/* :remove-start: */}
           {/* JWT log in component needs to be here, as we
             need an anonymous user to call an app services
             function. */}
           <LogInWithJWT />
+          <RefreshUserAcessToken />
+          {/* :remove-end: */}
         </UserProvider>
       </AppProvider>
     </ScrollView>
@@ -65,6 +69,7 @@ function UserInformation() {
           testID="list-container"
           data={user.identities}
           keyExtractor={item => item.id}
+          scrollEnabled={false}
           renderItem={({item}) => (
             <UserIdentity
               id={item.id}
@@ -90,6 +95,38 @@ function UserInformation() {
   }
   // :remove-end:
 }
+// :snippet-end:
+
+// :snippet-start: refresh-access-token
+const RefreshUserAcessToken = () => {
+  const user = useUser();
+  const [accessToken, setAccessToken] = useState<string | null>();
+
+  // Gets a valid user access token to authenticate requests
+  const refreshAccessToken = async () => {
+    // An already logged in user's access token might be stale. To
+    // guarantee that the token is valid, refresh it if necessary.
+    await user.refreshCustomData();
+
+    setAccessToken(user.accessToken);
+  };
+
+  // Use access token...
+  // :remove-start:
+  return (
+    <View>
+      <Text testID="access-token">
+        {accessToken ? accessToken : 'No access token found.'}
+      </Text>
+      <Button
+        testID="refresh-token"
+        title="Refresh token"
+        onPress={refreshAccessToken}
+      />
+    </View>
+  );
+  // :remove-end:
+};
 // :snippet-end:
 
 const UserIdentity = ({

--- a/examples/react-native/v12/TestApp/src/components/authentication/login/RealmWrapper.tsx
+++ b/examples/react-native/v12/TestApp/src/components/authentication/login/RealmWrapper.tsx
@@ -9,6 +9,7 @@ import {View, Text, FlatList, StyleSheet} from 'react-native';
 import {useUser, useAuth, useApp} from '@realm/react';
 import {APP_ID} from '../../../../appServicesConfig';
 import {Button} from '../../utility-components/Button';
+import {LogInWithJWT} from './LoginWithJwt';
 // :remove-end:
 
 export const LoginExample = () => {
@@ -23,6 +24,7 @@ export const LoginExample = () => {
             to the user. These components only mount if
             there's an authenticated user. */}
         <UserInformation />
+        <LogInWithJWT />
       </UserProvider>
     </AppProvider>
   );
@@ -59,12 +61,23 @@ function UserInformation() {
           data={user.identities}
           keyExtractor={item => item.id}
           renderItem={({item}) => (
-            <UserIdentity id={item.id} providerType={item.providerType} />
+            <UserIdentity
+              id={item.id}
+              providerType={item.providerType}
+            />
           )}
         />
 
-        <Button testID="log-out" title="Log out" onPress={performLogout} />
-        <Button testID="delete-user" title="Delete user" onPress={deleteUser} />
+        <Button
+          testID="log-out"
+          title="Log out"
+          onPress={performLogout}
+        />
+        <Button
+          testID="delete-user"
+          title="Delete user"
+          onPress={deleteUser}
+        />
       </View>
     );
   } else {
@@ -82,7 +95,9 @@ const UserIdentity = ({
   providerType: string;
 }) => {
   return (
-    <View testID="user-identity" style={styles.identity}>
+    <View
+      testID="user-identity"
+      style={styles.identity}>
       <Text testID="user-id">ID: {id}</Text>
       {providerType && (
         <Text testID="user-provider">Provider type: {providerType}</Text>

--- a/examples/react-native/v12/TestApp/testSetup.ts
+++ b/examples/react-native/v12/TestApp/testSetup.ts
@@ -7,12 +7,9 @@ flags.ALLOW_CLEAR_TEST_STATE = true;
 // avoid error: Cannot find module 'NativeAnimatedHelper'
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
 
-global.console = {
-  ...global.console,
-  log: jest.fn(),
-  error: jest.fn(),
-  warn: jest.fn(),
-};
+// Suppress noisy warnings. Should probably investigate
+// all warnings at some point.
+global.console.warn = jest.fn();
 
 beforeEach(async () => {
   // Close and remove all realms in the default directory.

--- a/source/examples/generated/react-native/v12/LoginWithFunction.snippet.login-function.tsx.rst
+++ b/source/examples/generated/react-native/v12/LoginWithFunction.snippet.login-function.tsx.rst
@@ -1,0 +1,13 @@
+.. code-block:: typescript
+
+   export const LogInWithFunction = () => {
+     const {logInWithFunction, result} = useAuth();
+
+     const performFunctionLogin = async (email: string, password: string) => {
+       // Pass arbitrary information to the Atlas function configured
+       // for your App's Custom Function provider.
+       logInWithFunction({email, password});
+     };
+
+     // Handle `result`...
+   };

--- a/source/examples/generated/react-native/v12/LoginWithJwt.snippet.login-jwt.tsx.rst
+++ b/source/examples/generated/react-native/v12/LoginWithJwt.snippet.login-jwt.tsx.rst
@@ -1,0 +1,20 @@
+.. code-block:: typescript
+
+   export const LogInWithJWT = () => {
+     const {logInWithJWT, result} = useAuth();
+     // Get the current anonymous user so we can call
+     // an App Services Function later.
+     const anonymousUser = useUser();
+
+     const performJWTLogin = async () => {
+       // Get a JWT from a provider. In this case, from
+       // an App Services Function.
+       const token = (await await anonymousUser.callFunction(
+         'generateJWT',
+       )) as string;
+
+       logInWithJWT(token);
+     };
+
+     // Handle `result`...
+   };

--- a/source/examples/generated/react-native/v12/LoginWithJwt.snippet.login-jwt.tsx.rst
+++ b/source/examples/generated/react-native/v12/LoginWithJwt.snippet.login-jwt.tsx.rst
@@ -8,10 +8,8 @@
 
      const performJWTLogin = async () => {
        // Get a JWT from a provider. In this case, from
-       // an App Services Function.
-       const token = (await await anonymousUser.callFunction(
-         'generateJWT',
-       )) as string;
+       // an App Services Function called "generateJWT".
+       const token = (await anonymousUser.functions.generateJWT()) as string;
 
        logInWithJWT(token);
      };

--- a/source/examples/generated/react-native/v12/RealmWrapper.snippet.configure-user-provider.tsx.rst
+++ b/source/examples/generated/react-native/v12/RealmWrapper.snippet.configure-user-provider.tsx.rst
@@ -8,17 +8,19 @@
 
    export const LoginExample = () => {
      return (
-       <AppProvider id={APP_ID}>
-         {/* If there is no authenticated user, mount the
+       <ScrollView>
+         <AppProvider id={APP_ID}>
+           {/* If there is no authenticated user, mount the
             `fallback` component. When user successfully
              authenticates, the app unmounts the `fallback`
              component (in this case, the `LogIn` component). */}
-         <UserProvider fallback={LogIn}>
-           {/* Components inside UserProvider have access
+           <UserProvider fallback={LogIn}>
+             {/* Components inside UserProvider have access
                to the user. These components only mount if
                there's an authenticated user. */}
-           <UserInformation />
-         </UserProvider>
-       </AppProvider>
+             <UserInformation />
+           </UserProvider>
+         </AppProvider>
+       </ScrollView>
      );
    };

--- a/source/examples/generated/react-native/v12/RealmWrapper.snippet.refresh-access-token.tsx.rst
+++ b/source/examples/generated/react-native/v12/RealmWrapper.snippet.refresh-access-token.tsx.rst
@@ -1,0 +1,17 @@
+.. code-block:: typescript
+
+   const RefreshUserAcessToken = () => {
+     const user = useUser();
+     const [accessToken, setAccessToken] = useState<string | null>();
+
+     // Gets a valid user access token to authenticate requests
+     const refreshAccessToken = async () => {
+       // An already logged in user's access token might be stale. To
+       // guarantee that the token is valid, refresh it if necessary.
+       await user.refreshCustomData();
+
+       setAccessToken(user.accessToken);
+     };
+
+     // Use access token...
+   };

--- a/source/sdk/react-native/manage-users/authenticate-users.txt
+++ b/source/sdk/react-native/manage-users/authenticate-users.txt
@@ -343,19 +343,7 @@ Get a User Access Token
 
 .. include:: /includes/user-access-token.rst
 
-.. tabs-realm-languages::
-   
-   .. tab::
-      :tabid: javascript
-
-      .. literalinclude:: /examples/generated/node/authenticate.snippet.get-user-access-token.js
-         :language: javascript
-   
-   .. tab::
-      :tabid: typescript
-      
-      .. literalinclude:: /examples/generated/node/authenticate.snippet.get-user-access-token.ts
-         :language: typescript
+.. include:: /examples/generated/react-native/v12/RealmWrapper.snippet.refresh-access-token.tsx.rst
 
 Refresh Token Expiration
 ------------------------

--- a/source/sdk/react-native/manage-users/authenticate-users.txt
+++ b/source/sdk/react-native/manage-users/authenticate-users.txt
@@ -115,8 +115,8 @@ Anonymous User
 The :ref:`Anonymous <anonymous-authentication>` provider allows users to log in
 to your application with temporary accounts that have no associated information.
 
-Calling any log in method when a user is currently logged in, switches the 
-current user to the new user.
+Calling an authentication method when a user is currently logged in, switches
+the current user to the new user.
 
 If you call ``logInWithAnonymous()`` in the fallback of the ``UserProvider``,
 then ``UserProvider``'s children render as soon as the anonymous log in succeeds.
@@ -139,7 +139,7 @@ The :ref:`email/password <email-password-authentication>` authentication
 provider allows users to log in to your application with an email address and a
 password.
 
-You can use the ``useEmailPasswordAuth`` hook to handle user log in in your
+You can use the ``useEmailPasswordAuth`` hook to handle user log in your
 client. For a quick ``useEmailPasswordAuth`` reference, refer to
 :ref:`useEmailPasswordAuth Hook <react-native-email-pass-hook>` on the Manage
 Email/Password Users page.

--- a/source/sdk/react-native/manage-users/authenticate-users.txt
+++ b/source/sdk/react-native/manage-users/authenticate-users.txt
@@ -193,15 +193,22 @@ To log in a custom JWT user:
 Custom Function User
 ~~~~~~~~~~~~~~~~~~~~
 
-The :ref:`Custom Function <custom-function-authentication>` authentication
+The Custom Function authentication
 provider allows you to handle user authentication by running a :ref:`function
-<functions>` that receives a payload of arbitrary information about a user.
+<functions>` that receives a payload of arbitrary information about a user. Refer
+to :ref:`Custom Function Authentication <custom-function-authentication>` for
+details.
 
-To log in with the custom function provider, create a Custom Function credential
-with a payload object and pass it to ``App.logIn()``:
+To log in a user with the custom function provider:
 
-.. literalinclude:: /examples/generated/node/authenticate.snippet.custom-function-login.js
-   :language: javascript
+#. Create an App Services function to handle your authentication needs.
+#. Enable the Custom Function Provider for your App Services App and configure
+   it to use the function you created earlier.
+#. Destructure ``logInWithFunction`` and ``result`` from the ``useAuth`` hook.
+#. Pass any relevant user data (like a username) to ``logInWithFunction()``.
+#. Handle the ``result``.
+
+.. include:: examples/generated/react-native/v12/LoginWithFunction.snippet.login-function.tsx.rst
 
 .. _react-native-facebook-login:
 .. _react-native-login-facebook:

--- a/source/sdk/react-native/manage-users/authenticate-users.txt
+++ b/source/sdk/react-native/manage-users/authenticate-users.txt
@@ -174,14 +174,18 @@ Custom JWT User
 ~~~~~~~~~~~~~~~
 
 The :ref:`Custom JWT <custom-jwt-authentication>` authentication provider
-allows you to handle user authentication with any authentication system that
-returns a :ref:`JSON web token <json-web-tokens>`.
+handles user authentication with any authentication system that returns a
+:ref:`JSON web token <json-web-tokens>`.
 
-To log in, create a Custom JWT credential with a JWT from the external system
-and pass it to ``App.logIn()``:
+To log in a custom JWT user:
 
-.. literalinclude:: /examples/generated/node/authenticate.snippet.custom-jwt-login.js
-   :language: javascript
+#. Set up the JWT authentication provider in your App Services backend.
+#. Get a JWT from an external system.
+#. Destructure ``logInWithJWT`` and ``result`` from the ``useAuth`` hook.
+#. Pass the JWT to ``logInWithJWT()``.
+#. Handle the ``result``.
+
+.. include:: /examples/generated/react-native/v12/LoginWithJwt.snippet.login-jwt.tsx.rst
 
 .. _react-native-custom-function-login:
 .. _react-native-login-custom-function:

--- a/source/sdk/react-native/manage-users/authenticate-users.txt
+++ b/source/sdk/react-native/manage-users/authenticate-users.txt
@@ -220,7 +220,7 @@ The :ref:`Facebook <facebook-authentication>` authentication provider allows
 you to authenticate users through a Facebook app using their existing Facebook
 account.
 
-To log a user in with their existing Facebook account, you must configure and
+To log a user in with an existing Facebook account, you must configure and
 enable the :ref:`Facebook authentication provider <facebook-authentication>`
 for your App Services App.
 
@@ -233,14 +233,19 @@ to your React Native app and use to finish logging the user in to your app.
 
 .. code-block:: javascript
 
-   // Get the access token from a client application using the Facebook SDK
-   const accessToken = getFacebookAccessToken();
+   export const LogInWithFacebook = () => {
+     const {logInWithFacebook, result} = useAuth();
 
-   // Log the user in to your app
-   const credentials = Realm.Credentials.facebook(accessToken);
-   app.logIn(credentials).then(user => {
-   console.log(`Logged in with id: ${user.id}`);
-   });
+     const performLogin = () => {
+       // Get an access token using the Facebook SDK.
+       // You must define this function.
+       const token = getFacebookToken();
+
+       logInWithFacebook(token);
+     };
+
+     // Handle `result`...
+   };
 
 .. _react-native-google-login:
 .. _react-native-login-google:
@@ -254,44 +259,32 @@ authenticate users with their existing Google account.
 To authenticate a Google user, you must configure the :ref:`Google
 authentication provider <google-authentication>` for your App Services App.
 
-There is no official Sign in with Google integration with React Native. The simplest
-approach to integrating Sign in With Google into your React Native app
-with Realm authentication is to use a third-party library.
-The below example uses the library
-:github:`React Native Google Sign In <react-native-google-signin/google-signin>`.
-You can also build your own solution using :google:`Google Identity Services <identity>` to handle the user
-authentication and redirect flow from a client application.
+There is no official Sign in With Google integration for React Native. The
+simplest approach to integrating Sign in With Google into your React Native app
+with Realm authentication is to use a third-party library. You can also build
+your own solution using :google:`Google Identity Services <identity>` to handle
+the user authentication and redirect flow from a client application.
 
-Regardless of implementation, you must retrieve an ID token from the Google Authorization server.
-Use that ID token to log into Realm.
-
-.. code-block:: javascript
-
-   // Get the Google OAuth 2.0 access token
-   const idToken = getGoogleAccessToken();
-
-   // Log the user in to your app
-   const credentials = Realm.Credentials.google({ idToken });
-   app.logIn(credentials).then((user) => {
-      console.log(`Logged in with id: ${user.id}`);
-   });
+Regardless of implementation, you must retrieve an ID token from the Google
+Authorization server. Use that ID token to log into Realm.
 
 .. _example-auth-google-react-native:
 
-.. example:: Authenticate with Google in React Native
+.. code-block:: javascript
 
-   This example uses the library
-   :github:`React Native Google Sign In<react-native-google-signin/google-signin>`.
-   In addition to the React Native code, you must also set up additional configuration
-   in your project's ``ios`` and ``android`` directories to use Sign in with Google.
-   Refer to the package's documentation for
-   :github:`iOS-specific <react-native-google-signin/google-signin/blob/master/docs/ios-guide.md>`
-   and :github:`Android-specific <react-native-google-signin/google-signin/blob/master/docs/android-guide.md>`
-   documentation.
+   export const LogInWithGoogle = () => {
+     const {logInWithGoogle, result} = useAuth();
 
-   .. literalinclude:: /examples/generated/rn/sign-in-with-google.snippet.react-native-sign-in-with-google.jsx
-      :caption: SignInWithGoogleButton.jsx
-      :language: javascript
+     const performLogin = () => {
+       // Get an access token using a third-party library
+       // or build your own solution. You must define this function.
+       const token = getGoogleToken();
+
+       logInWithGoogle(token);
+     };
+
+     // Handle `result`...
+   };
 
 .. _react-native-apple-login:
 .. _react-native-login-apple:
@@ -313,14 +306,19 @@ use to finish logging the user in to your app.
 
 .. code-block:: javascript
 
-   // Get the access token from a client application using the Apple JS SDK
-   const idToken = getAppleIdToken();
+   export const LogInWithApple = () => {
+     const {logInWithApple, result} = useAuth();
 
-   // Log the user in to your app
-   const credentials = Realm.Credentials.apple(idToken);
-   app.logIn(credentials).then(user => {
-      console.log(`Logged in with id: ${user.id}`);
-   });
+     const performLogin = () => {
+       // Get an access token using the Apple SDK.
+       // You must define this function.
+       const token = getAppleToken();
+
+       logInWithApple(token);
+     };
+
+     // Handle `result`...
+   };
 
 .. include:: /includes/authorization-appleidcredential-string.rst
 


### PR DESCRIPTION
## Pull Request Info

This PR adds tests and content updates for lots of authentication content. For Facebook, Google, and Apple auth, I updated examples, but not they're not part of the test suite. Setting up real auth through these services would take considerable time.
- Custom JWT
- Custom function
- Facebook
- Google
- Apple
- Get a User Access Token

I didn't get to updating the offline login example in this PR. I'll take another look at it later in this little epic.

I also fixed several annoying bugs in the React Native test suite itself and refactored some other auth examples to make them less brittle.

**CI Tests**
Seems like the CI tests are still a bit flaky. But they pass consistently locally. I don't have time to make CI happy right now, but here's a screenshot of local tests passing:
<img width="626" alt="Screenshot 2023-11-14 at 9 20 59 PM" src="https://github.com/mongodb/docs-realm/assets/115574589/9d92f6ef-f3b9-423c-8bcb-d5fd997116f4">

### Jira

- https://jira.mongodb.org/browse/DOCSP-33535

### Staged Changes

- [Authenticate Users](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/DOCSP-33535/sdk/react-native/manage-users/authenticate-users/)

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

<img src="https://i.chzbgr.com/full/9566515968/hB5AF53C7/hat-as" width=400>
