### PR TITLE
DOCSP-35846: Update BaseUrl in Flutter SDK

### DIFF
--- a/examples/dart/test/app_services_test.dart
+++ b/examples/dart/test/app_services_test.dart
@@ -4,7 +4,6 @@ import "dart:io";
 import "dart:convert";
 import "dart:isolate";
 
-
 void main() {
   const APP_ID = "example-testers-kvjdy";
 
@@ -30,6 +29,24 @@ void main() {
       expect(appConfig.defaultRequestTimeout, Duration(seconds: 120));
     });
 
+    test('BaseUrl not cached on App config', () {
+      final newUrl = Uri.parse('https://dart.dev');
+      
+      // Instantiate App with default BaseUrl
+      final appConfig = AppConfiguration(APP_ID,
+          defaultRequestTimeout: const Duration(seconds: 120)
+          );
+      var app = App(appConfig);
+      expect(app.baseUrl.toString(), 'https://realm.mongodb.com');
+
+      // Update with new BaseUrl
+      final newConfig = AppConfiguration(APP_ID,
+          defaultRequestTimeout: const Duration(seconds: 120), 
+          baseUrl:newUrl);
+      app = App(newConfig);
+      expect(app.baseUrl.toString(), 'https://dart.dev');
+    });
+
     test('Access App on background isolate by id', () async {
       // :snippet-start: access-app-by-id
       // Create an App instance once on main isolate,
@@ -53,7 +70,7 @@ void main() {
         try {
           final backgroundApp = App.getById(appId); // :emphasize:
 
-          // ... Access App users 
+          // ... Access App users
           final user = backgroundApp?.currentUser!;
           expect(user, isNotNull); // :remove:
 
@@ -68,11 +85,11 @@ void main() {
 
       receivePort.listen((message) {
         expect(message, equals('Background task completed'));
-        receivePort.close(); 
+        receivePort.close();
       });
-        if (app.currentUser != null) {
-          app.deleteUser(anonUser);
-         }
+      if (app.currentUser != null) {
+        app.deleteUser(anonUser);
+      }
     });
 
     test("Custom SSL Certificate", () async {

--- a/source/sdk/flutter/app-services/connect-to-app.txt
+++ b/source/sdk/flutter/app-services/connect-to-app.txt
@@ -56,7 +56,21 @@ information.
 .. literalinclude:: /examples/generated/flutter/app_services_test.snippet.access-app-client.dart
    :language: dart
 
-.. include:: /includes/multiple-app-client-details-and-app-config-cache.rst
+You can create multiple App client instances to connect to multiple
+Apps. All App client instances that share the same App ID use the same 
+underlying connection.
+
+.. important:: Changing an App Config After Initializing the App
+
+   When you initialize the App client, the configuration is cached internally. 
+   Attempting to "close" and then re-open an App with a changed configuration
+   within the same process has no effect. The client continues to use the 
+   cached configuration. 
+
+   In Flutter SDK version 1.9.0 and later, the :flutter-sdk:`baseUrl <realm/AppConfiguration/baseUrl.html>`
+   configuration property is *not* cached in the App configuration. This 
+   means that you can change the ``baseUrl`` at runtime, and the App client will use the updated configuration. In earlier SDK versions, changes to the ``baseUrl`` in a cached App configuration have no 
+   effect.
 
 .. _flutter-app-client-configuration:
 
@@ -66,6 +80,9 @@ Advanced Configuration
 .. deprecated:: 1.6.0
    ``App.localAppName`` and ``App.localAppVersion`` are no longer used.
 
+.. versionchanged:: 1.9.0
+   ``baseUrl`` is no longer cached in the ``AppConfiguration``.
+
 You can add optional arguments to the ``AppConfiguration`` for more granular control
 of your ``App`` client. You may want to add things like custom timeouts
 for connections or keys for local metadata encryption.
@@ -73,7 +90,7 @@ To learn about the available configuration options, refer to the
 :flutter-sdk:`AppConfiguration <realm/AppConfiguration-class.html>` reference documentation.
 
 .. literalinclude:: /examples/generated/flutter/app_services_test.snippet.app-client-advanced-configuration.dart
-   :language: dart
+   :language: dart 
 
 .. note:: Connect Using Android 7 or Older
 

--- a/source/sdk/flutter/app-services/connect-to-app.txt
+++ b/source/sdk/flutter/app-services/connect-to-app.txt
@@ -67,9 +67,11 @@ underlying connection.
    within the same process has no effect. The client continues to use the 
    cached configuration. 
 
-   In Flutter SDK version 1.9.0 and later, the :flutter-sdk:`baseUrl <realm/AppConfiguration/baseUrl.html>`
-   configuration property is *not* cached in the App configuration. This 
-   means that you can change the ``baseUrl`` at runtime, and the App client will use the updated configuration. In earlier SDK versions, changes to the ``baseUrl`` in a cached App configuration have no 
+   In Flutter SDK version 1.8.0 and later, the :flutter-sdk:`baseUrl <realm/AppConfiguration/baseUrl.html>` 
+   is *not* cached in the App configuration. This means that you can change the 
+   ``baseUrl`` - including at runtime - and the App client will use the updated 
+   configuration. In earlier SDK versions, changes to the ``baseUrl`` in a 
+   cached App configuration have no 
    effect.
 
 .. _flutter-app-client-configuration:
@@ -80,7 +82,7 @@ Advanced Configuration
 .. deprecated:: 1.6.0
    ``App.localAppName`` and ``App.localAppVersion`` are no longer used.
 
-.. versionchanged:: 1.9.0
+.. versionchanged:: 1.8.0
    ``baseUrl`` is no longer cached in the ``AppConfiguration``.
 
 You can add optional arguments to the ``AppConfiguration`` for more granular control

--- a/source/sdk/flutter/crud/read.txt
+++ b/source/sdk/flutter/crud/read.txt
@@ -155,7 +155,7 @@ Retrieve a collection of all objects of a data model in the database with the
 Query Related Objects
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 1.9.0
+.. versionadded:: 1.8.0
 
 If your data model includes objects that reference other objects, you can 
 query the :ref:`relationship <flutter-client-relationships>` 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-35846

- [Connect to App Services - Flutter SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-35846-dart-baseurl/sdk/flutter/app-services/connect-to-app/): Replaced the sharedInclude with new note indicating that, starting in v1.8.0, the ``baseUrl`` is no longer cached in the ``AppConfig``

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Flutter** SDK
  - Atlas App Services/Connect to App Services: Note that, starting in v1.8.0, you can update the baseUrl in the AppConfiguration because the App client no longer caches it.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
