### PR TITLE
(DOCSP-36783) Add deprecation banners for GraphQL API

### DIFF
--- a/source/includes/user-access-token.rst
+++ b/source/includes/user-access-token.rst
@@ -4,8 +4,7 @@ tokens, refreshes them when they expire, and includes a valid access token for
 the current user with each request. Realm *does not* automatically refresh 
 the refresh token. When the refresh token expires, the user must log in again. 
 
-If you send requests outside of the SDK (for
-example, through the GraphQL API) then you need to include the user's access
+If you send requests outside of the SDK then you need to include the user's access
 token with each request, and manually refresh the token when it expires.
 
 You can access and refresh a logged in user's access token in the SDK from their

--- a/source/includes/user-access-token.rst
+++ b/source/includes/user-access-token.rst
@@ -4,8 +4,8 @@ tokens, refreshes them when they expire, and includes a valid access token for
 the current user with each request. Realm *does not* automatically refresh 
 the refresh token. When the refresh token expires, the user must log in again. 
 
-If you send requests outside of the SDK then you need to include the user's access
-token with each request, and manually refresh the token when it expires.
+If you send requests outside of the SDK, you need to include the user's access
+token with each request and manually refresh the token when it expires.
 
 You can access and refresh a logged in user's access token in the SDK from their
 ``Realm.User`` object, as in the following example:

--- a/source/index.txt
+++ b/source/index.txt
@@ -46,9 +46,9 @@ Welcome to the Atlas Device SDK Docs
 
 The SDKs provide tools to read and write Atlas data from devices. Your app 
 can sync automatically with MongoDB Atlas and other devices using Device Sync. 
-You can access the MongoDB GraphQL API, or call Atlas Functions from a 
-device. The device persistence layer is Realm, an embedded, object-oriented 
-database that lets you build real-time, offline-first applications. 
+You can call Atlas Functions from a device. The device persistence layer is
+Realm, an embedded, object-oriented database that lets you build real-time,
+offline-first applications. 
 
 We provide SDKs for most popular languages, frameworks, and platforms. Each 
 SDK is language-idiomatic and includes:
@@ -127,7 +127,7 @@ SDK is language-idiomatic and includes:
       :icon: /images/icons/web_sdk.svg
       :icon-alt: Web SDK icon
 
-      Build web applications in JavaScript or TypeScript. Access data with GraphQL and MongoDB queries.
+      Build web applications in JavaScript or TypeScript. Access data with MongoDB queries.
 
    .. card::
       :headline: Flutter SDK

--- a/source/introduction.txt
+++ b/source/introduction.txt
@@ -22,7 +22,6 @@ on a broad range of devices:
 - An offline-first object database to persist data on device.
 - The ability to call Atlas Functions to do work in the cloud.
 - A client to query MongoDB data sources directly from your app.
-- The ability to access the MongoDB GraphQL API from the client.
 
 You can use the SDK's object store, Realm, to read, write, and 
 react to changes in your data on device. Add Device Sync, Atlas Functions, 
@@ -106,8 +105,6 @@ with data from your app:
 - :ref:`Atlas Triggers <triggers>` automatically execute an Atlas Function
   at a scheduled time or when an event occurs,
   such as a change to a MongoDB database in Atlas or a user logs in.
-- The :ref:`Atlas GraphQL API <graphql-api>` accesses data stored
-  in a linked MongoDB cluster with a standard GraphQL client.
 - :ref:`App Services Rules <rules>` control who accesses what data.
 - :ref:`App Services Values and Secrets <values-and-secrets>`
   define global variables and private credentials once and

--- a/source/sdk.txt
+++ b/source/sdk.txt
@@ -73,7 +73,7 @@ and platforms. Each SDK is language-idiomatic and includes:
       :icon: /images/icons/web_sdk.svg
       :icon-alt: Web SDK icon
 
-      Build web applications in JavaScript or TypeScript. Access data with GraphQL and MongoDB queries.
+      Build web applications in JavaScript or TypeScript. Access data with MongoDB queries.
 
    .. card::
       :headline: Flutter SDK

