### PR TITLE
(DOCSP-35919): Fix JS SDK version in deprecated logger

### DIFF
--- a/source/sdk/node/sync/log-level.txt
+++ b/source/sdk/node/sync/log-level.txt
@@ -15,7 +15,7 @@ Set the Client Log Level - Node.js SDK
 .. warning::
 
    This page shows how to set a Sync client log level in Realm Node.js SDK
-   versions 11.9.0 and earlier. Realm Node.js SDK v12.0.0 supersedes this 
+   versions 11.10.2 and earlier. Realm Node.js SDK v12.0.0 supersedes this 
    logging implementation with a Realm logger you can set and configure
    for your application. For information on how to set a Realm logger in a later 
    version, refer to :ref:`node-logging`.

--- a/source/sdk/react-native/sync-data/log-level.txt
+++ b/source/sdk/react-native/sync-data/log-level.txt
@@ -16,7 +16,7 @@ Set the Client Log Level - React Native SDK
 .. warning::
 
    This page shows how to set a Sync client log level in Realm React Native SDK
-   versions 11.9.0 and earlier. Realm React Native SDK v12.0.0 supersedes this 
+   versions 11.10.2 and earlier. Realm React Native SDK v12.0.0 supersedes this 
    logging implementation with a Realm logger you can set and configure
    for your application. For information on how to set a Realm logger in a later 
    version, refer to :ref:`react-native-logging`.


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35919

- [Set the Client Log Level - Node.js](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35919/sdk/node/sync/log-level/): Update the version number for using the old syntax.
- [Set the Client Log Level - React Native](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-35919/sdk/react-native/sync-data/log-level/): Update the version number for using the old syntax.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Node.js SDK**
  - Sync Data/Set the Client Log Level: Correct the JS SDK version number for using the old syntax from 11.9.0 to 11.10.2.
- **React Native SDK**
  - Sync Data/Set the Client Log Level: Correct the JS SDK version number for using the old syntax from 11.9.0 to 11.10.2.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
