### PR TITLE
(DOCSP-35190): C++: Add docs for compacting a realm

### DIFF
--- a/examples/cpp/compact/CMakeLists.txt
+++ b/examples/cpp/compact/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(examples-compact)
+
+set(CMAKE_CXX_STANDARD 17)
+
+Include(FetchContent)
+
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v3.5.0 # or a later release
+)
+FetchContent_Declare(
+  cpprealm
+  GIT_REPOSITORY https://github.com/realm/realm-cpp.git
+  GIT_TAG        d85365a3e49030cf96d742c351e42bbde5070e06
+)
+
+FetchContent_MakeAvailable(Catch2 cpprealm)
+
+add_executable(examples-compact
+  compact.cpp
+)
+
+target_link_libraries(examples-compact PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(examples-compact PRIVATE cpprealm)

--- a/examples/cpp/compact/compact.cpp
+++ b/examples/cpp/compact/compact.cpp
@@ -1,0 +1,52 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cpprealm/experimental/sdk.hpp>
+#include <cpprealm/sdk.hpp>
+
+using namespace realm::experimental;
+
+struct Dog {
+  std::string name;
+  int64_t age;
+};
+REALM_SCHEMA(Dog, name, age)
+
+TEST_CASE("Compact a realm example", "[write]") {
+  auto relative_realm_path_directory = "compact-realm/";
+  std::filesystem::create_directories(relative_realm_path_directory);
+  std::filesystem::path path =
+      std::filesystem::current_path().append(relative_realm_path_directory);
+  path = path.append("compact");
+  path = path.replace_extension("realm");
+  // :snippet-start: compact-database
+  // Create a database configuration.
+  auto config = realm::db_config();
+  config.set_path(path);  // :remove:
+
+  config.should_compact_on_launch([&](uint64_t totalBytes, uint64_t usedBytes) {
+    // totalBytes refers to the size of the file on disk in bytes (data + free
+    // space). usedBytes refers to the number of bytes used by data in the file
+    // Compact if the file is over 100MB in size and less than 50% 'used'
+    auto oneHundredMB = 100 * 1024 * 1024;
+    return (totalBytes > oneHundredMB) && (usedBytes / totalBytes) < 0.5;
+  });
+
+  // The database is compacted on the first open if the configuration block
+  // conditions were met.
+  auto realm = db(config);
+  // :snippet-end:
+
+  auto dog = Dog{.name = "Maui", .age = 3};
+
+  realm.write([&] { realm.add(std::move(dog)); });
+
+  auto managedDogs = realm.objects<Dog>();
+  auto specificDog = managedDogs[0];
+  REQUIRE(specificDog.name == "Maui");
+  REQUIRE(specificDog.age == static_cast<long long>(3));
+  REQUIRE(managedDogs.size() == 1);
+
+  realm.write([&] { realm.remove(specificDog); });
+
+  auto managedDogsAfterDelete = realm.objects<Dog>();
+  REQUIRE(managedDogsAfterDelete.size() == 0);
+}

--- a/source/examples/generated/cpp/compact.snippet.compact-database.cpp
+++ b/source/examples/generated/cpp/compact.snippet.compact-database.cpp
@@ -1,0 +1,14 @@
+// Create a database configuration.
+auto config = realm::db_config();
+
+config.should_compact_on_launch([&](uint64_t totalBytes, uint64_t usedBytes) {
+  // totalBytes refers to the size of the file on disk in bytes (data + free
+  // space). usedBytes refers to the number of bytes used by data in the file
+  // Compact if the file is over 100MB in size and less than 50% 'used'
+  auto oneHundredMB = 100 * 1024 * 1024;
+  return (totalBytes > oneHundredMB) && (usedBytes / totalBytes) < 0.5;
+});
+
+// The database is compacted on the first open if the configuration block
+// conditions were met.
+auto realm = db(config);

--- a/source/sdk/cpp/realm-files.txt
+++ b/source/sdk/cpp/realm-files.txt
@@ -8,4 +8,5 @@ Work with Realm Files - C++ SDK Preview
    :titlesonly:
 
    Configure & Open a Realm </sdk/cpp/realm-files/configure-and-open-a-realm>
+   Reduce Realm File Size </sdk/cpp/realm-files/compact-realm>
    Encrypt a Realm </sdk/cpp/realm-files/encrypt-a-realm>

--- a/source/sdk/cpp/realm-files/compact-realm.txt
+++ b/source/sdk/cpp/realm-files/compact-realm.txt
@@ -1,0 +1,53 @@
+.. _cpp-compact-realm:
+
+================================
+Reduce Realm File Size - C++ SDK
+================================
+
+.. meta::
+   :keywords: code example
+   :description: Reduce the database file size on disk to improve performance in resource-constrained environments.
+
+.. facet::
+  :name: genre
+  :values: reference
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/compaction-introduction.rst
+
+Automatic Compaction
+--------------------
+
+.. include:: /includes/automatic-compaction.rst 
+
+Manual Compaction Options
+-------------------------
+
+Manual compaction can be used for applications that require stricter 
+management of file size.
+
+Realm manual compaction works by:
+
+1. Reading the entire contents of the realm file
+2. Writing the contents to a new file at a different location
+3. Replacing the original file
+
+If the file contains a lot of data, this can be an expensive operation.
+
+Use the 
+:cpp-sdk:`should_compact_on_launch() <structrealm_1_1internal_1_1bridge_1_1realm_1_1config.html>` 
+method on the database configuration to attempt to compact the database. 
+Specify conditions to execute this method, such as:
+
+- The size of the file on disk
+- How much free space the file contains
+
+.. literalinclude:: /examples/generated/cpp/compact.snippet.compact-database.cpp
+   :language: cpp
+
+.. include:: /includes/compaction-tips.rst

--- a/source/sdk/cpp/realm-files/compact-realm.txt
+++ b/source/sdk/cpp/realm-files/compact-realm.txt
@@ -47,7 +47,13 @@ Specify conditions to execute this method, such as:
 - The size of the file on disk
 - How much free space the file contains
 
+The following example shows setting the conditions to compact a realm if the 
+file is above 100 MB and 50% or more of the space in the realm file is unused.
+
 .. literalinclude:: /examples/generated/cpp/compact.snippet.compact-database.cpp
    :language: cpp
+
+Tips for Manually Compacting a Realm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/compaction-tips.rst

--- a/source/sdk/cpp/realm-files/compact-realm.txt
+++ b/source/sdk/cpp/realm-files/compact-realm.txt
@@ -48,7 +48,7 @@ Specify conditions to execute this method, such as:
 - How much free space the file contains
 
 The following example shows setting the conditions to compact a realm if the 
-file is above 100 MB and 50% or less of the space in the realm file is unused.
+file is above 100 MB and 50% or less of the space in the realm file is used.
 
 .. literalinclude:: /examples/generated/cpp/compact.snippet.compact-database.cpp
    :language: cpp

--- a/source/sdk/cpp/realm-files/compact-realm.txt
+++ b/source/sdk/cpp/realm-files/compact-realm.txt
@@ -48,7 +48,7 @@ Specify conditions to execute this method, such as:
 - How much free space the file contains
 
 The following example shows setting the conditions to compact a realm if the 
-file is above 100 MB and 50% or more of the space in the realm file is unused.
+file is above 100 MB and 50% or less of the space in the realm file is unused.
 
 .. literalinclude:: /examples/generated/cpp/compact.snippet.compact-database.cpp
    :language: cpp


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35190

- [Reduce Realm File Size](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35190/sdk/cpp/realm-files/compact-realm/): New page with example for compacting a realm in C++ SDK.

Note: This example is in a new one-off unit test suite and uses the experimental namespace. When the SDK merges the PR that removes the experimental namespace, I'll get my corresponding docs PR merged and then move this into the local test suite established there, and remove this from the experimental namespace. 

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **C++ SDK**
  - Realm Files/Compact a Realm: New page with example for compacting a realm in C++ SDK.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