--- a/source/sdk/cpp/users/authenticate-users.txt
+++ b/source/sdk/cpp/users/authenticate-users.txt
@@ -133,9 +133,8 @@ The Realm SDK automatically manages access tokens, refreshes them when they
 expire, and includes a valid access token for the current user with each 
 request. 
 
-If you send requests outside of the SDK - for example, through the :ref:`GraphQL 
-API <graphql-api>` - then you must include the user's access token with 
-each request. In this scenario, you must manually refresh the token when 
+If you send requests outside of the SDK then you must include the user's access
+token with each request. In this scenario, you must manually refresh the token when 
 it expires. Access tokens expire after 30 minutes.
 
 You can call :cpp-sdk:`.refresh_custom_user_data() 

--- a/source/sdk/flutter.txt
+++ b/source/sdk/flutter.txt
@@ -175,12 +175,6 @@ other clients.
          You can :ref:`call serverless Atlas Functions <flutter-call-function>`
          that run in an App Services backend from your client application.
 
-         Query MongoDB Atlas with GraphQL
-         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-         You can :ref:`query data stored in MongoDB with the Atlas GraphQL API <flutter-graphql-api>`
-         directly from your client application code.
-
          Authenticate Users
          ~~~~~~~~~~~~~~~~~~
 

--- a/source/sdk/flutter/app-services.txt
+++ b/source/sdk/flutter/app-services.txt
@@ -18,6 +18,11 @@ Application Services Overview - Flutter SDK
    :depth: 2
    :class: singlecol
 
+.. banner::
+   :variant:  warning
+
+   GraphQL is deprecated. :ref:`Learn More <migrate-hosting-graphql>`.
+
 Overview
 --------
 

--- a/source/sdk/flutter/app-services/graphql-api.txt
+++ b/source/sdk/flutter/app-services/graphql-api.txt
@@ -10,6 +10,11 @@ Atlas GraphQL API
    :depth: 2
    :class: singlecol
 
+.. banner::
+   :variant:  warning
+
+   GraphQL is deprecated. :ref:`Learn More <migrate-hosting-graphql>`.
+
 You can query your data in MongoDB Atlas from your client app
 using the Atlas GraphQL API and the Realm Flutter SDK.
 You can use any standard GraphQL client to query the Atlas GraphQL API.

--- a/source/sdk/flutter/users/access-token.txt
+++ b/source/sdk/flutter/users/access-token.txt
@@ -18,6 +18,11 @@ Get the User Access Token - Flutter SDK
    :depth: 2
    :class: singlecol
 
+.. banner::
+   :variant:  warning
+
+   GraphQL is deprecated. :ref:`Learn More <migrate-hosting-graphql>`.
+
 Every User object contains a JWT token that you can use to access Atlas App Services.
 
 You can use the access token to query the Atlas GraphQL API from your client application.

--- a/source/sdk/kotlin/users/authenticate-users.txt
+++ b/source/sdk/kotlin/users/authenticate-users.txt
@@ -420,9 +420,8 @@ property:
 .. literalinclude:: /examples/generated/kotlin/AuthenticationTest.snippet.access-token-get.kt
    :language: kotlin
 
-If you send requests outside of the SDK (e.g. through the :ref:`GraphQL 
-API <graphql-api>`), then you must include the user's access token with 
-each request and manually refresh the token when it expires. 
+If you send requests outside of the SDK, then you must include the user's access
+token with each request and manually refresh the token when it expires. 
 Access tokens expire 30 minutes after a user logs in.
 
 You can get the current refresh token for a logged-in user with the

--- a/source/sdk/kotlin/users/authenticate-users.txt
+++ b/source/sdk/kotlin/users/authenticate-users.txt
@@ -420,7 +420,7 @@ property:
 .. literalinclude:: /examples/generated/kotlin/AuthenticationTest.snippet.access-token-get.kt
    :language: kotlin
 
-If you send requests outside of the SDK, then you must include the user's access
+If you send requests outside of the SDK, you must include the user's access
 token with each request and manually refresh the token when it expires. 
 Access tokens expire 30 minutes after a user logs in.
 

--- a/source/sdk/swift/sync/write-to-synced-realm.txt
+++ b/source/sdk/swift/sync/write-to-synced-realm.txt
@@ -381,7 +381,7 @@ Atlas:
 
 - Query Atlas with the :ref:`Realm Swift SDK MongoClient <ios-mongodb-data-access>`
 - Pass data to an :ref:`App Services Function <ios-call-a-function>` 
-- Make HTTPS calls with the :ref:`Data API <data-api>` or :ref:`GraphQL API <graphql-api>`
+- Make HTTPS calls with the :ref:`Data API <data-api>`
 
 Then, any device that has a network connection is always getting the most 
 up-to-date information, without waiting for the user to open your main app 

--- a/source/sdk/swift/users/authenticate-users.txt
+++ b/source/sdk/swift/users/authenticate-users.txt
@@ -183,9 +183,8 @@ The Realm SDK automatically manages access tokens, refreshes them when they
 expire, and includes a valid access token for the current user with each 
 request. 
 
-If you send requests outside of the SDK - for example, through the :ref:`GraphQL 
-API <graphql-api>` - then you must include the user's access token with 
-each request. In this scenario, you must manually refresh the token when 
+If you send requests outside of the SDK, then you must include the user's access
+token with each request. In this scenario, you must manually refresh the token when 
 it expires. Access tokens expire after 30 minutes.
 
 You can call :swift-sdk:`.refreshCustomData() 

