### PR TITLE
(DOCSP-33255): Add asymmetric object link details for SDKs

### DIFF
--- a/source/sdk/dotnet/sync/asymmetric-sync.txt
+++ b/source/sdk/dotnet/sync/asymmetric-sync.txt
@@ -4,6 +4,13 @@
 Unidirectional Data Ingest - .NET SDK
 =====================================
 
+.. meta:: 
+  :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/sdk/dotnet/sync/asymmetric-sync.txt
+++ b/source/sdk/dotnet/sync/asymmetric-sync.txt
@@ -26,6 +26,8 @@ within the same realm.
 Sync Data Unidirectionally from a Client Application
 ----------------------------------------------------
 
+.. versionchanged:: 11.6.0
+
 Before you set up Data Ingest, you need to understand the following rules:
 
 - The C# objects that you will sync with Atlas must implement the 
@@ -33,9 +35,14 @@ Before you set up Data Ingest, you need to understand the following rules:
   interface or derive from the 
   :dotnet-sdk:`AsymmetricObject <reference/Realms.AsymmetricObject.html>` class.
 
-- An object that implements ``IAsymmetricObject`` can contain 
+- Starting in .NET SDK version 11.6.0 and later, an object that implements 
+  ``IAsymmetricObject`` can contain
   :dotnet-sdk:`IEmbeddedObject <reference/Realms.IEmbeddedObject.html>` types, 
-  but not ``IRealmObject`` types or other ``IAsymmetricObject`` types.
+  and links to ``IRealmObject`` types. In .NET SDK versions 11.5.0 and earlier, 
+  an object that implements ``IAsymmetricObject`` can only contain
+  :dotnet-sdk:`IEmbeddedObject <reference/Realms.IEmbeddedObject.html>` types - 
+  it does not support links to ``IRealmObject`` types or other 
+  ``IAsymmetricObject`` types. 
 
 - ``IRealmObject`` and ``IEmbeddedObject`` types cannot contain ``IAsymmetricObject``
   types as properties. 

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -327,6 +327,11 @@ Asymmetric objects require Flexible Sync. To define an asymmetric object, pass
    :language: dart
    :emphasize-lines: 1
 
+In versions Flutter SDK versions 1.5.0 and earlier, you cannot link from
+``asymmetricObject`` types to ``RealmObjects``. In SDK versions 1.6.0 and
+later, ``asymmetricObject`` types can link to ``RealmObjects`` types in 
+addition to :ref:`embedded object types <flutter-embedded-objects>`.
+
 .. note:: Attempting to Read Asymmetric Objects
 
    Asymmetric objects can't be read. If you attempt to query an asymmetric

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -4,6 +4,13 @@
 Define a Realm Object Schema - Flutter SDK
 ==========================================
 
+.. meta:: 
+  :keywords: code example, android, ios, data modeling
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
+++ b/source/sdk/flutter/realm-database/model-data/define-realm-object-schema.txt
@@ -327,9 +327,9 @@ Asymmetric objects require Flexible Sync. To define an asymmetric object, pass
    :language: dart
    :emphasize-lines: 1
 
-In versions Flutter SDK versions 1.5.0 and earlier, you cannot link from
+In Flutter SDK versions 1.5.0 and earlier, you cannot link from
 ``asymmetricObject`` types to ``RealmObjects``. In SDK versions 1.6.0 and
-later, ``asymmetricObject`` types can link to ``RealmObjects`` types in 
+later, ``asymmetricObject`` types can link to ``RealmObjects`` in 
 addition to :ref:`embedded object types <flutter-embedded-objects>`.
 
 .. note:: Attempting to Read Asymmetric Objects

--- a/source/sdk/kotlin/realm-database/schemas/define-realm-object-model.txt
+++ b/source/sdk/kotlin/realm-database/schemas/define-realm-object-model.txt
@@ -202,6 +202,11 @@ interface:
 .. literalinclude:: /examples/generated/kotlin/Schema.snippet.define-asymmetric-model.kt 
     :language: kotlin
 
+In Kotlin SDK versions 1.11.1 and earlier, you cannot link from
+``AsymmetricRealmObject`` types to ``RealmObject`` types. In SDK versions 
+1.12.0 and later, ``AsymmetricRealmObject`` types can link to ``RealmObject``
+types in addition to ``EmbeddedRealmObject`` types.
+
 .. _kotlin-define-collections:
 
 Define Collection Properties

--- a/source/sdk/node/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/node/model-data/define-a-realm-object-model.txt
@@ -375,6 +375,8 @@ A ``Manufacturer`` object can embed a list of ``Warranty`` objects, whereas a
 Define an Asymmetric Object
 ---------------------------
 
+.. versionchanged:: 12.2.1
+
 If you are using Flexible Sync and need to sync a collection unidirectionally
 from your device to your Atlas database, you can set the ``asymmetric`` property
 on your object schema.
