### PR TITLE
Fix React Native sample highlighting

### DIFF
--- a/examples/react-native/v12/TestApp/src/components/subscribe-api/AlwaysWait.tsx
+++ b/examples/react-native/v12/TestApp/src/components/subscribe-api/AlwaysWait.tsx
@@ -12,9 +12,11 @@ import {Subscription} from 'realm/dist/bundle';
 export const AlwaysWait = () => {
   const realm = useRealm();
   // Get all local birds that have not been seen yet.
+  // :emphasize-start:
   const unSeenBirds = useQuery(Bird, collection =>
     collection.filtered('haveSeen == false'),
-  ); // :emphasize:
+  );
+  // :emphasize-end:
   const [unSeenBirdsSubscription, setUnseenBirdsSubscription] =
     useState<Subscription | null>();
 

--- a/examples/react-native/v12/TestApp/src/components/subscribe-api/BasicSubscription.tsx
+++ b/examples/react-native/v12/TestApp/src/components/subscribe-api/BasicSubscription.tsx
@@ -9,9 +9,11 @@ import {Subscription} from 'realm/dist/bundle';
 export const BasicSubscription = () => {
   const realm = useRealm();
   // Get all local birds that have not been seen yet.
+  // :emphasize-start:
   const seenBirds = useQuery(Bird, collection =>
     collection.filtered('haveSeen == true'),
-  ); // :emphasize:
+  );
+  // :emphasize-end:
   const [seenBirdsSubscription, setSeenBirdsSubscription] =
     useState<Subscription | null>();
 

--- a/examples/react-native/v12/TestApp/src/components/subscribe-api/WaitFirstTime.tsx
+++ b/examples/react-native/v12/TestApp/src/components/subscribe-api/WaitFirstTime.tsx
@@ -12,9 +12,11 @@ export const WaitFirstTime = () => {
   const [birdName, setBirdName] = useState('Change me!');
 
   // Get local birds that have been marked as "haveSeen".
+  // :emphasize-start:
   const seenBirds = useQuery(Bird, collection =>
     collection.filtered('haveSeen == true'),
-  ); // :emphasize:
+  );
+  // :emphasize-end:
   const [seenBirdsSubscription, setSeenBirdsSubscription] =
     useState<Subscription | null>();
 
@@ -71,7 +73,10 @@ export const WaitFirstTime = () => {
         </Text>
       )}
 
-      <TextInput onChangeText={setBirdName} value={birdName} />
+      <TextInput
+        onChangeText={setBirdName}
+        value={birdName}
+      />
 
       <Button
         testID="add-bird"

--- a/source/examples/generated/react-native/v12/AlwaysWait.snippet.always-sync.tsx.rst
+++ b/source/examples/generated/react-native/v12/AlwaysWait.snippet.always-sync.tsx.rst
@@ -1,12 +1,12 @@
 .. code-block:: typescript
-   :emphasize-lines: 6, 16, 18
+   :emphasize-lines: 4-6, 16, 18
 
    export const AlwaysWait = () => {
      const realm = useRealm();
      // Get all local birds that have not been seen yet.
      const unSeenBirds = useQuery(Bird, collection =>
        collection.filtered('haveSeen == false'),
-     ); 
+     );
      const [unSeenBirdsSubscription, setUnseenBirdsSubscription] =
        useState<Subscription | null>();
 

--- a/source/examples/generated/react-native/v12/BasicSubscription.snippet.subscribe-query.tsx.rst
+++ b/source/examples/generated/react-native/v12/BasicSubscription.snippet.subscribe-query.tsx.rst
@@ -1,5 +1,5 @@
 .. code-block:: typescript
-   :emphasize-lines: 13, 21-23
+   :emphasize-lines: 11-13, 21-23
 
    import React, {useEffect, useState} from 'react';
    import {useRealm, useQuery} from '@realm/react';
@@ -13,7 +13,7 @@
      // Get all local birds that have not been seen yet.
      const seenBirds = useQuery(Bird, collection =>
        collection.filtered('haveSeen == true'),
-     ); 
+     );
      const [seenBirdsSubscription, setSeenBirdsSubscription] =
        useState<Subscription | null>();
 

