### PR TITLE
(DOCSP-35365): Swift: Sync supports in-memory realms

### DIFF
--- a/examples/ios/Examples/Sync.swift
+++ b/examples/ios/Examples/Sync.swift
@@ -85,6 +85,31 @@ class Sync: AnonymouslyLoggedInTestCase {
         expectation.fulfill()
         await fulfillment(of: [expectation], timeout: 10, enforceOrder: true)
     }
+    
+    func testInMemorySyncedRealm() async throws {
+        let expectation = XCTestExpectation(description: "it completes")
+        // :snippet-start: open-synced-realm-in-memory
+        // Instantiate the app and get a user.
+        let app = App(id: APPID)
+        let user = try await app.login(credentials: Credentials.anonymous)
+
+        // Create a configuration.
+        var configuration = user.flexibleSyncConfiguration()
+        configuration.objectTypes = [FlexibleSync_Task.self, FlexibleSync_Team.self]
+        
+        // Specify an in-memory identifier for the configuration.
+        configuration.inMemoryIdentifier = "YOUR-IDENTIFIER-STRING"
+        
+        // Open a Realm with this configuration.
+        let realm = try await Realm(configuration: configuration)
+        print("Successfully opened realm: \(realm)")
+        // Add subscriptions and work with the realm
+        // :snippet-end:
+        XCTAssertNotNil(realm)
+        XCTAssert(realm.configuration.inMemoryIdentifier == "YOUR-IDENTIFIER-STRING")
+        expectation.fulfill()
+        await fulfillment(of: [expectation], timeout: 10, enforceOrder: true)
+    }
 
     func testPauseResumeSyncSession() async throws {
         let app = App(id: APPID)

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1473,7 +1473,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 10.45.3;
+				version = 10.46.0;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/source/examples/generated/code/start/Sync.snippet.open-synced-realm-in-memory.swift
+++ b/source/examples/generated/code/start/Sync.snippet.open-synced-realm-in-memory.swift
@@ -1,0 +1,15 @@
+// Instantiate the app and get a user.
+let app = App(id: APPID)
+let user = try await app.login(credentials: Credentials.anonymous)
+
+// Create a configuration.
+var configuration = user.flexibleSyncConfiguration()
+configuration.objectTypes = [Task.self, Team.self]
+
+// Specify an in-memory identifier for the configuration.
+configuration.inMemoryIdentifier = "YOUR-IDENTIFIER-STRING"
+
+// Open a Realm with this configuration.
+let realm = try await Realm(configuration: configuration)
+print("Successfully opened realm: \(realm)")
+// Add subscriptions and work with the realm

--- a/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
@@ -110,7 +110,7 @@ realm is open and discards them immediately when all instances are
 closed.
 
 Note that this property cannot be combined with ``fileURL``. In Swift SDK 
-versions 10.45.3 and earlier, this property cannot be confined with 
+versions 10.45.3 and earlier, this property cannot be combined with 
 ``syncConfiguration``.
 
 .. tabs-realm-languages::

--- a/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
+++ b/source/sdk/swift/realm-files/configure-and-open-a-realm.txt
@@ -4,6 +4,14 @@
 Configure & Open a Realm - Swift SDK
 ====================================
 
+.. meta:: 
+   :description: Open a database for persistence on device. Use configuration options to encrypt the database, reduce its file size, use it in memory, and more.
+   :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: reference
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -93,11 +101,17 @@ Open a Default Realm or Realm at a File URL
 Open an In-Memory Realm
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionchanged:: 10.46.0 Supports opening a synced database in memory.
+
 You can open a realm entirely in memory, which will not create a
 ``.realm`` file or its associated :ref:`auxiliary files
 <ios-realm-file>`. Instead the SDK stores objects in memory while the
 realm is open and discards them immediately when all instances are
 closed.
+
+Note that this property cannot be combined with ``fileURL``. In Swift SDK 
+versions 10.45.3 and earlier, this property cannot be confined with 
+``syncConfiguration``.
 
 .. tabs-realm-languages::
    
@@ -106,8 +120,7 @@ closed.
 
       Set the :swift-sdk:`inMemoryIdentifier
       <Structs/Realm/Configuration.html#/s:10RealmSwift0A0V13ConfigurationV18inMemoryIdentifierSSSgvp>`
-      property of the realm configuration. Note that this property
-      cannot be combined with ``fileURL`` or ``syncConfiguration``.
+      property of the realm configuration.
 
       .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.snippet.open-in-memory-realm.swift
          :language: swift
@@ -117,8 +130,7 @@ closed.
 
       Set the :objc-sdk:`inMemoryIdentifier
       <Classes/RLMRealmConfiguration.html#/c:objc(cs)RLMRealmConfiguration(py)inMemoryIdentifier>`
-      property of the realm configuration. Note that this property
-      cannot be combined with ``fileURL`` or ``syncConfiguration``.
+      property of the realm configuration.
 
       .. literalinclude:: /examples/generated/code/start/OpenCloseRealm.snippet.open-in-memory-realm.m
          :language: objectivec

--- a/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
+++ b/source/sdk/swift/sync/configure-and-open-a-synced-realm.txt
@@ -4,6 +4,14 @@
 Configure & Open a Synced Realm - Swift SDK
 ===========================================
 
+.. meta:: 
+   :description: Open a synced database to share data across devices. Provide an app user, and specify whether to download changes before opening the database.
+   :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: reference
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -104,6 +112,26 @@ to open a synced realm.
 
    This does not apply to :ref:`Data Ingest <optimize-data-ingest>`.
    You cannot create a subscription for an ``AsymmetricObject``.
+
+.. _ios-open-sync-realm-in-memory:
+
+Open a Synced Realm In Memory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 10.46.0
+
+You can open a synced database entirely in memory, which does not create 
+a ``.realm`` file or its associated :ref:`auxiliary files
+<ios-realm-file>`. Instead the SDK stores objects in memory while the
+realm is open and discards them immediately when all instances are
+closed.
+
+To open a synced realm in memory, set the :swift-sdk:`inMemoryIdentifier
+<Structs/Realm/Configuration.html#/s:10RealmSwift0A0V13ConfigurationV18inMemoryIdentifierSSSgvp>`
+property of the realm configuration to a string identifier.
+
+.. literalinclude:: /examples/generated/code/start/Sync.snippet.open-synced-realm-in-memory.swift
+   :language: swift
 
 .. _ios-open-synced-realm-as-different-sync-user:
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35365

- [Configure & Open a Realm](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35365/sdk/swift/realm-files/configure-and-open-a-realm/#open-an-in-memory-realm): Note that as of 10.46.0, you can use in-memory realms with `syncConfiguration`.
- [Configure & Open a Synced Realm](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35365/sdk/swift/sync/configure-and-open-a-synced-realm/#open-a-synced-realm-in-memory): New "Open a Synced Realm In Memory" section with details and a tested, Bluehawked code example.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Swift SDK**
  - Realm Files/Configure & Open a Realm: Note that as of 10.46.0, you can use in-memory realms with `syncConfiguration`.
  - Sync Data/Configure & Open a Synced Realm: New "Open a Synced Realm In Memory" section with details and a tested, Bluehawked code example.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
