### PR TITLE
(DOCSP-35259) Add Map data type docs

### DIFF
--- a/examples/dart/bundle_example/pubspec.lock
+++ b/examples/dart/bundle_example/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -335,26 +335,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -476,26 +476,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -532,10 +532,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.1"
   timing:
     dependency: transitive
     description:
@@ -568,6 +568,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -585,5 +593,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.2 <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.10.2"

--- a/examples/dart/pubspec.lock
+++ b/examples/dart/pubspec.lock
@@ -493,26 +493,26 @@ packages:
     dependency: transitive
     description:
       name: realm_common
-      sha256: c1ca3cf5cf1d143684c313b7faa82699442e41d943bf9818a04b72987fd365d3
+      sha256: "77c41debbc84b5afdebbb3f6c3076db993180bfef84468e552e0e67b1abed8ba"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "1.7.0"
   realm_dart:
     dependency: "direct main"
     description:
       name: realm_dart
-      sha256: a2f4e67aafed8b77d791a90a915f0c303d45a1e18225c4cdb8a128b5439dc626
+      sha256: c8d063835df0339a52f94c7392af4ca7a0bb2d7f11a16faf2e4b7249b21f0084
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "1.7.0"
   realm_generator:
     dependency: transitive
     description:
       name: realm_generator
-      sha256: c0886b4abb269f5241da289f7a74441f5d93113532270b986d6c3bc4b4f5958f
+      sha256: "2743bcf5b1f0168cc4e8a10a8f62712cd223569a8f41c17fc603074514acffb5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "1.7.0"
   rxdart:
     dependency: transitive
     description:

--- a/examples/dart/test/data_types_test.dart
+++ b/examples/dart/test/data_types_test.dart
@@ -136,6 +136,14 @@ class _BinaryExample {
 }
 // :snippet-end:
 
+// :snippet-start: map-model
+@RealmModel()
+class _MapExample {
+  late Map<String, int> map;
+  late Map<String, int?> nullableMap;
+}
+// :snippet-end:
+
 main() {
   test('Uuid', () {
     // :snippet-start: uuid-use
@@ -411,6 +419,52 @@ main() {
     expect(testObject.first.requiredBinaryProperty, Uint8List.fromList([1, 2]));
 
     print(testObject.length);
+    cleanUpRealm(realm);
+  });
+
+  test("Map model", () {
+    // :snippet-start: map-work-with
+    final realm = Realm(Configuration.local([MapExample.schema]));
+
+    // Pass native Dart Maps to the object to create RealmMaps
+    final mapExample = MapExample(
+      map: {
+        'first': 1,
+        'second': 2,
+        'third': 3,
+      },
+      nullableMap: {
+        'first': null,
+        'second': 2,
+        'third': null,
+      },
+    );
+
+    // Add RealmObject to realm database
+    realm.write(() => realm.add(mapExample));
+
+    // Qeury for all MapExample objects
+    final realmMap = realm.all<MapExample>()[0];
+
+    // :remove-start:
+    expect(realmMap, isA<MapExample>());
+    expect(realmMap.map['third'], 3);
+    expect(realmMap.nullableMap['third'], null);
+    // :remove-end:
+    // Modify RealmMaps in write transactions
+    realm.write(() {
+      realmMap.map.update('first', (value) => 5);
+      realmMap.nullableMap.update('second', (value) => null);
+
+      // Add a new Map to a RealmMap
+      const newMap = {'fourth': 4};
+      realmMap.map.addEntries(newMap.entries);
+    });
+    // :snippet-end:
+
+    expect(realmMap.map['first'], 5);
+    expect(realmMap.nullableMap['second'], null);
+    expect(realmMap.map.length, 4);
     cleanUpRealm(realm);
   });
 }

--- a/examples/dart/test/data_types_test.g.dart
+++ b/examples/dart/test/data_types_test.g.dart
@@ -646,3 +646,50 @@ class BinaryExample extends _BinaryExample
     ]);
   }
 }
