### PR TITLE
(DOCSP-35366): Swift: Add details about Apple Privacy Manifest

### DIFF
--- a/source/sdk/swift/app-services/connect-to-app-services-backend.txt
+++ b/source/sdk/swift/app-services/connect-to-app-services-backend.txt
@@ -2,7 +2,7 @@
 .. _ios-connect-to-a-mongodb-realm-backend-app:
 
 ====================================================
-Connect to an Atlas App Services backend - Swift SDK
+Connect to an Atlas App Services Backend - Swift SDK
 ====================================================
 
 .. meta:: 

--- a/source/sdk/swift/app-services/connect-to-app-services-backend.txt
+++ b/source/sdk/swift/app-services/connect-to-app-services-backend.txt
@@ -11,14 +11,21 @@ Connect to an Atlas App Services backend - Swift SDK
    :depth: 2
    :class: singlecol
 
-Overview
---------
-
 The App client is the interface to the App Services backend. It
 provides access to the :ref:`authentication functionality
 <ios-authenticate-users>`, :ref:`functions <ios-call-a-function>`, 
 :ref:`querying a MongoDB Atlas data source <ios-mongodb-data-access>`, 
 and :ref:`Device Sync <ios-sync-changes-between-devices>`.
+
+.. note:: Apple Privacy Manifest
+
+   The SDK's Apple privacy manifest does not cover connecting to Atlas, or
+   any usage of data through the App client. If your app connects to App
+   Services, and you intend to distribute it through the Apple App Store, 
+   you may need to provide your own disclosures in your app's Apple privacy 
+   manifest.
+
+   For more information, refer to :ref:`ios-apple-privacy-manifest`.
 
 .. _ios-access-the-app-client:
 

--- a/source/sdk/swift/app-services/connect-to-app-services-backend.txt
+++ b/source/sdk/swift/app-services/connect-to-app-services-backend.txt
@@ -5,6 +5,14 @@
 Connect to an Atlas App Services backend - Swift SDK
 ====================================================
 
+.. meta:: 
+   :description: Connect to Atlas App Services from the Atlas Device SDK. Specify configuration details to customize network access.
+   :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: reference
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -4,6 +4,13 @@
 Install the SDK for iOS, macOS, tvOS, and watchOS
 =================================================
 
+.. meta:: 
+   :description: Install Atlas Device SDK for Swift using popular package managers, or as a static framework. 
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -418,3 +418,37 @@ Actor Support
 
 The Swift SDK supports actor-isolated realm instances. For more information,
 refer to :ref:`swift-actor-isolated-realm`.
+
+.. _ios-apple-privacy-manifest:
+
+Apple Privacy Manifest
+----------------------
+
+Starting in Spring 2024, Apple requires apps that use ``RealmSwift`` to
+provide details about the SDK's data collection and use practices when 
+submitting new apps or app updates to the App Store. For more details about 
+Apple's requirements, refer to 
+:apple:`Upcoming third-party SDK requirements <support/third-party-SDK-requirements/>`
+on the Apple Developer website.
+
+Starting in Swift SDK version 10.46.0, the SDK ships with privacy manifests
+for ``Realm`` and ``RealmSwift``.
+
+The Swift SDK does not include analytics code in builds for the App Store. The
+SDK does not log into Atlas on its own behalf. The only privacy-related 
+implementation detail inherent in the SDK is the usage of file timestamp
+APIs, which is declared in the privacy manifest.
+
+If you write an app that uses any App Services functionality, such as 
+:ref:`initializing an App client <ios-init-appclient>` to:
+
+- :ref:`Call an Atlas Function <ios-call-a-function>`
+- :ref:`Authenticate and manage users <ios-work-with-users>`
+- :ref:`Query MongoDB Atlas <ios-mongodb-remote-access>`
+- :ref:`Open a synced database <ios-configure-and-open-a-synced-realm>`
+
+You may need to add additional disclosures to your app's privacy manifest 
+detailing your data collection and use practices when using these APIs. 
+
+For more information, refer to Apple's 
+:apple:`Privacy manifest files documentation <documentation/bundleresources/privacy_manifest_files>`.

--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -441,10 +441,10 @@ on the Apple Developer website.
 Starting in Swift SDK version 10.46.0, the SDK ships with privacy manifests
 for ``Realm`` and ``RealmSwift``.
 
-The Swift SDK does not include analytics code in builds for the App Store. The
-SDK does not log into Atlas on its own behalf. The only privacy-related 
-implementation detail inherent in the SDK is the usage of file timestamp
-APIs, which is declared in the privacy manifest.
+The only privacy-related implementation detail inherent in the SDK is the usage 
+of file timestamp APIs, which is declared in the privacy manifest. The Swift SDK does 
+not include analytics code in builds for the App Store. The SDK does not log into 
+Atlas on its own behalf. 
 
 If you write an app that uses any App Services functionality, such as 
 :ref:`initializing an App client <ios-init-appclient>` to:

--- a/source/sdk/swift/telemetry.txt
+++ b/source/sdk/swift/telemetry.txt
@@ -3,3 +3,13 @@ Telemetry - Swift SDK
 =====================
 
 .. include:: /includes/sdk-telemetry.rst
+
+Apple Privacy Manifest
+----------------------
+
+The Swift SDK does not include analytics in builds for the App Store. Because
+we do not collect telemetry on those builds, the SDK's Apple privacy manifest
+does not mention this telemetry. The SDK's Apple privacy manifest only covers
+Apple's API disclosure requirements.
+
+For more details, refer to :ref:`ios-apple-privacy-manifest`.

--- a/source/sdk/swift/telemetry.txt
+++ b/source/sdk/swift/telemetry.txt
@@ -2,6 +2,13 @@
 Telemetry - Swift SDK
 =====================
 
+.. meta:: 
+   :description: Atlas Device SDK collects anonymized telemetry during app development, but not in production builds.
+
+.. facet::
+  :name: genre
+  :values: reference
+
 .. include:: /includes/sdk-telemetry.rst
 
 Apple Privacy Manifest


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35366

- [Install](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35366/sdk/swift/install/#apple-privacy-manifest): New "Apple Privacy Manifest" section detailing what's covered in the SDK privacy manifest, additional disclosures that developers may need to make, and links out to the Apple documentation.
- [Connect to App Services](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35366/sdk/swift/app-services/connect-to-app-services-backend/): Add a note that developers may need to make additional disclosures about data collection in the privacy manifest, and link to the new section on the Install page.
- [SDK Telemetry](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35366/sdk/swift/telemetry/): Note that the SDK's privacy manifest does not cover SDK telemetry, since builds submitted to the App Store do not collect analytics.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Swift SDK**
  - Install: New "Apple Privacy Manifest" section detailing what's covered in the SDK privacy manifest, additional disclosures that developers may need to make, and links out to the Apple documentation.
  - Application Services/Connect to an App Services App: Add a note that developers may need to make additional disclosures about data collection in the privacy manifest, and link to the new section on the Install page.
  - SDK Telemetry: Note that the SDK's privacy manifest does not cover SDK telemetry, since builds submitted to the App Store do not collect analytics.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
