### PR TITLE
DOCSP-37163 Remove Outdated Electron Guides from TOC

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1290,3 +1290,4 @@ raw: ${prefix}/sdk/react-native/use-realm-react -> ${base}/sdk/react-native/api-
 
 raw: ${prefix}/sdk/node/integrations/electron-cra -> ${base}/sdk/node/
 raw: ${prefix}/sdk/node/integrations/electron -> ${base}/sdk/node/
+raw: ${prefix}/sdk/node/integrations -> ${base}/sdk/node/

--- a/config/redirects
+++ b/config/redirects
@@ -1285,3 +1285,8 @@ raw: ${prefix}/sdk/flutter/realm-database/read-and-write-data -> ${base}/sdk/flu
 # Smartling missing redirect
 
 raw: ${prefix}/sdk/react-native/use-realm-react -> ${base}/sdk/react-native/api-reference/realm-provider/
+
+# DOCSP-37163 Remove Electron Guides from TOC
+
+raw: ${prefix}/sdk/node/integrations/electron-cra -> ${base}/sdk/node/
+raw: ${prefix}/sdk/node/integrations/electron -> ${base}/sdk/node/

--- a/source/sdk/node.txt
+++ b/source/sdk/node.txt
@@ -25,7 +25,6 @@ Atlas Device SDK for Node.js
    Atlas App Services </sdk/node/app-services>
    Manage Users </sdk/node/manage-users>
    Sync Data </sdk/node/sync>
-   Integration Guides </sdk/node/integrations>
    Logging </sdk/node/logging>
    SDK Telemetry </sdk/node/telemetry>
    API Reference <https://www.mongodb.com/docs/realm-sdks/js/latest/>


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-37163

- [Node](https://preview-mongodblindseymoore.gatsbyjs.io/realm/DOCSP-37163/sdk/node/): removed Integration Guides section from TOC.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

<!--
- **Kotlin** SDK
  - Realm/Manage Realm Files/Encrypt a Realm: Add information on encryption for
    local and synced realms.
-->

**Node.js SDK**
- Integration Guides: Remove Integration Guides section from TOC, as these electron guides are outdated.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
