### PR TITLE
RN Dictionary Page: Fix bullet formatting

### DIFF
--- a/source/sdk/react-native/model-data/data-types/dictionaries.txt
+++ b/source/sdk/react-native/model-data/data-types/dictionaries.txt
@@ -73,14 +73,14 @@ In the following ``CreateHomeOwner`` example, we :ref:`create a new object
 The ``CreateHomeOwner`` component does the following:
 
 - Create React `state <https://react.dev/reference/react/Component#state>`__
-   that represents the homeowner's name and address, respectively.
+  that represents the homeowner's name and address, respectively.
 - Get access to an open realm instance by calling the ``useRealm()`` hook within
-   the component.
+  the component.
 - Create a component method ``SubmitHomeOwner()`` that performs a write
-   transaction and creates a new ``HomeOwner`` object based on the ``TextInput``
-   values for the homeowner's name and address, respectively.
+  transaction and creates a new ``HomeOwner`` object based on the ``TextInput``
+  values for the homeowner's name and address, respectively.
 - Add an `onPress <https://reactnative.dev/docs/handling-touches>`__ event on
-   the submit button that calls ``SubmitHomeOwner()``
+  the submit button that calls ``SubmitHomeOwner()``
 
 .. literalinclude:: /examples/generated/react-native/ts/dictionary-test.snippet.create-object-with-dictionary-value.tsx
    :language: typescript


### PR DESCRIPTION
## Pull Request Info

- [Dictionaries](https://preview-mongodbdacharyc.gatsbyjs.io/realm/fix-bullet-formatting/sdk/react-native/model-data/data-types/dictionaries/): Fix bullet list formatting.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **React Native SDK**
  - Model Data/Data Types/Dictionaries: Fix bullet list formatting.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