+
+class MapExample extends _MapExample
+    with RealmEntity, RealmObjectBase, RealmObject {
+  MapExample({
+    Map<String, int> map = const {},
+    Map<String, int?> nullableMap = const {},
+  }) {
+    RealmObjectBase.set<RealmMap<int>>(this, 'map', RealmMap<int>(map));
+    RealmObjectBase.set<RealmMap<int?>>(
+        this, 'nullableMap', RealmMap<int?>(nullableMap));
+  }
+
+  MapExample._();
+
+  @override
+  RealmMap<int> get map =>
+      RealmObjectBase.get<int>(this, 'map') as RealmMap<int>;
+  @override
+  set map(covariant RealmMap<int> value) => throw RealmUnsupportedSetError();
+
+  @override
+  RealmMap<int?> get nullableMap =>
+      RealmObjectBase.get<int?>(this, 'nullableMap') as RealmMap<int?>;
+  @override
+  set nullableMap(covariant RealmMap<int?> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<MapExample>> get changes =>
+      RealmObjectBase.getChanges<MapExample>(this);
+
+  @override
+  MapExample freeze() => RealmObjectBase.freezeObject<MapExample>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(MapExample._);
+    return const SchemaObject(
+        ObjectType.realmObject, MapExample, 'MapExample', [
+      SchemaProperty('map', RealmPropertyType.int,
+          collectionType: RealmCollectionType.map),
+      SchemaProperty('nullableMap', RealmPropertyType.int,
+          optional: true, collectionType: RealmCollectionType.map),
+    ]);
+  }
+}

