### PR TITLE
(DOCSP-26119) Add sync client reconnect docs [Flutter]

### DIFF
--- a/examples/dart/scripts/bluehawk_create_snippets.sh
+++ b/examples/dart/scripts/bluehawk_create_snippets.sh
@@ -6,13 +6,13 @@ GENERATED_EXAMPLES=$PROJECT/source/examples/generated/flutter
 
 # standard bluehawking
 echo "Bluehawking Dart unit test examples"
-bluehawk snip $DART_EXAMPLES/test -o $GENERATED_EXAMPLES
+npx bluehawk snip $DART_EXAMPLES/test -o $GENERATED_EXAMPLES
 
 # Bluehawk bundle example
 echo "Bluehawking Flutter bundle example"
-bluehawk snip $DART_EXAMPLES/bin/myapp.dart -o $GENERATED_EXAMPLES
-bluehawk snip $DART_EXAMPLES/bundle_example -o $GENERATED_EXAMPLES
+npx bluehawk snip $DART_EXAMPLES/bin/myapp.dart -o $GENERATED_EXAMPLES
+npx bluehawk snip $DART_EXAMPLES/bundle_example -o $GENERATED_EXAMPLES
 
 # Bluehawk testing SDK examples
 echo "Bluehawking testing SDK examples"
-bluehawk snip $DART_EXAMPLES/test_sdk_example/test -o $GENERATED_EXAMPLES
+npx bluehawk snip $DART_EXAMPLES/test_sdk_example/test -o $GENERATED_EXAMPLES

--- a/examples/dart/test/manage_sync_session_test.dart
+++ b/examples/dart/test/manage_sync_session_test.dart
@@ -140,5 +140,27 @@ main() {
       streamListener.cancel();
       expect(isConnected, isTrue);
     });
+
+    test("Manually reconnect all sync sessions", () async {
+      final session = realm.syncSession;
+
+      session.pause();
+      expect(session.connectionState, ConnectionState.disconnected);
+
+      expectLater(
+        session.connectionStateChanges.map((c) => c.current).distinct(),
+        emitsInOrder(<ConnectionState>[
+          ConnectionState.connecting,
+          ConnectionState.connected,
+        ]),
+      );
+
+      session.resume();
+
+      // :snippet-start: session-reconnect
+      app.reconnect();
+      // :snippet-end:
+      expect(session.connectionState, ConnectionState.connected);
+    });
   });
 }

--- a/source/examples/generated/flutter/manage_sync_session_test.snippet.session-reconnect.dart
+++ b/source/examples/generated/flutter/manage_sync_session_test.snippet.session-reconnect.dart
@@ -1,0 +1,1 @@
+app.reconnect();

--- a/source/sdk/flutter/sync/manage-sync-session.txt
+++ b/source/sdk/flutter/sync/manage-sync-session.txt
@@ -4,6 +4,14 @@
 Manage a Sync Session - Flutter SDK
 ===================================
 
+.. facet::
+  :name: genre
+  :values: tutorial
+
+.. meta::
+   :description: Pause and resume sync sessions and monitor sync upload progress
+     with the Atlas Device SDK for Flutter.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/sdk/flutter/sync/manage-sync-session.txt
+++ b/source/sdk/flutter/sync/manage-sync-session.txt
@@ -136,14 +136,14 @@ You can access the current and previous ``ConnectionState`` from ``ConnectionSta
 Manually Reconnect All Sync Sessions
 ------------------------------------
 
-Realm automatically detects when a device regains connectivity after being 
-offline and attempts to reconnect using an incremental backoff strategy.
+The Flutter SDK automatically detects when a device regains connectivity after
+being offline and attempts to reconnect using an incremental backoff strategy.
 
 You can choose to manually trigger a reconnect attempt with the 
 :flutter-sdk:`App.reconnect() <realm/App/reconnect.html>` instead of waiting for
 the duration of the incremental backoff. This is useful if you have a more
 accurate understanding of the network conditions and don't want to rely on
-Realm's automatic reconnect detection.
+automatic reconnect detection.
 
 .. literalinclude:: /examples/generated/flutter/manage_sync_session_test.snippet.session-reconnect.dart
    :language: dart
@@ -153,7 +153,7 @@ reconnect immediately and resets any timers used for incremental backoff.
 
 .. important:: Cannot Reconnect Within Socket Read Timeout Duration
    
-   Realm has an internal default socket read timeout of 2 minutes, where 
-   Realm will time out if a read operation does not receive any data 
+   The Flutter SDK has an internal default socket read timeout of 2 minutes,
+   where the SDK will time out if a read operation does not receive any data 
    within a 2-minute window. If you call ``App.Sync.reconnect()`` 
-   within that window, the Kotlin SDK does *not* attempt to reconnect.
+   within that window, the Flutter SDK does *not* attempt to reconnect.

--- a/source/sdk/flutter/sync/manage-sync-session.txt
+++ b/source/sdk/flutter/sync/manage-sync-session.txt
@@ -124,3 +124,28 @@ You can access the current and previous ``ConnectionState`` from ``ConnectionSta
 
 .. literalinclude:: /examples/generated/flutter/manage_sync_session_test.snippet.monitor-network-connection.dart
    :language: dart
+
+Manually Reconnect All Sync Sessions
+------------------------------------
+
+Realm automatically detects when a device regains connectivity after being 
+offline and attempts to reconnect using an incremental backoff strategy.
+
+You can choose to manually trigger a reconnect attempt with the 
+:flutter-sdk:`App.reconnect() <realm/App/reconnect.html>` instead of waiting for
+the duration of the incremental backoff. This is useful if you have a more
+accurate understanding of the network conditions and don't want to rely on
+Realm's automatic reconnect detection.
+
+.. literalinclude:: /examples/generated/flutter/manage_sync_session_test.snippet.session-reconnect.dart
+   :language: dart
+
+When you call this method, the SDK forces all sync sessions to attempt to 
+reconnect immediately and resets any timers used for incremental backoff.
+
+.. important:: Cannot Reconnect Within Socket Read Timeout Duration
+   
+   Realm has an internal default socket read timeout of 2 minutes, where 
+   Realm will time out if a read operation does not receive any data 
+   within a 2-minute window. If you call ``App.Sync.reconnect()`` 
+   within that window, the Kotlin SDK does *not* attempt to reconnect.


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-26119
Staged changes: [Manage a Sync Session](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/DOCSP-26119/sdk/flutter/sync/manage-sync-session/#manually-reconnect-all-sync-sessions)

The work described in the ticket links to four other RDART tickets. Three of those weren't implemented. The only sync client method to document is `App.reconnect()`.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Flutter SDK**
  - Sync/Manage A Sync Session: Add documentation for `App.reconnect()`.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

<img src="https://imgix.ranker.com/user_node_img/50101/1002014998/original/yee-haw-photo-u1?auto=format&q=60&fit=crop&fm=pjpg&dpr=2&w=375" width=400>
