### PR TITLE
(DOCSP-34763): C++: Remove version directives

### DIFF
--- a/source/sdk/cpp/app-services/call-a-function.txt
+++ b/source/sdk/cpp/app-services/call-a-function.txt
@@ -41,9 +41,6 @@ member function on the ``user`` object. Pass in the name of the
 function as a string for the first parameter. This function takes two arguments,
 which we provide as a ``BsonArray`` of arguments:
 
-.. versionchanged:: 0.2.0 Returns std::future instead of std::promise
-.. versionchanged:: v0.4.0-preview Replaces deprecated realm::App(...) with realm::App(const realm::App::configuration&)
-
 .. literalinclude:: /examples/generated/cpp/call-function.snippet.beta-call-a-function.cpp
    :language: cpp
 

--- a/source/sdk/cpp/app-services/connect-to-app.txt
+++ b/source/sdk/cpp/app-services/connect-to-app.txt
@@ -39,8 +39,6 @@ To learn how to find your App ID in the App Services UI, refer to
 Access the App Client
 ---------------------
 
-.. versionchanged:: v0.4.0-preview Replaces deprecated realm::App(...) with realm::App(const realm::App::configuration&)
-
 #. :ref:`Find the App ID in the Realm UI <find-your-app-id>`.
 #. Create an :cpp-sdk:`App object <classrealm_1_1App.html>` 
    with your App's ID as the argument. You use this ``App`` instance to access 
@@ -60,8 +58,6 @@ Access the App Client
 
 Set Custom HTTP Headers
 -----------------------
-
-.. versionchanged:: v0.4.0-preview replaces deprecated realm::App(...) with realm::App(const realm::App::configuration&)
 
 If you use App Services or Device Sync with a proxy setup, you may need
 to set custom HTTP headers. The Realm C++ SDK supports setting custom 
@@ -86,8 +82,6 @@ additionally :ref:`set the headers on the Flexible Sync configuration
 Use an HTTP Proxy with Realm
 ----------------------------
 
-.. versionadded:: v0.5.0-preview
-
 If you have configured an HTTP proxy, you can use HTTP tunneling to 
 route your Realm traffic. 
 
@@ -106,8 +100,6 @@ To configure Realm to use your HTTP proxy:
 
 Encrypt App Metadata
 --------------------
-
-.. versionadded:: v0.4.0-preview
 
 When you connect to App Services, Realm creates additional metadata files 
 on a device. For more information about these metadata files, refer to 

--- a/source/sdk/cpp/crud/create.txt
+++ b/source/sdk/cpp/crud/create.txt
@@ -348,8 +348,6 @@ For more information about modeling a to-many relationship, refer to:
 Create an Object with an Inverse Relationship
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.2.0
-
 To create an object with a inverse relationship to another object, 
 assign the raw pointer of the related object to the relationship 
 property of the main object. Move the object into the realm using the 
@@ -440,8 +438,6 @@ For more information about supported map data types, refer to:
 
 Create an Object with a Set Property
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: v0.4.0-preview
 
 You can create objects that contain :cpp-sdk:`set 
 <structrealm_1_1experimental_1_1managed_3_01std_1_1set_3_01T_01_5_01_4_01_4.html>` 

--- a/source/sdk/cpp/crud/delete.txt
+++ b/source/sdk/cpp/crud/delete.txt
@@ -51,8 +51,6 @@ Delete an Object
 Delete an Inverse Relationship
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.2.0
-
 You can't delete an inverse relationship directly. Instead, an 
 inverse relationship automatically updates by removing the relationship 
 through the related object.
@@ -105,8 +103,6 @@ pass the key name to ``erase()``:
 
 Delete Set Values
 ~~~~~~~~~~~~~~~~~
-
-.. versionadded:: v0.4.0-preview
 
 You can delete a :cpp-sdk:`set element 
 <structrealm_1_1experimental_1_1managed_3_01std_1_1set_3_01T_01_5_01_4_01_4.html>` 

--- a/source/sdk/cpp/crud/read.txt
+++ b/source/sdk/cpp/crud/read.txt
@@ -197,8 +197,6 @@ as you would a standard C++ `map <https://en.cppreference.com/w/cpp/container/ma
 Read a Set Property
 ~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: v0.4.0-preview