--- a/source/examples/generated/react-native/v12/WaitFirstTime.snippet.wait-firsttime.tsx.rst
+++ b/source/examples/generated/react-native/v12/WaitFirstTime.snippet.wait-firsttime.tsx.rst
@@ -1,5 +1,5 @@
 .. code-block:: typescript
-   :emphasize-lines: 16, 24
+   :emphasize-lines: 14-16, 24
 
    import React, {useEffect, useState} from 'react';
    import {BSON, WaitForSync} from 'realm';
@@ -16,7 +16,7 @@
      // Get local birds that have been marked as "haveSeen".
      const seenBirds = useQuery(Bird, collection =>
        collection.filtered('haveSeen == true'),
-     ); 
+     );
      const [seenBirdsSubscription, setSeenBirdsSubscription] =
        useState<Subscription | null>();
 

--- a/source/sdk/react-native/crud/create.txt
+++ b/source/sdk/react-native/crud/create.txt
@@ -76,7 +76,7 @@ To create an object with a to-one relationship to another object:
 
 .. literalinclude:: /examples/generated/react-native/ts/create-test.test.snippet.crud-create-to-one-object.tsx
    :language: typescript
-   :emphasize-lines: 4, 8-15, 23
+   :emphasize-lines: 4, 8-15, 26
    :linenos:
 
 Create an Object with a To-Many Relationship
@@ -112,7 +112,7 @@ To create an object with a to-many relationship to another object:
 
 .. literalinclude:: /examples/generated/react-native/ts/create-test.test.snippet.crud-create-to-many-object.tsx
    :language: typescript
-   :emphasize-lines: 2, 8-14, 21
+   :emphasize-lines: 2, 8-14, 20
    :linenos:
 
 Create an Embedded Object
@@ -142,7 +142,7 @@ Address into a new Contact object:
 
        .. literalinclude:: /examples/generated/react-native/ts/Business.snippet.ts-business-schema.ts
           :language: typescript
-          :emphasize-lines: 12
+          :emphasize-lines: 13
           :linenos:
 
     .. tab::
@@ -177,7 +177,7 @@ The ``CreateContact`` component does the following:
 
 .. literalinclude:: /examples/generated/react-native/ts/embedded-objects-test.snippet.create-embedded-object.tsx
    :language: typescript
-   :emphasize-lines: 13-25
+   :emphasize-lines: 13-18, 20-25
    :linenos:
 
 Create an Asymmetric Object

--- a/source/sdk/react-native/crud/create.txt
+++ b/source/sdk/react-native/crud/create.txt
@@ -112,7 +112,7 @@ To create an object with a to-many relationship to another object:
 
 .. literalinclude:: /examples/generated/react-native/ts/create-test.test.snippet.crud-create-to-many-object.tsx
    :language: typescript
-   :emphasize-lines: 2, 8-14, 20
+   :emphasize-lines: 2, 8-14, 25
    :linenos:
 
 Create an Embedded Object

--- a/source/sdk/react-native/crud/delete.txt
+++ b/source/sdk/react-native/crud/delete.txt
@@ -121,14 +121,12 @@ In the following example of a ``DogList`` component, we:
       
       .. literalinclude:: /examples/generated/react-native/ts/delete.test.snippet.crud-delete-multiple-objects.tsx
          :language: typescript
-         :emphasize-lines: 3, 6-9, 12-14
 
    .. tab::
       :tabid: javascript
 
       .. literalinclude:: /examples/generated/react-native/js/delete.test.snippet.crud-delete-multiple-objects.jsx
          :language: javascript
-         :emphasize-lines: 3, 6-9, 12-14
 
 .. _react-native-delete-all-objects-in-a-realm:
 

--- a/source/sdk/react-native/crud/query-data.txt
+++ b/source/sdk/react-native/crud/query-data.txt
@@ -71,7 +71,6 @@ To filter data, pass a query made with Realm Query Language to
 
 .. literalinclude:: /examples/generated/realm-query-language/realm-query-language.snippet.simple-query.js
    :language: js
-   :emphasize-lines: 3
 
 .. _react-native-fts-filter:
 

--- a/source/sdk/react-native/crud/read.txt
+++ b/source/sdk/react-native/crud/read.txt
@@ -112,14 +112,14 @@ In the following example of a ``TaskList`` component, we:
       
       .. literalinclude:: /examples/generated/react-native/ts/read.test.snippet.crud-read-filter-data.tsx
          :language: typescript