--- a/examples/dart/test/geospatial_data_test.dart
+++ b/examples/dart/test/geospatial_data_test.dart
@@ -11,7 +11,7 @@ part 'geospatial_data_test.g.dart';
 class _MyGeoPoint {
   // These two properties are required to persist geo data.
   final String type = 'Point';
-  final List<double> coordinates = const [0, 0];
+  final List<double> coordinates = const [];
 
   // You can optionally implement convenience methods to simplify
   // creating and working with geospatial data.

--- a/source/examples/generated/flutter/data_types_test.snippet.map-model.dart
+++ b/source/examples/generated/flutter/data_types_test.snippet.map-model.dart
@@ -1,0 +1,5 @@
+@RealmModel()
+class _MapExample {
+  late Map<String, int> map;
+  late Map<String, int?> nullableMap;
+}

--- a/source/examples/generated/flutter/data_types_test.snippet.map-work-with.dart
+++ b/source/examples/generated/flutter/data_types_test.snippet.map-work-with.dart
@@ -1,0 +1,31 @@
+final realm = Realm(Configuration.local([MapExample.schema]));
+
+// Pass native Dart Maps to the object to create RealmMaps
+final mapExample = MapExample(
+  map: {
+    'first': 1,
+    'second': 2,
+    'third': 3,
+  },
+  nullableMap: {
+    'first': null,
+    'second': 2,
+    'third': null,
+  },
+);
+
+// Add RealmObject to realm database
+realm.write(() => realm.add(mapExample));
+
+// Qeury for all MapExample objects
+final realmMap = realm.all<MapExample>()[0];
+
+// Modify RealmMaps in write transactions
+realm.write(() {
+  realmMap.map.update('first', (value) => 5);
+  realmMap.nullableMap.update('second', (value) => null);
+
+  // Add a new Map to a RealmMap
+  const newMap = {'fourth': 4};
+  realmMap.map.addEntries(newMap.entries);
+});

--- a/source/examples/generated/flutter/geospatial_data_test.snippet.define-geopoint-class.dart
+++ b/source/examples/generated/flutter/geospatial_data_test.snippet.define-geopoint-class.dart
@@ -4,7 +4,7 @@
 class _MyGeoPoint {
   // These two properties are required to persist geo data.
   final String type = 'Point';
-  final List<double> coordinates = const [0, 0];
+  final List<double> coordinates = const [];
 
   // You can optionally implement convenience methods to simplify
   // creating and working with geospatial data.

--- a/source/sdk/flutter/realm-database/model-data/data-types.txt
+++ b/source/sdk/flutter/realm-database/model-data/data-types.txt
@@ -164,6 +164,35 @@ For more information about all available methods, refer to the
 .. literalinclude:: /examples/generated/flutter/data_types_test.snippet.realm-set-examples.dart
    :language: dart
 
+.. _flutter-realm-map:
+
+RealmMap
+~~~~~~~~
+
+Realm objects can contain maps of any supported data type.
+Realm uses the :flutter-sdk:`RealmList <realm/RealmMap-class.html>` data type
+to store the data. Map keys may not contain ``.`` or start with ``$``.
+
+A ``RealmMap`` is mutable and you can add and remove elements in a ``RealmMap``
+within a write transaction. You can listen for RealmMap entry changes using a
+:ref:`change listener <flutter-realm-list-change-listener>`.
+
+Add a RealmMap to a Schema
+``````````````````````````
+
+You can add a ``RealmMap`` to your Realm Object schema by defining a property as
+type ``RealmMap<T>`` where ``T`` can be any :ref:`supported Realm data type 
+<flutter-data-types>` (except other collections), in your Realm Object model.
+
+.. literalinclude:: /examples/generated/flutter/data_types_test.snippet.map-model.dart
+   :language: dart
+
+Work with a RealmMap
+````````````````````
+
+.. literalinclude:: /examples/generated/flutter/data_types_test.snippet.map-work-with.dart
+   :language: dart
+
 .. _flutter-realm-results:
 
 RealmResults

--- a/source/sdk/flutter/realm-database/model-data/data-types.txt
+++ b/source/sdk/flutter/realm-database/model-data/data-types.txt
@@ -175,9 +175,10 @@ RealmMap
 
 .. versionadded:: 1.7.0
 
-Realm objects can contain maps of any supported data type.
-Realm uses the :flutter-sdk:`RealmMap <realm/RealmMap-class.html>` data type
-to store the data. Map keys may not contain ``.`` or start with ``$``.
+:flutter-sdk:`RealmMap <realm/RealmMap-class.html>` is a collection that
+contains key-value pairs of ``<String, T>``, where ``T`` is any data type
+supported by the SDK. Map keys may not contain ``.`` or start with ``$`` unless
+you use `percent-encoding <https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding>`__.
 
 A ``RealmMap`` is mutable and you can add and remove elements in a ``RealmMap``
 within a write transaction. You can listen for RealmMap entry changes using a
@@ -187,7 +188,7 @@ Add a RealmMap to a Schema
 ``````````````````````````
 
 You can add a ``RealmMap`` to your Realm Object schema by defining a property as
-type ``RealmMap<T>`` where ``T`` can be any :ref:`supported Realm data type 
+type ``RealmMap<String, T>`` where ``T`` can be any :ref:`supported Realm data type 
 <flutter-data-types>` (except other collections), in your Realm Object model.
 
 .. literalinclude:: /examples/generated/flutter/data_types_test.snippet.map-model.dart

--- a/source/sdk/flutter/realm-database/model-data/data-types.txt
+++ b/source/sdk/flutter/realm-database/model-data/data-types.txt
@@ -173,8 +173,10 @@ For more information about all available methods, refer to the
 RealmMap
 ~~~~~~~~
 
+.. versionadded:: 1.7.0
+
 Realm objects can contain maps of any supported data type.
-Realm uses the :flutter-sdk:`RealmList <realm/RealmMap-class.html>` data type
+Realm uses the :flutter-sdk:`RealmMap <realm/RealmMap-class.html>` data type
 to store the data. Map keys may not contain ``.`` or start with ``$``.
 
 A ``RealmMap`` is mutable and you can add and remove elements in a ``RealmMap``

--- a/source/sdk/flutter/realm-database/model-data/data-types.txt
+++ b/source/sdk/flutter/realm-database/model-data/data-types.txt
@@ -4,6 +4,10 @@
 Data Types - Flutter SDK
 ========================
 
+.. meta:: 
+  :keywords: code example, flutter
+  :description: Learn about the data types Atlas Device SDK for Flutter supports and how to use them.
+
 .. contents:: On this page
    :local:
    :backlinks: none


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35259
Staged changes: 
- [Data Types](https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/DOCSP-35259/sdk/flutter/realm-database/model-data/data-types/): Add new documentation for the RealmMap data type, which supports native Dart maps.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Flutter SDK** 
  - Realm Database/Model Data/Data Types: Add new documentation for the RealmMap data type, which supports native Dart maps.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

### Animal Wearing a Hat

![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR7Dcpc6QbRAVww9eN01Ravr5s97Obk3eeJsQ&usqp=CAU)
