### PR TITLE
DOCSP-39166: Kotlin: Change baseURL during runtime

### DIFF
--- a/examples/kotlin/settings.gradle.kts
+++ b/examples/kotlin/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            version("realm", "1.14.0")
+            version("realm", "1.16.0")
             version("kotlinx-coroutines", "1.7.0")
             version("kotlinx-serialization", "1.5.0")
             library("realm-plugin", "io.realm.kotlin", "gradle-plugin").versionRef("realm")

--- a/examples/kotlin/shared/build.gradle.kts
+++ b/examples/kotlin/shared/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
     iosX64()
     iosArm64()
     jvm()
-    
+
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -24,18 +24,18 @@ kotlin {
                 api("co.touchlab:kermit:0.1.8")
             }
         }
-        sourceSets["commonMain"].kotlin.setSrcDirs(listOf("src/commonMain/kotlin"))
         val commonTest by getting {
             dependencies {
                 implementation(libs.kotlinx.coroutines.test) // required to use coroutines in test suite
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(kotlin("test-junit"))
+                implementation("org.jetbrains.kotlin:kotlin-stdlib")
+                implementation("org.jetbrains.kotlin:kotlin-stdlib-common")
                 implementation("com.google.android.gms:play-services-auth:20.7.0")
                 implementation("com.google.android.gms:play-services-base:18.2.0")
             }
         }
-        sourceSets["commonTest"].kotlin.setSrcDirs(listOf("src/commonTest/kotlin"))
         val androidMain by getting {
             dependencies {
                 implementation(libs.kotlinx.coroutines.android)
@@ -43,14 +43,12 @@ kotlin {
                 implementation("com.google.android.gms:play-services-base:18.2.0")
             }
         }
-        sourceSets["androidMain"].kotlin.setSrcDirs(listOf("src/androidMain/kotlin"))
         val androidTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))
                 implementation("junit:junit:4.13.2")
             }
         }
