### PR TITLE
(DOCSP-37396): Swift: Fix PBS page showing FS example

### DIFF
--- a/examples/ios/Examples/MongoDBRemoteAccess.swift
+++ b/examples/ios/Examples/MongoDBRemoteAccess.swift
@@ -160,7 +160,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 }
             }
         }
-        wait(for: [expectation, expectation2, expectation3], timeout: 20)
+        wait(for: [expectation, expectation2, expectation3], timeout: 30)
     }
 
     // MARK: Find One
@@ -320,7 +320,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 }
             }
         }
-        wait(for: [expectation, expectation2, expectation3], timeout: 20)
+        wait(for: [expectation, expectation2, expectation3], timeout: 30)
     }
     
     // MARK: Find and Sort Many
@@ -856,7 +856,7 @@ class MongoDBRemoteAccessTestCase: XCTestCase {
                 }
             }
         }
-        wait(for: [expectation], timeout: 10)
+        wait(for: [expectation], timeout: 20)
     }
 
     // MARK: ChangeEventDelegate
@@ -1289,7 +1289,7 @@ class MongoDBRemoteAccessTestCaseAsyncAPIs: XCTestCase {
                 print("Received event: \(event.documentValue!)")
             }
         }
-        await fulfillment(of: [openEx], timeout: 5.0) // :remove:
+        await fulfillment(of: [openEx], timeout: 30.0) // :remove:
         
         // Updating a document in the collection triggers a change event.
         let queryFilter: Document = ["_id": AnyBSON(objectId) ]

--- a/examples/ios/Examples/MongoDBRemoteAccessAggregate.swift
+++ b/examples/ios/Examples/MongoDBRemoteAccessAggregate.swift
@@ -184,7 +184,7 @@ class MongoDBRemoteAccessAggregationTestCase: XCTestCase {
                 }
             }
         }
-        wait(for: [expectation, expectation2, expectation3, expectation4], timeout: 25)
+        wait(for: [expectation, expectation2, expectation3, expectation4], timeout: 35)
     }
 
     // MARK: Aggregation Project
@@ -276,7 +276,7 @@ class MongoDBRemoteAccessAggregationTestCase: XCTestCase {
                 }
             }
         }
-        wait(for: [expectation, expectation2, expectation3], timeout: 20)
+        wait(for: [expectation, expectation2, expectation3], timeout: 30)
     }
 
     // MARK: Aggregation Add Fields
@@ -361,7 +361,7 @@ class MongoDBRemoteAccessAggregationTestCase: XCTestCase {
                 }
             }
         }
-        wait(for: [expectation, expectation2, expectation3], timeout: 25)
+        wait(for: [expectation, expectation2, expectation3], timeout: 35)
     }
 
     // MARK: Aggregation Unwind
@@ -456,6 +456,6 @@ class MongoDBRemoteAccessAggregationTestCase: XCTestCase {
                 }
             }
         }
-        wait(for: [expectation, expectation2, expectation3], timeout: 25)
+        wait(for: [expectation, expectation2, expectation3], timeout: 35)
     }
 }

--- a/examples/ios/Examples/Sync.swift
+++ b/examples/ios/Examples/Sync.swift
@@ -161,15 +161,27 @@ class Sync: AnonymouslyLoggedInTestCase {
 
     // Leaving this example using Partition-Based Sync
     // since progress notifications are currently only supported in PBS
+    // IMPORTANT: this example is also used on the PBS page for opening
+    // a synced realm, so leave it even after progress notifications
+    // are supported in Flexible Sync.
     func testCheckProgress() {
+        // :snippet-start: open-realm-partition-based-sync
         let app = App(id: YOUR_APP_SERVICES_APP_ID)
+        
+        // Store a configuration that consists of the current user,
+        // authenticated to this instance of your app. If there is no
+        // user, your code should log one in.
         let user = app.currentUser
         let partitionValue = "some partition value"
         var configuration = user!.configuration(partitionValue: partitionValue)
         // :remove-start:
         configuration.objectTypes = [SyncExamples_Task.self]
         // :remove-end:
+        
+        // Open the database with the user's configuration.
         let syncedRealm = try! Realm(configuration: configuration)
+        print("Successfully opened the synced realm: \(syncedRealm)")
+        // :snippet-end:
         let expectation = XCTestExpectation(description: "it completes")
         expectation.assertForOverFulfill = false
 

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1477,7 +1477,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 10.47.0;
+				version = 10.48.1;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/source/examples/generated/code/start/Sync.snippet.open-realm-partition-based-sync.swift
+++ b/source/examples/generated/code/start/Sync.snippet.open-realm-partition-based-sync.swift
@@ -1,0 +1,12 @@
+let app = App(id: YOUR_APP_SERVICES_APP_ID)
+
+// Store a configuration that consists of the current user,
+// authenticated to this instance of your app. If there is no
+// user, your code should log one in.
+let user = app.currentUser
+let partitionValue = "some partition value"
+var configuration = user!.configuration(partitionValue: partitionValue)
+
+// Open the database with the user's configuration.
+let syncedRealm = try! Realm(configuration: configuration)
+print("Successfully opened the synced realm: \(syncedRealm)")

--- a/source/sdk/swift/sync/partition-based-sync.txt
+++ b/source/sdk/swift/sync/partition-based-sync.txt
@@ -58,7 +58,7 @@ This enables you to specify a partition value whose data should sync to the real
       specify download behavior, this opens a realm with data that is on
       the device, and attempts to sync changes in the background.
 
-      .. literalinclude:: /examples/generated/code/start/Sync.snippet.open-synced-realm.swift
+      .. literalinclude:: /examples/generated/code/start/Sync.snippet.open-realm-partition-based-sync.swift
          :language: swift
 
    .. tab::


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-37396

- [Partition-Based Sync](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-37396/sdk/swift/sync/partition-based-sync/#open-a-partition-based-sync-realm): Correctly display a Partition-Based Sync example of opening the realm instead of a Flexible Sync example.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [ ] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Swift SDK**
  - Sync/Partition-Based Sync: Correctly display a Partition-Based Sync example of opening the realm instead of a Flexible Sync example.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
