### PR TITLE
(DOCSP-34476) Add cancellationToken parameter to Session.wait methods [Dart/Flutter]

### DIFF
--- a/examples/dart/test/utils.dart
+++ b/examples/dart/test/utils.dart
@@ -8,7 +8,7 @@ Future<void> cleanUpRealm(Realm realm, [App? app]) async {
   if (!realm.isClosed) {
     realm.close();
   }
-  sleep(Duration(milliseconds: 250));
+  sleep(Duration(milliseconds: 500));
   Realm.deleteRealm(realm.config.path);
 }
 

--- a/source/examples/generated/flutter/manage_sync_session_test.snippet.cancel-waitfor.dart
+++ b/source/examples/generated/flutter/manage_sync_session_test.snippet.cancel-waitfor.dart
@@ -1,0 +1,9 @@
+final cancellationToken = CancellationToken();
+
+final waitForDownloadFuture =
+    realm.syncSession.waitForDownload(cancellationToken);
+cancellationToken.cancel();
+
+final waitForUploadFuture =
+    realm.syncSession.waitForUpload(cancellationToken);
+cancellationToken.cancel();

--- a/source/sdk/flutter/sync/manage-sync-session.txt
+++ b/source/sdk/flutter/sync/manage-sync-session.txt
@@ -54,12 +54,13 @@ to download to your synced realm, call :flutter-sdk:`Session.waitForDownload()
 .. literalinclude:: /examples/generated/flutter/manage_sync_session_test.snippet.wait-upload-download.dart
    :language: dart
 
-You can add an optional ``CancellationToken`` to both ``waitForUpload()`` and
+You can add an optional :flutter-sdk:`CancellationToken 
+<realm/CancellationToken-class.html>` to ``waitForUpload()`` and
 ``waitForDownload()``.
 
 .. literalinclude:: /examples/generated/flutter/manage_sync_session_test.snippet.cancel-waitfor.dart
    :language: dart
-   
+
 .. _flutter-pause-resume-sync:
 
 Pause and Resume a Sync Session

--- a/source/sdk/flutter/sync/manage-sync-session.txt
+++ b/source/sdk/flutter/sync/manage-sync-session.txt
@@ -54,6 +54,12 @@ to download to your synced realm, call :flutter-sdk:`Session.waitForDownload()
 .. literalinclude:: /examples/generated/flutter/manage_sync_session_test.snippet.wait-upload-download.dart
    :language: dart
 
+You can add an optional ``CancellationToken`` to both ``waitForUpload()`` and
+``waitForDownload()``.
+
+.. literalinclude:: /examples/generated/flutter/manage_sync_session_test.snippet.cancel-waitfor.dart
+   :language: dart
+   
 .. _flutter-pause-resume-sync:
 
 Pause and Resume a Sync Session


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34476
Staged link: [Manage a Sync Session](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/DOCSP-34476/sdk/flutter/sync/manage-sync-session/#wait-for-changes-to-upload-and-download): Added example for using `cancellationToken`.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Flutter SDK**
  - Sync/Manage A Sync Session: Add cancellationToken parameter to Session.wait methods.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

<img src="https://i0.wp.com/growingwithplants.com/wp-content/uploads/2015/06/ducky.jpg?fit=650%2C611&ssl=1" width=400>