### PR TITLE
C++ GA Fast Follows

### DIFF
--- a/examples/cpp/asymmetric/CMakeLists.txt
+++ b/examples/cpp/asymmetric/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        8eba9728ea535a6cd78beaef37ed6d22b73fe889
+  GIT_TAG        v1.0.0
 )
 FetchContent_Declare(
   json

--- a/examples/cpp/local/CMakeLists.txt
+++ b/examples/cpp/local/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.25)
 
 project(examples-local)
 
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        8eba9728ea535a6cd78beaef37ed6d22b73fe889
+  GIT_TAG        v1.0.0
 )
 
 FetchContent_MakeAvailable(Catch2 cpprealm)

--- a/examples/cpp/scripts/bluehawk.sh
+++ b/examples/cpp/scripts/bluehawk.sh
@@ -13,5 +13,5 @@ echo "Bluehawking C++ local examples"
 npx bluehawk snip $CPP_EXAMPLES/local --ignore build -o $GENERATED_EXAMPLES
 
 # Bluehawk sync examples
-echo "Bluehawking C++ sync SDK examples"
+echo "Bluehawking C++ sync examples"
 npx bluehawk snip $CPP_EXAMPLES/sync --ignore build -o $GENERATED_EXAMPLES

--- a/examples/cpp/sync/CMakeLists.txt
+++ b/examples/cpp/sync/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        8eba9728ea535a6cd78beaef37ed6d22b73fe889
+  GIT_TAG        v1.0.0
 )
 FetchContent_Declare(
   json

--- a/source/includes/note-cpp-supports-subset-of-rql.rst
+++ b/source/includes/note-cpp-supports-subset-of-rql.rst
@@ -1,0 +1,4 @@
+.. note::
+
+   The C++ SDK does not yet support the full range of query expressions 
+   that the other SDKs provide.

--- a/source/sdk/cpp/crud/filter-data.txt
+++ b/source/sdk/cpp/crud/filter-data.txt
@@ -22,10 +22,7 @@ To filter data in your realm, you can leverage
 Realm's query engine. You can also sort filtered data. For an example of
 how to sort query results, refer to :ref:`cpp-sort-lists-and-results`.
 
-.. note::
-
-   While the Realm C++ SDK is in development, it does not yet support the 
-   full range of query expressions that the other Realm SDKs provide.
+.. include:: /includes/note-cpp-supports-subset-of-rql.rst
 
 About the Examples on This Page
 -------------------------------

--- a/source/sdk/cpp/realm-files.txt
+++ b/source/sdk/cpp/realm-files.txt
@@ -10,3 +10,7 @@ Work with Realm Files - C++ SDK
    Configure & Open a Realm </sdk/cpp/realm-files/configure-and-open-a-realm>
    Reduce Realm File Size </sdk/cpp/realm-files/compact-realm>
    Encrypt a Realm </sdk/cpp/realm-files/encrypt-a-realm>
+
+- :doc:`Configure & Open a Realm </sdk/cpp/realm-files/configure-and-open-a-realm>`
+- :doc:`Reduce Realm File Size </sdk/cpp/realm-files/compact-realm>`
+- :doc:`Encrypt a Realm </sdk/cpp/realm-files/encrypt-a-realm>`

--- a/source/sdk/cpp/sync/sync-subscriptions.txt
+++ b/source/sdk/cpp/sync/sync-subscriptions.txt
@@ -138,6 +138,8 @@ filter also applies to writes. If you try to write a ``Dog`` object where
 the ``age`` is ``4``, you get a compensating write error and the write 
 reverts.
 
+.. include:: /includes/note-cpp-supports-subset-of-rql.rst
+
 .. _cpp-update-subscriptions:
 
 Update Sync Subscriptions


### PR DESCRIPTION
## Pull Request Info

This ticket incorporates a few outstanding review comments from #3140, and it updates the unit test suites to use the release version - `v1.0.0`.

- [CRUD/Filter Data](https://preview-mongodbdacharyc.gatsbyjs.io/realm/cpp-ga-fast-follows/sdk/cpp/crud/filter-data/): Update the note about supporting a subset of RQL and make it an include.
- [Sync Data/Manage Sync Subscriptions](https://preview-mongodbdacharyc.gatsbyjs.io/realm/cpp-ga-fast-follows/sdk/cpp/sync/sync-subscriptions/#subscribe-to-objects-that-match-a-query): Add the note about C++ supporting a subset of RQL to the section about subscribing to objects that match a query.
- [Realm Files](https://preview-mongodbdacharyc.gatsbyjs.io/realm/cpp-ga-fast-follows/sdk/cpp/realm-files/): Add ToC to the blank container page in case someone navigates to it.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
