### PR TITLE
(DOCSP-35852): Swift: Base URL can change in App config

### DIFF
--- a/source/sdk/swift/app-services/connect-to-app-services-backend.txt
+++ b/source/sdk/swift/app-services/connect-to-app-services-backend.txt
@@ -41,7 +41,18 @@ You can pass a configuration object to ``App``:
 .. literalinclude:: /examples/generated/code/start/RealmApp.snippet.realm-app-config.swift
    :language: swift
 
-.. include:: /includes/multiple-app-client-details-and-app-config-cache.rst
+You can create multiple App client instances to connect to multiple
+Apps. All App client instances that share the same App ID use the same 
+underlying connection.
+
+.. important:: Changing an App Config After Initializing the App
+
+   Starting with Swift SDK version 10.46.0, you can change a ``baseURL``
+   in the App config and the App client uses the new ``baseURL``. In Swift
+   SDK versions 10.45.3 and earlier, when you initialize the App client, 
+   the configuration is cached internally. Attempting to "close" an App and 
+   then re-open it with a changed configuration within the same process has 
+   no effect. The client continues to use the cached configuration.
 
 Sync Connection Sharing
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35852

- [Connect to an App Services Backend](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35852/sdk/swift/app-services/connect-to-app-services-backend/#configuration): Note that starting in 10.46.0, you can change a `baseURL` and the App client no longer uses the cached value.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Swift SDK**
  - Application Services/Connect to an App Services App: Note that starting in 10.46.0, you can change a `baseURL` and the App client no longer uses the cached value.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
