### PR TITLE
(DOCSP-34827) Fix one-character typo in Node.js docs

### DIFF
--- a/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
@@ -94,7 +94,7 @@ for more control.
    :emphasize-lines: 1
 
 If ``baseFilePath`` is set, metadata is always stored in
-``<baseFilePath>/mongodb-realm/``. If ``baseFilePath`` isn't sßet, then metadata
+``<baseFilePath>/mongodb-realm/``. If ``baseFilePath`` isn't set, then metadata
 is stored in ``<Realm.defaultPath>/mongodb-realm``.
 
 Where exactly your Realm file is stored can vary depending

--- a/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/node/sync/configure-and-open-a-synced-realm.txt
@@ -5,6 +5,14 @@
 Configure & Open a Synced Realm - Node.js SDK
 =============================================
 
+.. meta:: 
+  :description: Learn how to configure a synced realm using the Atlas Device
+    SDK for Node.js.
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34827

- [Configure & Open a Synced Realm](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/DOCSP-34827/sdk/node/sync/configure-and-open-a-synced-realm/#open-synced-realm-at-specific-path): Replace `sßet` with `set`.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
