### PR TITLE
Remove extra "define"

### DIFF
--- a/source/sdk/react-native/model-data/data-types/dictionaries.txt
+++ b/source/sdk/react-native/model-data/data-types/dictionaries.txt
@@ -27,7 +27,7 @@ is defined as a ``dictionary`` type could look like this:
 Realm Object Models
 -------------------
 
-You can define define a dictionary of mixed values for a :ref:`Realm object model
+You can define a dictionary of mixed values for a :ref:`Realm object model
 <react-native-define-a-realm-object-model>` in three ways:
 
 - set the data type of your field to an empty object, ``"{}"``. 


### PR DESCRIPTION
Typo fix. Suggested through the feedback widget by a reader.