@@ -394,6 +396,11 @@ on your object schema.
       .. literalinclude::  /examples/generated/node/asymmetric-sync.snippet.asymmetric-sync-object.js
          :language: javascript
          :emphasize-lines: 6
+
+In Node.js SDK versions 12.2.0 and earlier, you cannot link from
+asymmetric objects to ``Realm.Object`` types. In SDK versions 
+12.2.1 and later, asymmetric objects can link to ``Realm.Object``
+types in addition to embedded objects.
 
 .. note:: Attempting to Read Asymmetric Objects
 

--- a/source/sdk/node/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/node/model-data/define-a-realm-object-model.txt
@@ -4,6 +4,13 @@
 Define a Realm Object Model- Node.js SDK
 ========================================
 
+.. meta:: 
+  :keywords: code example, data modeling
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/sdk/react-native/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/react-native/model-data/define-a-realm-object-model.txt
@@ -275,6 +275,11 @@ on your object schema.
          :language: typescript
          :emphasize-lines: 12
 
+In ``realm`` JS SDK versions 12.2.0 and earlier, you cannot link from
+asymmetric objects to ``Realm.Object`` types. In SDK versions 
+12.2.1 and later, asymmetric objects can link to ``Realm.Object``
+types in addition to embedded objects.
+
 .. note:: Attempting to Read Asymmetric Objects
 
    Asymmetric objects cannot be read. If you attempt to query an asymmetric object, you

--- a/source/sdk/react-native/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/react-native/model-data/define-a-realm-object-model.txt
@@ -5,6 +5,13 @@
 Define a Realm Object Model - React Native SDK
 ===============================================
 
+.. meta:: 
+  :keywords: code example, android, ios, data modeling
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -275,7 +282,9 @@ on your object schema.
          :language: typescript
          :emphasize-lines: 12
 
-In ``realm`` JS SDK versions 12.2.0 and earlier, you cannot link from
+.. versionchanged:: realm@12.2.1
+
+In JS SDK versions 12.2.0 and earlier, you cannot link from
 asymmetric objects to ``Realm.Object`` types. In SDK versions 
 12.2.1 and later, asymmetric objects can link to ``Realm.Object``
 types in addition to embedded objects.

--- a/source/sdk/react-native/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/react-native/model-data/define-a-realm-object-model.txt
@@ -282,7 +282,7 @@ on your object schema.
          :language: typescript
          :emphasize-lines: 12
 
-.. versionchanged:: realm@12.2.1
+.. versionchanged:: ``realm@12.2.1``
 
 In JS SDK versions 12.2.0 and earlier, you cannot link from
 asymmetric objects to ``Realm.Object`` types. In SDK versions 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: 

- https://jira.mongodb.org/browse/DOCSP-33255
- https://jira.mongodb.org/browse/DOCSP-33256
- https://jira.mongodb.org/browse/DOCSP-33257
- https://jira.mongodb.org/browse/DOCSP-33258
- https://jira.mongodb.org/browse/DOCSP-33259

Staged changes:

- [Flutter - Define a Realm Object Schema](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-33255/sdk/flutter/realm-database/model-data/define-realm-object-schema/#define-an-asymmetric-object)
- [Kotlin - Define an Object Model](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-33255/sdk/kotlin/realm-database/schemas/define-realm-object-model/#define-an-asymmetric-object-type)
- [.NET - Stream Data to Atlas](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-33255/sdk/dotnet/sync/asymmetric-sync/#sync-data-unidirectionally-from-a-client-application)
- [Node.js - Define a Realm Object Model](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-33255/sdk/node/model-data/define-a-realm-object-model/#define-an-asymmetric-object)
- [RN - Define an Object Model](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-33255/sdk/react-native/model-data/define-a-realm-object-model/#define-an-asymmetric-object)

These changes come along with a Core version update. I did not add `.. versionchanged::` admonitions in SDKs where we already have `.. versionadded::` for Asymmetric Sync, because this didn't seem to warrant stacking version admonitions. But that's an arbitrary decision so it may make sense to do this differently.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for corresponding docs-realm docs-app-services, if any

### Release Notes


- **Flutter SDK**
  - Realm Database/Model Data/Define a Realm Object Schema: Note that asymmetric objects support linking to Realm objects starting in v1.6.0.
- **Kotlin SDK**
  - Realm/Model Data/Define an Object Model: Note that asymmetric objects support linking to Realm objects starting in v1.12.0.
- **.NET SDK**
  - Sync Data/Stream Data to Atlas: Note that asymmetric objects support linking to Realm objects starting in v11.6.0.
- **Node.js SDK**
  - Model Data/Define an Object Model: Note that asymmetric objects support linking to Realm objects starting in v12.2.1.
- **React Native SDK**
  - Model Data/Define an Object Model: Note that asymmetric objects support linking to Realm objects starting in v12.2.1.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
