### PR TITLE
Add missing namespace to quick start snippet

### DIFF
--- a/examples/cpp/sync/quick-start.cpp
+++ b/examples/cpp/sync/quick-start.cpp
@@ -20,8 +20,10 @@ struct Local_Todo {
   std::string status;
 };
 REALM_SCHEMA(Local_Todo, _id, name, status);
+}  // namespace realm
 
 // :snippet-start: model
+namespace realm {
 struct Sync_Todo {
   realm::primary_key<realm::object_id> _id{realm::object_id::generate()};
   std::string name;
@@ -31,8 +33,8 @@ struct Sync_Todo {
   std::string ownerId;
 };
 REALM_SCHEMA(Sync_Todo, _id, name, status, ownerId);
-// :snippet-end:
 }  // namespace realm
+// :snippet-end:
 
 TEST_CASE("non-sync quick start", "[realm][write]") {
   auto relative_realm_path_directory = "quick-start/";

--- a/source/examples/generated/cpp/quick-start.snippet.model.cpp
+++ b/source/examples/generated/cpp/quick-start.snippet.model.cpp
@@ -1,3 +1,4 @@
+namespace realm {
 struct Todo {
   realm::primary_key<realm::object_id> _id{realm::object_id::generate()};
   std::string name;
@@ -7,3 +8,4 @@ struct Todo {
   std::string ownerId;
 };
 REALM_SCHEMA(Todo, _id, name, status, ownerId);
+}  // namespace realm


### PR DESCRIPTION
## Pull Request Info

- [Quick Start](https://preview-mongodbdacharyc.gatsbyjs.io/realm/cpp-add-missing-namespace/sdk/cpp/quick-start/): Add the missing `namespace` line to the quick start model.

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **C++ SDK**
  - Quick Start: Fix omitted `namespace` line in the object model.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