-        sourceSets["androidTest"].kotlin.setSrcDirs(listOf("src/androidTest/kotlin"))
         val iosX64Main by getting
         val iosArm64Main by getting
         val iosMain by creating {
@@ -67,7 +65,7 @@ kotlin {
         }
         jvm().compilations["main"].defaultSourceSet {
             dependencies {
-                implementation(kotlin("stdlib-jdk8"))
+                implementation("org.jetbrains.kotlin:kotlin-stdlib")
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.coroutines.test)
             }

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/AppClientTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/AppClientTest.kt
@@ -79,7 +79,7 @@ class AppClientTest : RealmTest() {
             val customBaseUrl = "http://localhost:80"
             // :snippet-start: change-base-url
             // Specify a custom baseUrl to connect to.
-            // In this case, an Edge Server instance running on the device.
+            // In this case, an Edge Server instance running on the device:
             val config = AppConfiguration.Builder(EDGE_SERVER_APP_ID)
                 .baseUrl("http://localhost:80")
                 .build()
@@ -92,7 +92,8 @@ class AppClientTest : RealmTest() {
             assertNotNull(app.currentUser)
             // :remove-end:
 
-            // Later, change the baseUrl to the default:
+            // Later, change the baseUrl.
+            // In this case, pass `null` to reset to default:
             // https://services.cloud.mongodb.com
             app.updateBaseUrl(null)
             // :snippet-end:

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/AuthenticationTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/AuthenticationTest.kt
@@ -471,9 +471,9 @@ class AuthenticationTest: RealmTest() {
         app.close()
     }
 
-    /*
- ** Tests for Multi-User Applications page **
-  */
+/*
+** Tests for Multi-User Applications page **
+*/
 
     private val app = App.create(YOUR_APP_ID)
     val joeEmail = getRandomEmail()

--- a/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/RealmTest.kt
+++ b/examples/kotlin/shared/src/commonTest/kotlin/com/mongodb/realm/realmkmmapp/RealmTest.kt
@@ -43,6 +43,7 @@ open class RealmTest {
 
     val SYNCED_REALM_SCHEMA = setOf(Frog::class, Sample::class)
     val YOUR_APP_ID: String = "kmm-example-testers-viybt"
+    val EDGE_SERVER_APP_ID = "sync-edge-server-cskhoow"
     val yourAppId = AppConfiguration.Builder(YOUR_APP_ID).syncRootDirectory("tmp/sync/".plus(getRandom())).build()
 
     val TESTER_APP_ID: String = "example-testers-kvjdy"

--- a/source/examples/generated/kotlin/AppClientTest.snippet.change-base-url.kt
+++ b/source/examples/generated/kotlin/AppClientTest.snippet.change-base-url.kt
@@ -1,0 +1,12 @@
+// Specify a custom baseUrl to connect to.
+// In this case, an Edge Server instance running on the device.
+val config = AppConfiguration.Builder(EDGE_SERVER_APP_ID)
+    .baseUrl("http://localhost:80")
+    .build()
+val app = App.create(config)
+
+// ... log in a user and use the app ...
+
+// Later, change the baseUrl to the default:
+// https://services.cloud.mongodb.com
+app.updateBaseUrl(null)

--- a/source/examples/generated/kotlin/AppClientTest.snippet.change-base-url.kt
+++ b/source/examples/generated/kotlin/AppClientTest.snippet.change-base-url.kt
@@ -1,5 +1,5 @@
 // Specify a custom baseUrl to connect to.
-// In this case, an Edge Server instance running on the device.
+// In this case, an Edge Server instance running on the device:
 val config = AppConfiguration.Builder(EDGE_SERVER_APP_ID)
     .baseUrl("http://localhost:80")
     .build()
@@ -7,6 +7,7 @@ val app = App.create(config)
 
 // ... log in a user and use the app ...
 
-// Later, change the baseUrl to the default:
+// Later, change the baseUrl.
+// In this case, pass `null` to reset to default:
 // https://services.cloud.mongodb.com
 app.updateBaseUrl(null)

--- a/source/examples/generated/kotlin/AppClientTest.snippet.custom-base-url.kt
+++ b/source/examples/generated/kotlin/AppClientTest.snippet.custom-base-url.kt
@@ -1,0 +1,4 @@
+// Specify a baseUrl to connect to instead of the default
+val config = AppConfiguration.Builder(YOUR_APP_ID)
+    .baseUrl("https://example.com")
+    .build()

--- a/source/examples/generated/kotlin/AppClientTest.snippet.experimental-opt-in.kt
+++ b/source/examples/generated/kotlin/AppClientTest.snippet.experimental-opt-in.kt
@@ -1,0 +1,2 @@
+// Opt in to the experimental Edge Server API
+@OptIn(ExperimentalEdgeServerApi::class)

--- a/source/sdk/kotlin/app-services/connect-to-app-services-backend.txt
+++ b/source/sdk/kotlin/app-services/connect-to-app-services-backend.txt
@@ -300,16 +300,13 @@ annotation:
 .. literalinclude:: /examples/generated/kotlin/AppClientTest.snippet.experimental-opt-in.kt
    :language: kotlin
 
-Change Server with Logged-In User
-`````````````````````````````````
-
-If you want to change the ``baseUrl`` after you have logged in a user and
+If you change the ``baseUrl`` *after* you have logged in a user and
 have opened a synced database, the app must perform a client reset. For more
-information, refer to :ref:`flutter-client-reset`.
+information, refer to :ref:`kotlin-client-reset`.
 
 Perform the following in your code:
 
-1. :ref:`Pause the Sync session <flutter-pause-resume-sync>`
+1. :ref:`Pause the Sync session <kotlin-pause-resume-sync>`
 2. Update the ``baseUrl`` using the ``app.updateBaseUrl`` method
 3. Re-authenticate the user to log in using the new ``baseUrl``
 4. Open a synced database pulling data from the new server

--- a/source/sdk/kotlin/app-services/connect-to-app-services-backend.txt
+++ b/source/sdk/kotlin/app-services/connect-to-app-services-backend.txt
@@ -21,8 +21,8 @@ Connect to Atlas App Services - Kotlin SDK
 This page describes how to initialize your App client and connect to the Atlas
 App Services backend using the Kotlin SDK.
 
-The **App client** is the client-side interface to the App Services backend. 
-It lets you interact with your App Services App and provides access to App 
+The **App client** is the client-side interface to the App Services backend.
+It lets you interact with your App Services App and provides access to App
 Services functionality, including:
 
 - :ref:`Authenticating <kotlin-authenticate>` app users
@@ -30,15 +30,15 @@ Services functionality, including:
   client app using Device Sync
 - :ref:`Calling Atlas functions <kotlin-call-function>`
 
-Each App client is associated with a single App ID. To learn how to find your 
-App ID in the App Services UI, refer to 
+Each App client is associated with a single App ID. To learn how to find your
+App ID in the App Services UI, refer to
 :ref:`Find Your App ID <find-your-app-id>` in the App Services documentation.
 
 Prerequisites
 -------------
 
 Before you can connect to Atlas App Services, you need an App Services App
-with an App ID. 
+with an App ID.
 
 To get started, refer to :ref:`Create an App <create-a-realm-app>`
 in the App Services documentation.
@@ -50,11 +50,11 @@ Initialize the App Client
 
 The Kotlin SDK uses the
 `App <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app/index.html>`__
-interface to access an ``App`` client. 
+interface to access an ``App`` client.
 
-Each ``App`` client is associated with a single App ID. 
+Each ``App`` client is associated with a single App ID.
 You can have multiple App client instances that connect to multiple
-Apps, but all App client instances that share the same App ID use the same 
+Apps, but all App client instances that share the same App ID use the same
 underlying connection.
 
 You can initialize an App client by calling one of the following methods:
@@ -69,7 +69,7 @@ access App Services functionality.
 Default App Client
 ~~~~~~~~~~~~~~~~~~
 
-To initialize an App with default configuration values, pass the App ID 
+To initialize an App with default configuration values, pass the App ID
 for your App Services App to the
 `App.create()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app-configuration/-companion/create.html>`__
@@ -100,27 +100,27 @@ and call the ``.build()`` method to pass a configuration object:
 Configuration Caching
 `````````````````````
 
-.. versionchanged:: 1.14.0 
+.. versionchanged:: 1.14.0
    ``baseUrl`` is not cached in the ``AppConfiguration``
 
-When you initialize the App client, the configuration is cached internally. 
+When you initialize the App client, the configuration is cached internally.
 
 Attempting to close and then re-open an App with a changed configuration
-within the same process has no effect. The client continues to use the 
-cached configuration. 
+within the same process has no effect. The client continues to use the
+cached configuration.
 
-Starting with Kotlin SDK version 1.14.0, the 
+Starting with Kotlin SDK version 1.14.0, the
 `baseUrl() <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app-configuration/index.html#-175646410%2FProperties%2F380376748>`__
-is *no longer* cached in the ``AppConfiguration``. This means that you can 
-change the ``baseUrl``, and the App client will use the updated configuration. 
-In earlier SDK versions, changes to the ``baseUrl`` in a cached App 
+is *no longer* cached in the ``AppConfiguration``. This means that you can
+change the ``baseUrl``, and the App client will use the updated configuration.
+In earlier SDK versions, changes to the ``baseUrl`` in a cached App
 configuration have no effect.
 
 Configure the App Client
 ------------------------
 
-The following sections describe how to build the ``AppConfiguration`` client 
-with specific properties. 
+The following sections describe how to build the ``AppConfiguration`` client
+with specific properties.
 
 .. _kotlin-share-sync-connections:
 
@@ -235,9 +235,9 @@ Enable Platform Networking
 
 .. versionadded:: 1.14.0
 
-Atlas Device SDK's **platform networking** lets you use your platform's networking 
-stack instead of the default WebSocket client for Device Sync 
-traffic. 
+Atlas Device SDK's **platform networking** lets you use your platform's networking
+stack instead of the default WebSocket client for Device Sync
+traffic.
 
 When enabled, you can configure applications running on Android and
 Java Virtual Machine (JVM) platforms to use managed WebSockets over
@@ -245,7 +245,7 @@ Java Virtual Machine (JVM) platforms to use managed WebSockets over
 configuration support for proxies and firewalls that require authentication.
 
 Platform networking is disabled by default. You can enable it on the
-``AppConfiguration`` using the 
+``AppConfiguration`` using the
 `AppConfiguration.usePlatformNetworking()
 <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app-configuration/-builder/use-platform-networking.html>`__
 method, which accepts a Boolean value.
@@ -254,9 +254,69 @@ method, which accepts a Boolean value.
    :language: kotlin
 
 .. note:: Android and JVM platforms only
-   
-   This feature is currently only available on Android and Java Virtual 
+
+   This feature is currently only available on Android and Java Virtual
    Machine (JVM) platforms.
+
+.. _kotlin-connect-to-specific-server:
+
+Connect to a Specific Server
+----------------------------
+
+By default, Atlas Device SDK connects to Atlas using the global ``baseUrl``
+of ``https://services.cloud.mongodb.com``. In some cases, you may want to
+connect to a different server:
+
+- Your App Services App uses local deployment, and you want to connect directly to a local ``baseUrl`` in your region. For more information, refer to the :ref:`<local-deployment>` App Services documentation.
+- You want to connect to an Edge Server instance. For more information, refer to
+  the :ref:`edge-server-connect-from-client` App Services documentation.
+
+You can specify a ``baseUrl`` in the
+`AppConfiguration <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app-configuration/index.html>`__:
+
+.. literalinclude:: /examples/generated/kotlin/AppClientTest.snippet.custom-base-url.kt
+   :language: kotlin
+
+Connect to a Different Server During Runtime
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.16.0
+
+In some cases, you might want to change the ``baseUrl`` while the app is
+running. For example, you might want to roam between Edge Servers or
+move from an App Services connection to an Edge Server connection.
+
+To change the ``baseUrl`` during runtime, call the experimental
+`app.updateBaseUrl <{+kotlin-sync-prefix+}io.realm.kotlin.mongodb/-app/index.html#2007791704%2FFunctions%2F380376748>`__ method. You can
+pass ``null`` to reset the ``baseUrl`` to the default value.
+
+.. literalinclude:: /examples/generated/kotlin/AppClientTest.snippet.change-base-url.kt
+   :language: kotlin
+
+This API is experimental and requires the `@ExperimentalEdgeServerApi
+<{+kotlin-sync-prefix+}io.realm.kotlin.mongodb.annotations/-experimental-edge-server-api/index.html>`__
+annotation:
+
+.. literalinclude:: /examples/generated/kotlin/AppClientTest.snippet.experimental-opt-in.kt
+   :language: kotlin
+
+Change Server with Logged-In User
+`````````````````````````````````
+
+If you want to change the ``baseUrl`` after you have logged in a user and
+have opened a synced database, the app must perform a client reset. For more
+information, refer to :ref:`flutter-client-reset`.
+
+Perform the following in your code:
+
+1. :ref:`Pause the Sync session <flutter-pause-resume-sync>`
+2. Update the ``baseUrl`` using the ``app.updateBaseUrl`` method
+3. Re-authenticate the user to log in using the new ``baseUrl``
+4. Open a synced database pulling data from the new server
+
+Both the server and the client *must* be online for the user to authenticate and
+connect to the new server. If the server is not online or the client does not
+have a network connection, the user cannot authenticate and open the database.
 
 Close the App Client
 --------------------


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-39166

- [Connect to Atlas App Services - Kotlin SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-39166-kotlin-baseurl/sdk/kotlin/app-services/connect-to-app-services-backend/#connect-to-a-specific-server): New "Connect to a Specific Server" section with baseURL info. New "Connect to a Different Server During Runtime" subsection with info about the experimental API

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Kotlin** SDK
  - Connect to Atlas/Connect to App Services: New "Connect to a Specific Server" section with baseUrl info. New "Connect to a Different Server During Runtime" subsection with info about the experimental API.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
