### PR TITLE
(DOCSP-35706): Fix broken links

### DIFF
--- a/source/sdk/cpp/crud/threading.txt
+++ b/source/sdk/cpp/crud/threading.txt
@@ -100,7 +100,7 @@ created them.
 You can copy thread-confined instances to another thread as follows:
 
 1. Initialize a :cpp-sdk:`thread_safe_reference 
-   <structrealm_1_1thread__safe__reference_3_01T_01_4.html>` 
+   <structrealm_1_1thread__safe__reference.html>` 
    with the thread-confined object.
 #. Pass the reference to the target thread.
 #. Resolve the reference on the target thread. If the referred object is a realm

--- a/source/sdk/cpp/crud/threading.txt
+++ b/source/sdk/cpp/crud/threading.txt
@@ -5,7 +5,8 @@ Threading - C++ SDK
 ===================
 
 .. meta:: 
-  :keywords: code example
+   :description: Learn how to handle multithreaded applications with thread-safe references, immutable objects, and schedulers. 
+   :keywords: code example
 
 .. facet::
   :name: genre

--- a/source/sdk/flutter/crud/read.txt
+++ b/source/sdk/flutter/crud/read.txt
@@ -13,6 +13,7 @@ CRUD - Read - Flutter SDK
 
 .. meta::
    :description: Read objects using the Flutter SDK.
+   :keywords: code example
 
 .. contents:: On this page
    :local:

--- a/source/sdk/flutter/crud/read.txt
+++ b/source/sdk/flutter/crud/read.txt
@@ -154,7 +154,7 @@ Retrieve a collection of all objects of a data model in the database with the
 Query Lists
 ~~~~~~~~~~~
 
-You can query any list of :flutter-sdk:`RealmObjects <realm/RealmObject-mixin.html>`
+You can query any list of :flutter-sdk:`RealmObjects <realm/RealmObjectBase-mixin.html>`
 or primitives.
 
 .. literalinclude:: /examples/generated/flutter/read_write_data_test.snippet.query-realm-list.dart

--- a/source/sdk/flutter/crud/read.txt
+++ b/source/sdk/flutter/crud/read.txt
@@ -12,7 +12,7 @@ CRUD - Read - Flutter SDK
   :values: tutorial
 
 .. meta::
-   :description: Read objects using the Flutter SDK.
+   :description: Read objects using the Atlas Device SDK for Flutter.
    :keywords: code example
 
 .. contents:: On this page

--- a/source/sdk/flutter/users/access-token.txt
+++ b/source/sdk/flutter/users/access-token.txt
@@ -4,6 +4,14 @@
 Get the User Access Token - Flutter SDK
 =======================================
 
+.. facet::
+  :name: genre
+  :values: reference
+
+.. meta::
+   :description: Get or refresh a user access token to make API calls to Atlas App Services.
+   :keywords: code example
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/sdk/flutter/users/access-token.txt
+++ b/source/sdk/flutter/users/access-token.txt
@@ -36,7 +36,7 @@ Refresh it with :flutter-sdk:`User.refreshCustomData() <realm/User/refreshCustom
    :language: dart
 
 You can also periodically refresh the access token 
-with `Timer.periodic() <https://api.dart.dev/be/180360/dart-async/Timer-class.html>`__
+with `Timer.periodic() <https://api.flutter.dev/flutter/dart-async/Timer-class.html>`__
 from the ``dart:async`` library. Wrap the call to ``User.refreshCustomData()``
 with the timer's callback function.
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35706

Fix broken links, per the "Broken Links in Docs" report.

C++:
- [CRUD/Threading](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35706/sdk/cpp/crud/threading/#pass-instances-across-threads): Fix a broken API reference link to `thread_safe_reference`.

Flutter:
- [Realm Database/CRUD/Read](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35706/sdk/flutter/crud/read/#query-lists): Fix a broken API reference link to `RealmObjects`.
- [Manage Users/Get an Access Token](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35706/sdk/flutter/users/access-token/#refresh-the-access-token): Fix a broken link to Dart `Timer.periodic()`.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **C++ SDK**
  - CRUD/Threading: Fix a broken API reference link.
- **Flutter SDK**
  - Realm Database/CRUD/Read: Fix a broken API reference link.
  - Manage Users/Get an Access Token: Fix a broken link to a Dart API reference document.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
