### PR TITLE
(DOCSP-34627): C++ SDK: Add freeze/thaw documentation

### DIFF
--- a/examples/cpp/beta/local/CMakeLists.txt
+++ b/examples/cpp/beta/local/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        2b6f2b6131b4900ce68f1fd45eaab7e759879451
+  GIT_TAG        v0.6.0-preview
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/beta/local/CMakeLists.txt
+++ b/examples/cpp/beta/local/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        v0.5.0-preview
+  GIT_TAG        2b6f2b6131b4900ce68f1fd45eaab7e759879451
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/beta/local/CMakeLists.txt
+++ b/examples/cpp/beta/local/CMakeLists.txt
@@ -9,7 +9,7 @@ Include(FetchContent)
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.0.1 # or a later release
+  GIT_TAG        v3.4.0 # or a later release
 )
 FetchContent_Declare(
   cpprealm

--- a/examples/cpp/beta/local/CMakeLists.txt
+++ b/examples/cpp/beta/local/CMakeLists.txt
@@ -29,5 +29,7 @@ add_executable(examples-beta-local
   threading.cpp
 )
 
+set(USE_EXAMPLE_MAIN 1)
+
 target_link_libraries(examples-beta-local PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(examples-beta-local PRIVATE cpprealm)

--- a/examples/cpp/beta/local/threading.cpp
+++ b/examples/cpp/beta/local/threading.cpp
@@ -40,26 +40,26 @@ TEST_CASE("thread safe reference", "[write]") {
   auto managedItem = managedItems[0];
 
   // :snippet-start: beta-thread-safe-reference
-  // Put a managed realm object into a thread safe reference
+  // Put a managed realm object into a thread safe reference.
   auto threadSafeItem =
       realm::thread_safe_reference<Beta_ThreadingExample_Item>{managedItem};
 
-  // Move the thread safe reference to a background thread
+  // Move the thread safe reference to a background thread.
   auto thread =
       std::thread([threadSafeItem = std::move(threadSafeItem), path]() mutable {
-        // Open the realm again on the background thread
+        // Open the realm again on the background thread.
         auto backgroundConfig = realm::db_config();
         backgroundConfig.set_path(path);
         auto backgroundRealm = db(std::move(backgroundConfig));
 
         // Resolve the ThreadingExample_Item instance via the thread safe
-        // reference
+        // reference.
         auto item = backgroundRealm.resolve(std::move(threadSafeItem));
 
         // ... use item ...
       });
 
-  // Wait for thread to complete
+  // Wait for thread to complete.
   thread.join();
   // :snippet-end:
 }
@@ -107,32 +107,36 @@ TEST_CASE("scheduler", "[write]") {
     // ...
   };
 
-  // :uncomment-start:
-  // int main() {
-  // :uncomment-end:
-  // Set up a custom scheduler
-  auto scheduler = std::make_shared<MyScheduler>();
+// :remove-start:
+// NOTE: Switched from using Bluehawk uncomment to the #if here because
+// when `int main() {` was commented out, the linter was removing the indent
+// for the code inside the block. Switching to an #if that never runs
+// this code lets the linter properly lint this example.
+#if USE_EXAMPLE_MAIN
+  // :remove-end:
+  int main() {
+    // Set up a custom scheduler.
+    auto scheduler = std::make_shared<MyScheduler>();
 
-  // Pass the scheduler instance to the realm configuration
-  auto config = realm::db_config{path, scheduler};
+    // Pass the scheduler instance to the realm configuration.
+    auto config = realm::db_config{path, scheduler};
 
-  // Start the program main loop
-  auto done = false;
-  while (!done) {
-    // This assumes the scheduler is implemented so that it
-    // continues processing tasks on background threads until
-    // the scheduler goes out of scope.
+    // Start the program main loop.
+    auto done = false;
+    while (!done) {
+      // This assumes the scheduler is implemented so that it
+      // continues processing tasks on background threads until
+      // the scheduler goes out of scope.
 
-    // Handle input here
-    // ...
-    if (shouldQuitProgram) {
-      done = true;
+      // Handle input here.
+      // ...
+      if (shouldQuitProgram) {
+        done = true;
+      }
     }
   }
-  // :uncomment-start:
-  // }
-  // :uncomment-end:
-  // :snippet-end:
+// :snippet-end:
+#endif
 }
 
 TEST_CASE("test freeze", "[write]") {
@@ -156,7 +160,7 @@ TEST_CASE("test freeze", "[write]") {
 
   realm.write([&] { realm.add(std::move(item)); });
   // :remove-end:
-  // Get an immutable copy of the realm that can be passed across threads
+  // Get an immutable copy of the realm that can be passed across threads.
   auto frozenRealm = realm.freeze();
 
   // :snippet-start: is-frozen
@@ -169,25 +173,25 @@ TEST_CASE("test freeze", "[write]") {
   }
   // :snippet-end:
 
-  // You can freeze collections
+  // You can freeze collections.
   auto managedItems = realm.objects<Beta_ThreadingExample_Item>();
   auto frozenItems = managedItems.freeze();
 
   CHECK(frozenItems.is_frozen());
 
-  // You can read from frozen realms
+  // You can read from frozen realms.
   auto itemsFromFrozenRealm = frozenRealm.objects<Beta_ThreadingExample_Item>();
 
   CHECK(itemsFromFrozenRealm.is_frozen());
 
-  // You can freeze objects
+  // You can freeze objects.
   auto managedItem = managedItems[0];
   CHECK(managedItem.get_realm().is_frozen() == false);  // :remove:
   auto frozenItem = managedItem.freeze();
 
   CHECK(frozenItem.is_frozen());
 
-  // Frozen objects have a reference to a frozen realm
+  // Frozen objects have a reference to a frozen realm.
   CHECK(frozenItem.get_realm().is_frozen());
   // :snippet-end:
 
@@ -216,17 +220,17 @@ TEST_CASE("test thaw", "[write]") {
   CHECK(frozenRealm.is_frozen());
 
   // :snippet-start: thaw
-  // Read from a frozen realm
+  // Read from a frozen realm.
   auto frozenItems = frozenRealm.objects<Beta_ThreadingExample_Item>();
 
-  // The collection that we pull from the frozen realm is also frozen
+  // The collection that we pull from the frozen realm is also frozen.
   CHECK(frozenItems.is_frozen());
 
-  // Get an individual item from the collection
+  // Get an individual item from the collection.
   auto frozenItem = frozenItems[0];
 
-  // To modify the item, you must first thaw it
-  // You can also thaw collections and realms
+  // To modify the item, you must first thaw it.
+  // You can also thaw collections and realms.
   auto thawedItem = frozenItem.thaw();
 
   // Check to make sure the item is valid. An object is
@@ -234,7 +238,7 @@ TEST_CASE("test thaw", "[write]") {
   // or when its managing realm has invalidate() called on it.
   REQUIRE(thawedItem.is_invalidated() == false);
 
-  // Thawing the item also thaws the frozen realm it references
+  // Thawing the item also thaws the frozen realm it references.
   auto thawedRealm = thawedItem.get_realm();
   REQUIRE(thawedRealm.is_frozen() == false);
 
@@ -288,7 +292,7 @@ TEST_CASE("append to frozen collection", "[write]") {
   // but you might also be passing them across threads.
   auto frozenItems = frozenRealm.objects<Beta_ThreadingExample_Item>();
 
-  // The collection that we pull from the frozen realm is also frozen
+  // The collection that we pull from the frozen realm is also frozen.
   CHECK(frozenItems.is_frozen());
 
   // Get the individual objects we want to work with.

--- a/examples/cpp/beta/local/threading.cpp
+++ b/examples/cpp/beta/local/threading.cpp
@@ -4,263 +4,318 @@
 //   }
 // }
 #include <catch2/catch_test_macros.hpp>
-#include <cpprealm/sdk.hpp>
 #include <cpprealm/experimental/sdk.hpp>
+#include <cpprealm/sdk.hpp>
 
 using namespace realm::experimental;
 
 struct Beta_ThreadingExample_Item {
-    std::string name;
+  std::string name;
 };
 REALM_SCHEMA(Beta_ThreadingExample_Item, name)
 
 TEST_CASE("thread safe reference", "[write]") {
-    auto relative_realm_path_directory = "beta_tsr/";
-    std::filesystem::create_directories(relative_realm_path_directory);
-    std::filesystem::path path = std::filesystem::current_path().append(relative_realm_path_directory);
-    path = path.append("tsr_objects");
-    path = path.replace_extension("realm");
-    
-    auto config = realm::db_config();
-    config.set_path(path);
-    auto realm = db(std::move(config));
+  auto relative_realm_path_directory = "beta_tsr/";
+  std::filesystem::create_directories(relative_realm_path_directory);
+  std::filesystem::path path =
+      std::filesystem::current_path().append(relative_realm_path_directory);
+  path = path.append("tsr_objects");
+  path = path.replace_extension("realm");
 
-    auto item = Beta_ThreadingExample_Item {
-        .name = "Save the cheerleader",
-    };
+  auto config = realm::db_config();
+  config.set_path(path);
+  auto realm = db(std::move(config));
 
-    realm.write([&] {
-        realm.add(std::move(item));
-    });
-    
-    realm.refresh();
+  auto item = Beta_ThreadingExample_Item{
+      .name = "Save the cheerleader",
+  };
 
-    auto managedItems = realm.objects<Beta_ThreadingExample_Item>();
-    auto managedItem = managedItems[0];
-    
-    // :snippet-start: beta-thread-safe-reference
-    // Put a managed realm object into a thread safe reference
-    auto threadSafeItem = realm::thread_safe_reference<Beta_ThreadingExample_Item>{managedItem};
-    
-    // Move the thread safe reference to a background thread
-    auto thread = std::thread([threadSafeItem = std::move(threadSafeItem), path]() mutable {
+  realm.write([&] { realm.add(std::move(item)); });
+
+  realm.refresh();
+
+  auto managedItems = realm.objects<Beta_ThreadingExample_Item>();
+  auto managedItem = managedItems[0];
+
+  // :snippet-start: beta-thread-safe-reference
+  // Put a managed realm object into a thread safe reference
+  auto threadSafeItem =
+      realm::thread_safe_reference<Beta_ThreadingExample_Item>{managedItem};
+
+  // Move the thread safe reference to a background thread
+  auto thread =
+      std::thread([threadSafeItem = std::move(threadSafeItem), path]() mutable {
         // Open the realm again on the background thread
         auto backgroundConfig = realm::db_config();
         backgroundConfig.set_path(path);
         auto backgroundRealm = db(std::move(backgroundConfig));
-        
-        // Resolve the ThreadingExample_Item instance via the thread safe reference
+
+        // Resolve the ThreadingExample_Item instance via the thread safe
+        // reference
         auto item = backgroundRealm.resolve(std::move(threadSafeItem));
 
         // ... use item ...
-    });
+      });
 
-    // Wait for thread to complete
-    thread.join();
-    // :snippet-end:
+  // Wait for thread to complete
+  thread.join();
+  // :snippet-end:
 }
 
 TEST_CASE("scheduler", "[write]") {
-    auto shouldQuitProgram = true;
-    
-    auto relative_realm_path_directory = "beta_scheduler/";
-    std::filesystem::create_directories(relative_realm_path_directory);
-    std::filesystem::path path = std::filesystem::current_path().append(relative_realm_path_directory);
-    path = path.append("scheduler");
-    path = path.replace_extension("realm");
-    
-    // :snippet-start: beta-scheduler
-    struct MyScheduler : realm::scheduler {
-        MyScheduler() {
-            // ... Kick off task processor thread(s) and run until the scheduler
-            // goes out of scope ...
-        }
+  auto shouldQuitProgram = true;
 
-        ~MyScheduler() override {
-            // ... Call in the processor thread(s) and block until return ...
-        }
-        
-        void invoke(realm::Function<void()> &&task) override {
-            // ... Add the task to the (lock-free) processor queue ...
-        }
+  auto relative_realm_path_directory = "beta_scheduler/";
+  std::filesystem::create_directories(relative_realm_path_directory);
+  std::filesystem::path path =
+      std::filesystem::current_path().append(relative_realm_path_directory);
+  path = path.append("scheduler");
+  path = path.replace_extension("realm");
 
-        [[nodiscard]] bool is_on_thread() const noexcept override {
-            // ... Return true if the caller is on the same thread as a processor thread ...
-            return false; // :remove:
-        }
+  // :snippet-start: beta-scheduler
+  struct MyScheduler : realm::scheduler {
+    MyScheduler() {
+      // ... Kick off task processor thread(s) and run until the scheduler
+      // goes out of scope ...
+    }
 
-        bool is_same_as(const realm::scheduler *other) const noexcept override {
-            // ... Compare scheduler instances ...
-            return false; // :remove:
-        }
+    ~MyScheduler() override {
+      // ... Call in the processor thread(s) and block until return ...
+    }
 
-        [[nodiscard]] bool can_invoke() const noexcept override {
-            // ... Return true if the scheduler can accept tasks ...
-            return false; // :remove:
-        }
-        // ...
-    };
+    void invoke(realm::Function<void()>&& task) override {
+      // ... Add the task to the (lock-free) processor queue ...
+    }
 
-    // :uncomment-start:
-    // int main() {
-    // :uncomment-end:
-        // Set up a custom scheduler
-        auto scheduler = std::make_shared<MyScheduler>();
-        
-        // Pass the scheduler instance to the realm configuration
-        auto config = realm::db_config{
-            path, scheduler
-        };
-        
-        // Start the program main loop
-        auto done = false;
-        while (!done) {
-            // This assumes the scheduler is implemented so that it
-            // continues processing tasks on background threads until
-            // the scheduler goes out of scope.
-            
-            // Handle input here
-            // ...
-            if (shouldQuitProgram) {
-                done = true;
-            }
-        }
-    // :uncomment-start:
-    // }
-    // :uncomment-end:
-    // :snippet-end:
+    [[nodiscard]] bool is_on_thread() const noexcept override {
+      // ... Return true if the caller is on the same thread as a processor
+      // thread ...
+      return false;  // :remove:
+    }
+
+    bool is_same_as(const realm::scheduler* other) const noexcept override {
+      // ... Compare scheduler instances ...
+      return false;  // :remove:
+    }
+
+    [[nodiscard]] bool can_invoke() const noexcept override {
+      // ... Return true if the scheduler can accept tasks ...
+      return false;  // :remove:
+    }
+    // ...
+  };
+
+  // :uncomment-start:
+  // int main() {
+  // :uncomment-end:
+  // Set up a custom scheduler
+  auto scheduler = std::make_shared<MyScheduler>();
+
+  // Pass the scheduler instance to the realm configuration
+  auto config = realm::db_config{path, scheduler};
+
+  // Start the program main loop
+  auto done = false;
+  while (!done) {
+    // This assumes the scheduler is implemented so that it
+    // continues processing tasks on background threads until
+    // the scheduler goes out of scope.
+
+    // Handle input here
+    // ...
+    if (shouldQuitProgram) {
+      done = true;
+    }
+  }
+  // :uncomment-start:
+  // }
+  // :uncomment-end:
+  // :snippet-end:
 }
 
 TEST_CASE("test freeze", "[write]") {
-    auto relative_realm_path_directory = "beta_freeze/";
-    std::filesystem::create_directories(relative_realm_path_directory);
-    std::filesystem::path path = std::filesystem::current_path().append(relative_realm_path_directory);
-    path = path.append("frozen_objects");
-    path = path.replace_extension("realm");
-    
-    auto config = realm::db_config();
-    config.set_path(path);
-    
-    // :snippet-start: freeze
-    auto realm = db(std::move(config));
+  auto relative_realm_path_directory = "beta_freeze/";
+  std::filesystem::create_directories(relative_realm_path_directory);
+  std::filesystem::path path =
+      std::filesystem::current_path().append(relative_realm_path_directory);
+  path = path.append("frozen_objects");
+  path = path.replace_extension("realm");
 
-    // :remove-start:
-    auto item = Beta_ThreadingExample_Item {
-        .name = "Save the cheerleader",
-    };
+  auto config = realm::db_config();
+  config.set_path(path);
 
-    realm.write([&] {
-        realm.add(std::move(item));
-    });
-    // :remove-end:
-    // Get an immutable copy of the realm that can be passed across threads
-    auto frozenRealm = realm.freeze();
-    
-    // :snippet-start: is-frozen
-    CHECK(frozenRealm.is_frozen()); // :remove:
-    if (frozenRealm.is_frozen()) {
-        // Do something with the frozen realm.
-        // You may pass a frozen realm, collection, or objects
-        // across threads. Or you may need to `.thaw()`
-        // to make it mutable again.
-    }
-    // :snippet-end:
+  // :snippet-start: freeze
+  auto realm = db(std::move(config));
 
-    // You can freeze collections
-    auto managedItems = realm.objects<Beta_ThreadingExample_Item>();
-    auto frozenItems = managedItems.freeze();
-    
-    CHECK(frozenItems.is_frozen());
-    
-    // You can read from frozen realms
-    auto itemsFromFrozenRealm = frozenRealm.objects<Beta_ThreadingExample_Item>();
-    
-    CHECK(itemsFromFrozenRealm.is_frozen());
-    
-    // You can freeze objects
-    auto managedItem = managedItems[0];
-    
-    CHECK(!managedItem.m_realm.is_frozen());
-    
-    auto frozenItem = managedItem.freeze();
-    
-    CHECK(frozenItem.is_frozen());
-    
-    // Frozen objects have a reference to a frozen realm
-    CHECK(frozenItem.m_realm.is_frozen());
-    // :snippet-end:
-    
-    realm.write([&] {
-        realm.remove(managedItem);
-    });
+  // :remove-start:
+  auto item = Beta_ThreadingExample_Item{
+      .name = "Save the cheerleader",
+  };
+
+  realm.write([&] { realm.add(std::move(item)); });
+  // :remove-end:
+  // Get an immutable copy of the realm that can be passed across threads
+  auto frozenRealm = realm.freeze();
+
+  // :snippet-start: is-frozen
+  CHECK(frozenRealm.is_frozen());  // :remove:
+  if (frozenRealm.is_frozen()) {
+    // Do something with the frozen realm.
+    // You may pass a frozen realm, collection, or objects
+    // across threads. Or you may need to `.thaw()`
+    // to make it mutable again.
+  }
+  // :snippet-end:
+
+  // You can freeze collections
+  auto managedItems = realm.objects<Beta_ThreadingExample_Item>();
+  auto frozenItems = managedItems.freeze();
+
+  CHECK(frozenItems.is_frozen());
+
+  // You can read from frozen realms
+  auto itemsFromFrozenRealm = frozenRealm.objects<Beta_ThreadingExample_Item>();
+
+  CHECK(itemsFromFrozenRealm.is_frozen());
+
+  // You can freeze objects
+  auto managedItem = managedItems[0];
+  CHECK(managedItem.get_realm().is_frozen() == false);  // :remove:
+  auto frozenItem = managedItem.freeze();
+
+  CHECK(frozenItem.is_frozen());
+
+  // Frozen objects have a reference to a frozen realm
+  CHECK(frozenItem.get_realm().is_frozen());
+  // :snippet-end:
+
+  realm.write([&] { realm.remove(managedItem); });
 }
 
 TEST_CASE("test thaw", "[write]") {
-    auto relative_realm_path_directory = "beta_thaw/";
-    std::filesystem::create_directories(relative_realm_path_directory);
-    std::filesystem::path path = std::filesystem::current_path().append(relative_realm_path_directory);
-    path = path.append("thaw_test_objects");
-    path = path.replace_extension("realm");
-    
-    auto config = realm::db_config();
-    config.set_path(path);
-    auto realm = db(std::move(config));
-    auto item = Beta_ThreadingExample_Item {
-        .name = "Save the cheerleader",
-    };
+  auto relative_realm_path_directory = "beta_thaw/";
+  std::filesystem::create_directories(relative_realm_path_directory);
+  std::filesystem::path path =
+      std::filesystem::current_path().append(relative_realm_path_directory);
+  path = path.append("thaw_test_objects");
+  path = path.replace_extension("realm");
 
-    realm.write([&] {
-        realm.add(std::move(item));
-    });
+  auto config = realm::db_config();
+  config.set_path(path);
+  auto realm = db(std::move(config));
+  auto item = Beta_ThreadingExample_Item{
+      .name = "Save the cheerleader",
+  };
 
-    auto frozenRealm = realm.freeze();
-    
-    CHECK(frozenRealm.is_frozen());
+  realm.write([&] { realm.add(std::move(item)); });
 
-    // :snippet-start: thaw
-    // Read from a frozen realm
-    auto frozenItems = frozenRealm.objects<Beta_ThreadingExample_Item>();
-    
-    // The collection that we pull from the frozen realm is also frozen
-    CHECK(frozenItems.is_frozen());
-    
-    // :remove-start:
-    // Removing this part of the example as it's waiting for
-    // .thaw() to be exposed on an object
-    // Get an individual item from the collection
-    auto frozenItem = frozenItems[0];
-    
-    // To modify the item, you must first thaw it
-    // You can also thaw collections and realms
-    // This won't compile with the error 'No member named 'thaw' in 'realm::experimental::managed<Beta_ThreadingExample_Item>''
-    //auto thawedItem = frozenItem.thaw();
-    // :remove-end:
-    // To modify objects, you must first thaw them.
-    // Currently, you can thaw collections or realms.
-    auto thawedItems = frozenItems.thaw();
-    
-    auto thawedItem = thawedItems[0];
-    
-    // Check to make sure the item is valid. An object is
-    // invalidated when it is deleted from its managing realm,
-    // or when its managing realm has invalidate() called on it.
-    REQUIRE(thawedItem.is_invalidated() == false);
-    
-    // :snippet-end:
-    // Ending the snippet here because I'm getting issues with what
-    // I'm trying to do below. I'll update after the `.thaw()`
-    // PR that adds a realm getter and use that method to retrieve
-    // the managing realm and write to it.
-    SKIP();
-    auto thawedRealm = frozenRealm.thaw();
-    
-    thawedRealm.write([&] {
-        thawedItem.name = "Save the world";
-    });
-    REQUIRE(thawedItem.name == "Save the world");
-    
-    thawedRealm.write([&] {
-        thawedRealm.remove(thawedItem);
-    });
+  auto frozenRealm = realm.freeze();
+
+  CHECK(frozenRealm.is_frozen());
+
+  // :snippet-start: thaw
+  // Read from a frozen realm
+  auto frozenItems = frozenRealm.objects<Beta_ThreadingExample_Item>();
+
+  // The collection that we pull from the frozen realm is also frozen
+  CHECK(frozenItems.is_frozen());
+
+  // Get an individual item from the collection
+  auto frozenItem = frozenItems[0];
+
+  // To modify the item, you must first thaw it
+  // You can also thaw collections and realms
+  auto thawedItem = frozenItem.thaw();
+
+  // Check to make sure the item is valid. An object is
+  // invalidated when it is deleted from its managing realm,
+  // or when its managing realm has invalidate() called on it.
+  REQUIRE(thawedItem.is_invalidated() == false);
+
+  // Thawing the item also thaws the frozen realm it references
+  auto thawedRealm = thawedItem.get_realm();
+  REQUIRE(thawedRealm.is_frozen() == false);
+
+  // With both the object and its managing realm thawed, you
+  // can safely modify the object.
+  thawedRealm.write([&] { thawedItem.name = "Save the world"; });
+  // :snippet-end:
+  REQUIRE(thawedItem.name == "Save the world");
+
+  thawedRealm.write([&] { thawedRealm.remove(thawedItem); });
+}
+
+// :snippet-start: model-with-collection-property
+struct Beta_ThreadingExample_Project {
+  std::string name;
+  std::vector<Beta_ThreadingExample_Item*> items;
+};
+REALM_SCHEMA(Beta_ThreadingExample_Project, name, items)
+// :snippet-end:
+
+TEST_CASE("append to frozen collection", "[write]") {
+  auto relative_realm_path_directory = "beta_frozen_collection/";
+  std::filesystem::create_directories(relative_realm_path_directory);
+  std::filesystem::path path =
+      std::filesystem::current_path().append(relative_realm_path_directory);
+  path = path.append("frozen_collection_test_objects");
+  path = path.replace_extension("realm");
+
+  auto config = realm::db_config();
+  config.set_path(path);
+  auto realm = db(std::move(config));
+  auto item = Beta_ThreadingExample_Item{
+      .name = "Save the cheerleader",
+  };
+  auto project = Beta_ThreadingExample_Project{
+      .name = "Heroes: Genesis",
+  };
+
+  realm.write([&] {
+    realm.add(std::move(item));
+    realm.add(std::move(project));
+  });
+
+  auto frozenRealm = realm.freeze();
+
+  CHECK(frozenRealm.is_frozen());
+
+  // :snippet-start: append-to-frozen-collection
+  // Get frozen objects.
+  // Here, we're getting them from a frozen realm,
+  // but you might also be passing them across threads.
+  auto frozenItems = frozenRealm.objects<Beta_ThreadingExample_Item>();
+
+  // The collection that we pull from the frozen realm is also frozen
+  CHECK(frozenItems.is_frozen());
+
+  // Get the individual objects we want to work with.
+  auto specificFrozenItems = frozenItems.where(
+      [](auto const& item) { return item.name == "Save the cheerleader"; });
+  auto frozenProjects =
+      frozenRealm.objects<Beta_ThreadingExample_Project>().where(
+          [](auto const& project) {
+            return project.name == "Heroes: Genesis";
+          });
+  ;
+  auto frozenItem = specificFrozenItems[0];
+  auto frozenProject = frozenProjects[0];
+
+  // Thaw the frozen objects. You must thaw both the object
+  // you want to append and the object whose collection
+  // property you want to append to.
+  auto thawedItem = frozenItem.thaw();
+  auto thawedProject = frozenProject.thaw();
+  REQUIRE(thawedProject.items.size() == 0);  // :remove:
+
+  auto managingRealm = thawedProject.get_realm();
+  managingRealm.write([&] { thawedProject.items.push_back(thawedItem); });
+  // :snippet-end:
+  REQUIRE(thawedProject.items.size() == 1);
+
+  managingRealm.write([&] {
+    managingRealm.remove(thawedProject);
+    managingRealm.remove(thawedItem);
+  });
 }
 // :replace-end:

--- a/examples/cpp/beta/local/threading.cpp
+++ b/examples/cpp/beta/local/threading.cpp
@@ -85,7 +85,7 @@ TEST_CASE("scheduler", "[write]") {
       // ... Call in the processor thread(s) and block until return ...
     }
 
-    void invoke(realm::Function<void()>&& task) override {
+    void invoke(std::function<void()>&& task) override {
       // ... Add the task to the (lock-free) processor queue ...
     }
 

--- a/examples/cpp/beta/local/threading.cpp
+++ b/examples/cpp/beta/local/threading.cpp
@@ -9,10 +9,12 @@
 
 using namespace realm::experimental;
 
+// :snippet-start: item-model
 struct Beta_ThreadingExample_Item {
   std::string name;
 };
 REALM_SCHEMA(Beta_ThreadingExample_Item, name)
+// :snippet-end:
 
 TEST_CASE("thread safe reference", "[write]") {
   auto relative_realm_path_directory = "beta_tsr/";

--- a/source/examples/generated/cpp/threading.snippet.append-to-frozen-collection.cpp
+++ b/source/examples/generated/cpp/threading.snippet.append-to-frozen-collection.cpp
@@ -1,0 +1,28 @@
+// Get frozen objects.
+// Here, we're getting them from a frozen realm,
+// but you might also be passing them across threads.
+auto frozenItems = frozenRealm.objects<Item>();
+
+// The collection that we pull from the frozen realm is also frozen
+CHECK(frozenItems.is_frozen());
+
+// Get the individual objects we want to work with.
+auto specificFrozenItems = frozenItems.where(
+    [](auto const& item) { return item.name == "Save the cheerleader"; });
+auto frozenProjects =
+    frozenRealm.objects<Project>().where(
+        [](auto const& project) {
+          return project.name == "Heroes: Genesis";
+        });
+;
+auto frozenItem = specificFrozenItems[0];
+auto frozenProject = frozenProjects[0];
+
+// Thaw the frozen objects. You must thaw both the object
+// you want to append and the object whose collection
+// property you want to append to.
+auto thawedItem = frozenItem.thaw();
+auto thawedProject = frozenProject.thaw();
+
+auto managingRealm = thawedProject.get_realm();
+managingRealm.write([&] { thawedProject.items.push_back(thawedItem); });

--- a/source/examples/generated/cpp/threading.snippet.append-to-frozen-collection.cpp
+++ b/source/examples/generated/cpp/threading.snippet.append-to-frozen-collection.cpp
@@ -3,7 +3,7 @@
 // but you might also be passing them across threads.
 auto frozenItems = frozenRealm.objects<Item>();
 
-// The collection that we pull from the frozen realm is also frozen
+// The collection that we pull from the frozen realm is also frozen.
 CHECK(frozenItems.is_frozen());
 
 // Get the individual objects we want to work with.

--- a/source/examples/generated/cpp/threading.snippet.beta-scheduler.cpp
+++ b/source/examples/generated/cpp/threading.snippet.beta-scheduler.cpp
@@ -1,51 +1,50 @@
 struct MyScheduler : realm::scheduler {
-    MyScheduler() {
-        // ... Kick off task processor thread(s) and run until the scheduler
-        // goes out of scope ...
-    }
+  MyScheduler() {
+    // ... Kick off task processor thread(s) and run until the scheduler
+    // goes out of scope ...
+  }
 
-    ~MyScheduler() override {
-        // ... Call in the processor thread(s) and block until return ...
-    }
-    
-    void invoke(realm::Function<void()> &&task) override {
-        // ... Add the task to the (lock-free) processor queue ...
-    }
+  ~MyScheduler() override {
+    // ... Call in the processor thread(s) and block until return ...
+  }
 
-    [[nodiscard]] bool is_on_thread() const noexcept override {
-        // ... Return true if the caller is on the same thread as a processor thread ...
-    }
+  void invoke(realm::Function<void()>&& task) override {
+    // ... Add the task to the (lock-free) processor queue ...
+  }
 
-    bool is_same_as(const realm::scheduler *other) const noexcept override {
-        // ... Compare scheduler instances ...
-    }
+  [[nodiscard]] bool is_on_thread() const noexcept override {
+    // ... Return true if the caller is on the same thread as a processor
+    // thread ...
+  }
 
-    [[nodiscard]] bool can_invoke() const noexcept override {
-        // ... Return true if the scheduler can accept tasks ...
-    }
-    // ...
+  bool is_same_as(const realm::scheduler* other) const noexcept override {
+    // ... Compare scheduler instances ...
+  }
+
+  [[nodiscard]] bool can_invoke() const noexcept override {
+    // ... Return true if the scheduler can accept tasks ...
+  }
+  // ...
 };
 
 int main() {
-    // Set up a custom scheduler
-    auto scheduler = std::make_shared<MyScheduler>();
-    
-    // Pass the scheduler instance to the realm configuration
-    auto config = realm::db_config{
-        path, scheduler
-    };
-    
-    // Start the program main loop
-    auto done = false;
-    while (!done) {
-        // This assumes the scheduler is implemented so that it
-        // continues processing tasks on background threads until
-        // the scheduler goes out of scope.
-        
-        // Handle input here
-        // ...
-        if (shouldQuitProgram) {
-            done = true;
-        }
-    }
+// Set up a custom scheduler
+auto scheduler = std::make_shared<MyScheduler>();
+
+// Pass the scheduler instance to the realm configuration
+auto config = realm::db_config{path, scheduler};
+
+// Start the program main loop
+auto done = false;
+while (!done) {
+  // This assumes the scheduler is implemented so that it
+  // continues processing tasks on background threads until
+  // the scheduler goes out of scope.
+
+  // Handle input here
+  // ...
+  if (shouldQuitProgram) {
+    done = true;
+  }
+}
 }

--- a/source/examples/generated/cpp/threading.snippet.beta-scheduler.cpp
+++ b/source/examples/generated/cpp/threading.snippet.beta-scheduler.cpp
@@ -1,50 +1,50 @@
-struct MyScheduler : realm::scheduler {
-  MyScheduler() {
-    // ... Kick off task processor thread(s) and run until the scheduler
-    // goes out of scope ...
+  struct MyScheduler : realm::scheduler {
+    MyScheduler() {
+      // ... Kick off task processor thread(s) and run until the scheduler
+      // goes out of scope ...
+    }
+
+    ~MyScheduler() override {
+      // ... Call in the processor thread(s) and block until return ...
+    }
+
+    void invoke(realm::Function<void()>&& task) override {
+      // ... Add the task to the (lock-free) processor queue ...
+    }
+
+    [[nodiscard]] bool is_on_thread() const noexcept override {
+      // ... Return true if the caller is on the same thread as a processor
+      // thread ...
+    }
+
+    bool is_same_as(const realm::scheduler* other) const noexcept override {
+      // ... Compare scheduler instances ...
+    }
+
+    [[nodiscard]] bool can_invoke() const noexcept override {
+      // ... Return true if the scheduler can accept tasks ...
+    }
+    // ...
+  };
+
+  int main() {
+    // Set up a custom scheduler.
+    auto scheduler = std::make_shared<MyScheduler>();
+
+    // Pass the scheduler instance to the realm configuration.
+    auto config = realm::db_config{path, scheduler};
+
+    // Start the program main loop.
+    auto done = false;
+    while (!done) {
+      // This assumes the scheduler is implemented so that it
+      // continues processing tasks on background threads until
+      // the scheduler goes out of scope.
+
+      // Handle input here.
+      // ...
+      if (shouldQuitProgram) {
+        done = true;
+      }
+    }
   }
-
-  ~MyScheduler() override {
-    // ... Call in the processor thread(s) and block until return ...
-  }
-
-  void invoke(realm::Function<void()>&& task) override {
-    // ... Add the task to the (lock-free) processor queue ...
-  }
-
-  [[nodiscard]] bool is_on_thread() const noexcept override {
-    // ... Return true if the caller is on the same thread as a processor
-    // thread ...
-  }
-
-  bool is_same_as(const realm::scheduler* other) const noexcept override {
-    // ... Compare scheduler instances ...
-  }
-
-  [[nodiscard]] bool can_invoke() const noexcept override {
-    // ... Return true if the scheduler can accept tasks ...
-  }
-  // ...
-};
-
-int main() {
-// Set up a custom scheduler
-auto scheduler = std::make_shared<MyScheduler>();
-
-// Pass the scheduler instance to the realm configuration
-auto config = realm::db_config{path, scheduler};
-
-// Start the program main loop
-auto done = false;
-while (!done) {
-  // This assumes the scheduler is implemented so that it
-  // continues processing tasks on background threads until
-  // the scheduler goes out of scope.
-
-  // Handle input here
-  // ...
-  if (shouldQuitProgram) {
-    done = true;
-  }
-}
-}

--- a/source/examples/generated/cpp/threading.snippet.beta-scheduler.cpp
+++ b/source/examples/generated/cpp/threading.snippet.beta-scheduler.cpp
@@ -8,7 +8,7 @@
       // ... Call in the processor thread(s) and block until return ...
     }
 
-    void invoke(realm::Function<void()>&& task) override {
+    void invoke(std::function<void()>&& task) override {
       // ... Add the task to the (lock-free) processor queue ...
     }
 

--- a/source/examples/generated/cpp/threading.snippet.beta-thread-safe-reference.cpp
+++ b/source/examples/generated/cpp/threading.snippet.beta-thread-safe-reference.cpp
@@ -1,18 +1,21 @@
 // Put a managed realm object into a thread safe reference
-auto threadSafeItem = realm::thread_safe_reference<Item>{managedItem};
+auto threadSafeItem =
+    realm::thread_safe_reference<Item>{managedItem};
 
 // Move the thread safe reference to a background thread
-auto thread = std::thread([threadSafeItem = std::move(threadSafeItem), path]() mutable {
-    // Open the realm again on the background thread
-    auto backgroundConfig = realm::db_config();
-    backgroundConfig.set_path(path);
-    auto backgroundRealm = db(std::move(backgroundConfig));
-    
-    // Resolve the ThreadingExample_Item instance via the thread safe reference
-    auto item = backgroundRealm.resolve(std::move(threadSafeItem));
+auto thread =
+    std::thread([threadSafeItem = std::move(threadSafeItem), path]() mutable {
+      // Open the realm again on the background thread
+      auto backgroundConfig = realm::db_config();
+      backgroundConfig.set_path(path);
+      auto backgroundRealm = db(std::move(backgroundConfig));
 
-    // ... use item ...
-});
+      // Resolve the ThreadingExample_Item instance via the thread safe
+      // reference
+      auto item = backgroundRealm.resolve(std::move(threadSafeItem));
+
+      // ... use item ...
+    });
 
 // Wait for thread to complete
 thread.join();

--- a/source/examples/generated/cpp/threading.snippet.beta-thread-safe-reference.cpp
+++ b/source/examples/generated/cpp/threading.snippet.beta-thread-safe-reference.cpp
@@ -1,21 +1,21 @@
-// Put a managed realm object into a thread safe reference
+// Put a managed realm object into a thread safe reference.
 auto threadSafeItem =
     realm::thread_safe_reference<Item>{managedItem};
 
-// Move the thread safe reference to a background thread
+// Move the thread safe reference to a background thread.
 auto thread =
     std::thread([threadSafeItem = std::move(threadSafeItem), path]() mutable {
-      // Open the realm again on the background thread
+      // Open the realm again on the background thread.
       auto backgroundConfig = realm::db_config();
       backgroundConfig.set_path(path);
       auto backgroundRealm = db(std::move(backgroundConfig));
 
       // Resolve the ThreadingExample_Item instance via the thread safe
-      // reference
+      // reference.
       auto item = backgroundRealm.resolve(std::move(threadSafeItem));
 
       // ... use item ...
     });
 
-// Wait for thread to complete
+// Wait for thread to complete.
 thread.join();

--- a/source/examples/generated/cpp/threading.snippet.freeze.cpp
+++ b/source/examples/generated/cpp/threading.snippet.freeze.cpp
@@ -4,10 +4,10 @@ auto realm = db(std::move(config));
 auto frozenRealm = realm.freeze();
 
 if (frozenRealm.is_frozen()) {
-    // Do something with the frozen realm.
-    // You may pass a frozen realm, collection, or objects
-    // across threads. Or you may need to `.thaw()`
-    // to make it mutable again.
+  // Do something with the frozen realm.
+  // You may pass a frozen realm, collection, or objects
+  // across threads. Or you may need to `.thaw()`
+  // to make it mutable again.
 }
 
 // You can freeze collections
@@ -23,12 +23,9 @@ CHECK(itemsFromFrozenRealm.is_frozen());
 
 // You can freeze objects
 auto managedItem = managedItems[0];
-
-CHECK(!managedItem.m_realm.is_frozen());
-
 auto frozenItem = managedItem.freeze();
 
 CHECK(frozenItem.is_frozen());
 
 // Frozen objects have a reference to a frozen realm
-CHECK(frozenItem.m_realm.is_frozen());
+CHECK(frozenItem.get_realm().is_frozen());

--- a/source/examples/generated/cpp/threading.snippet.freeze.cpp
+++ b/source/examples/generated/cpp/threading.snippet.freeze.cpp
@@ -1,6 +1,6 @@
 auto realm = db(std::move(config));
 
-// Get an immutable copy of the realm that can be passed across threads
+// Get an immutable copy of the realm that can be passed across threads.
 auto frozenRealm = realm.freeze();
 
 if (frozenRealm.is_frozen()) {
@@ -10,22 +10,22 @@ if (frozenRealm.is_frozen()) {
   // to make it mutable again.
 }
 
-// You can freeze collections
+// You can freeze collections.
 auto managedItems = realm.objects<Item>();
 auto frozenItems = managedItems.freeze();
 
 CHECK(frozenItems.is_frozen());
 
-// You can read from frozen realms
+// You can read from frozen realms.
 auto itemsFromFrozenRealm = frozenRealm.objects<Item>();
 
 CHECK(itemsFromFrozenRealm.is_frozen());
 
-// You can freeze objects
+// You can freeze objects.
 auto managedItem = managedItems[0];
 auto frozenItem = managedItem.freeze();
 
 CHECK(frozenItem.is_frozen());
 
-// Frozen objects have a reference to a frozen realm
+// Frozen objects have a reference to a frozen realm.
 CHECK(frozenItem.get_realm().is_frozen());

--- a/source/examples/generated/cpp/threading.snippet.freeze.cpp
+++ b/source/examples/generated/cpp/threading.snippet.freeze.cpp
@@ -1,0 +1,34 @@
+auto realm = db(std::move(config));
+
+// Get an immutable copy of the realm that can be passed across threads
+auto frozenRealm = realm.freeze();
+
+if (frozenRealm.is_frozen()) {
+    // Do something with the frozen realm.
+    // You may pass a frozen realm, collection, or objects
+    // across threads. Or you may need to `.thaw()`
+    // to make it mutable again.
+}
+
+// You can freeze collections
+auto managedItems = realm.objects<Item>();
+auto frozenItems = managedItems.freeze();
+
+CHECK(frozenItems.is_frozen());
+
+// You can read from frozen realms
+auto itemsFromFrozenRealm = frozenRealm.objects<Item>();
+
+CHECK(itemsFromFrozenRealm.is_frozen());
+
+// You can freeze objects
+auto managedItem = managedItems[0];
+
+CHECK(!managedItem.m_realm.is_frozen());
+
+auto frozenItem = managedItem.freeze();
+
+CHECK(frozenItem.is_frozen());
+
+// Frozen objects have a reference to a frozen realm
+CHECK(frozenItem.m_realm.is_frozen());

--- a/source/examples/generated/cpp/threading.snippet.is-frozen.cpp
+++ b/source/examples/generated/cpp/threading.snippet.is-frozen.cpp
@@ -1,0 +1,6 @@
+if (frozenRealm.is_frozen()) {
+    // Do something with the frozen realm.
+    // You may pass a frozen realm, collection, or objects
+    // across threads. Or you may need to `.thaw()`
+    // to make it mutable again.
+}

--- a/source/examples/generated/cpp/threading.snippet.is-frozen.cpp
+++ b/source/examples/generated/cpp/threading.snippet.is-frozen.cpp
@@ -1,6 +1,6 @@
 if (frozenRealm.is_frozen()) {
-    // Do something with the frozen realm.
-    // You may pass a frozen realm, collection, or objects
-    // across threads. Or you may need to `.thaw()`
-    // to make it mutable again.
+  // Do something with the frozen realm.
+  // You may pass a frozen realm, collection, or objects
+  // across threads. Or you may need to `.thaw()`
+  // to make it mutable again.
 }

--- a/source/examples/generated/cpp/threading.snippet.item-model.cpp
+++ b/source/examples/generated/cpp/threading.snippet.item-model.cpp
@@ -1,0 +1,4 @@
+struct Item {
+  std::string name;
+};
+REALM_SCHEMA(Item, name)

--- a/source/examples/generated/cpp/threading.snippet.model-with-collection-property.cpp
+++ b/source/examples/generated/cpp/threading.snippet.model-with-collection-property.cpp
@@ -1,0 +1,5 @@
+struct Project {
+  std::string name;
+  std::vector<Item*> items;
+};
+REALM_SCHEMA(Project, name, items)

--- a/source/examples/generated/cpp/threading.snippet.thaw.cpp
+++ b/source/examples/generated/cpp/threading.snippet.thaw.cpp
@@ -1,14 +1,14 @@
-// Read from a frozen realm
+// Read from a frozen realm.
 auto frozenItems = frozenRealm.objects<Item>();
 
-// The collection that we pull from the frozen realm is also frozen
+// The collection that we pull from the frozen realm is also frozen.
 CHECK(frozenItems.is_frozen());
 
-// Get an individual item from the collection
+// Get an individual item from the collection.
 auto frozenItem = frozenItems[0];
 
-// To modify the item, you must first thaw it
-// You can also thaw collections and realms
+// To modify the item, you must first thaw it.
+// You can also thaw collections and realms.
 auto thawedItem = frozenItem.thaw();
 
 // Check to make sure the item is valid. An object is
@@ -16,7 +16,7 @@ auto thawedItem = frozenItem.thaw();
 // or when its managing realm has invalidate() called on it.
 REQUIRE(thawedItem.is_invalidated() == false);
 
-// Thawing the item also thaws the frozen realm it references
+// Thawing the item also thaws the frozen realm it references.
 auto thawedRealm = thawedItem.get_realm();
 REQUIRE(thawedRealm.is_frozen() == false);
 

--- a/source/examples/generated/cpp/threading.snippet.thaw.cpp
+++ b/source/examples/generated/cpp/threading.snippet.thaw.cpp
@@ -1,0 +1,17 @@
+// Read from a frozen realm
+auto frozenItems = frozenRealm.objects<Item>();
+
+// The collection that we pull from the frozen realm is also frozen
+CHECK(frozenItems.is_frozen());
+
+// To modify objects, you must first thaw them.
+// Currently, you can thaw collections or realms.
+auto thawedItems = frozenItems.thaw();
+
+auto thawedItem = thawedItems[0];
+
+// Check to make sure the item is valid. An object is
+// invalidated when it is deleted from its managing realm,
+// or when its managing realm has invalidate() called on it.
+REQUIRE(thawedItem.is_invalidated() == false);
+

--- a/source/examples/generated/cpp/threading.snippet.thaw.cpp
+++ b/source/examples/generated/cpp/threading.snippet.thaw.cpp
@@ -4,14 +4,22 @@ auto frozenItems = frozenRealm.objects<Item>();
 // The collection that we pull from the frozen realm is also frozen
 CHECK(frozenItems.is_frozen());
 
-// To modify objects, you must first thaw them.
-// Currently, you can thaw collections or realms.
-auto thawedItems = frozenItems.thaw();
+// Get an individual item from the collection
+auto frozenItem = frozenItems[0];
 
-auto thawedItem = thawedItems[0];
+// To modify the item, you must first thaw it
+// You can also thaw collections and realms
+auto thawedItem = frozenItem.thaw();
 
 // Check to make sure the item is valid. An object is
 // invalidated when it is deleted from its managing realm,
 // or when its managing realm has invalidate() called on it.
 REQUIRE(thawedItem.is_invalidated() == false);
 
+// Thawing the item also thaws the frozen realm it references
+auto thawedRealm = thawedItem.get_realm();
+REQUIRE(thawedRealm.is_frozen() == false);
+
+// With both the object and its managing realm thawed, you
+// can safely modify the object.
+thawedRealm.write([&] { thawedItem.name = "Save the world"; });

--- a/source/sdk/cpp/crud/threading.txt
+++ b/source/sdk/cpp/crud/threading.txt
@@ -247,7 +247,7 @@ instead of blocking the UI.
       - A ``Project`` object that has a list property of ``Item`` objects
       - An ``Item`` object
 
-      We must thaw both objects before we can append the Item to 
+      We must thaw both objects before we can append the ``Item`` to 
       the ``items`` list collection on the ``Project``. If we thaw only the 
       ``Project`` object but not the ``Item``, Realm throws an error.
 
@@ -259,9 +259,11 @@ instead of blocking the UI.
 
       .. literalinclude:: /examples/generated/cpp/threading.snippet.item-model.cpp
          :language: cpp
+         :caption: Item Model
 
       .. literalinclude:: /examples/generated/cpp/threading.snippet.model-with-collection-property.cpp
          :language: cpp
+         :caption: Project Model
 
 .. _cpp-scheduler-thread-management:
 

--- a/source/sdk/cpp/crud/threading.txt
+++ b/source/sdk/cpp/crud/threading.txt
@@ -154,7 +154,7 @@ instances will map to the same file on disk.
 Pass Immutable Copies Across Threads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: v0.5.0-preview
+.. versionadded:: v0.5.0-preview & v0.6.0-preview
 
 Live, thread-confined objects work fine in most cases.
 However, some apps -- those based on reactive, event
@@ -269,6 +269,9 @@ instead of blocking the UI.
 
 Schedulers (Run Loops)
 ----------------------
+
+.. versionchanged:: v0.6.0-preview 
+   ``realm::Function`` replaced with ``std::function``
 
 Some platforms or frameworks automatically set up a **scheduler** (or **run
 loop**), which continuously processes events during the lifetime of your

--- a/source/sdk/cpp/crud/threading.txt
+++ b/source/sdk/cpp/crud/threading.txt
@@ -230,21 +230,38 @@ Append to a Frozen Collection
 `````````````````````````````
 
 When you append to a frozen :ref:`collection <cpp-collection-types>`, 
-you must thaw both the collection and the object that you want to append. 
-In this example, we query for two objects in a frozen Realm:
-
-- A ``Project`` object that has a list property of ``Item`` objects
-- An ``Item`` object
-
-We must thaw both objects before we can append the Item to 
-the ``Items`` list collection on the ``Project``. If we thaw only the 
-``Project`` object but not the ``Item``, Realm throws an error.
+you must thaw both the object containing the collection and the object 
+that you want to append. 
 
 The same rule applies when passing frozen objects across threads. A common 
 case might be calling a function on a background thread to do some work 
 instead of blocking the UI.
 
-.. TODO: add a code example once thawing an object is added
+.. tabs::
+
+   .. tab:: Append to frozen collection
+      :tabid: append-to-collection
+
+      In this example, we query for two objects in a frozen Realm:
+
+      - A ``Project`` object that has a list property of ``Item`` objects
+      - An ``Item`` object
+
+      We must thaw both objects before we can append the Item to 
+      the ``items`` list collection on the ``Project``. If we thaw only the 
+      ``Project`` object but not the ``Item``, Realm throws an error.
+
+      .. literalinclude:: /examples/generated/cpp/threading.snippet.append-to-frozen-collection.cpp
+         :language: cpp
+
+   .. tab:: Object Models
+      :tabid: models
+
+      .. literalinclude:: /examples/generated/cpp/threading.snippet.item-model.cpp
+         :language: cpp
+
+      .. literalinclude:: /examples/generated/cpp/threading.snippet.model-with-collection-property.cpp
+         :language: cpp
 
 .. _cpp-scheduler-thread-management:
 

--- a/source/sdk/cpp/crud/threading.txt
+++ b/source/sdk/cpp/crud/threading.txt
@@ -78,6 +78,9 @@ on your use case:
   a :ref:`thread_safe_reference <cpp-thread-safe-reference>` to the realm
   instance or object.
 
+- To send a fast, read-only view of the object to other threads,
+  :ref:`"freeze" <cpp-frozen-objects>` the object.
+
 .. _cpp-thread-safe-reference:
 
 Pass Instances Across Threads
@@ -127,7 +130,7 @@ again on that thread. But if the object does not have a primary
 key, it is not trivial to query for it. You can use ``thread_safe_reference`` 
 on any object, regardless of whether it has a primary key.
 
-.. _ios-use-realm-across-threads:
+.. _cpp-use-realm-across-threads:
 
 Use the Same Realm Across Threads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -138,6 +141,103 @@ To use the same Realm file across threads, open a different realm instance on
 each thread. As long as you use the same :cpp-sdk:`configuration
 <structrealm_1_1internal_1_1bridge_1_1realm_1_1config.html>`, all Realm
 instances will map to the same file on disk.
+
+.. _cpp-pass-immutable-copies-across-threads:
+
+Pass Immutable Copies Across Threads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: v0.5.0-preview
+
+Live, thread-confined objects work fine in most cases.
+However, some apps -- those based on reactive, event
+stream-based architectures, for example -- need to send
+immutable copies around to many threads for processing
+before ultimately ending up on the UI thread. Making a deep
+copy every time would be expensive, and Realm does not allow
+live instances to be shared across threads. In this case,
+you can **freeze** and **thaw** objects, collections, and realms.
+
+Freezing creates an immutable view of a specific object,
+collection, or realm. The frozen object, collection, or realm still 
+exists on disk, and does not need to be deeply copied when passed around 
+to other threads. You can freely share the frozen object across threads
+without concern for thread issues. When you freeze a realm, its child 
+objects also become frozen.
+
+Frozen objects are not live and do not automatically update.
+They are effectively snapshots of the object state at the
+time of freezing. Thawing an object returns a live version of the frozen 
+object.
+
+To freeze a realm, collection, or object, call the ``.freeze()`` method:
+
+.. literalinclude:: /examples/generated/cpp/threading.snippet.freeze.cpp
+   :language: cpp
+
+.. include:: /includes/tip-cpp-beta-experimental-features.rst
+
+When working with frozen objects, an attempt to do any of
+the following throws an exception:
+
+- Opening a write transaction on a frozen realm.
+- Modifying a frozen object.
+- Adding a change listener to a frozen realm, collection, or object.
+
+You can use ``.is_frozen()`` to check if the object is frozen. This is always
+thread-safe. 
+
+.. literalinclude:: /examples/generated/cpp/threading.snippet.is-frozen.cpp
+   :language: cpp
+
+Frozen objects remain valid as long as the live realm that
+spawned them stays open. Therefore, avoid closing the live
+realm until all threads are done with the frozen objects.
+You can close a frozen realm before the live realm is closed.
+
+.. important:: On caching frozen objects
+
+   Caching too many frozen objects can have a negative
+   impact on the realm file size. "Too many" depends on your
+   specific target device and the size of your Realm
+   objects. If you need to cache a large number of versions,
+   consider copying what you need out of the realm instead.
+
+.. _cpp-modify-frozen-object:
+
+Modify a Frozen Object
+``````````````````````
+
+To modify a frozen object, you must thaw the object. Alternately, you can 
+query for it on an unfrozen realm, then modify it. Calling ``.thaw()`` 
+on a live object, collection, or realm returns itself.
+
+Thawing an object or collection also thaws the realm it references.
+
+.. literalinclude:: /examples/generated/cpp/threading.snippet.thaw.cpp
+   :language: cpp
+
+.. _cpp-append-to-frozen-collection:
+
+Append to a Frozen Collection
+`````````````````````````````
+
+When you append to a frozen :ref:`collection <cpp-collection-types>`, 
+you must thaw both the collection and the object that you want to append. 
+In this example, we query for two objects in a frozen Realm:
+
+- A ``Project`` object that has a list property of ``Item`` objects
+- An ``Item`` object
+
+We must thaw both objects before we can append the Item to 
+the ``Items`` list collection on the ``Project``. If we thaw only the 
+``Project`` object but not the ``Item``, Realm throws an error.
+
+The same rule applies when passing frozen objects across threads. A common 
+case might be calling a function on a background thread to do some work 
+instead of blocking the UI.
+
+.. TODO: add a code example once thawing an object is added
 
 .. _cpp-scheduler-thread-management:
 

--- a/source/sdk/cpp/crud/threading.txt
+++ b/source/sdk/cpp/crud/threading.txt
@@ -4,6 +4,13 @@
 Threading - C++ SDK Preview
 ===========================
 
+.. meta:: 
+  :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -79,7 +86,7 @@ on your use case:
   instance or object.
 
 - To send a fast, read-only view of the object to other threads,
-  :ref:`"freeze" <cpp-frozen-objects>` the object.
+  :ref:`"freeze" <cpp-pass-immutable-copies-across-threads>` the object.
 
 .. _cpp-thread-safe-reference:
 

--- a/source/sdk/swift/crud/threading.txt
+++ b/source/sdk/swift/crud/threading.txt
@@ -454,7 +454,7 @@ thread-safe.
 Frozen objects remain valid as long as the live realm that
 spawned them stays open. Therefore, avoid closing the live
 realm until all threads are done with the frozen objects.
-You can close frozen realm before the live realm is closed.
+You can close a frozen realm before the live realm is closed.
 
 .. important:: On caching frozen objects
 

--- a/source/sdk/swift/crud/threading.txt
+++ b/source/sdk/swift/crud/threading.txt
@@ -4,6 +4,13 @@
 Threading - Swift SDK
 =====================
 
+.. meta:: 
+  :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34627

Staged changes:

- [Threading (C++ SDK)](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-34627/sdk/cpp/crud/threading/#pass-immutable-copies-across-threads): Add a "Pass Immutable Copies Across Threads" section about freeze/thaw
- [Threading (Swift SDK)](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-34627/sdk/swift/crud/threading/#frozen-objects): Typo fix

Note: This PR is currently pending some additional work in the C++ SDK to add freeze/thaw for an object, and a managing realm getter. The existing code example will be extended/fixed, and a new example added, when this work is done in the SDK - PRIOR to merging these docs.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for corresponding docs-realm docs-app-services, if any

### Release Notes

- **C++ SDK**
  - CRUD/Threading: Add a "Pass Immutable Copies Across Threads" section with tested, Bluehawked code examples for freeze/thaw.
- **Swift SDK**
  - CRUD/Threading: Typo fix.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
