### PR TITLE
DOCSP-34729: Update Manage Subscriptions page with Subscribe API for Flutter

### DIFF
--- a/examples/dart/test/manage_sync_subscription_test.dart
+++ b/examples/dart/test/manage_sync_subscription_test.dart
@@ -47,15 +47,18 @@ void main() {
           Credentials.emailPassword("lisa@example.com", "abc123");
       currentUser = await app.logIn(credentials);
     });
+
     tearDownAll(() async {
       await app.currentUser?.logOut();
     });
+
     setUp(() async {
       final config = Configuration.flexibleSync(
         currentUser,
         [Plane.schema, Train.schema, Boat.schema],
         path: 'flex-${generateRandomString(10)}.realm',
       );
+
       realm = Realm(config);
       await realm.subscriptions.waitForSynchronization();
       final planeQuery = realm.all<Plane>();
@@ -66,6 +69,7 @@ void main() {
       });
       await realm.subscriptions.waitForSynchronization();
     });
+
     tearDown(() async {
       realm.subscriptions.update((MutableSubscriptionSet mutableSubscriptions) {
         mutableSubscriptions.clear();
@@ -75,6 +79,7 @@ void main() {
       await Future.delayed(Duration(milliseconds: 300));
       Realm.deleteRealm(realm.config.path);
     });
+
     // Starting with 2 subscriptions from setUp: all-planes, long-trains
     test('Add query to subscription set', () async {
       // :snippet-start: add-subscription
@@ -87,14 +92,16 @@ void main() {
       });
       await realm.subscriptions.waitForSynchronization();
       // :snippet-end:
-      expect(realm.subscriptions.length, 3); // +1 planes
+      expect(realm.subscriptions.length, 3); // +1 subscription
     });
+
     test('Get subscriptions', () async {
       // :snippet-start: get-subscriptions
       final subscriptions = realm.subscriptions;
       // :snippet-end:
-      expect(subscriptions.length, 2); // 0
+      expect(subscriptions.length, 2); // +0
     });
+
     test('Wait for subscription changes to sync', () async {
       // :snippet-start: wait-for-subscription-change
       await realm.subscriptions.waitForSynchronization();
@@ -111,9 +118,10 @@ void main() {
             name: 'long-trains', update: true);
       });
       // :snippet-end:
-      expect(realm.subscriptions.length, 2); // 0
+      expect(realm.subscriptions.length, 2); // +0
       expect(realm.subscriptions.findByName('long-trains')?.queryString.trim(), "numCars > 10");
     });
