### PR TITLE
(DOCSP-34760): C++: Add client reset docs

### DIFF
--- a/examples/cpp/client-reset/CMakeLists.txt
+++ b/examples/cpp/client-reset/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(examples-client-reset)
+
+set(CMAKE_CXX_STANDARD 17)
+
+Include(FetchContent)
+
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v3.5.0 # or a later release
+)
+FetchContent_Declare(
+  cpprealm
+  GIT_REPOSITORY https://github.com/realm/realm-cpp.git
+  GIT_TAG        077433a5ce78e495c9bccc4b1b99dfa068032f37
+)
+
+FetchContent_MakeAvailable(Catch2 cpprealm)
+
+add_executable(examples-client-reset
+  client-reset.cpp
+)
+
+target_link_libraries(examples-client-reset PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(examples-client-reset PRIVATE cpprealm)

--- a/examples/cpp/client-reset/client-reset.cpp
+++ b/examples/cpp/client-reset/client-reset.cpp
@@ -20,22 +20,22 @@ TEST_CASE("Recover unsynced changes example", "[write]") {
   auto app = realm::App(appConfig);
 
   // :snippet-start: before-after-blocks
-  // You can define blocks to call before and after the client reset occur
-  // if you need to execute specific logic, such as reporting or debugging.
+  /* You can define blocks to call before and after the client reset occur
+     if you need to execute specific logic, such as reporting or debugging. */
   auto beforeReset = [&](realm::experimental::db before) {
-    // A block called after a client reset error is detected, but before the
-    // client recovery process is executed. You could use this block for any
-    // custom logic, reporting, debugging etc. You have access to the database
-    // before the client reset occurs in this block.
+    /* A block called after a client reset error is detected, but before the
+       client recovery process is executed. You could use this block for any
+       custom logic, reporting, debugging etc. You have access to the database
+       before the client reset occurs in this block. */
   };
 
   auto afterReset = [&](realm::experimental::db device,
                         realm::experimental::db server) {
-    // A block called after the client recovery process has executed.
-    // This block could be used for custom recovery, reporting, debugging etc.
-    // You have access to the database that is currently on the device - the
-    // one that can no longer sync - and the new database that has been
-    // restored from the server.
+    /* A block called after the client recovery process has executed.
+       This block could be used for custom recovery, reporting, debugging etc.
+       You have access to the database that is currently on the device - the
+       one that can no longer sync - and the new database that has been
+       restored from the server. */
   };
   // :snippet-end:
 
@@ -169,8 +169,8 @@ TEST_CASE("Manual example", "[write]") {
   syncConfig.sync_config().set_error_handler(
       [&](realm::sync_session session, realm::sync_error error) {
         if (error.is_client_reset_requested()) {
-          // You might use this for reporting or to instruct the user to delete
-          // and re-install the app.
+          /* You might use this for reporting or to instruct the user to delete
+             and re-install the app. */
         };
       });
 

--- a/examples/cpp/client-reset/client-reset.cpp
+++ b/examples/cpp/client-reset/client-reset.cpp
@@ -1,0 +1,217 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cpprealm/experimental/sdk.hpp>
+#include <cpprealm/sdk.hpp>
+
+static const std::string APP_ID = "cpp-tester-uliix";
+
+using namespace realm::experimental;
+
+struct FlexibleSync_Dog {
+  realm::experimental::primary_key<realm::object_id> _id{
+      realm::object_id::generate()};
+  std::string name;
+  int64_t age;
+};
+REALM_SCHEMA(FlexibleSync_Dog, _id, name, age)
+
+TEST_CASE("Recover unsynced changes example", "[write]") {
+  auto appConfig = realm::App::configuration();
+  appConfig.app_id = APP_ID;
+  auto app = realm::App(appConfig);
+
+  // :snippet-start: before-after-blocks
+  // You can define blocks to call before and after the client reset occur
+  // if you need to execute specific logic, such as reporting or debugging.
+  auto beforeReset = [&](realm::experimental::db before) {
+    // A block called after a client reset error is detected, but before the
+    // client recovery process is executed. You could use this block for any
+    // custom logic, reporting, debugging etc. You have access to the database
+    // before the client reset occurs in this block.
+  };
+
+  auto afterReset = [&](realm::experimental::db device,
+                        realm::experimental::db server) {
+    // A block called after the client recovery process has executed.
+    // This block could be used for custom recovery, reporting, debugging etc.
+    // You have access to the database that is currently on the device - the
+    // one that can no longer sync - and the new database that has been
+    // restored from the server.
+  };
+  // :snippet-end:
+
+  // :snippet-start: recover-unsynced-changes
+  auto user = app.login(realm::App::credentials::anonymous()).get();
+  auto syncConfig = user.flexible_sync_configuration();
+
+  // Set the client reset handler with your preferred client reset mode.
+  syncConfig.set_client_reset_handler(
+      realm::client_reset::recover_unsynced_changes(beforeReset, afterReset));
+
+  auto syncedRealm = realm::experimental::db(syncConfig);
+  // :snippet-end:
+
+  // Not actually attempting to test a client reset here as the SDK handles
+  // that. Just confirming we can write to the server with this config.
+  auto updateSubscriptionSuccess =
+      syncedRealm.subscriptions()
+          .update(
+              [](realm::mutable_sync_subscription_set &subs) { subs.clear(); })
+          .get();
+  CHECK(updateSubscriptionSuccess == true);
+  CHECK(syncedRealm.subscriptions().size() == 0);
+
+  updateSubscriptionSuccess =
+      syncedRealm.subscriptions()
+          .update([](realm::mutable_sync_subscription_set &subs) {
+            subs.add<FlexibleSync_Dog>("puppies",
+                                       [](auto &obj) { return obj.age < 3; });
+          })
+          .get();
+  REQUIRE(updateSubscriptionSuccess == true);
+  CHECK(syncedRealm.subscriptions().size() == 1);
+
+  auto syncSession = syncedRealm.get_sync_session();
+
+  auto dog = FlexibleSync_Dog{.name = "Maui", .age = 2};
+
+  syncedRealm.write([&] { syncedRealm.add(std::move(dog)); });
+
+  auto managedDogs = syncedRealm.objects<FlexibleSync_Dog>();
+  auto specificDog = managedDogs[0];
+  REQUIRE(specificDog.name == "Maui");
+  REQUIRE(specificDog.age == static_cast<long long>(2));
+  REQUIRE(managedDogs.size() == 1);
+
+  syncedRealm.write([&] { syncedRealm.remove(specificDog); });
+
+  auto managedDogsAfterDelete = syncedRealm.objects<FlexibleSync_Dog>();
+  REQUIRE(managedDogsAfterDelete.size() == 0);
+  syncSession->wait_for_upload_completion().get();
+}
+
+TEST_CASE("Discard unsynced changes example", "[write]") {
+  auto appConfig = realm::App::configuration();
+  appConfig.app_id = APP_ID;
+  auto app = realm::App(appConfig);
+
+  auto beforeReset = [&](realm::experimental::db before) {
+    // A block called after a client reset error is detected, but before the
+  };
+
+  auto afterReset = [&](realm::experimental::db device,
+                        realm::experimental::db server) {
+    // A block called after the client recovery process has executed.
+  };
+
+  // :snippet-start: discard-unsynced-changes
+  auto user = app.login(realm::App::credentials::anonymous()).get();
+  auto syncConfig = user.flexible_sync_configuration();
+
+  // Set the client reset handler with your preferred client reset mode.
+  syncConfig.set_client_reset_handler(
+      realm::client_reset::discard_unsynced_changes(beforeReset, afterReset));
+
+  auto syncedRealm = realm::experimental::db(syncConfig);
+  // :snippet-end:
+
+  // Not actually attempting to test a client reset here as the SDK handles
+  // that. Just confirming we can write to the server with this config.
+  auto updateSubscriptionSuccess =
+      syncedRealm.subscriptions()
+          .update(
+              [](realm::mutable_sync_subscription_set &subs) { subs.clear(); })
+          .get();
+  CHECK(updateSubscriptionSuccess == true);
+  CHECK(syncedRealm.subscriptions().size() == 0);
+
+  updateSubscriptionSuccess =
+      syncedRealm.subscriptions()
+          .update([](realm::mutable_sync_subscription_set &subs) {
+            subs.add<FlexibleSync_Dog>("puppies",
+                                       [](auto &obj) { return obj.age < 3; });
+          })
+          .get();
+  REQUIRE(updateSubscriptionSuccess == true);
+  CHECK(syncedRealm.subscriptions().size() == 1);
+
+  auto syncSession = syncedRealm.get_sync_session();
+
+  auto dog = FlexibleSync_Dog{.name = "Maui", .age = 2};
+
+  syncedRealm.write([&] { syncedRealm.add(std::move(dog)); });
+
+  auto managedDogs = syncedRealm.objects<FlexibleSync_Dog>();
+  auto specificDog = managedDogs[0];
+  REQUIRE(specificDog.name == "Maui");
+  REQUIRE(specificDog.age == static_cast<long long>(2));
+  REQUIRE(managedDogs.size() == 1);
+
+  syncedRealm.write([&] { syncedRealm.remove(specificDog); });
+
+  auto managedDogsAfterDelete = syncedRealm.objects<FlexibleSync_Dog>();
+  REQUIRE(managedDogsAfterDelete.size() == 0);
+  syncSession->wait_for_upload_completion().get();
+}
+
+TEST_CASE("Manual example", "[write]") {
+  auto appConfig = realm::App::configuration();
+  appConfig.app_id = APP_ID;
+  auto app = realm::App(appConfig);
+
+  // :snippet-start: manual-client-reset
+  auto user = app.login(realm::App::credentials::anonymous()).get();
+  auto syncConfig = user.flexible_sync_configuration();
+
+  // Set the client reset handler to manual client reset mode.
+  syncConfig.set_client_reset_handler(realm::client_reset::manual());
+
+  // Define a Sync error handler for handling the client reset.
+  syncConfig.sync_config().set_error_handler(
+      [&](realm::sync_session session, realm::sync_error error) {
+        if (error.is_client_reset_requested()) {
+          // You might use this for reporting or to instruct the user to delete
+          // and re-install the app.
+        };
+      });
+
+  auto syncedRealm = realm::experimental::db(syncConfig);
+  // :snippet-end:
+
+  // Not actually attempting to test a client reset here as the SDK handles
+  // that. Just confirming we can write to the server with this config.
+  auto updateSubscriptionSuccess =
+      syncedRealm.subscriptions()
+          .update(
+              [](realm::mutable_sync_subscription_set &subs) { subs.clear(); })
+          .get();
+  CHECK(updateSubscriptionSuccess == true);
+  CHECK(syncedRealm.subscriptions().size() == 0);
+
+  updateSubscriptionSuccess =
+      syncedRealm.subscriptions()
+          .update([](realm::mutable_sync_subscription_set &subs) {
+            subs.add<FlexibleSync_Dog>("puppies",
+                                       [](auto &obj) { return obj.age < 3; });
+          })
+          .get();
+  REQUIRE(updateSubscriptionSuccess == true);
+  CHECK(syncedRealm.subscriptions().size() == 1);
+
+  auto syncSession = syncedRealm.get_sync_session();
+
+  auto dog = FlexibleSync_Dog{.name = "Maui", .age = 2};
+
+  syncedRealm.write([&] { syncedRealm.add(std::move(dog)); });
+
+  auto managedDogs = syncedRealm.objects<FlexibleSync_Dog>();
+  auto specificDog = managedDogs[0];
+  REQUIRE(specificDog.name == "Maui");
+  REQUIRE(specificDog.age == static_cast<long long>(2));
+  REQUIRE(managedDogs.size() == 1);
+
+  syncedRealm.write([&] { syncedRealm.remove(specificDog); });
+
+  auto managedDogsAfterDelete = syncedRealm.objects<FlexibleSync_Dog>();
+  REQUIRE(managedDogsAfterDelete.size() == 0);
+  syncSession->wait_for_upload_completion().get();
+}

--- a/source/examples/generated/cpp/client-reset.snippet.before-after-blocks.cpp
+++ b/source/examples/generated/cpp/client-reset.snippet.before-after-blocks.cpp
@@ -1,0 +1,17 @@
+// You can define blocks to call before and after the client reset occur
+// if you need to execute specific logic, such as reporting or debugging.
+auto beforeReset = [&](realm::experimental::db before) {
+  // A block called after a client reset error is detected, but before the
+  // client recovery process is executed. You could use this block for any
+  // custom logic, reporting, debugging etc. You have access to the database
+  // before the client reset occurs in this block.
+};
+
+auto afterReset = [&](realm::experimental::db device,
+                      realm::experimental::db server) {
+  // A block called after the client recovery process has executed.
+  // This block could be used for custom recovery, reporting, debugging etc.
+  // You have access to the database that is currently on the device - the
+  // one that can no longer sync - and the new database that has been
+  // restored from the server.
+};

--- a/source/examples/generated/cpp/client-reset.snippet.before-after-blocks.cpp
+++ b/source/examples/generated/cpp/client-reset.snippet.before-after-blocks.cpp
@@ -1,17 +1,17 @@
-// You can define blocks to call before and after the client reset occur
-// if you need to execute specific logic, such as reporting or debugging.
+/* You can define blocks to call before and after the client reset occur
+   if you need to execute specific logic, such as reporting or debugging. */
 auto beforeReset = [&](realm::experimental::db before) {
-  // A block called after a client reset error is detected, but before the
-  // client recovery process is executed. You could use this block for any
-  // custom logic, reporting, debugging etc. You have access to the database
-  // before the client reset occurs in this block.
+  /* A block called after a client reset error is detected, but before the
+     client recovery process is executed. You could use this block for any
+     custom logic, reporting, debugging etc. You have access to the database
+     before the client reset occurs in this block. */
 };
 
 auto afterReset = [&](realm::experimental::db device,
                       realm::experimental::db server) {
-  // A block called after the client recovery process has executed.
-  // This block could be used for custom recovery, reporting, debugging etc.
-  // You have access to the database that is currently on the device - the
-  // one that can no longer sync - and the new database that has been
-  // restored from the server.
+  /* A block called after the client recovery process has executed.
+     This block could be used for custom recovery, reporting, debugging etc.
+     You have access to the database that is currently on the device - the
+     one that can no longer sync - and the new database that has been
+     restored from the server. */
 };

--- a/source/examples/generated/cpp/client-reset.snippet.discard-unsynced-changes.cpp
+++ b/source/examples/generated/cpp/client-reset.snippet.discard-unsynced-changes.cpp
@@ -1,0 +1,8 @@
+auto user = app.login(realm::App::credentials::anonymous()).get();
+auto syncConfig = user.flexible_sync_configuration();
+
+// Set the client reset handler with your preferred client reset mode.
+syncConfig.set_client_reset_handler(
+    realm::client_reset::discard_unsynced_changes(beforeReset, afterReset));
+
+auto syncedRealm = realm::experimental::db(syncConfig);

--- a/source/examples/generated/cpp/client-reset.snippet.manual-client-reset.cpp
+++ b/source/examples/generated/cpp/client-reset.snippet.manual-client-reset.cpp
@@ -8,8 +8,8 @@ syncConfig.set_client_reset_handler(realm::client_reset::manual());
 syncConfig.sync_config().set_error_handler(
     [&](realm::sync_session session, realm::sync_error error) {
       if (error.is_client_reset_requested()) {
-        // You might use this for reporting or to instruct the user to delete
-        // and re-install the app.
+        /* You might use this for reporting or to instruct the user to delete
+           and re-install the app. */
       };
     });
 

--- a/source/examples/generated/cpp/client-reset.snippet.manual-client-reset.cpp
+++ b/source/examples/generated/cpp/client-reset.snippet.manual-client-reset.cpp
@@ -1,0 +1,16 @@
+auto user = app.login(realm::App::credentials::anonymous()).get();
+auto syncConfig = user.flexible_sync_configuration();
+
+// Set the client reset handler to manual client reset mode.
+syncConfig.set_client_reset_handler(realm::client_reset::manual());
+
+// Define a Sync error handler for handling the client reset.
+syncConfig.sync_config().set_error_handler(
+    [&](realm::sync_session session, realm::sync_error error) {
+      if (error.is_client_reset_requested()) {
+        // You might use this for reporting or to instruct the user to delete
+        // and re-install the app.
+      };
+    });
+
+auto syncedRealm = realm::experimental::db(syncConfig);

--- a/source/examples/generated/cpp/client-reset.snippet.recover-unsynced-changes.cpp
+++ b/source/examples/generated/cpp/client-reset.snippet.recover-unsynced-changes.cpp
@@ -1,0 +1,8 @@
+auto user = app.login(realm::App::credentials::anonymous()).get();
+auto syncConfig = user.flexible_sync_configuration();
+
+// Set the client reset handler with your preferred client reset mode.
+syncConfig.set_client_reset_handler(
+    realm::client_reset::recover_unsynced_changes(beforeReset, afterReset));
+
+auto syncedRealm = realm::experimental::db(syncConfig);

--- a/source/sdk/cpp/sync/handle-sync-errors.txt
+++ b/source/sdk/cpp/sync/handle-sync-errors.txt
@@ -6,6 +6,7 @@ Handle Sync Errors - C++ SDK
 
 .. meta:: 
   :keywords: code example
+   :description: Atlas Device Sync error handling and client reset errors.
 
 .. facet::
   :name: genre
@@ -56,3 +57,207 @@ occurred.
          :language: cpp
 
 .. include:: /includes/sync-errors-in-app-services.rst
+
+.. _cpp-client-reset:
+
+Client Reset
+------------
+
+When using :ref:`Device Sync <sync>`, a **client reset** is an
+error recovery task that your client app must perform when given
+synced data on the server can no longer sync with the device database. 
+In this case, the device must reset its synced database to a state that 
+matches the server in order to restore the ability to sync.
+
+When this occurs, the unsyncable database on the device may contain data that 
+has not yet synced to the server. The SDKs can attempt to recover or 
+discard that data during the client reset process.
+
+For more information about what might cause a client reset to occur, go to
+:ref:`Client Resets in the App Services documentation <client-resets>`.
+
+.. _cpp-automatic-vs-manual-client-reset:
+
+Automatic vs. Manual Client Reset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The SDKs provide :ref:`client reset modes <cpp-specify-client-reset-mode>` 
+that automatically handle most client reset errors. Automatic client 
+reset modes restore your device's synced database file to a syncable state 
+without closing the database or missing notifications.
+
+All the client reset modes except ``manual()`` perform an automatic client 
+reset. The differences between the modes are based on how they handle 
+changes on the device that have not yet synced to the backend.
+
+Choose ``recover_unsynced_changes()`` to handle most client reset 
+scenarios automatically. This attempts to recover unsynced changes when a 
+client reset occurs.
+
+In some cases, you may want or need to :ref:`set a manual client reset handler 
+<cpp-manual-client-reset-handler>`. You may want to do this if your app 
+requires specific client reset logic that can't be handled automatically.
+
+.. _cpp-specify-client-reset-mode:
+
+Specify a Client Reset Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The SDK provides the option to specify a client reset handler in your 
+:cpp-sdk:`database configuration <structrealm_1_1internal_1_1bridge_1_1realm_1_1config.html>`. 
+This client reset handler can take blocks to execute before and after the
+client reset, as well as the mode to use when handling the client reset:
+
+.. literalinclude:: /examples/generated/cpp/client-reset.snippet.recover-unsynced-changes.cpp
+   :language: cpp
+
+You can use one of the available client reset modes to specify how the SDK 
+should attempt to resolve any unsynced data on the device during a client reset: 
+
+- ``recover_unsynced_changes()``
+- ``recover_or_discard_unsynced_changes()``
+- ``discard_unsynced_changes()`` 
+- ``manual()``
+
+You can specify a before and after block to execute during the automatic client 
+reset process. You might use this to perform recovery logic that is important 
+to your application.
+
+.. literalinclude:: /examples/generated/cpp/client-reset.snippet.before-after-blocks.cpp
+   :language: cpp
+
+If your app has specific client recovery needs, you 
+can specify the ``manual()`` client reset mode and set a :ref:`manual client
+reset handler <cpp-manual-client-reset-handler>`. You might do this if 
+you have specific custom logic your app must perform during a client reset,
+or if the :ref:`client recovery rules <cpp-client-recovery-rules>` do not 
+work for your app.
+
+.. _cpp-handle-schema-changes:
+
+Handle Schema Changes
+~~~~~~~~~~~~~~~~~~~~~
+
+:ref:`Client Recovery <enable-or-disable-recovery-mode>` is a feature that is
+enabled by default when you :ref:`configure Device Sync <enable-sync>`. When 
+Client Recovery is enabled, the SDK can automatically manage the 
+client reset process in most cases. When you make schema changes:
+
+- The client can :ref:`recover unsynced changes <cpp-recover-unsynced-changes>` 
+  when there are no schema changes, or non-breaking schema changes.
+- When you make breaking schema changes, the automatic client reset modes fall
+  back to a manual error handler. You can set a :ref:`manual client 
+  reset error handler <cpp-manual-client-reset-handler>` for this case. 
+  Automatic client recovery cannot occur when your app makes breaking 
+  schema changes.
+
+For information on breaking vs. non-breaking schema changes, see 
+:ref:`breaking-change-quick-reference`.
+
+.. _cpp-recover-unsynced-changes:
+
+Recover Unsynced Changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+During a client reset, client applications can attempt to recover data 
+in the synced database on the device that has not yet synced to the backend. 
+To recover unsynced changes, :ref:`Client Recovery <recover-unsynced-changes>` 
+must be :ref:`enabled in your App Services App <enable-or-disable-recovery-mode>`, 
+as it is by default.
+
+If you want your app to recover changes that have not yet synced, use one 
+of these client recovery modes:
+
+- ``recover_unsynced_changes()``: When you choose this mode, the client attempts 
+  to recover unsynced changes. Choose this mode when you do not want to fall
+  through to discard unsynced changes. 
+- ``recover_or_discard_unsynced_changes()``: The client first attempts to 
+  recover changes that have not yet synced. If the client cannot recover 
+  unsynced data, it falls through to :ref:`discard unsynced changes 
+  <cpp-discard-local-changes>` but continues to automatically perform the 
+  client reset. Choose this mode when you want to enable automatic client 
+  recovery to fall back to discard unsynced changes. 
+
+.. literalinclude:: /examples/generated/cpp/client-reset.snippet.recover-unsynced-changes.cpp
+   :language: cpp
+
+There may be times when the client reset operation cannot complete in 
+recover unsynced changes mode, like when there are breaking schema changes or
+:ref:`Client Recovery <recover-unsynced-changes>` is disabled in the 
+Device Sync configuration. To handle this case, your app can handle a client
+reset error in the Sync error handler. For more information, refer to 
+:ref:`manual client reset mode <cpp-manual-client-reset-handler>`.
+
+.. _cpp-client-recovery-rules:
+
+Client Recovery Rules
+`````````````````````
+
+.. include:: /includes/client-recovery-rules.rst
+
+.. _cpp-discard-local-changes:
+
+Discard Unsynced Changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The **discard unsynced changes** client reset mode permanently deletes all 
+unsynced changes on the device since the last successful sync. You might 
+use this mode when your app requires client recovery logic that is not 
+consistent with the Device Sync :ref:`Client Recovery Rules 
+<cpp-client-recovery-rules>`, or when you don't want to recover unsynced data.
+
+Do not use discard unsynced changes mode if your application cannot lose 
+device data that has not yet synced to the backend.
+
+To perform an automatic client reset that discards unsynced changes, use the 
+``discard_unsynced_changes()`` client reset mode.
+
+.. literalinclude:: /examples/generated/cpp/client-reset.snippet.discard-unsynced-changes.cpp
+   :language: cpp
+
+.. note:: Discard with Recovery
+
+   If you'd like to attempt to recover unsynced changes, but but discard 
+   any changes that cannot be recovered, refer to the 
+   ``recover_or_discard_unsynced_changes()`` documentation in :ref:`Recover 
+   Unsynced Changes <cpp-recover-unsynced-changes>`.
+
+There may be times when the client reset operation cannot complete in 
+discard unsynced changes mode, like when there are breaking schema changes.
+To handle this case, your app can handle a client reset error in the Sync 
+error handler. For more information, refer to 
+:ref:`manual client reset mode <cpp-manual-client-reset-handler>`.
+
+.. _cpp-manual-client-reset-handler:
+.. _cpp-manual-mode:
+
+Manual Client Reset Mode
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you use ``manual()`` client reset mode, you must implement 
+a custom client reset handler in the Sync error handler. We recommend using the
+:ref:`automatic client recovery modes <cpp-automatic-vs-manual-client-reset>` 
+when possible, and only choosing ``manual()`` mode if the automatic recovery 
+logic is not suitable for your app.
+
+.. literalinclude:: /examples/generated/cpp/client-reset.snippet.manual-client-reset.cpp
+   :language: cpp
+
+If the client reset operation cannot complete automatically, like when there 
+are breaking schema changes, the client reset process falls through to the 
+manual error handler. This may occur in any of these automatic client reset modes:
+
+- ``recover_unsynced_changes()``
+- ``recover_or_discard_unsynced_changes()``
+- ``discard_unsynced_changes()`` 
+
+We recommend treating the manual handler as a tool for fatal error 
+recovery situations where you advise users to update the app or perform some 
+other action. 
+
+.. _cpp-test-client-reset-handling:
+
+Test Client Reset Handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/test-client-reset.rst

--- a/source/sdk/cpp/sync/handle-sync-errors.txt
+++ b/source/sdk/cpp/sync/handle-sync-errors.txt
@@ -105,8 +105,13 @@ Specify a Client Reset Mode
 
 The SDK provides the option to specify a client reset handler in your 
 :cpp-sdk:`database configuration <structrealm_1_1internal_1_1bridge_1_1realm_1_1config.html>`. 
-This client reset handler can take blocks to execute before and after the
-client reset, as well as the mode to use when handling the client reset:
+This client reset handler can take a 
+:cpp-sdk:`client_reset_mode_base <structrealm_1_1internal_1_1bridge_1_1client__reset__mode__base.html>`.
+This struct allows you to specify:
+
+- A block to execute before the client reset
+- A block to execute after the client reset
+- The mode to use when handling the client reset
 
 .. literalinclude:: /examples/generated/cpp/client-reset.snippet.recover-unsynced-changes.cpp
    :language: cpp

--- a/source/sdk/cpp/sync/handle-sync-errors.txt
+++ b/source/sdk/cpp/sync/handle-sync-errors.txt
@@ -64,13 +64,13 @@ Client Reset
 ------------
 
 When using :ref:`Device Sync <sync>`, a **client reset** is an
-error recovery task that your client app must perform when given
-synced data on the server can no longer sync with the device database. 
-In this case, the device must reset its synced database to a state that 
-matches the server in order to restore the ability to sync.
+error recovery task that your client app must perform when the server can 
+no longer sync with the device database. In this case, the device must reset 
+its database to a state that matches the server in order to restore the 
+ability to sync.
 
 When this occurs, the unsyncable database on the device may contain data that 
-has not yet synced to the server. The SDKs can attempt to recover or 
+has not yet synced to the server. The SDK can attempt to recover or 
 discard that data during the client reset process.
 
 For more information about what might cause a client reset to occur, go to
@@ -81,9 +81,9 @@ For more information about what might cause a client reset to occur, go to
 Automatic vs. Manual Client Reset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The SDKs provide :ref:`client reset modes <cpp-specify-client-reset-mode>` 
+The SDK provides :ref:`client reset modes <cpp-specify-client-reset-mode>` 
 that automatically handle most client reset errors. Automatic client 
-reset modes restore your device's synced database file to a syncable state 
+reset modes restore your device's database file to a syncable state 
 without closing the database or missing notifications.
 
 All the client reset modes except ``manual()`` perform an automatic client 
@@ -103,7 +103,7 @@ requires specific client reset logic that can't be handled automatically.
 Specify a Client Reset Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The SDK provides the option to specify a client reset handler in your 
+The C++ SDK provides the option to specify a client reset handler in your 
 :cpp-sdk:`database configuration <structrealm_1_1internal_1_1bridge_1_1realm_1_1config.html>`. 
 This client reset handler can take a 
 :cpp-sdk:`client_reset_mode_base <structrealm_1_1internal_1_1bridge_1_1client__reset__mode__base.html>`.
@@ -168,14 +168,14 @@ During a client reset, client applications can attempt to recover data
 in the synced database on the device that has not yet synced to the backend. 
 To recover unsynced changes, :ref:`Client Recovery <recover-unsynced-changes>` 
 must be :ref:`enabled in your App Services App <enable-or-disable-recovery-mode>`, 
-as it is by default.
+which it is by default.
 
 If you want your app to recover changes that have not yet synced, use one 
 of these client recovery modes:
 
-- ``recover_unsynced_changes()``: When you choose this mode, the client attempts 
-  to recover unsynced changes. Choose this mode when you do not want to fall
-  through to discard unsynced changes. 
+- ``recover_unsynced_changes()``: The client attempts to recover unsynced 
+  changes. Choose this mode when you do not want to fall through to discard 
+  unsynced changes. 
 - ``recover_or_discard_unsynced_changes()``: The client first attempts to 
   recover changes that have not yet synced. If the client cannot recover 
   unsynced data, it falls through to :ref:`discard unsynced changes 
@@ -187,11 +187,12 @@ of these client recovery modes:
    :language: cpp
 
 There may be times when the client reset operation cannot complete in 
-recover unsynced changes mode, like when there are breaking schema changes or
-:ref:`Client Recovery <recover-unsynced-changes>` is disabled in the 
-Device Sync configuration. To handle this case, your app can handle a client
-reset error in the Sync error handler. For more information, refer to 
-:ref:`manual client reset mode <cpp-manual-client-reset-handler>`.
+``recover_unsynced_changes()`` mode, like when there are breaking schema 
+changes or :ref:`Client Recovery <recover-unsynced-changes>` is disabled in 
+the Device Sync configuration. To handle this case, your app can handle a 
+client reset error in the Sync error handler. For more information, refer to 
+the :ref:`manual client reset mode <cpp-manual-client-reset-handler>` section
+on this page.
 
 .. _cpp-client-recovery-rules:
 
@@ -205,10 +206,10 @@ Client Recovery Rules
 Discard Unsynced Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The **discard unsynced changes** client reset mode permanently deletes all 
+The ``discard_unsynced_changes()`` client reset mode permanently deletes all 
 unsynced changes on the device since the last successful sync. You might 
 use this mode when your app requires client recovery logic that is not 
-consistent with the Device Sync :ref:`Client Recovery Rules 
+consistent with the Device Sync :ref:`client recovery rules 
 <cpp-client-recovery-rules>`, or when you don't want to recover unsynced data.
 
 Do not use discard unsynced changes mode if your application cannot lose 
@@ -222,16 +223,16 @@ To perform an automatic client reset that discards unsynced changes, use the
 
 .. note:: Discard with Recovery
 
-   If you'd like to attempt to recover unsynced changes, but but discard 
+   If you'd like to attempt to recover unsynced changes, but discard 
    any changes that cannot be recovered, refer to the 
-   ``recover_or_discard_unsynced_changes()`` documentation in :ref:`Recover 
-   Unsynced Changes <cpp-recover-unsynced-changes>`.
+   ``recover_or_discard_unsynced_changes()`` documentation in the 
+   :ref:`cpp-recover-unsynced-changes` section on this page.
 
 There may be times when the client reset operation cannot complete in 
-discard unsynced changes mode, like when there are breaking schema changes.
-To handle this case, your app can handle a client reset error in the Sync 
-error handler. For more information, refer to 
-:ref:`manual client reset mode <cpp-manual-client-reset-handler>`.
+``discard_unsynced_changes()`` mode, like when there are breaking schema 
+changes. To handle this case, your app can handle a client reset error in the 
+Sync error handler. For more information, refer to the 
+:ref:`cpp-manual-client-reset-handler` section on this page.
 
 .. _cpp-manual-client-reset-handler:
 .. _cpp-manual-mode:

--- a/source/sdk/swift/sync/handle-sync-errors.txt
+++ b/source/sdk/swift/sync/handle-sync-errors.txt
@@ -244,7 +244,7 @@ in the :swift-sdk:`SyncConfiguration <Structs/SyncConfiguration.html>` to
 
 .. note:: Discard with Recovery
 
-   If you'd like to attempt to recover unsynced changes, but but discard 
+   If you'd like to attempt to recover unsynced changes, but discard 
    any changes that cannot be recovered, refer to the 
    ``.recoverOrDiscardUnsyncedChanges`` documentation in :ref:`Recover 
    Unsynced Changes <ios-recover-unsynced-changes>`.


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-34760

- [Handle Sync Errors](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-34760/sdk/cpp/sync/handle-sync-errors/#client-reset): New Client Reset section, with details and code examples showing client reset methods.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **C++ SDK**
  - Sync Data/Handle Sync Errors: Add information and code examples for client reset.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
