### PR TITLE
DOCSP-37163 Remove url link to electron guide

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1290,3 +1290,4 @@ raw: ${prefix}/sdk/react-native/use-realm-react -> ${base}/sdk/react-native/api-
 
 raw: ${prefix}/sdk/node/integrations/electron-cra -> ${base}/sdk/node/
 raw: ${prefix}/sdk/node/integrations/electron -> ${base}/sdk/node/
+raw: ${prefix}/sdk/node/integrations -> ${base}/sdk/node/

--- a/config/redirects
+++ b/config/redirects
@@ -1285,3 +1285,8 @@ raw: ${prefix}/sdk/flutter/realm-database/read-and-write-data -> ${base}/sdk/flu
 # Smartling missing redirect
 
 raw: ${prefix}/sdk/react-native/use-realm-react -> ${base}/sdk/react-native/api-reference/realm-provider/
+
+# DOCSP-37163 Remove Electron Guides from TOC
+
+raw: ${prefix}/sdk/node/integrations/electron-cra -> ${base}/sdk/node/
+raw: ${prefix}/sdk/node/integrations/electron -> ${base}/sdk/node/

--- a/config/redirects
+++ b/config/redirects
@@ -79,8 +79,8 @@ raw: ${prefix}/node/collections -> ${base}/sdk/node/model-data/data-types/collec
 raw: ${prefix}/node/create-manage-api-keys -> ${base}/sdk/node/users/manage-user-api-keys/
 raw: ${prefix}/node/data-model -> ${base}/sdk/node/realm-files/
 raw: ${prefix}/node/database -> ${base}/sdk/node/realm-files/
-raw: ${prefix}/node/electron-cra -> ${base}/sdk/node/integrations/electron-cra/
-raw: ${prefix}/node/electron -> ${base}/sdk/node/integrations/electron/
+raw: ${prefix}/node/electron-cra -> ${base}/sdk/node/
+raw: ${prefix}/node/electron -> ${base}/sdk/node/
 raw: ${prefix}/node/embedded-objects -> ${base}/sdk/node/model-data/relationships-and-embedded-objects/
 raw: ${prefix}/node/encrypt -> ${base}/sdk/node/realm-files/encrypt/
 raw: ${prefix}/node/init-realmclient -> ${base}/sdk/node/app-services/connect-to-app-services-backend/

--- a/source/sdk/node.txt
+++ b/source/sdk/node.txt
@@ -25,7 +25,6 @@ Atlas Device SDK for Node.js
    Atlas App Services </sdk/node/app-services>
    Manage Users </sdk/node/manage-users>
    Sync Data </sdk/node/sync>
-   Integration Guides </sdk/node/integrations>
    Logging </sdk/node/logging>
    SDK Telemetry </sdk/node/telemetry>
    API Reference <https://www.mongodb.com/docs/realm-sdks/js/latest/>

--- a/source/sdk/node.txt
+++ b/source/sdk/node.txt
@@ -169,15 +169,6 @@ Recommended Reading
 
       Explore generated reference docs for the Node.js SDK.
 
-   .. card::
-      :headline: Electron Integration Guide
-      :cta: Use the SDK with Electron apps
-      :url: https://www.mongodb.com/docs/realm/sdk/node/integrations/electron/
-      :icon: /images/icons/electron_logo.png
-      :icon-alt: Electron Icon
-
-      Use the Node.js SDK in an Electron desktop application.
-
 Example Projects
 ----------------
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-37163

- [Node Landing Page](https://preview-mongodblindseymoore.gatsbyjs.io/realm/DOCSP-37163/sdk/node/)

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

<!--
- **Kotlin** SDK
  - Realm/Manage Realm Files/Encrypt a Realm: Add information on encryption for
    local and synced realms.
-->

**Node SDK**
- Landing Page: Remove link to outdated electron guide from Node.js landing page. 

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