--- a/source/sdk/swift/users/authenticate-users.txt
+++ b/source/sdk/swift/users/authenticate-users.txt
@@ -183,7 +183,7 @@ The Realm SDK automatically manages access tokens, refreshes them when they
 expire, and includes a valid access token for the current user with each 
 request. 
 
-If you send requests outside of the SDK, then you must include the user's access
+If you send requests outside of the SDK, you must include the user's access
 token with each request. In this scenario, you must manually refresh the token when 
 it expires. Access tokens expire after 30 minutes.
 

--- a/source/web.txt
+++ b/source/web.txt
@@ -28,6 +28,11 @@ Atlas Device SDK for the Web
    Upgrade from Stitch to Realm </web/migrate>
    Release Notes <https://github.com/realm/realm-js/releases>
 
+.. banner::
+   :variant:  warning
+
+   GraphQL is deprecated. :ref:`Learn More <migrate-hosting-graphql>`.
+
 The Atlas Device SDK for the Web lets browser-based applications access
 data stored in Atlas and interact with App Services services like
 Functions and authentication. The Web SDK supports both JavaScript and

--- a/source/web.txt
+++ b/source/web.txt
@@ -40,7 +40,6 @@ TypeScript.
 
 Web apps built with the SDK can query Atlas using the following methods:
 
-- :ref:`Atlas GraphQL API <graphql-api>`
 - The standard MongoDB query API with the :ref:`MongoDB client <web-query-mongodb>`
 - :ref:`Atlas Device Sync <web-sync>`
 

--- a/source/web/api-reference.txt
+++ b/source/web/api-reference.txt
@@ -17,9 +17,8 @@ However, the reference documentation doesn't differentiate between the subset of
 classes and namespaces supported by the Web SDK versus those only supported 
 by Node.Js and React Native.
 The Web SDK doesn't support creating a non-synced database. 
-Web apps built with the Web SDK use :ref:`GraphQL <graphql-api>` 
-and the :ref:`Query API <web-query-mongodb>` to query data stored in 
-Atlas. 
+Web apps built with the Web SDK use the :ref:`Query API <web-query-mongodb>` to
+query data stored in Atlas. 
 
 Read the :js-sdk:`Realm JavaScript API reference <index.html>`. 
 

