### PR TITLE
Readability workflow: Check out a version tag instead of missing branch

### DIFF
--- a/.github/workflows/readability.yml
+++ b/.github/workflows/readability.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: cbush/docdoctor
-          ref: "readability"
+          ref: "0.1.2"
           path: "docdoctor"
       - name: Display workspace directory structure (debugging log statement)
         run: |


### PR DESCRIPTION
The existing readability workflow points to a ref that existed on the old source repo (my fork of Chris's branch) but that ref does not exist on Chris's branch. Attempting to check out a version tag instead of a branch ref that doesn't exist to fix the failing workflow.