-
 You can iterate, check the size of a set, and find values in a :cpp-sdk:`set property
 <structrealm_1_1experimental_1_1managed_3_01std_1_1set_3_01T_01_5_01_4_01_4.html>`:
 
@@ -209,8 +207,6 @@ You can iterate, check the size of a set, and find values in a :cpp-sdk:`set pro
 
 Sort Lists and Query Results
 ----------------------------
-
-.. versionadded:: v0.5.0-preview
 
 A sort operation allows you to configure the order in which Realm returns 
 list objects and query results. You can sort based on one or more properties 

--- a/source/sdk/cpp/crud/threading.txt
+++ b/source/sdk/cpp/crud/threading.txt
@@ -154,8 +154,6 @@ instances will map to the same file on disk.
 Pass Immutable Copies Across Threads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: v0.5.0-preview & v0.6.0-preview
-
 Live, thread-confined objects work fine in most cases.
 However, some apps -- those based on reactive, event
 stream-based architectures, for example -- need to send
@@ -269,9 +267,6 @@ instead of blocking the UI.
 
 Schedulers (Run Loops)
 ----------------------
-
-.. versionchanged:: v0.6.0-preview 
-   ``realm::Function`` replaced with ``std::function``
 
 Some platforms or frameworks automatically set up a **scheduler** (or **run
 loop**), which continuously processes events during the lifetime of your

--- a/source/sdk/cpp/crud/update.txt
+++ b/source/sdk/cpp/crud/update.txt
@@ -148,8 +148,6 @@ This example uses the following model:
 Update an Inverse Relationship
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.2.0
-
 You can't update an inverse relationship property directly. Instead, an 
 inverse relationship automatically updates by changing assignment through 
 its relevant related object.
@@ -222,8 +220,6 @@ This example uses the following model:
 
 Update a Set Property
 ~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: v0.4.0-preview
 
 You can update a :cpp-sdk:`set property
 <structrealm_1_1experimental_1_1managed_3_01std_1_1set_3_01T_01_5_01_4_01_4.html>`

--- a/source/sdk/cpp/model-data/object-models.txt
+++ b/source/sdk/cpp/model-data/object-models.txt
@@ -297,13 +297,10 @@ Atlas App Services App.
 An ``asymmetric_object`` broadly has the same :ref:`supported types 
 <cpp-supported-property-types>` as ``realm::object``, with a few exceptions:
 
-- Asymmetric objects can only link to embedded objects in some versions
-   - ``object`` and ``std::vector<object>`` properties are not supported 
-     in C++ SDK versions v0.4.0-preview and earlier. In C++ SDK versions
-     v0.4.0-preview and later, asymmetric objects can link to ``object``
-     types in addition to ``embedded_object`` types.
-   - ``embedded_object`` and ``std::vector<embedded_object>`` links *are* 
-     supported in all versions of the C++ SDK that support Data Ingest.
+- Asymmetric objects can link to the following types:
+  - ``object``
+  - ``embedded_object``
+  - ``std::vector<embedded_object>``
 
 Asymmetric objects do not function in the same way as other Realm objects. 
 You cannot:

--- a/source/sdk/cpp/model-data/relationships.txt
+++ b/source/sdk/cpp/model-data/relationships.txt
@@ -139,8 +139,6 @@ number of employees as a to-many relationship.
 Define an Inverse Relationship
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.2.0
-
 To define an inverse relationship, use ``linking_objects`` in your object 
 model. The ``linking_objects`` definition specifies the object type and 
 property name of the relationship that it inverts.

--- a/source/sdk/cpp/model-data/supported-types.txt
+++ b/source/sdk/cpp/model-data/supported-types.txt
@@ -334,8 +334,6 @@ For more information, refer to :ref:`the Read documentation <cpp-crud-read>`.
 Set
 ~~~
 
-.. versionadded:: v0.4.0-preview
-
 The C++ SDK set collection represents a 
 :ref:`to-many relationship <cpp-to-many-relationship>` containing 
 distinct values. A C++ SDK set supports the following types (and their 

--- a/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/cpp/realm-files/configure-and-open-a-realm.txt
@@ -262,8 +262,6 @@ To open a synced realm:
 Set Custom HTTP Headers When Using a Synced Realm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: v0.3.0-preview
-
 To use custom HTTP headers with Device Sync, you must :ref:`set the headers
 on the App <cpp-set-custom-http-headers-on-app>` *and* on the 
 ``flexible_sync_configuration()``.

--- a/source/sdk/cpp/realm-files/encrypt-a-realm.txt
+++ b/source/sdk/cpp/realm-files/encrypt-a-realm.txt
@@ -23,8 +23,6 @@ integrity using a :wikipedia:`hash-based message authentication code
 
 .. include:: /includes/encrypt-use-strong-cryptographic-hash.rst
 
