### PR TITLE
(DOCSP-35099): Flutter: fix failing unit tests

### DIFF
--- a/examples/dart/test/authenticate_users_test.dart
+++ b/examples/dart/test/authenticate_users_test.dart
@@ -324,7 +324,7 @@ void main() {
       // :snippet-start: list-all-users
       final users = app.users;
       // :snippet-end:
-      expect(users.length, 4);
+      expect(users.length, 3);
     });
     test('Change the active user', () async {
       final otherUser = lisa;

--- a/examples/dart/test/open_flexible_sync_realm_test.dart
+++ b/examples/dart/test/open_flexible_sync_realm_test.dart
@@ -211,17 +211,15 @@ void main() {
 
       expect(testCompensatingWriteError, isA<CompensatingWriteError>());
 
-      final sessionError =
-          testCompensatingWriteError.as<CompensatingWriteError>();
-      expect(sessionError.category, SyncErrorCategory.session);
-      expect(sessionError.code, SyncSessionErrorCode.compensatingWrite);
-      expect(sessionError.compensatingWrites, isNotNull);
+      final sessionError = testCompensatingWriteError as CompensatingWriteError;
 
+      expect(sessionError.message,
+          startsWith('Client attempted a write that is not allowed'));
       final writeReason = sessionError.compensatingWrites!.first;
       expect(writeReason, isNotNull);
       expect(writeReason.objectType, "Car");
       expect(writeReason.reason,
-          'write to "$carId" in table "${writeReason.objectType}" not allowed; object is outside of the current query view');
+          'write to ObjectID("$carId") in table "${writeReason.objectType}" not allowed; object is outside of the current query view');
       expect(writeReason.primaryKey.value, carId);
 
       await cleanUpRealm(realm, app);

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -151,8 +151,8 @@ why a compensating write error occurs.
 
 .. _flutter-writes-outside-subscription:
 
-Write that Don't Match the Query Subscription
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Writes that Don't Match the Query Subscription
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can only write objects to a Flexible Sync realm if they match the
 subscription query. If you perform a write that does not match the


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35099

The remaining failing test is in `manage_sync_session_test.dart`, which Kyle modified and may have fixed in #3122 ? 

### Release Notes

- **Flutter SDK**
  - Internal: Fix failing code example tests related to SDK changes.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
