### PR TITLE
(DOCSP-35269): Update base URL to new App Services base URL

### DIFF
--- a/examples/backend/functions/deleteAUser.js
+++ b/examples/backend/functions/deleteAUser.js
@@ -1,4 +1,4 @@
-const apiUrl = "https://realm.mongodb.com/api/admin/v3.0/groups/5f60207f14dfb25d23101102/apps/6388f860cb722c5a5e002425";
+const apiUrl = "https://services.cloud.mongodb.com/api/admin/v3.0/groups/5f60207f14dfb25d23101102/apps/6388f860cb722c5a5e002425";
 
 
 // deleteAUser() deletes a single user from the database using the Admin API 
@@ -18,7 +18,7 @@ exports = async function(arg){
     const username = context.values.get("adminApiPublicKey");
     const apiKey = context.values.get("adminApiPrivateKey");
     const response = await context.http.post({
-      url: "https://realm.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login",
+      url: "https://services.cloud.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login",
       body: {username, apiKey},
       encodeBodyAsJSON: true,
     });

--- a/examples/backend/functions/deleteAllUsers.js
+++ b/examples/backend/functions/deleteAllUsers.js
@@ -1,11 +1,11 @@
 let token;
-const apiUrl = "https://realm.mongodb.com/api/admin/v3.0/groups/5f60207f14dfb25d23101102/apps/6388f860cb722c5a5e002425";
+const apiUrl = "https://services.cloud.mongodb.com/api/admin/v3.0/groups/5f60207f14dfb25d23101102/apps/6388f860cb722c5a5e002425";
 
 async function adminLogIn() {
   const username = context.values.get("adminApiPublicKey");
   const apiKey = context.values.get("adminApiPrivateKey");
   const response = await context.http.post({
-    url: "https://realm.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login",
+    url: "https://services.cloud.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login",
     body: {username, apiKey},
     encodeBodyAsJSON: true,
   });

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -9,7 +9,7 @@ When you're already set up but you have edited source code, start with
 
 If you just want to run the tests, go to **Run the Tests**.
 
-The Flexible Sync backend that this app hits is the [cpp-tester App Services app in the Realm Example Testers Atlas project of the Bushicorp Atlas Organization](https://realm.mongodb.com/groups/5f60207f14dfb25d23101102/apps/6388f860cb722c5a5e002425/dashboard)
+The Flexible Sync backend that this app hits is the [cpp-tester App Services app in the Realm Example Testers Atlas project of the Bushicorp Atlas Organization](https://services.cloud.mongodb.com/groups/5f60207f14dfb25d23101102/apps/6388f860cb722c5a5e002425/dashboard)
 
 ## Unit Test Structure
 

--- a/examples/dart/test/graphql_test.dart
+++ b/examples/dart/test/graphql_test.dart
@@ -12,7 +12,7 @@ import "dart:async"; // used to refresh access token
 // Note: using web tester b/c has GraphQL configured
 const YOUR_APP_ID = 'web_tester-ifnyw';
 const YOUR_GRAPHQL_URL =
-    'https://us-east-1.aws.realm.mongodb.com/api/client/v2.0/app/web_tester-ifnyw/graphql';
+    'https://us-east-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/web_tester-ifnyw/graphql';
 // :remove-end:
 void main() async {
   late GraphQLClient higherScopeClient;

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -96,7 +96,7 @@ Total tests: 18
 # The Testing Backend
 
 You can find the backend MongoDB Realm App used for these tests in the
-CHT organization of Atlas in a project called Realmtest [here](https://realm.mongodb.com/groups/5ed68f962ffddd4c32690cfd/apps/5f5fe0a7991e260dd9941711).
+CHT organization of Atlas in a project called Realmtest [here](https://services.cloud.mongodb.com/groups/5ed68f962ffddd4c32690cfd/apps/5f5fe0a7991e260dd9941711).
 If you need permissions for tasks like editing schemas or enabling/disabling
 Sync, you can request permissions from the current project owners,
 Caleb Thompson and Nathan Contino.

--- a/examples/ios/Examples/RealmApp.swift
+++ b/examples/ios/Examples/RealmApp.swift
@@ -15,7 +15,7 @@ class RealmAppTest: XCTestCase {
     func testRealmAppWithConfig() {
         // :snippet-start: realm-app-config
         let configuration = AppConfiguration(
-           baseURL: "https://realm.mongodb.com", // Custom base URL
+           baseURL: "https://services.cloud.mongodb.com", // Custom base URL
            transport: nil, // Custom RLMNetworkTransportProtocol
            localAppName: "My App",
            localAppVersion: "3.14.159",

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -3,9 +3,9 @@
 The Realm Examples project contains the Swift, SwiftUI and iOS code examples 
 for Realm and their unit and UI tests.
 
-The Partition-Based Sync backend that this app hits is located in the [example-testers App Services app of the Realm Example Testers Atlas project of the Bushicorp Atlas organization](https://realm.mongodb.com/groups/5f60207f14dfb25d23101102/apps/5f6020d292050452b72032e2/dashboard).
+The Partition-Based Sync backend that this app hits is located in the [example-testers App Services app of the Realm Example Testers Atlas project of the Bushicorp Atlas organization](https://services.cloud.mongodb.com/groups/5f60207f14dfb25d23101102/apps/5f6020d292050452b72032e2/dashboard).
 
-The Flexible Sync backend that this app hits is located in the [swift-flexible App Services app of the Realm Example Testers Atlas project of the Bushicorp Atlas Organization](https://realm.mongodb.com/groups/5f60207f14dfb25d23101102/apps/61eeda562b57b7279f705b95/dashboard)
+The Flexible Sync backend that this app hits is located in the [swift-flexible App Services app of the Realm Example Testers Atlas project of the Bushicorp Atlas Organization](https://services.cloud.mongodb.com/groups/5f60207f14dfb25d23101102/apps/61eeda562b57b7279f705b95/dashboard)
 
 ## Get Started
 

--- a/examples/java/sync/README.md
+++ b/examples/java/sync/README.md
@@ -3,7 +3,7 @@
 The Realm Examples project contains Java and Kotlin code examples and unit tests for the Realm SDK.
 
 This project uses Realm Sync with the Realm app *android-example-testers-rztwe*, in the org *Bushicorp*. You can
-view the Realm app [here](https://realm.mongodb.com/groups/5f60207f14dfb25d23101102/apps/5fd8f1267b48d7cff86b1766/dashboard).
+view the Realm app [here](https://services.cloud.mongodb.com/groups/5f60207f14dfb25d23101102/apps/5fd8f1267b48d7cff86b1766/dashboard).
 
 ## Get Started
 

--- a/examples/web/nextjs/.env.local.example
+++ b/examples/web/nextjs/.env.local.example
@@ -1,3 +1,3 @@
 NEXT_PUBLIC_APP_ID=abc-123
-NEXT_PUBLIC_GRAPHQL_API_ENDPOINT=https://<aws-region>.realm.mongodb.com/api/client/v2.0/app/${NEXT_PUBLIC_APP_ID}/graphql
+NEXT_PUBLIC_GRAPHQL_API_ENDPOINT=https://<aws-region>.services.cloud.mongodb.com/api/client/v2.0/app/${NEXT_PUBLIC_APP_ID}/graphql
 REALM_API_KEY=abc123xyz

--- a/examples/web/src/__tests__/apollo-graphql-client.test.jsx
+++ b/examples/web/src/__tests__/apollo-graphql-client.test.jsx
@@ -14,12 +14,12 @@ import { APP_ID } from "../realm.config.json";
 describe("Set up Apollo Client", () => {
   it("Create an Apollo GraphQL Client", () => {
     // :snippet-start: create-apollo-client
-    // Add your Realm App ID
+    // Add your App ID
     const graphqlUri = `https://services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`;
     // Local apps should use a local URI!
-    // const graphqlUri = `https://us-east-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
-    // const graphqlUri = `https://eu-west-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
-    // const graphqlUri = `https://ap-southeast-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
+    // const graphqlUri = `https://us-east-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
+    // const graphqlUri = `https://eu-west-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
+    // const graphqlUri = `https://ap-southeast-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
 
     const client = new ApolloClient({
       link: new HttpLink({

--- a/examples/web/src/__tests__/apollo-graphql-client.test.jsx
+++ b/examples/web/src/__tests__/apollo-graphql-client.test.jsx
@@ -15,7 +15,7 @@ describe("Set up Apollo Client", () => {
   it("Create an Apollo GraphQL Client", () => {
     // :snippet-start: create-apollo-client
     // Add your Realm App ID
-    const graphqlUri = `https://realm.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`;
+    const graphqlUri = `https://services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`;
     // Local apps should use a local URI!
     // const graphqlUri = `https://us-east-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
     // const graphqlUri = `https://eu-west-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
@@ -55,7 +55,7 @@ describe("Set up Apollo Client", () => {
     // Configure the ApolloClient to connect to your app's GraphQL endpoint
     const client = new ApolloClient({
       link: new HttpLink({
-        uri: `https://realm.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`,
+        uri: `https://services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`,
         // We define a custom fetch handler for the Apollo client that lets us authenticate GraphQL requests.
         // The function intercepts every Apollo HTTP request and adds an Authorization header with a valid
         // access token before sending the request.
@@ -88,7 +88,7 @@ describe("Set up Apollo Client", () => {
       );
     }
     expect(client.link.options.uri).toBe(
-      `https://realm.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
+      `https://services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
     );
   });
 });

--- a/examples/web/src/realm.config.json
+++ b/examples/web/src/realm.config.json
@@ -1,5 +1,5 @@
 {
   "APP_ID": "example-testers-kvjdy",
   "GRAPHQL_APP_ID": "web_tester-ifnyw",
-  "GRAPHQL_ENDPOINT": "https://us-east-1.aws.realm.mongodb.com/api/client/v2.0/app/web_tester-ifnyw/graphql"
+  "GRAPHQL_ENDPOINT": "https://us-east-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/web_tester-ifnyw/graphql"
 }

--- a/source/examples/generated/code/start/RealmApp.snippet.realm-app-config.swift
+++ b/source/examples/generated/code/start/RealmApp.snippet.realm-app-config.swift
@@ -1,5 +1,5 @@
 let configuration = AppConfiguration(
-   baseURL: "https://realm.mongodb.com", // Custom base URL
+   baseURL: "https://services.cloud.mongodb.com", // Custom base URL
    transport: nil, // Custom RLMNetworkTransportProtocol
    localAppName: "My App",
    localAppVersion: "3.14.159",

--- a/source/examples/generated/web/apollo-graphql-client.test.snippet.create-apollo-client.jsx
+++ b/source/examples/generated/web/apollo-graphql-client.test.snippet.create-apollo-client.jsx
@@ -1,5 +1,5 @@
 // Add your Realm App ID
-const graphqlUri = `https://realm.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`;
+const graphqlUri = `https://services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`;
 // Local apps should use a local URI!
 // const graphqlUri = `https://us-east-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
 // const graphqlUri = `https://eu-west-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`

--- a/source/examples/generated/web/apollo-graphql-client.test.snippet.create-apollo-client.jsx
+++ b/source/examples/generated/web/apollo-graphql-client.test.snippet.create-apollo-client.jsx
@@ -1,9 +1,9 @@
-// Add your Realm App ID
+// Add your App ID
 const graphqlUri = `https://services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`;
 // Local apps should use a local URI!
-// const graphqlUri = `https://us-east-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
-// const graphqlUri = `https://eu-west-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
-// const graphqlUri = `https://ap-southeast-1.aws.stitch.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
+// const graphqlUri = `https://us-east-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
+// const graphqlUri = `https://eu-west-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
+// const graphqlUri = `https://ap-southeast-1.aws.services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`
 
 const client = new ApolloClient({
   link: new HttpLink({

--- a/source/examples/generated/web/apollo-graphql-client.test.snippet.set-up-user-auth.jsx
+++ b/source/examples/generated/web/apollo-graphql-client.test.snippet.set-up-user-auth.jsx
@@ -20,7 +20,7 @@ async function getValidAccessToken() {
 // Configure the ApolloClient to connect to your app's GraphQL endpoint
 const client = new ApolloClient({
   link: new HttpLink({
-    uri: `https://realm.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`,
+    uri: `https://services.cloud.mongodb.com/api/client/v2.0/app/${APP_ID}/graphql`,
     // We define a custom fetch handler for the Apollo client that lets us authenticate GraphQL requests.
     // The function intercepts every Apollo HTTP request and adds an Authorization header with a valid
     // access token before sending the request.

--- a/source/sdk/flutter/sync/write-to-synced-realm.txt
+++ b/source/sdk/flutter/sync/write-to-synced-realm.txt
@@ -190,7 +190,7 @@ The error message in the client-side logs in this scenario is:
    is outside of permissions or query filters; it has been reverted
    [ERROR] Realm: SyncSessionError message: Client attempted a write that
    is outside of permissions or query filters; it has been reverted
-   Logs: https://realm.mongodb.com/groups/5f60207f14dfb25d23101102/apps/639340a757271cb5e3a0f0cf/logs?co_id=6424433efb0c6bbcc330347c
+   Logs: https://services.cloud.mongodb.com/groups/5f60207f14dfb25d23101102/apps/639340a757271cb5e3a0f0cf/logs?co_id=6424433efb0c6bbcc330347c
    category: SyncErrorCategory.session code: SyncSessionErrorCode.compensatingWrite isFatal: false
 
 App Services Error
@@ -252,7 +252,7 @@ an object that is outside the App Services permissions:
    is outside of permissions or query filters; it has been reverted
    [ERROR] Realm: SyncSessionError message: Client attempted a write that
    is outside of permissions or query filters; it has been reverted
-   Logs: https://realm.mongodb.com/groups/5f60207f14dfb25d23101102/apps/639340a757271cb5e3a0f0cf/logs?co_id=6424433efb0c6bbcc330347c
+   Logs: https://services.cloud.mongodb.com/groups/5f60207f14dfb25d23101102/apps/639340a757271cb5e3a0f0cf/logs?co_id=6424433efb0c6bbcc330347c
    category: SyncErrorCategory.session code: SyncSessionErrorCode.compensatingWrite isFatal: false
 
 App Services Error


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35269

- [Flutter/Write Data to a Synced Realm](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35269/sdk/flutter/sync/write-to-synced-realm/): Updated code examples show new base URL.
- [Swift/Connect to an App Services App](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35269/sdk/swift/app-services/connect-to-app-services-backend/): Updated code example shows new base URL.
- [Web/Apollo GraphQL Client (React)](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35269/web/graphql-apollo-react/#create-an-apollo-graphql-client): Updated code examples show new base URL.

Note for reviewer regarding failing tests: failing tests are unrelated to this change, and are resolved in:
- #3151 
- #3152 

### Release Notes

- Throughout Docs
  - Update base URL (realm.mongodb.com) to new App Services base URL (services.cloud.mongodb.com).

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
