### PR TITLE
DOP-4452: Rehoming /docs/realm pages to /docs/atlas/device-sdks/

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,7 @@
 define: prefix docs/realm
 define: base https://www.mongodb.com/${prefix}
 define: appServicesBase https://www.mongodb.com/docs/atlas/app-services
+define: deviceSDKsBase https://www.mongodb.com/docs/atlas/device-sdks
 
 raw: ${prefix}/tutorials -> ${base}/tutorial/
 raw: ${prefix}/deploy/application-schema -> ${base}/deploy/application-configuration-files/
@@ -1291,3 +1292,11 @@ raw: ${prefix}/sdk/react-native/use-realm-react -> ${base}/sdk/react-native/api-
 raw: ${prefix}/sdk/node/integrations/electron-cra -> ${base}/sdk/node/
 raw: ${prefix}/sdk/node/integrations/electron -> ${base}/sdk/node/
 raw: ${prefix}/sdk/node/integrations -> ${base}/sdk/node/
+
+# DOP-4255 Rehoming /docs/realm docs at /docs/atlas/device-sdks
+raw: ${prefix} -> ${deviceSDKsBase}/
+raw: ${prefix}/introduction -> ${deviceSDKsBase}/introduction/
+raw: ${prefix}/realm-query-language -> ${deviceSDKsBase}/realm-query-language/
+raw: ${prefix}/example-projects -> ${deviceSDKsBase}/example-projects/
+raw: ${prefix}/help -> ${deviceSDKsBase}/help/
+raw: ${prefix}/migrate -> ${deviceSDKsBase}/migrate/

--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "realm"
-title = "Atlas Device SDK"
+title = "Atlas Device SDKs"
 
 intersphinx = [
   "https://www.mongodb.com/docs/manual/objects.inv",


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOP-4452

[Here](https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/atlas/device-sdks/) is a staging link - unfortunately, however, redirects do not work in preprod :sob:

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [ ] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [ ] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

This adds redirects from /docs/realm/ to /docs/atlas/device-sdks/ for routes not covered by the [AWS bucket routing rules](https://github.com/mongodb/docs-worker-pool/pull/1026) added for top-level directories. I believe I have covered all pages that still seem to have content/exist (out of top-level routes), but might be missing some things if they're hidden outside of the `/source` folder.

I also updated the title to be plural so that it shows up as such in the sidenav.

<!--
- **Kotlin** SDK
  - Realm/Manage Realm Files/Encrypt a Realm: Add information on encryption for
    local and synced realms.
-->

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
