### PR TITLE
(DOCSP-34741): Kotlin: Add key path change listener documentation

### DIFF
--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/NotificationsTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/NotificationsTest.kt
@@ -365,7 +365,7 @@ class NotificationsTest: RealmTest() {
                 assertIs<UpdatedObject<*>>(objChange)
                 assertEquals(1, objChange.changedFields.size)
                 // While you can watch for updates to a nested property, the notification
-                // only reports the change to the top-level property. In this case, there
+                // only reports the change on the top-level property. In this case, there
                 // was a change to one of the elements in the `members` property, so `members`
                 // is what the notification reports - not `age`.
                 assertEquals("members", objChange.changedFields.first())
@@ -425,7 +425,7 @@ class NotificationsTest: RealmTest() {
                 assertIs<UpdatedObject<*>>(objChange)
                 assertEquals(1, objChange.changedFields.size)
                 // While you can watch for updates to a nested property, the notification
-                // only reports the change to the top-level property. In this case, there
+                // only reports the change on the top-level property. In this case, there
                 // was a change to one of the elements in the `members` property, so `members`
                 // is what the notification reports - not `age`.
                 assertEquals("members", objChange.changedFields.first())

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/NotificationsTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/NotificationsTest.kt
@@ -1,5 +1,4 @@
 package com.mongodb.realm.realmkmmapp
-
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.ext.realmListOf
@@ -21,7 +20,11 @@ import io.realm.kotlin.types.annotations.PrimaryKey
 import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 class NotificationsTest: RealmTest() {
     // :snippet-start: sample-data-models
@@ -250,5 +253,187 @@ class NotificationsTest: RealmTest() {
 
             realm.close()
         }
+    }
+
+    @Test
+    fun keyPathChangeListenerTest() {
+        val REALM_NAME = getRandom()
+        val channel = Channel<SingleQueryChange<Character>>(1)
+        val config = RealmConfiguration.Builder(setOf(Fellowship::class, Character::class))
+                .directory("/tmp/")
+                .name(REALM_NAME)
+                .build()
+        val realm = Realm.open(config)
+        Log.v("Successfully opened realm: ${realm.configuration.name}")
+        // :snippet-start: realm-object-keypath-listener
+        runBlocking {
+            // Query for the specific object you intend to listen to.
+            val frodoQuery = realm.query(Character::class, "name == 'Frodo'").first()
+            val observer = async {
+                val frodoFlow = frodoQuery.asFlow(listOf("age"))
+                frodoFlow.collect { changes: SingleQueryChange<Character> ->
+                    // Change listener stuff in here.
+                    channel.send(changes) // :remove:
+                }
+            }
+            // :remove-start:
+            channel.receiveOrFail().let { objChange ->
+                assertIs<PendingObject<*>>(objChange)
+            }
+            val frodoObject = realm.writeBlocking {
+                copyToRealm(Character("Frodo", "Hobbit", 51))
+            }
+            channel.receiveOrFail().let { objChange ->
+                assertIs<InitialObject<*>>(objChange)
+            }
+            // :remove-end:
+            // Changing a property whose key path you're not observing does not trigger a notification.
+            realm.writeBlocking {
+                findLatest(frodoObject)!!.species = "Ring Bearer"
+            }
+
+            // Changing a property whose key path you are observing triggers a notification.
+            realm.writeBlocking {
+                findLatest(frodoObject)!!.age = 52
+            }
+            // :remove-start:
+            val updatedFrodoObject = realm.query(Character::class, "name == 'Frodo'").first().find()
+            assertEquals(52, updatedFrodoObject!!.age)
+            // :remove-end:
+            // For this example, we send the object change to a Channel where we can verify the
+            // changes we expect. In your application code, you might use the notification to
+            // update the UI or take some other action based on your business logic.
+            channel.receiveOrFail().let { objChange ->
+                assertIs<UpdatedObject<*>>(objChange)
+                assertEquals(1, objChange.changedFields.size)
+                // Because we are observing only the `age` property, the change to
+                // the `species` property does not trigger a notification.
+                // The first notification we receive is a change to the `age` property.
+                assertEquals("age", objChange.changedFields.first())
+            }
+            observer.cancel()
+            channel.close()
+        }
+        // :snippet-end:
+        realm.close()
+    }
+
+    @Test
+    fun nestedKeyPathChangeListenerTest() {
+        val REALM_NAME = getRandom()
+        seedSampleData(REALM_NAME)
+        val channel = Channel<SingleQueryChange<Fellowship>>(1)
+        val config = RealmConfiguration.Builder(setOf(Fellowship::class, Character::class))
+            .directory("/tmp/")
+            .name(REALM_NAME)
+            .build()
+        val realm = Realm.open(config)
+        Log.v("Successfully opened realm: ${realm.configuration.name}")
+        // :snippet-start: nested-keypath-listener
+        runBlocking {
+            // Query for the specific object you intend to listen to.
+            val fellowshipQuery = realm.query(Fellowship::class).first()
+            val observer = async {
+                val fellowshipFlow = fellowshipQuery.asFlow(listOf("members.age"))
+                fellowshipFlow.collect { changes: SingleQueryChange<Fellowship> ->
+                    // Change listener stuff in here.
+                    channel.send(changes) // :remove:
+                }
+            }
+            // :remove-start:
+            realm.writeBlocking {
+                findLatest(fellowshipQuery.find()!!.members.first())!!.species = "Ring Bearer"
+            }
+            channel.receiveOrFail().let { objChange ->
+                assertIs<InitialObject<*>>(objChange)
+            }
+            // :remove-end:
+
+            // Changing a property whose nested key path you are observing triggers a notification.
+            val fellowship = fellowshipQuery.find()!!
+            realm.writeBlocking {
+                findLatest(fellowship)!!.members[0].age = 52
+            }
+            // :remove-start:
+            val updatedFrodoObject = realm.query(Character::class, "name == 'Frodo'").first().find()
+            assertEquals(52, updatedFrodoObject!!.age)
+            // :remove-end:
+            // For this example, we send the object change to a Channel where we can verify the
+            // changes we expect. In your application code, you might use the notification to
+            // update the UI or take some other action based on your business logic.
+            channel.receiveOrFail().let { objChange ->
+                assertIs<UpdatedObject<*>>(objChange)
+                assertEquals(1, objChange.changedFields.size)
+                // While you can watch for updates to a nested property, the notification
+                // only reports the change to the top-level property. In this case, there
+                // was a change to one of the elements in the `members` property, so `members`
+                // is what the notification reports - not `age`.
+                assertEquals("members", objChange.changedFields.first())
+            }
+            observer.cancel()
+            channel.close()
+        }
+        // :snippet-end:
+        realm.close()
+    }
+
+    @Test
+    fun wildcardKeyPathChangeListenerTest() {
+        val REALM_NAME = getRandom()
+        seedSampleData(REALM_NAME)
+        val channel = Channel<SingleQueryChange<Fellowship>>(1)
+        val config = RealmConfiguration.Builder(setOf(Fellowship::class, Character::class))
+            .directory("/tmp/")
+            .name(REALM_NAME)
+            .build()
+        val realm = Realm.open(config)
+        Log.v("Successfully opened realm: ${realm.configuration.name}")
+        // :snippet-start: wildcard-keypath-listener
+        runBlocking {
+            // Query for the specific object you intend to listen to.
+            val fellowshipQuery = realm.query(Fellowship::class).first()
+            val observer = async {
+                // Use a wildcard to observe changes to any key path at the level of the wildcard.
+                val fellowshipFlow = fellowshipQuery.asFlow(listOf("members.*"))
+                fellowshipFlow.collect { changes: SingleQueryChange<Fellowship> ->
+                    // Change listener stuff in here.
+                    channel.send(changes) // :remove:
+                }
+            }
+            // :remove-start:
+            realm.writeBlocking {
+                findLatest(fellowshipQuery.find()!!.members.first())!!.species = "Ring Bearer"
+            }
+            channel.receiveOrFail().let { objChange ->
+                assertIs<InitialObject<*>>(objChange)
+            }
+            // :remove-end:
+
+            // Changing any property at the level of the key path wild card triggers a notification.
+            val fellowship = fellowshipQuery.find()!!
+            realm.writeBlocking {
+                findLatest(fellowship)!!.members[0].age = 52
+            }
+            // :remove-start:
+            val updatedFrodoObject = realm.query(Character::class, "name == 'Frodo'").first().find()
+            assertEquals(52, updatedFrodoObject!!.age)
+            // :remove-end:
+            // For this example, we send the object change to a Channel where we can verify the
+            // changes we expect. In your application code, you might use the notification to
+            // update the UI or take some other action based on your business logic.
+            channel.receiveOrFail().let { objChange ->
+                assertIs<UpdatedObject<*>>(objChange)
+                assertEquals(1, objChange.changedFields.size)
+                // While you can watch for updates to a nested property, the notification
+                // only reports the change to the top-level property. In this case, there
+                // was a change to one of the elements in the `members` property, so `members`
+                // is what the notification reports - not `age`.
+                assertEquals("members", objChange.changedFields.first())
+            }
+            observer.cancel()
+            channel.close()
+        }
+        // :snippet-end:
+        realm.close()
     }
 }

--- a/source/examples/generated/kotlin/NotificationsTest.snippet.nested-keypath-listener.kt
+++ b/source/examples/generated/kotlin/NotificationsTest.snippet.nested-keypath-listener.kt
@@ -1,0 +1,30 @@
+runBlocking {
+    // Query for the specific object you intend to listen to.
+    val fellowshipQuery = realm.query(Fellowship::class).first()
+    val observer = async {
+        val fellowshipFlow = fellowshipQuery.asFlow(listOf("members.age"))
+        fellowshipFlow.collect { changes: SingleQueryChange<Fellowship> ->
+            // Change listener stuff in here.
+        }
+    }
+
+    // Changing a property whose nested key path you are observing triggers a notification.
+    val fellowship = fellowshipQuery.find()!!
+    realm.writeBlocking {
+        findLatest(fellowship)!!.members[0].age = 52
+    }
+    // For this example, we send the object change to a Channel where we can verify the
+    // changes we expect. In your application code, you might use the notification to
+    // update the UI or take some other action based on your business logic.
+    channel.receiveOrFail().let { objChange ->
+        assertIs<UpdatedObject<*>>(objChange)
+        assertEquals(1, objChange.changedFields.size)
+        // While you can watch for updates to a nested property, the notification
+        // only reports the change to the top-level property. In this case, there
+        // was a change to one of the elements in the `members` property, so `members`
+        // is what the notification reports - not `age`.
+        assertEquals("members", objChange.changedFields.first())
+    }
+    observer.cancel()
+    channel.close()
+}

--- a/source/examples/generated/kotlin/NotificationsTest.snippet.nested-keypath-listener.kt
+++ b/source/examples/generated/kotlin/NotificationsTest.snippet.nested-keypath-listener.kt
@@ -20,7 +20,7 @@ runBlocking {
         assertIs<UpdatedObject<*>>(objChange)
         assertEquals(1, objChange.changedFields.size)
         // While you can watch for updates to a nested property, the notification
-        // only reports the change to the top-level property. In this case, there
+        // only reports the change on the top-level property. In this case, there
         // was a change to one of the elements in the `members` property, so `members`
         // is what the notification reports - not `age`.
         assertEquals("members", objChange.changedFields.first())

--- a/source/examples/generated/kotlin/NotificationsTest.snippet.realm-object-keypath-listener.kt
+++ b/source/examples/generated/kotlin/NotificationsTest.snippet.realm-object-keypath-listener.kt
@@ -1,0 +1,32 @@
+runBlocking {
+    // Query for the specific object you intend to listen to.
+    val frodoQuery = realm.query(Character::class, "name == 'Frodo'").first()
+    val observer = async {
+        val frodoFlow = frodoQuery.asFlow(listOf("age"))
+        frodoFlow.collect { changes: SingleQueryChange<Character> ->
+            // Change listener stuff in here.
+        }
+    }
+    // Changing a property whose key path you're not observing does not trigger a notification.
+    realm.writeBlocking {
+        findLatest(frodoObject)!!.species = "Ring Bearer"
+    }
+
+    // Changing a property whose key path you are observing triggers a notification.
+    realm.writeBlocking {
+        findLatest(frodoObject)!!.age = 52
+    }
+    // For this example, we send the object change to a Channel where we can verify the
+    // changes we expect. In your application code, you might use the notification to
+    // update the UI or take some other action based on your business logic.
+    channel.receiveOrFail().let { objChange ->
+        assertIs<UpdatedObject<*>>(objChange)
+        assertEquals(1, objChange.changedFields.size)
+        // Because we are observing only the `age` property, the change to
+        // the `species` property does not trigger a notification.
+        // The first notification we receive is a change to the `age` property.
+        assertEquals("age", objChange.changedFields.first())
+    }
+    observer.cancel()
+    channel.close()
+}

--- a/source/examples/generated/kotlin/NotificationsTest.snippet.wildcard-keypath-listener.kt
+++ b/source/examples/generated/kotlin/NotificationsTest.snippet.wildcard-keypath-listener.kt
@@ -21,7 +21,7 @@ runBlocking {
         assertIs<UpdatedObject<*>>(objChange)
         assertEquals(1, objChange.changedFields.size)
         // While you can watch for updates to a nested property, the notification
-        // only reports the change to the top-level property. In this case, there
+        // only reports the change on the top-level property. In this case, there
         // was a change to one of the elements in the `members` property, so `members`
         // is what the notification reports - not `age`.
         assertEquals("members", objChange.changedFields.first())

--- a/source/examples/generated/kotlin/NotificationsTest.snippet.wildcard-keypath-listener.kt
+++ b/source/examples/generated/kotlin/NotificationsTest.snippet.wildcard-keypath-listener.kt
@@ -1,0 +1,31 @@
+runBlocking {
+    // Query for the specific object you intend to listen to.
+    val fellowshipQuery = realm.query(Fellowship::class).first()
+    val observer = async {
+        // Use a wildcard to observe changes to any key path at the level of the wildcard.
+        val fellowshipFlow = fellowshipQuery.asFlow(listOf("members.*"))
+        fellowshipFlow.collect { changes: SingleQueryChange<Fellowship> ->
+            // Change listener stuff in here.
+        }
+    }
+
+    // Changing any property at the level of the key path wild card triggers a notification.
+    val fellowship = fellowshipQuery.find()!!
+    realm.writeBlocking {
+        findLatest(fellowship)!!.members[0].age = 52
+    }
+    // For this example, we send the object change to a Channel where we can verify the
+    // changes we expect. In your application code, you might use the notification to
+    // update the UI or take some other action based on your business logic.
+    channel.receiveOrFail().let { objChange ->
+        assertIs<UpdatedObject<*>>(objChange)
+        assertEquals(1, objChange.changedFields.size)
+        // While you can watch for updates to a nested property, the notification
+        // only reports the change to the top-level property. In this case, there
+        // was a change to one of the elements in the `members` property, so `members`
+        // is what the notification reports - not `age`.
+        assertEquals("members", objChange.changedFields.first())
+    }
+    observer.cancel()
+    channel.close()
+}

--- a/source/includes/note-key-path-notification-execution.rst
+++ b/source/includes/note-key-path-notification-execution.rst
@@ -1,0 +1,6 @@
+.. note::
+
+   Multiple notification tokens on the same object which filter for
+   separate key paths *do not* filter exclusively. If one key path
+   change is satisfied for one notification token, then all notification
+   token blocks for that object will execute.

--- a/source/sdk/kotlin/realm-database/react-to-changes.txt
+++ b/source/sdk/kotlin/realm-database/react-to-changes.txt
@@ -299,6 +299,8 @@ string property names to specify the key path or key paths to watch.
 When you specify key paths, only changes to those key paths trigger 
 notification blocks. Any other changes do not trigger notification blocks.
 
+In the following example, we register a key path change listener for the ``age`` property:
+
 .. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.realm-object-keypath-listener.kt
    :language: kotlin
 
@@ -309,6 +311,8 @@ You can use dot notation to observe nested key paths. By default, the SDK
 only reports notifications for objects nested up to four layers deep. Observe
 a specific key path if you need to observe changes on more deeply nested 
 objects.
+
+In the following example, we watch for updates to the nested property ``members.age``. Note that the SDK reports the change to the top-level ``members`` property, even though we're watching for changes to a nested property:
 
 .. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.nested-keypath-listener.kt
    :language: kotlin

--- a/source/sdk/kotlin/realm-database/react-to-changes.txt
+++ b/source/sdk/kotlin/realm-database/react-to-changes.txt
@@ -4,6 +4,14 @@
 React to Changes - Kotlin SDK
 =============================
 
+.. meta::
+  :description: SDK notifications allow you to watch for and react to changes in your data.
+  :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/sdk/kotlin/realm-database/react-to-changes.txt
+++ b/source/sdk/kotlin/realm-database/react-to-changes.txt
@@ -286,7 +286,7 @@ changes to the collection.
 .. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.realm-list-change-listener.kt
    :language: kotlin
    
-.. _kotlin-key-path-notification:
+.. _kotlin-key-path-notifications:
 
 Register a Key Path Change Listener
 -----------------------------------

--- a/source/sdk/kotlin/realm-database/react-to-changes.txt
+++ b/source/sdk/kotlin/realm-database/react-to-changes.txt
@@ -299,10 +299,13 @@ string property names to specify the key path or key paths to watch.
 When you specify key paths, only changes to those key paths trigger 
 notification blocks. Any other changes do not trigger notification blocks.
 
-In the following example, we register a key path change listener for the ``age`` property:
+In the following example, we register a key path change listener for the ``age`` 
+property:
 
 .. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.realm-object-keypath-listener.kt
    :language: kotlin
+
+.. include:: /includes/note-key-path-notification-execution.rst
 
 Observe Nested Key Paths
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -312,7 +315,10 @@ only reports notifications for objects nested up to four layers deep. Observe
 a specific key path if you need to observe changes on more deeply nested 
 objects.
 
-In the following example, we watch for updates to the nested property ``members.age``. Note that the SDK reports the change to the top-level ``members`` property, even though we're watching for changes to a nested property:
+In the following example, we watch for updates to the nested property 
+``members.age``. Note that the SDK reports the change to the top-level 
+``members`` property, even though we're watching for changes to a nested 
+property:
 
 .. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.nested-keypath-listener.kt
    :language: kotlin
@@ -322,6 +328,13 @@ Observe Key Paths with Wildcards
 
 You can use wildcards (``*``) to observe changes to all key paths at the 
 level of the wildcard.
+
+In the following example, we use the wildcard watch for changes to any nested 
+properties one level deep within the ``members`` property. Based on the model
+used in this example, this change listener would report changes to any member's
+``age``, ``species``, or ``name`` properties. Note that the SDK reports the 
+change to the top-level ``members`` property, even though we're watching for 
+changes to a nested property:
 
 .. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.wildcard-keypath-listener.kt
    :language: kotlin

--- a/source/sdk/kotlin/realm-database/react-to-changes.txt
+++ b/source/sdk/kotlin/realm-database/react-to-changes.txt
@@ -30,6 +30,11 @@ You can subscribe to changes on the following events:
 - :ref:`Realm object <kotlin-realm-object-change-listener>`
 - :ref:`Realm collections (e.g. list) <kotlin-realm-list-change-listener>`
 
+The SDK only provides notifications for objects nested up to four layers deep. 
+If you need to react to changes in more deeply-nested objects, register a
+key path change listener. For more information, refer to 
+**Register a Key Path Change Listener** on this page.
+
 You can also react to changes in user authentication state. For more information,
 refer to :ref:`kotlin-authentication-change-listener`.
 
@@ -273,6 +278,36 @@ changes to the collection.
 .. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.realm-list-change-listener.kt
    :language: kotlin
    
+.. _kotlin-key-path-notification:
+
+Register a Key Path Change Listener
+-----------------------------------
+
+.. versionadded:: 1.13.0
+
+When you register a notification handler, you can pass an optional list of 
+string property names to specify the key path or key paths to watch.
+
+When you specify key paths, only changes to those key paths trigger 
+notification blocks. Any other changes do not trigger notification blocks.
+
+.. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.realm-object-keypath-listener.kt
+   :language: kotlin
+
+You can use dot notation to observe nested key paths. By default, the SDK
+only reports notifications for objects nested up to four layers deep. Observe
+a specific key path if you need to observe changes on more deeply nested 
+objects.
+
+.. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.nested-keypath-listener.kt
+   :language: kotlin
+
+You can use wildcards (``*``) to observe changes to all key paths at the 
+level of the wildcard.
+
+.. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.wildcard-keypath-listener.kt
+   :language: kotlin
+
 Unsubscribe a Change Listener
 -----------------------------
 

--- a/source/sdk/kotlin/realm-database/react-to-changes.txt
+++ b/source/sdk/kotlin/realm-database/react-to-changes.txt
@@ -302,6 +302,9 @@ notification blocks. Any other changes do not trigger notification blocks.
 .. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.realm-object-keypath-listener.kt
    :language: kotlin
 
+Observe Nested Key Paths
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 You can use dot notation to observe nested key paths. By default, the SDK
 only reports notifications for objects nested up to four layers deep. Observe
 a specific key path if you need to observe changes on more deeply nested 
@@ -309,6 +312,9 @@ objects.
 
 .. literalinclude:: /examples/generated/kotlin/NotificationsTest.snippet.nested-keypath-listener.kt
    :language: kotlin
+
+Observe Key Paths with Wildcards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use wildcards (``*``) to observe changes to all key paths at the 
 level of the wildcard.

--- a/source/sdk/swift/react-to-changes.txt
+++ b/source/sdk/swift/react-to-changes.txt
@@ -168,12 +168,7 @@ notification blocks.
    notification. However, a change to ``someSibling.name`` would not trigger
    a notification, unless you explicitly observed ``["siblings.name"]``.
 
-.. note::
-
-   Multiple notification tokens on the same object which filter for
-   separate key paths *do not* filter exclusively. If one key path
-   change is satisfied for one notification token, then all notification
-   token blocks for that object will execute.
+.. include:: /includes/note-key-path-notification-execution.rst
 
 Realm Collections
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34741

- [React to Changes](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-34741/sdk/kotlin/realm-database/react-to-changes/#register-a-key-path-change-listener): New "Register a Key Path Change Listener" section with details and tested, Bluehawked code examples.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Kotlin SDK**
  - Realm/React to Changes: Add a new "Register a Key Path Change Listener" section with details and tested, Bluehawked code examples for key path filtering.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
