### PR TITLE
(DOCSP-37617): Swift SDK: Update privacy manifest documentation

### DIFF
--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -441,10 +441,14 @@ on the Apple Developer website.
 Starting in Swift SDK version 10.46.0, the SDK ships with privacy manifests
 for ``Realm`` and ``RealmSwift``.
 
-The only privacy-related implementation detail inherent in the SDK is the usage 
-of file timestamp APIs, which is declared in the privacy manifest. The Swift SDK does 
-not include analytics code in builds for the App Store. The SDK does not log into 
-Atlas on its own behalf. 
+You can view the privacy manifests, and the required reasons for the API 
+usage declared there, in each package, or in the ``realm-swift`` GitHub repository:
+
+- ``Realm``: `https://github.com/realm/realm-swift/blob/master/Realm/PrivacyInfo.xcprivacy <https://github.com/realm/realm-swift/blob/master/Realm/PrivacyInfo.xcprivacy>`_
+- ``RealmSwift``: `https://github.com/realm/realm-swift/blob/master/RealmSwift/PrivacyInfo.xcprivacy <https://github.com/realm/realm-swift/blob/master/RealmSwift/PrivacyInfo.xcprivacy>`_
+
+The Swift SDK does not include analytics code in builds for the App Store. 
+The SDK does not log into Atlas on its own behalf. 
 
 If you write an app that uses any App Services functionality, such as 
 :ref:`initializing an App client <ios-init-appclient>` to:

--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -439,10 +439,11 @@ Apple's requirements, refer to
 on the Apple Developer website.
 
 Starting in Swift SDK version 10.46.0, the SDK ships with privacy manifests
-for ``Realm`` and ``RealmSwift``.
+for ``Realm`` and ``RealmSwift``. Each package contains its own privacy manifest
+with Apple's required API disclosures and the reasons for using those APIs.
 
-You can view the privacy manifests, and the required reasons for the API 
-usage declared there, in each package, or in the ``realm-swift`` GitHub repository:
+You can view the privacy manifests in each package, or in the ``realm-swift`` 
+GitHub repository:
 
 - ``Realm``: `https://github.com/realm/realm-swift/blob/master/Realm/PrivacyInfo.xcprivacy <https://github.com/realm/realm-swift/blob/master/Realm/PrivacyInfo.xcprivacy>`_
 - ``RealmSwift``: `https://github.com/realm/realm-swift/blob/master/RealmSwift/PrivacyInfo.xcprivacy <https://github.com/realm/realm-swift/blob/master/RealmSwift/PrivacyInfo.xcprivacy>`_


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-37617

- [Install](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-37617/sdk/swift/install/#apple-privacy-manifest): Make the privacy manifest info more generic and link out to the manifests themselves for details.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Swift SDK**
  - Install: Remove API info from the privacy manifest details and link out to the manifests themselves, instead.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
