### PR TITLE
(DOCSP-34268): C++ SDK: Add HTTP tunneling details to docs

### DIFF
--- a/examples/cpp/beta/sync/CMakeLists.txt
+++ b/examples/cpp/beta/sync/CMakeLists.txt
@@ -9,12 +9,12 @@ Include(FetchContent)
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.0.1 # or a later release
+  GIT_TAG        v3.4.0 # or a later release
 )
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        v0.4.0-preview
+  GIT_TAG        v0.5.0-preview
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/beta/sync/app.cpp
+++ b/examples/cpp/beta/sync/app.cpp
@@ -29,6 +29,32 @@ TEST_CASE("test custom headers compile", "[realm][sync]") {
     REQUIRE(user.access_token().empty());
 }
 
+TEST_CASE("test proxy config compiles", "[realm][sync]") {
+    // :snippet-start: set-proxy-config
+    auto proxyConfig = realm::proxy_config();
+    proxyConfig.port = 8080;
+    proxyConfig.address = "127.0.0.1";
+    proxyConfig.username_password = {"username", "password"};
+
+    auto appConfig = realm::App::configuration();
+    appConfig.proxy_configuration = proxyConfig;
+    // :remove-start:
+    // Skipping the rest of this test because of the complexity
+    // involved in setting up a proxy we can use in the CI.
+    // It's not a good use of docs time to test this properly.
+    // But maintaining this example in the test suite does give us
+    // compiler checking for code correctness.
+    SKIP();
+    // :remove-end:
+    auto app = realm::App(appConfig);
+    
+    auto user = app.get_current_user();
+    auto syncConfig = user->flexible_sync_configuration();
+    syncConfig.set_proxy_config(proxyConfig);
+    auto syncedRealm = realm::experimental::db(syncConfig);
+    // :snippet-end:
+}
+
 struct Beta_FlexibleSync_Dog {
     realm::experimental::primary_key<realm::object_id> _id{realm::object_id::generate()};
     std::string name;

--- a/source/examples/generated/cpp/app.snippet.set-proxy-config.cpp
+++ b/source/examples/generated/cpp/app.snippet.set-proxy-config.cpp
@@ -1,0 +1,13 @@
+auto proxyConfig = realm::proxy_config();
+proxyConfig.port = 8080;
+proxyConfig.address = "127.0.0.1";
+proxyConfig.username_password = {"username", "password"};
+
+auto appConfig = realm::App::configuration();
+appConfig.proxy_configuration = proxyConfig;
+auto app = realm::App(appConfig);
+
+auto user = app.get_current_user();
+auto syncConfig = user->flexible_sync_configuration();
+syncConfig.set_proxy_config(proxyConfig);
+auto syncedRealm = realm::experimental::db(syncConfig);

--- a/source/sdk/cpp/app-services/connect-to-app.txt
+++ b/source/sdk/cpp/app-services/connect-to-app.txt
@@ -81,6 +81,25 @@ If you want to use custom headers with Device Sync, you must
 additionally :ref:`set the headers on the Flexible Sync configuration 
 <cpp-set-custom-headers-using-synced-realm>`.
 
+.. _cpp-http_proxy:
+
+Use an HTTP Proxy with Realm
+----------------------------
+
+If you have configured an HTTP proxy, you can use HTTP tunneling to 
+route your Realm traffic. 
+
+To configure Realm to use your HTTP proxy:
+
+1. Initialize a 
+   :cpp-sdk:`proxy_config <structrealm_1_1internal_1_1bridge_1_1realm_1_1sync__config_1_1proxy__config.html>` 
+   with the details for your proxy. 
+#. Set the proxy config on your :cpp-sdk:`realm::App::configuration <structrealm_1_1App_1_1configuration.html>`.
+#. Set the proxy config on your :cpp-sdk:`sync_config <structrealm_1_1internal_1_1bridge_1_1realm_1_1sync__config.html>`.
+
+.. literalinclude:: /examples/generated/cpp/app.snippet.set-proxy-config.cpp
+   :language: cpp
+
 .. _cpp-encrypt-app-metadata:
 
 Encrypt App Metadata

--- a/source/sdk/cpp/app-services/connect-to-app.txt
+++ b/source/sdk/cpp/app-services/connect-to-app.txt
@@ -86,6 +86,8 @@ additionally :ref:`set the headers on the Flexible Sync configuration
 Use an HTTP Proxy with Realm
 ----------------------------
 
+.. versionadded:: v0.5.0-preview
+
 If you have configured an HTTP proxy, you can use HTTP tunneling to 
 route your Realm traffic. 
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34628

Staged changes:

- [Connect to an App Services App](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-34628/sdk/cpp/app-services/connect-to-app/#use-an-http-proxy-with-realm)

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for corresponding docs-realm docs-app-services, if any

### Release Notes

- **C++ SDK**
  - App Services/Connect to an App Services App: Add a "Use an HTTP Proxy with Realm" section with details and Bluehawked code example.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