-         :emphasize-lines: 3, 6, 9-11
+         :emphasize-lines: 4-10, 12-18
 
    .. tab::
       :tabid: javascript
 
       .. literalinclude:: /examples/generated/react-native/js/read.test.snippet.crud-read-filter-data.jsx
          :language: javascript
-         :emphasize-lines: 3, 6, 9-13
+         :emphasize-lines: 4-10, 12-18
 
 .. tip:: Filter on Related and Embedded Object Properties
 
@@ -165,14 +165,12 @@ Finally, we map through each list of tasks and render them in the UI.
       
       .. literalinclude:: /examples/generated/react-native/ts/read.test.snippet.crud-read-sort-data.tsx
          :language: typescript
-         :emphasize-lines: 3, 5, 7, 9-12
           
    .. tab::
       :tabid: javascript
 
       .. literalinclude:: /examples/generated/react-native/js/read.test.snippet.crud-read-sort-data.jsx
          :language: javascript
-         :emphasize-lines: 3, 5, 7, 9-12
 
 .. tip:: Sort on Related and Embedded Object Properties
    

--- a/source/sdk/react-native/crud/read.txt
+++ b/source/sdk/react-native/crud/read.txt
@@ -112,14 +112,14 @@ In the following example of a ``TaskList`` component, we:
       
       .. literalinclude:: /examples/generated/react-native/ts/read.test.snippet.crud-read-filter-data.tsx
          :language: typescript
-         :emphasize-lines: 4-10, 12-18
+         :emphasize-lines: 4-10, 13-18
 
    .. tab::
       :tabid: javascript
 
       .. literalinclude:: /examples/generated/react-native/js/read.test.snippet.crud-read-filter-data.jsx
          :language: javascript
-         :emphasize-lines: 4-10, 12-18
+         :emphasize-lines: 4-10, 13-18
 
 .. tip:: Filter on Related and Embedded Object Properties
 

--- a/source/sdk/react-native/model-data/data-types/dictionaries.txt
+++ b/source/sdk/react-native/model-data/data-types/dictionaries.txt
@@ -120,7 +120,7 @@ The ``HomeList`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/ts/dictionary-test.snippet.query-objects-with-dictionary.tsx
          :language: typescript
-         :emphasize-lines: 3, 7, 11, 17
+         :emphasize-lines: 3, 7-9, 13-15, 19-21
          :linenos:
 
 
@@ -129,7 +129,7 @@ The ``HomeList`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/js/dictionary-test.snippet.query-objects-with-dictionary.jsx
          :language: javascript
-         :emphasize-lines: 3, 7, 11, 17
+         :emphasize-lines: 3, 7-9, 13-15, 19-21
          :linenos:
 
 Update a Dictionary
@@ -162,7 +162,7 @@ The ``UpdateHome`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/ts/dictionary-test.snippet.update-a-dictionary.tsx
          :language: typescript
-         :emphasize-lines: 3-6, 10-15
+         :emphasize-lines: 4-10, 12-20
          :linenos:
 
 
@@ -171,7 +171,7 @@ The ``UpdateHome`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/js/dictionary-test.snippet.update-a-dictionary.jsx
          :language: javascript
-         :emphasize-lines: 3-6, 10-15
+         :emphasize-lines: 4-10, 12-20
          :linenos:
 
 
@@ -199,7 +199,7 @@ The ``HomeInfo`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/ts/dictionary-test.snippet.delete-members-of-a-dictionary.tsx
          :language: typescript
-         :emphasize-lines: 2-5, 8-11
+         :emphasize-lines: 4-10, 12-15
          :linenos:
 
    .. tab::
@@ -207,5 +207,5 @@ The ``HomeInfo`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/js/dictionary-test.snippet.delete-members-of-a-dictionary.jsx
          :language: javascript
-         :emphasize-lines: 2-5, 8-11
+         :emphasize-lines: 4-10, 12-15
          :linenos:

--- a/source/sdk/react-native/model-data/data-types/dictionaries.txt
+++ b/source/sdk/react-native/model-data/data-types/dictionaries.txt
@@ -199,7 +199,7 @@ The ``HomeInfo`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/ts/dictionary-test.snippet.delete-members-of-a-dictionary.tsx
          :language: typescript
-         :emphasize-lines: 4-10, 12-15
+         :emphasize-lines: 3-9, 12-15
          :linenos:
 
    .. tab::
@@ -207,5 +207,5 @@ The ``HomeInfo`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/js/dictionary-test.snippet.delete-members-of-a-dictionary.jsx
          :language: javascript