+
     test('Remove subscription by query', () async {
       // :snippet-start: remove-subscriptions-by-query
       realm.subscriptions.update((MutableSubscriptionSet mutableSubscriptions) {
@@ -122,6 +130,7 @@ void main() {
       // :snippet-end:
       expect(realm.subscriptions.length, 1); // -1
     });
+
     test('Remove subscription by name', () async {
       // :snippet-start: remove-subscriptions-by-name
       realm.subscriptions.update((MutableSubscriptionSet mutableSubscriptions) {
@@ -130,6 +139,7 @@ void main() {
       // :snippet-end:
       expect(realm.subscriptions.length, 1); // -1
     });
+
     test('Remove all subscriptions by reference', () async {
       // :snippet-start: remove-subscriptions-by-reference
       final sub = realm.subscriptions[0];
@@ -139,6 +149,7 @@ void main() {
       // :snippet-end:
       expect(realm.subscriptions.length, 1); // -1
     });
+
     test('Remove all subscriptions by object type', () async {
       // :snippet-start: remove-subscriptions-by-object-type
       realm.subscriptions.update((MutableSubscriptionSet mutableSubscriptions) {
@@ -147,6 +158,7 @@ void main() {
       // :snippet-end:
       expect(realm.subscriptions.length, 1); // -1
     });
+
     test('Remove all subscriptions', () async {
       // :snippet-start: remove-all-subscriptions
       realm.subscriptions.update((MutableSubscriptionSet mutableSubscriptions) {
@@ -155,6 +167,7 @@ void main() {
       // :snippet-end:
       expect(realm.subscriptions, isEmpty); // clear all
     });
+
     test('Add query with subscribe api', () async {
       // :snippet-start: add-subscription-subscribe-api
       final boatQuery = realm.all<Boat>();
@@ -167,6 +180,7 @@ void main() {
       expect(realm.subscriptions.findByName("boats")?.queryString.trim(), "TRUEPREDICATE");
       expect(realm.subscriptions.findByName("big-planes")?.queryString.trim(), "numSeats > 100");
     });
+
     test('Update query with subscribe api', () async {
       final planeQuery = realm.query<Plane>("numSeats > 100");
       planeQuery.subscribe(name: "big-planes");
@@ -182,6 +196,7 @@ void main() {
       final updatedSubscription = realm.subscriptions.findByName("big-planes");
       expect(updatedSubscription?.queryString.trim(), "numSeats > 200");
     });
+
     test('Wait for query to sync with subscribe api', () async {
       realm.write(() {
         realm.deleteAll<Plane>();
@@ -202,6 +217,7 @@ void main() {
       expect(realm.subscriptions.length, 3); // +1
       expect(bigPlaneQuery.length, 1);
     });
+
     test('Wait with timeout with subscribe api', () async {
       realm.write(() {
         realm.deleteAll<Plane>();
@@ -223,6 +239,7 @@ void main() {
       expect(bigPlaneQuery.length, 2);
 
     });
+
     test('Remove subscription with unsubscribe api', () async {
       final planeQuery = realm.all<Plane>();
       final trainSubscription = realm.subscriptions.findByName("long-trains")?.queryString;

--- a/source/examples/generated/flutter/manage_sync_subscription_test.snippet.add-subscription-subscribe-api.dart
+++ b/source/examples/generated/flutter/manage_sync_subscription_test.snippet.add-subscription-subscribe-api.dart
@@ -1,0 +1,5 @@
+final boatQuery = realm.all<Boat>();
+final bigPlaneQuery = realm.query<Plane>("numSeats > 100");
+
+final boatSubscription = await boatQuery.subscribe(name: "boats");
+final planeSubscription = await bigPlaneQuery.subscribe(name: "big-planes");

--- a/source/examples/generated/flutter/manage_sync_subscription_test.snippet.remove-subscription-unsubscribe-api.dart
+++ b/source/examples/generated/flutter/manage_sync_subscription_test.snippet.remove-subscription-unsubscribe-api.dart
@@ -1,0 +1,2 @@
+planeQuery.unsubscribe();
+trainQuery.unsubscribe();

--- a/source/examples/generated/flutter/manage_sync_subscription_test.snippet.update-subscription-subscribe-api.dart
+++ b/source/examples/generated/flutter/manage_sync_subscription_test.snippet.update-subscription-subscribe-api.dart
@@ -1,0 +1,6 @@
+final updatedPlaneQuery = realm.query<Plane>("numSeats > 200");
+
+final planeSubscription = await updatedPlaneQuery.subscribe(
+    name: "big-planes",
+    update: true
+);

--- a/source/examples/generated/flutter/manage_sync_subscription_test.snippet.wait-first-time-subscribe-api.dart
+++ b/source/examples/generated/flutter/manage_sync_subscription_test.snippet.wait-first-time-subscribe-api.dart
@@ -1,0 +1,6 @@
+final bigPlaneQuery = realm.query<Plane>("numSeats > 100");
+
+final planeSubscription = await bigPlaneQuery.subscribe(
+    name: "firstTimeSync",
+    waitForSyncMode: WaitForSyncMode.firstTime,
+);

--- a/source/examples/generated/flutter/manage_sync_subscription_test.snippet.wait-with-timeout-subscribe-api.dart
+++ b/source/examples/generated/flutter/manage_sync_subscription_test.snippet.wait-with-timeout-subscribe-api.dart
@@ -1,0 +1,7 @@
+final bigPlaneQuery = realm.query<Plane>("numSeats > 200");
+
+final planeSubscription = await bigPlaneQuery.subscribe(
+    name: "alwaysWaitSync",
+    waitForSyncMode: WaitForSyncMode.always,
+    cancellationToken: TimeoutCancellationToken(Duration(seconds: 5)),
+);

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -72,7 +72,7 @@ Flutter v1.6.0 adds experimental APIs that subscribe to and unsubscribe
 from a query's results. These APIs abstract away the details of
 manually adding and removing subscriptions.
 
-For all subscriptions, you need :an :ref:`authenticated user <flutter-authenticate>` and a :ref:`synced realm <flutter-open-synced-realm>`.
+For all subscriptions, you need an :ref:`authenticated user <flutter-authenticate>` and a :ref:`synced realm <flutter-open-synced-realm>`.
 
 If you need more control over subscriptions for performance optimization or 
 business logic reasons, you can 
@@ -86,7 +86,7 @@ Subscribe to a Query
 
 You can subscribe to the ``RealmResults`` of a query using the 
 :flutter-sdk:`subscribe() <realm/RealmResultsOfRealmObject/subscribe.html>` 
-method. When called, the The SDK creates the new subscription and adds it to the
+method. When called, the SDK creates the new subscription and adds it to the
 ``MutableSubscriptionSet``, similar to  
 :ref:`manually creating subscription <flutter-sync-add-subscription>`.
 
@@ -101,13 +101,13 @@ every time your query string changes, ``subscribe()`` creates a new subscription
 To subscribe to a query, pass the following arguments to ``subscribe()``:
 
 - ``RealmResults query``: Required. A ``RealmResults`` object that you can create using the
-  :ref:`Realm Query Language query <rql>`.
+  :ref:`Realm Query Language <rql>`.
 - ``String name``: Optional. Name for the subscription that you can refer to. 
 - ``bool update``:  Optional. When true, adding a subscription with an existing name
   replaces the existing query with the new query. When false, the SDK
   throws an exception for duplicate subscriptions. Only use with named subscriptions.
 
-In the following example, we subscribe to 2 new named queries.
+In the following example, we subscribe to two new named queries.
 
 .. literalinclude:: /examples/generated/flutter/manage_sync_subscription_test.snippet.add-subscription-subscribe-api.dart
    :language: dart 

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -123,9 +123,7 @@ Wait for a Query Subscription to Sync
 
 When you subscribe to a query's results, the results do not contain objects
 until synced data is downloaded. When you do need to wait for synced objects to
-finish downloading, configure the :flutter-sdk:`waitForSyncMode <realm/WaitForSyncMode.html>` option. You can specify
-different behavior for your subscriptions and how they handle writing for
-downloads.
+finish downloading, configure the :flutter-sdk:`waitForSyncMode <realm/WaitForSyncMode.html>` option. 
 
 This example uses the ``firstTime`` option, which is the default behavior.
 A subscription with ``firstTime`` behavior only waits for sync to finish when a

--- a/source/sdk/flutter/sync/manage-sync-subscriptions.txt
+++ b/source/sdk/flutter/sync/manage-sync-subscriptions.txt
@@ -5,6 +5,14 @@
 Manage Sync Subscriptions - Flutter SDK
 =======================================
 
+.. meta::
+   :keywords: code example
+   :description: Create, update, and delete query subscriptions used by Atlas Device Sync.
+
+.. facet::
+  :name: genre
+  :values: reference
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -17,10 +25,10 @@ to determine which data to sync between Atlas and your app.
 You can add, update, and remove query subscriptions to determine which data
 syncs to the client device.
 
-.. include:: /includes/note-flexible-sync-prerequisite.rst
+Prerequisites
+-------------
 
-Before You Begin
-----------------
+.. include:: /includes/note-flexible-sync-prerequisite.rst
 
 To use Flexible Sync in a Flutter application:
 
@@ -53,8 +61,120 @@ You subscription queries can either:
     refer to the :ref:`Flexible Sync RQL Limitations
     <flutter-flexible-sync-rql-limitations>` section.
 
-Manage Your Subscriptions
--------------------------
+.. _flutter-subscribe-api:
+
+Subscribe to Queries
+--------------------
+
+.. versionadded:: v1.6.0
+
+Flutter v1.6.0 adds experimental APIs that subscribe to and unsubscribe
+from a query's results. These APIs abstract away the details of
+manually adding and removing subscriptions.
+
+For all subscriptions, you need :an :ref:`authenticated user <flutter-authenticate>` and a :ref:`synced realm <flutter-open-synced-realm>`.
+
+If you need more control over subscriptions for performance optimization or 
+business logic reasons, you can 
+:ref:`manually manage the subscription set <flutter-manually-manage-subscriptions>` 
+using the ``subscriptions`` API. Refer to the 
+:ref:`Performance Considerations <flutter-flex-sync-performance-considerations>` 
+section on this page for more information.
+
+Subscribe to a Query
+~~~~~~~~~~~~~~~~~~~~
+
+You can subscribe to the ``RealmResults`` of a query using the 
+:flutter-sdk:`subscribe() <realm/RealmResultsOfRealmObject/subscribe.html>` 
+method. When called, the The SDK creates the new subscription and adds it to the
+``MutableSubscriptionSet``, similar to  
+:ref:`manually creating subscription <flutter-sync-add-subscription>`.
+
+You can optionally pass a unique subscription name for the query. If you 
+add a subscription with the same name as an existing subscription, the SDK
+overwrites the existing subscription.
+
+If you do not pass a subscription name, the name is set to ``null``, and 
+the subscription identifier is based on the query string. This means that 
+every time your query string changes, ``subscribe()`` creates a new subscription.
+
+To subscribe to a query, pass the following arguments to ``subscribe()``:
+
+- ``RealmResults query``: Required. A ``RealmResults`` object that you can create using the
+  :ref:`Realm Query Language query <rql>`.
+- ``String name``: Optional. Name for the subscription that you can refer to. 
+- ``bool update``:  Optional. When true, adding a subscription with an existing name
+  replaces the existing query with the new query. When false, the SDK
+  throws an exception for duplicate subscriptions. Only use with named subscriptions.
+
+In the following example, we subscribe to 2 new named queries.
+
+.. literalinclude:: /examples/generated/flutter/manage_sync_subscription_test.snippet.add-subscription-subscribe-api.dart
+   :language: dart 
+
+.. tip:: Specify a Subscription Name
+
+   We recommend that you always specify a subscription name, especially if your application uses 
+   multiple subscriptions. This makes finding and managing
+   your subscriptions easier.
+
+Wait for a Query Subscription to Sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you subscribe to a query's results, the results do not contain objects
+until synced data is downloaded. When you do need to wait for synced objects to
+finish downloading, configure the :flutter-sdk:`waitForSyncMode <realm/WaitForSyncMode.html>` option. You can specify
+different behavior for your subscriptions and how they handle writing for
+downloads.
+
+This example uses the ``firstTime`` option, which is the default behavior.
+A subscription with ``firstTime`` behavior only waits for sync to finish when a
+subscription is first created.
+
+.. literalinclude:: /examples/generated/flutter/manage_sync_subscription_test.snippet.wait-first-time-subscribe-api.dart
+   :language: dart
+   :emphasize-lines: 5
+
+The other supported ``waitForSyncMode`` options are:
+
+- ``always``: Wait to download matching objects every time your app launches.
+  The app must have an internet connection at every launch.
+- ``never``: Never wait to download matching objects. The app needs an internet
+  connection for the user to authenticate the first time the app launches, but
+  can open offline on
+  subsequent launches using cached credentials.
+
+You can optionally specify a :flutter-sdk:`cancellationToken <realm/CancellationToken-class.html>` 
+to limit how long the sync download runs:
+
+.. literalinclude:: /examples/generated/flutter/manage_sync_subscription_test.snippet.wait-with-timeout-subscribe-api.dart
+   :language: dart
+   :emphasize-lines: 5-6
+
+Unsubscribe from a Query
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Subscriptions persist across user sessions unless you unsubscribe from them.
+You can unsubscribe from a query's results using :flutter-sdk:`unsubscribe() <realm/RealmResultsOfRealmObject/unsubscribe.html>`.
+
+This removes the subscription from the list of active subscriptions, similar to
+:ref:`manually removing a subscription <flutter-remove-subscriptions>`.
+Note that the results list may still contain objects after calling ``unsubscribe()`` 
+if another subscription exists that contains overlapping objects.
+
+When you call ``unsubscribe()`` on a query, the SDK removes any 
+subscriptions with queries that exactly match the one you call 
+``unsubscribe()`` on. This method returns before objects matching the 
+removed subscription are deleted from the realm. Sync continues in the 
+background based on the new set of subscriptions.
+
+.. literalinclude:: /examples/generated/flutter/manage_sync_subscription_test.snippet.remove-subscription-unsubscribe-api.dart
+   :language: dart
+
+.. _flutter-manually-manage-subscriptions:
+
+Manually Manage Subscriptions
+-----------------------------
 
 When configuring Flexible Sync on the backend, you specify which fields your
 client application can query. In the client application, use the
@@ -285,3 +405,23 @@ Flexible Sync RQL Requirements and Limitations
 -----------------------------------------------
 
 .. include:: /includes/flex-sync-limitations.rst
+
+.. _flutter-flex-sync-performance-considerations:
+
+Performance Considerations
+--------------------------
+
+API Efficiency
+~~~~~~~~~~~~~~
+
+Managing multiple subscriptions with the ``.subscribe()`` 
+API described in the :ref:`flutter-subscribe-api` section
+is less efficient than performing batch updates when you 
+manually manage subscriptions through the subscription set API. For better performance when 
+making multiple subscription changes, use the ``subscriptions.update`` API described in the 
+:ref:`flutter-manually-manage-subscriptions` section.
+
+Group Updates for Improved Performance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/sync-memory-performance.rst

--- a/source/sdk/react-native/sync-data/flexible-sync.txt
+++ b/source/sdk/react-native/sync-data/flexible-sync.txt
@@ -126,9 +126,7 @@ Wait for a Query Subscription to Sync
 
 When you subscribe to a query's results, the results do not contain objects
 until synced data is downloaded. When you do need to wait for synced objects to
-finish downloading, configure the ``waitForSync`` option. You can specify
-different behavior for your subscriptions and how they handle writing for
-downloads.
+finish downloading, configure the ``waitForSync`` option. 
 
 This example uses the ``FirstTime`` option, which is the default behavior.
 A subscription with ``FirstTime`` behavior only waits for sync to finish when a


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34729

- [Manage Subscriptions - Flutter SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-34729-subscribe-api/sdk/flutter/sync/manage-sync-subscriptions/#subscribe-to-queries): Update page with new documentation for new .subscribe() and .unsubscribe() methods, similar to the other SDKs.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Flutter** SDK
  - Sync Device Data/Manage Subscriptions: Update page to document the new Subscribe API with tested, Bluehawked code examples.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
