### PR TITLE
DOCSP-36259: Add user.changes documentation for Flutter

### DIFF
--- a/source/examples/generated/flutter/authenticate_users_test.snippet.user-change-listener.dart
+++ b/source/examples/generated/flutter/authenticate_users_test.snippet.user-change-listener.dart
@@ -1,0 +1,3 @@
+final userSubscription = user.changes.listen((changes) {
+  changes.user; // the User being listened to
+});

--- a/source/sdk/flutter/realm-database/react-to-changes.txt
+++ b/source/sdk/flutter/realm-database/react-to-changes.txt
@@ -36,6 +36,7 @@ You can subscribe to changes on the following events:
 - :ref:`Query on collection <flutter-query-change-listener>`
 - :ref:`Realm object <flutter-realm-object-change-listener>`
 - :ref:`Collections in a Realm object <flutter-realm-list-change-listener>`
+- :ref:`User instance <flutter-user-change-listener>`
 
 .. example:: About the Examples on This Page
 
@@ -270,6 +271,34 @@ changes since the last notification:
 
 .. literalinclude:: /examples/generated/flutter/react_to_changes_test.snippet.realm-list-change-listener.dart
   :language: dart
+
+.. _flutter-user-change-listener:
+
+Register a User Instance Change Listener
+----------------------------------------
+
+.. versionadded:: 1.9.0
+
+In Flutter SDK version 1.9.0 and later, you can register a notification handler 
+on a specific ``User`` instance within a realm.
+Realm notifies your handler when any of the user's properties change (for 
+example, the user acces token is updated or the user state changes).
+The handler receives a :flutter-sdk:`UserChanges <realm/UserChanges-class.html>` 
+object, which includes description of changes since the last notification.
+``UserChanges`` contains the following property:
+
+.. list-table::
+
+   * - Property
+     - Type
+     - Description
+
+   * - ``user``
+     - *User*
+     - The user instance that has changed.
+
+.. literalinclude:: /examples/generated/flutter/authenticate_users_test.snippet.user-change-listener.dart
+   :language: dart
 
 .. _flutter-pause-resume-change-listener:
 

--- a/source/sdk/flutter/users.txt
+++ b/source/sdk/flutter/users.txt
@@ -93,6 +93,16 @@ refer to the following documentation:
 - :ref:`User Metadata <flutter-user-metadata>` in the Flutter SDK documentation.
 - :flutter-sdk:`User <realm/User-class.html>` in Flutter SDK reference documentation.
 
+Listen for User Changes
+-----------------------
+
+You can listen for and react to changes to a user instance. For 
+example, receive notifications when a user state changes or a user 
+access token is updated.
+
+For more information, refer to 
+:ref:`Register a User Instance Change Listener <flutter-user-change-listener>`.
+
 .. _flutter-app-work-with-custom-user-data:
 
 Custom User Data


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-36259

- [React to Changes - Flutter SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-36259-dart-user-changes/sdk/flutter/realm-database/react-to-changes/#register-a-user-instance-change-listener): Add new Register a User Instance Change Listener section 
- [User Management - Flutter SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-36259-dart-user-changes/sdk/flutter/users/): Add new Listen for User Changes section that links to the React to Changes page's new section

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Flutter** SDK
  - Realm Database/React to Changes: Add new Register a User Instance Change Listener section documenting how to listen for user changes with a tested, Bluehawked code example.
  - Manage Users: Add Listen for User Changes section with link to React to Changes page.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
