### PR TITLE
Remove genre tag from 2 landing pages

### DIFF
--- a/source/introduction.txt
+++ b/source/introduction.txt
@@ -4,10 +4,6 @@
 Introduction to Realm
 =====================
 
-.. facet::
-   :name: genre 
-   :values: reference
-
 .. meta:: 
    :keywords: atlas, atlas app services
 

--- a/source/sdk/swift.txt
+++ b/source/sdk/swift.txt
@@ -11,10 +11,6 @@ Realm Swift SDK
 .. facet::
    :name: programming_language
    :values: swift, objective-c
-
-.. facet::
-   :name: genre
-   :values: reference
    
 .. meta:: 
    :keywords: iOS, SwiftUI


### PR DESCRIPTION
## Pull Request Info
There is no Jira ticket for this one; it just came up during the Realm Team's taxonomy training workshop session.  We determined not to put a genre tag for any Realm landing pages.  @dacharyc, if all looks good, will you please merge?

### Staged Changes

- https://preview-mongodbsarahemlin.gatsbyjs.io/realm/untag-landing-pages/