-         :emphasize-lines: 4-10, 12-15
+         :emphasize-lines: 3-9, 12-15
          :linenos:

--- a/source/sdk/react-native/model-data/data-types/embedded-objects.txt
+++ b/source/sdk/react-native/model-data/data-types/embedded-objects.txt
@@ -37,7 +37,7 @@ The ``CreateContact`` component does the following:
 
 .. literalinclude:: /examples/generated/react-native/ts/embedded-objects-test.snippet.create-embedded-object.tsx
    :language: typescript
-   :emphasize-lines: 13-25
+   :emphasize-lines: 13-18, 24
    :linenos:
 
 Query a Collection on Embedded Object Properties
@@ -67,7 +67,7 @@ The ``ContactList`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/ts/embedded-objects-test.snippet.query-embedded-object.tsx
          :language: typescript
-         :emphasize-lines: 3, 7-9
+         :emphasize-lines: 4-6
          :linenos:
 
    .. tab::
@@ -75,7 +75,7 @@ The ``ContactList`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/js/embedded-objects-test.snippet.query-embedded-object.jsx
          :language: javascript
-         :emphasize-lines: 3, 7-9
+         :emphasize-lines: 4-10
          :linenos:
 
 Update an Embedded Object Property
@@ -158,7 +158,7 @@ The ``OverwriteContact`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/ts/embedded-objects-test.snippet.overwrite-embedded-object.tsx
          :language: typescript
-         :emphasize-lines: 8, 14-21
+         :emphasize-lines: 16-21, 23
          :linenos:
 
    .. tab::
@@ -166,7 +166,7 @@ The ``OverwriteContact`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/js/embedded-objects-test.snippet.overwrite-embedded-object.jsx
          :language: javascript
-         :emphasize-lines: 6, 12-19
+         :emphasize-lines: 12-17, 19
          :linenos:
 
 Delete an Embedded Object
@@ -202,7 +202,7 @@ The ``DeleteContact`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/ts/embedded-objects-test.snippet.delete-embedded-object.tsx
          :language: typescript
-         :emphasize-lines: 8-10, 11-13, 20, 26-29
+         :emphasize-lines: 20, 16-20, 24-29
          :linenos:
 
    .. tab::
@@ -210,5 +210,5 @@ The ``DeleteContact`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/js/embedded-objects-test.snippet.delete-embedded-object.jsx
          :language: javascript
-         :emphasize-lines: 3-5, 6-8, 15, 21-24
+         :emphasize-lines: 19-23, 27-32
          :linenos:

--- a/source/sdk/react-native/model-data/data-types/mixed.txt
+++ b/source/sdk/react-native/model-data/data-types/mixed.txt
@@ -79,7 +79,6 @@ The ``CreateCatsInput`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/ts/mixed-test.snippet.create-mixed-object.tsx
          :language: typescript
-         :emphasize-lines: 2, 6-23
          :linenos:
 
    .. tab::
@@ -87,7 +86,6 @@ The ``CreateCatsInput`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/js/mixed-test.snippet.create-mixed-object.jsx
          :language: javascript
-         :emphasize-lines: 2, 6-23
          :linenos:
 
 Query for Objects with a Mixed Value