--- a/source/web/atlas-app-services.txt
+++ b/source/web/atlas-app-services.txt
@@ -54,18 +54,6 @@ a user accesses.
 
 To learn how to use the MongoDB APIs, see :ref:`Query MongoDB <web-mongodb-data-access>`.
 
-GraphQL API
------------
-
-Use the :ref:`Atlas GraphQL API <graphql-api>` with the Realm Web SDK to query
-data in MongoDB Atlas. The Atlas GraphQL API generates a schema from your data
-in Atlas, which you can extend with custom resolvers. Configure server-side
-:ref:`data access rules <mongodb-rules>` to dynamically determine
-read and write permissions for every query.
-
-To get started using the GraphQL API in a React web app,
-see the :ref:`Apollo GraphQL Client (React) integration guide <graphql-apollo-react>`.
-
 Call Functions
 --------------
 

--- a/source/web/graphql-apollo-react.txt
+++ b/source/web/graphql-apollo-react.txt
@@ -10,6 +10,11 @@ Apollo Client (React) - Web SDK
    :depth: 2
    :class: singlecol
 
+.. banner::
+   :variant:  warning
+
+   GraphQL is deprecated. :ref:`Learn More <migrate-hosting-graphql>`.
+
 Overview
 --------
 

--- a/source/web/nextjs.txt
+++ b/source/web/nextjs.txt
@@ -10,6 +10,11 @@ Next.js Integration Guide - Web SDK
    :depth: 1
    :class: singlecol
 
+.. banner::
+   :variant:  warning
+
+   GraphQL is deprecated. :ref:`Learn More <migrate-hosting-graphql>`.
+
 The following guide explains how to integrate the Realm Web SDK into a
 `Next.js <https://nextjs.org>`__ application. You can use the Realm Web SDK
 to access data in MongoDB Atlas from web apps, such as those made with Next.js.

--- a/source/web/quickstart.txt
+++ b/source/web/quickstart.txt
@@ -112,17 +112,3 @@ they were regular JavaScript functions defined on the object.
 
 .. literalinclude:: /examples/generated/web/quick-start.test.snippet.call-a-function.js
    :language: javascript
-
-.. _web-use-graphql:
-
-Use the GraphQL API
--------------------
-
-To execute CRUD operations and call custom resolvers through the :ref:`GraphQL
-API <graphql-api>`, we recommend that you use a third-party GraphQL library such
-as :ref:`Apollo Client <graphql-apollo-react>`. To authenticate your GraphQL
-request, include a valid user token in the Authorization header of the request.
-
-.. seealso::
-  - :doc:`Apollo Client (React) </web/graphql-apollo-react>`
-  - :ref:`Run GraphQL Operations from a CLI <graphql-cli>`

--- a/source/web/users.txt
+++ b/source/web/users.txt
@@ -35,7 +35,6 @@ Use Realm Web SDK to perform the following authentication and user management ac
 When you have a logged-in user, SDK methods enable you to:
 
 - :ref:`Query MongoDB Atlas <web-query-mongodb>`
-- :ref:`Use the Atlas GraphQL API <graphql-apollo-react>`
 - :ref:`Run a backend function <web-call-a-function>` as the logged-in user
 
 .. _web-create-and-delete-users:


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-36783
Staged site: https://preview-mongodbkrollinsmdb.gatsbyjs.io/realm/DOCSP-36783/sdk/flutter/app-services/graphql-api/

Lots of small changes on a bunch of pages. The primary goals:
- Add deprecation notices to pages with substantial GraphQL content
- Remove high-level references to our GraphQL API to make the feature less discoverable

This PR doesn't remove any GraqphQL content. I also didn't add tags to all the pages I touched, as that seems a lot of weakly-related work for a PR that touches a lot of files.

There's an autobuilder error because I've included a ref to a page that doesn't exist yet. It's added in the [App Services PR](https://github.com/mongodb/docs-app-services/pull/702).

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Throughout the Device SDK docs** 
  - Add deprecation notices to pages with substantial GraphQL content
  - Remove high-level references to our GraphQL API to make the feature less discoverable

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
