### PR TITLE
(DOCSP-37136): Fix truncated code example

### DIFF
--- a/examples/cpp/local/crud.cpp
+++ b/examples/cpp/local/crud.cpp
@@ -160,8 +160,7 @@ TEST_CASE("Define model example", "[write]") {
 TEST_CASE("Ignored property example", "[write]") {
   // :snippet-start: open-db-at-path
   auto relative_realm_path_directory = "custom_path_directory/";
-  std::filesystem::create_directories(
-      relative_realm_path_directory);  // :remove:
+  std::filesystem::create_directories(relative_realm_path_directory);
   // Construct a path
   std::filesystem::path path =
       std::filesystem::current_path().append(relative_realm_path_directory);

--- a/source/examples/generated/cpp/crud.snippet.open-db-at-path.cpp
+++ b/source/examples/generated/cpp/crud.snippet.open-db-at-path.cpp
@@ -1,5 +1,5 @@
 auto relative_realm_path_directory = "custom_path_directory/";
-std::filesystem::create_directories(
+std::filesystem::create_directories(relative_realm_path_directory);
 // Construct a path
 std::filesystem::path path =
     std::filesystem::current_path().append(relative_realm_path_directory);


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-37136

- [Configure & Open a Realm](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-37136/sdk/cpp/realm-files/configure-and-open-a-realm/#open-a-realm-at-a-file-path): Fixed truncated "Open a Realm at a File Path" code example.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **C++ SDK**
  - Realm Files/Configure & Open a Realm: Fixed truncated "Open a Realm at a File Path" code example.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