-.. versionadded:: v0.4.0-preview
-
 Encrypt a realm by calling the ``set_encryption_key()`` function on
 your :cpp-sdk:`db_config <structrealm_1_1internal_1_1bridge_1_1realm_1_1config.html>`:
 

--- a/source/sdk/cpp/sync/manage-sync-session.txt
+++ b/source/sdk/cpp/sync/manage-sync-session.txt
@@ -47,8 +47,6 @@ It is a lightweight handle that you can pass around by value.
 Wait for Changes to Upload and Download
 ---------------------------------------
 
-.. versionchanged:: 0.2.0 Returns std::future instead of std::promise
-
 To wait for all changes to upload to Atlas from your synced realm,
 use the member function ``.wait_for_upload_completion()``. 
 

--- a/source/sdk/cpp/sync/stream-data-to-atlas.txt
+++ b/source/sdk/cpp/sync/stream-data-to-atlas.txt
@@ -62,9 +62,6 @@ Sync Data Unidirectionally from a Client Application
       :ref:`connect to an App Services backend <cpp-connect-to-backend>` 
       and :ref:`authenticate a user <cpp-authenticate-users>`.
 
-      .. versionchanged:: 0.2.0 app.login returns std::future instead of std::promise
-      .. versionchanged:: v0.4.0-preview Replaces deprecated realm::App(...) with realm::App(const realm::App::configuration&)
-
       .. literalinclude:: /examples/generated/cpp/asymmetric-sync.snippet.beta-connect-and-authenticate.cpp
          :language: cpp
 

--- a/source/sdk/cpp/sync/sync-subscriptions.txt
+++ b/source/sdk/cpp/sync/sync-subscriptions.txt
@@ -23,8 +23,6 @@ data to sync between your Atlas App Services App and your client device.
 In the client, query subscriptions manage and filter the object types that
 can sync to the realm.
 
-.. versionchanged:: 0.2.0 app.login and subscriptions.update return std::future instead of std::promise
-
 Prerequisites
 -------------
 

--- a/source/sdk/cpp/sync/write-to-synced-realm.txt
+++ b/source/sdk/cpp/sync/write-to-synced-realm.txt
@@ -266,8 +266,6 @@ You will see the following error message in the App Services logs:
 Compensating Write Error Information
 ````````````````````````````````````
 
-.. versionadded:: v0.3.0-preview
-
 You can get additional information in the client about why a compensating 
 write occurs using the :cpp-sdk:`compensating_writes_info()
 <structrealm_1_1internal_1_1bridge_1_1compensating__write__error__info.html>` 

--- a/source/sdk/cpp/users/authenticate-users.txt
+++ b/source/sdk/cpp/users/authenticate-users.txt
@@ -20,9 +20,6 @@ Authenticate Users - C++ SDK Preview
 Log In
 ------
 
-.. versionchanged:: 0.2.0 Returns std::future instead of std::promise
-.. versionchanged:: v0.4.0-preview Replaces deprecated realm::App(...) with realm::App(const realm::App::configuration&)
-
 .. _cpp-login-anonymous:
 
 Anonymous User
@@ -148,8 +145,6 @@ on a logged-in user to refresh the user's auth session. Then, get the
 as a string you can use in your code. You might use code similar to this to 
 fetch an access token:
 
-.. versionchanged:: 0.2.0 Returns std::future instead of std::promise
-
 .. literalinclude:: /examples/generated/cpp/authentication.snippet.get-user-access-token.cpp
    :language: cpp
 