@@ -117,7 +115,7 @@ The ``CatInfoCard`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/ts/mixed-test.snippet.query-mixed-object.tsx
          :language: typescript
-         :emphasize-lines: 6-7
+         :emphasize-lines: 6-12
          :linenos:
 
    .. tab::
@@ -125,7 +123,7 @@ The ``CatInfoCard`` component does the following:
 
       .. literalinclude:: /examples/generated/react-native/js/mixed-test.snippet.query-mixed-object.jsx
          :language: javascript
-         :emphasize-lines: 4-5
+         :emphasize-lines: 4-10
          :linenos:
 
 Mixed Properties and Type Checking
@@ -140,4 +138,4 @@ checking.
 
 .. literalinclude:: /examples/generated/react-native/ts/mixed-test.snippet.type-check.tsx
    :language: javascript
-   :emphasize-lines: 3-9, 16-18
+   :emphasize-lines: 22-24

--- a/source/sdk/react-native/model-data/data-types/sets.txt
+++ b/source/sdk/react-native/model-data/data-types/sets.txt
@@ -86,7 +86,7 @@ The ``CreateInitialCharacters`` component does the following:
       
       .. literalinclude:: /examples/generated/react-native/ts/sets-test.snippet.create-set-object.tsx
          :language: typescript
-         :emphasize-lines: 8-9, 16-17
+         :emphasize-lines: 8-9, 17-18
          :linenos:
 
    .. tab::
@@ -137,7 +137,7 @@ The ``AddInventoryToCharacter`` component does the following:
       
       .. literalinclude:: /examples/generated/react-native/ts/sets-test.snippet.add-items-to-set.tsx
          :language: typescript
-         :emphasize-lines: 8-10
+         :emphasize-lines: 17-19
          :linenos:
 
    .. tab::
@@ -145,7 +145,7 @@ The ``AddInventoryToCharacter`` component does the following:
       
       .. literalinclude:: /examples/generated/react-native/js/sets-test.snippet.add-items-to-set.jsx
          :language: javascript
-         :emphasize-lines: 4-6
+         :emphasize-lines: 13-15
          :linenos:
 
 .. _react-native-check-if-set-has-items:
@@ -203,7 +203,7 @@ The ``QueryCharacterInventory`` component does the following:
       
       .. literalinclude:: /examples/generated/react-native/ts/sets-test.snippet.check-set-items-and-size.tsx
          :language: typescript
-         :emphasize-lines: 7-9, 12-13
+         :emphasize-lines: 16-17
          :linenos:
 
    .. tab::
@@ -211,7 +211,7 @@ The ``QueryCharacterInventory`` component does the following:
       
       .. literalinclude:: /examples/generated/react-native/js/sets-test.snippet.check-set-items-and-size.jsx
          :language: javascript
-         :emphasize-lines: 3-5, 8
+         :emphasize-lines: 12
          :linenos:
 
 .. _react-native-remove-specific-item-from-set:
@@ -259,7 +259,7 @@ The ``RemoveInventoryFromCharacter`` component does the following:
       
       .. literalinclude:: /examples/generated/react-native/ts/sets-test.snippet.remove-items-from-set.tsx
          :language: typescript
-         :emphasize-lines: 8-10, 13-15
+         :emphasize-lines: 17-19, 22-24
          :linenos:
 
    .. tab::
@@ -267,7 +267,7 @@ The ``RemoveInventoryFromCharacter`` component does the following:
       
       .. literalinclude:: /examples/generated/react-native/js/sets-test.snippet.remove-items-from-set.jsx
          :language: javascript
-         :emphasize-lines: 4-6, 9-11
+         :emphasize-lines: 13-15, 18-20
          :linenos:
 
 .. _react-native-traverse-set:
@@ -324,7 +324,7 @@ The ``TraverseCharacterInventory`` component does the following:
       
       .. literalinclude:: /examples/generated/react-native/ts/sets-test.snippet.traverse-a-set.tsx
          :language: typescript
-         :emphasize-lines: 10-12, 15-17
+         :emphasize-lines: 19-22
          :linenos:
 
    .. tab::
@@ -332,5 +332,5 @@ The ``TraverseCharacterInventory`` component does the following:
       
       .. literalinclude:: /examples/generated/react-native/js/sets-test.snippet.traverse-a-set.jsx
          :language: javascript
-         :emphasize-lines: 6-8, 11-13
+         :emphasize-lines: 15-18
          :linenos:

--- a/source/sdk/react-native/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/react-native/model-data/define-a-realm-object-model.txt
@@ -214,7 +214,7 @@ default value, like the ``timestamp`` property in the example below.
 
        .. literalinclude:: /examples/generated/react-native/ts/Car.snippet.ts-car-schema.ts
           :language: typescript
-          :emphasize-lines: 4, 11
+          :emphasize-lines: 4, 12
           :linenos:
 
 

--- a/source/sdk/react-native/quick-start.txt
+++ b/source/sdk/react-native/quick-start.txt
@@ -149,14 +149,14 @@ To learn more, refer to the :ref:`Query Data <react-native-query-data>`.
    
       .. literalinclude:: /examples/generated/react-native/ts/quickstart-find-sort-filter.test.snippet.find-sort-filter.tsx
          :language: typescript
-         :emphasize-lines: 46, 56
+         :emphasize-lines: 47-53, 63-69
    
    .. tab::
       :tabid: javascript
 
       .. literalinclude:: /examples/generated/react-native/js/quickstart-find-sort-filter.test.snippet.find-sort-filter.jsx
          :language: javascript
-         :emphasize-lines: 40, 50
+         :emphasize-lines: 41-47, 54-60
 
 .. _react-native-quickstart-local-create-realm-objects:
 .. _react-native-quickstart-local-modify-an-object:

--- a/source/sdk/react-native/quick-start.txt
+++ b/source/sdk/react-native/quick-start.txt
@@ -149,14 +149,14 @@ To learn more, refer to the :ref:`Query Data <react-native-query-data>`.
    
       .. literalinclude:: /examples/generated/react-native/ts/quickstart-find-sort-filter.test.snippet.find-sort-filter.tsx
          :language: typescript
-         :emphasize-lines: 44, 45
+         :emphasize-lines: 46, 56
    
    .. tab::
       :tabid: javascript
 
       .. literalinclude:: /examples/generated/react-native/js/quickstart-find-sort-filter.test.snippet.find-sort-filter.jsx
          :language: javascript
-         :emphasize-lines: 37, 38
+         :emphasize-lines: 40, 50
 
 .. _react-native-quickstart-local-create-realm-objects:
 .. _react-native-quickstart-local-modify-an-object:
@@ -346,14 +346,14 @@ You can add subscriptions in your components or set up
    
       .. literalinclude:: /examples/generated/react-native/ts/quickstart-sync.test.snippet.quickstart-setup.tsx
          :language: javascript
-         :emphasize-lines: 34-45
+         :emphasize-lines: 34-44
    
    .. tab::
       :tabid: javascript
 
       .. literalinclude:: /examples/generated/react-native/js/quickstart-sync.test.snippet.quickstart-setup.jsx
          :language: javascript
-         :emphasize-lines: 31-42
+         :emphasize-lines: 31-41
 
 The syntax to create, read, update, and delete objects in a synced realm is
 identical to the syntax for non-synced realms. While you work with local data, a

--- a/source/sdk/react-native/sync-data/flexible-sync.txt
+++ b/source/sdk/react-native/sync-data/flexible-sync.txt
@@ -259,7 +259,7 @@ result, which is not a valid ``query`` for ``MutableSubscriptionSet.add()``.
 
 .. literalinclude:: /examples/generated/react-native/ts/add-query-to-subs.test.snippet.add-query.tsx
    :language: javascript
-   :emphasize-lines: 10, 13-21
+   :emphasize-lines: 7-9, 12-18
 
 .. _react-native-sync-bootstrap-initial-subscriptions:
 
@@ -309,7 +309,7 @@ You can use subscription state to:
 
 .. literalinclude:: /examples/generated/react-native/ts/check-subs-status.test.snippet.check-sub-status.tsx
    :language: javascript
-   :emphasize-lines: 21
+   :emphasize-lines: 25
 
 .. versionadded:: ``realm@12.0.0``
 


### PR DESCRIPTION
Due to code format changes, highlighting was incorrect in a large number of samples. Eventually, I want to migrate all of the manual highlighting to use Bluehawk :emphasize: tags, but that's beyond the scope of this simple fix-it PR.

Staged changes:
- [Manage Sync Subscriptions](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/sync-data/flexible-sync/)
- [Dictionaries](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/model-data/data-types/dictionaries/)
- [Mixed](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/model-data/data-types/mixed/)
- [Sets](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/model-data/data-types/sets/)
- [Embedded Objects](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/model-data/data-types/embedded-objects/)
- [Create](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/crud/create/)
- [Delete](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/crud/delete/)
- [Query Data](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/crud/query-data/)
- [Read](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/crud/read/)
- [Define a Realm Object Model](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/model-data/define-a-realm-object-model/)
- [Quick Start](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/fix-rn-highlighting/sdk/react-native/quick-start/)

### Animal Wearing a Hat

<img src="https://sadanduseless.b-cdn.net/wp-content/uploads/2019/09/fruit-hats2.jpg" width=400 />