@@ -167,8 +162,6 @@ Once logged in, you can log out.
 
 .. include:: /includes/log-out-queries-in-progress.rst
 
-.. versionchanged:: 0.2.0 Returns std::future instead of std::promise
-
 .. literalinclude:: /examples/generated/cpp/authentication.snippet.log-user-out.cpp
    :language: cpp
 
@@ -176,8 +169,6 @@ Once logged in, you can log out.
 
 Get the Current User
 --------------------
-
-.. versionadded:: v0.3.0-preview
 
 You can get the current user with ``app::get_current_user()``:
 
@@ -188,8 +179,6 @@ You can get the current user with ``app::get_current_user()``:
 
 Confirm a User is Logged In
 ---------------------------
-
-.. versionadded:: v0.3.0-preview
 
 You can confirm a user is logged in with ``user::is_logged_in()``:
 

--- a/source/sdk/cpp/users/custom-user-data.txt
+++ b/source/sdk/cpp/users/custom-user-data.txt
@@ -22,8 +22,6 @@ data, see :ref:`Update Custom User Data
 <cpp-update-a-users-custom-data>`. To read the data, access the
 ``custom_data`` property on the ``User`` object of a logged-in user:
 
-.. versionchanged:: 0.2.0 user.refresh_custom_user_data() returns std::future instead of std::promise
-
 .. literalinclude:: /examples/generated/cpp/custom-user-data.snippet.read.cpp
    :language: cpp
 
@@ -83,8 +81,6 @@ The following example :ref:`calls a function <cpp-call-a-function>` to
 insert a document containing the user ID of the currently logged in user 
 and a ``favoriteColor`` value into the custom user data collection:
 
-.. versionchanged:: 0.2.0 user.call_function() returns std::future instead of std::promise
-
 .. literalinclude:: /examples/generated/cpp/custom-user-data.snippet.beta-create.cpp
    :language: cpp
 
@@ -108,8 +104,6 @@ MongoDB document whose user ID field contains the user ID of the user.
 The following example calls the same function used to create the custom user 
 data document above. Here, we update the ``favoriteColor`` field of the 
 the document containing the user ID of the currently logged in user:
-
-.. versionchanged:: 0.2.0 user.call_function() returns std::future instead of std::promise
 
 .. literalinclude:: /examples/generated/cpp/custom-user-data.snippet.update.cpp
    :language: cpp
@@ -146,8 +140,6 @@ deletes the custom user data document matching the user's ID.
 
 The code that calls this function requires only a logged-in user to call
 the function:
-
-.. versionchanged:: 0.2.0 user.call_function() returns std::future instead of std::promise
 
 .. literalinclude:: /examples/generated/cpp/custom-user-data.snippet.delete.cpp
    :language: cpp

--- a/source/sdk/cpp/users/manage-email-password-users.txt
+++ b/source/sdk/cpp/users/manage-email-password-users.txt
@@ -22,8 +22,6 @@ Register a New User
 You can register a new user by calling the :cpp-sdk:`App.register_user() <classrealm_1_1App.html>`
 member function with the desired username and password.
 
-.. versionchanged:: 0.2.0 Returns std::future instead of std::promise
-
 .. literalinclude:: /examples/generated/cpp/authentication.snippet.beta-register-user.cpp
    :language: cpp
 
@@ -36,8 +34,6 @@ users in a production environment.
 
 Log In or Log Out a User
 ------------------------
-
-.. versionchanged:: 0.2.0 Returns std::future instead of std::promise
 
 After you register a user, it is a separate step to log the user in.
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34763

- [C++ Staged Docs](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-34763/sdk/cpp/): Remove version directives that still exist in the docs after removing the experimental namespace. As part of removing the experimental namespace, I removed the "Current" and "Deprecated" tabs, so version directives that exist in those tabs have already been removed in the related PR (#3113 ). Apparently I also removed one on the Quick Start page that was next to a code example I updated. So these changes only touch version directives that were not touched in that PR.

I did a search for all the `.. version` directives in C++, and then I did a search for any remaining "version" references, and I compared every instance against the related PR, so I think this is good and includes all instances that should be touched here. But I welcome a second set of eyes!

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
