### PR TITLE
DOCSP-39270: Flutter: Add Privacy Manifest information 

### DIFF
--- a/source/includes/dotnet-frameworks.rst
+++ b/source/includes/dotnet-frameworks.rst
@@ -1,5 +1,6 @@
-You can use the .NET SDK to develop apps in C# .NET with several frameworks:
-`.NET MAUI <https://dotnet.microsoft.com/en-us/apps/maui>`__, `Xamarin
-<https://dotnet.microsoft.com/apps/xamarin>`__, `Avalonia UI <https://avaloniaui.net/>`__, 
-`UWP <https://docs.microsoft.com/en-us/windows/uwp/get-started/>`__, `Unity
-<https://unity.com/>`__, and others.
+You can use the Atlas Device SDK for .NET to develop apps in C# .NET with several frameworks, including
+`.NET MAUI <https://dotnet.microsoft.com/en-us/apps/maui>`__,
+`Xamarin <https://dotnet.microsoft.com/apps/xamarin>`__,
+`Avalonia UI <https://avaloniaui.net/>`__,
+`UWP <https://docs.microsoft.com/en-us/windows/uwp/get-started/>`__,
+`Unity <https://unity.com/>`__, and others.

--- a/source/sdk/flutter/app-services/call-function.txt
+++ b/source/sdk/flutter/app-services/call-function.txt
@@ -4,15 +4,22 @@
 Call an Atlas Function
 ======================
 
+.. meta::
+   :description: Call serverless Atlas Functions from a client application with Atlas Device SDK for Flutter.
+   :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none
    :depth: 3
    :class: singlecol
 
-
 You can call an **Atlas Function** from a client application
-using the Realm Flutter SDK.
+using the Atlas Device SDK for Flutter.
 Functions are serverless JavaScript functions that let you define and execute server-side logic.
 These server-side Functions can run in the context
 of the authenticated user, and thus honor the rules, roles, and permissions that

--- a/source/sdk/flutter/install.txt
+++ b/source/sdk/flutter/install.txt
@@ -276,3 +276,48 @@ depending on whether you have a Flutter or Dart standalone app:
       and restart the application.
       Note that deleting the ``.realm`` file also deletes all data stored in
       the database on that client.
+
+.. _flutter-apple-privacy-manifest:
+
+Apple Privacy Manifest
+----------------------
+
+.. versionadded:: 2.2.0
+
+Apple requires apps that use required reason APIs to provide details about the
+SDK's data collection and use practices when submitting new apps or app updates
+to the App Store. For more details about Apple's requirements, refer to
+:apple:`support/third-party-SDK-requirements/` on the Apple Developer website.
+
+Starting in Flutter SDK version 2.2.0, the SDK ships with a privacy manifest for
+``iOS`` and ``macOS`` environments, contained in the ``realm`` package. Both
+privacy manifests contain Apple's required API disclosures and the reasons for
+using those APIs.
+
+You can view the privacy manifests in the package or the ``realm-dart``
+GitHub repository:
+
+- ``iOS``:
+  `https://github.com/realm/realm-dart/blob/main/packages/realm/ios/Resources/PrivacyInfo.xcprivacy
+  <https://github.com/realm/realm-dart/blob/main/packages/realm/ios/Resources/PrivacyInfo.xcprivacy>`__
+- ``macOS``:
+  `https://github.com/realm/realm-dart/blob/main/packages/realm/macos/Resources/PrivacyInfo.xcprivacy
+  <https://github.com/realm/realm-dart/blob/main/packages/realm/macos/Resources/PrivacyInfo.xcprivacy>`__
+
+The Flutter SDK does *not*:
+
+- Include analytics code in builds for the App Store.
+- Log into Atlas on its own behalf.
+
+If you write an app that uses any App Services functionality, you may need to
+add additional disclosures to your app's privacy manifest detailing your data
+collection and use practices when using these APIs.
+For example, if your app :ref:`initializes an App client
+<flutter-access-the-app-client>` to:
+
+- :ref:`Call an Atlas Function <flutter-call-function>`
+- :ref:`Authenticate and manage users <flutter-work-with-users>`
+- :ref:`Open a synced database <flutter-open-synced-realm>`
+
+For more information, refer to Apple's
+:apple:`documentation/bundleresources/privacy_manifest_files` documentation.

--- a/source/sdk/flutter/install.txt
+++ b/source/sdk/flutter/install.txt
@@ -303,7 +303,7 @@ Apple Privacy Manifest
 
 .. versionadded:: 2.2.0
 
-Apple requires any apps or third-party SDKs that use *required reasons APIs*
+Apple requires any apps or third-party SDKs that use *required reasons APIs* to
 provide a privacy manifest. The manifest contains details about the app's or SDK's
 data collection and use practices, and it must be included when submitting new
 apps or app updates to the Apple App Store. For more details about these

--- a/source/sdk/flutter/install.txt
+++ b/source/sdk/flutter/install.txt
@@ -26,18 +26,17 @@ Prerequisites
 -------------
 
 To get started with the Atlas Device SDK for Flutter, you need to install
-Flutter or Dart:
+the following, depending on the type of app you are developing:
 
-- For Flutter or Dart apps, install Flutter in your development environment.
-  Note that the Flutter installation includes the full Dart SDK. To learn
-  how, refer to the official `Flutter Installation Guide
-  <https://docs.flutter.dev/get-started/install>`__.
+- For Flutter or Dart apps, install Flutter with Dart in your development environment.
+  The Flutter installation includes Dart. To learn how, refer to the official
+  `Flutter Installation Guide <https://docs.flutter.dev/get-started/install>`__.
 
-- For standalone Dart apps, you can choose install Dart in your development
-  environment without Flutter. To learn how, refer to the official `Dart
-  Installation Guide <https://dart.dev/get-dart>`__.
+- For standalone Dart apps, you can install Dart in your development
+  environment without Flutter. To learn how, refer to the official
+  `Dart Installation Guide <https://dart.dev/get-dart>`__.
 
-The latest version of the Device SDK for Flutter requires the following:
+The latest version of the Flutter SDK requires the following minimum versions:
 
 - Flutter version 3.19.0 or later.
 - Dart version 3.3.0 or later.
@@ -64,8 +63,8 @@ The Flutter SDK supports the following platforms:
 .. _flutter-install-steps:
 .. _dart-install-steps:
 
-Installation
-------------
+Install the SDK
+---------------
 
 The Atlas Device SDK for Flutter has two packages available to install,
 depending on whether you are developing a Flutter or Dart standalone app:
@@ -79,8 +78,7 @@ where otherwise noted.
 
 .. tip:: Atlas Device SDK and Realm
 
-   The SDK uses Realm Core database for device data persistence. When you
-   install the Kotlin SDK, the package names reflect Realm naming.
+   The Flutter SDK uses Realm Core database for device data persistence. When you install the Flutter SDK, the package names reflect Realm naming.
 
 .. procedure::
 
@@ -93,7 +91,7 @@ where otherwise noted.
 
             To create a Flutter project, run the following commands:
 
-            .. code-block::
+            .. code-block:: bash
 
                flutter create <app_name>
                cd <app_name>
@@ -106,7 +104,7 @@ where otherwise noted.
 
             To create a Dart project, run the following commands:
 
-            .. code-block::
+            .. code-block:: bash
 
                dart create <app_name>
                cd <app_name>
@@ -122,9 +120,9 @@ where otherwise noted.
          .. tab:: Flutter
             :tabid: flutter
 
-            To add the SDK to your project, run the following command:
+            To add the Flutter SDK to your project, run the following command:
 
-            .. code-block::
+            .. code-block:: bash
 
                flutter pub add realm
 
@@ -139,12 +137,23 @@ where otherwise noted.
                dependencies:
                   realm: <latest_version>
 
-            .. tab:: Standalone Dart
-               :tabid: dart
+            .. note:: Using Networking in your macOS App
 
-            To add the SDK to your project, run the  following command:
+               If you are developing with the Flutter SDK in the macOS App
+               Sandbox and require network access, you must enable network
+               entitlements in your app. By default, network requests are
+               not allowed due to built-in macOS security settings.
 
-            .. code-block::
+               To use networking in your macOS app, you must change your app's
+               macOS network entitlements. To learn how, refer to
+               :ref:`flutter-macos-development`.
+
+         .. tab:: Standalone Dart
+            :tabid: dart
+
+            To add the SDK to your project, run the following command:
+
+            .. code-block:: bash
 
                dart pub add realm_dart
 
@@ -162,7 +171,7 @@ where otherwise noted.
 
             After the package is added, run the following command to install it:
 
-            .. code-block::
+            .. code-block:: bash
 
                dart run realm_dart install
 
@@ -171,12 +180,13 @@ where otherwise noted.
 
    .. step:: Import the Package into Files
 
+      To use the SDK in your app, import the package into any files where you
+      will use it:
+
       .. tabs::
 
          .. tab:: Flutter
             :tabid: flutter
-
-            To use the Flutter SDK within your app, import the package into files where you will use it:
 
             .. code-block:: dart
                :caption: ExampleFile.dart
@@ -186,96 +196,105 @@ where otherwise noted.
          .. tab:: Standalone Dart
             :tabid: dart
 
-            To use the SDK within your Dart app, import the package into files where you will use it:
-
             .. code-block:: dart
                :caption: ExampleFile.dart
 
                import 'package:realm_dart/realm.dart';
 
-.. note:: Using Networking in your macOS App
-
-   If you are developing with the Flutter SDK in the macOS App Sandbox,
-   network requests do *not* work by default. This is due to the built-in macOS
-   security settings.
-
-   To use networking in your macOS app, you must change your app's macOS network
-   entitlements. To learn how, refer to :ref:`flutter-macos-development`.
-
 .. _flutter-update-package:
 
-Update Package Version
-----------------------
-
-.. include:: /includes/flutter-v2-breaking-change.rst
+Update the Package Version
+--------------------------
 
 To change the version of the SDK in your project, perform the following steps,
-depending on whether you have a Flutter or Dart standalone app:
+depending on whether you are using the ``realm`` or ``realm_dart`` package:
 
-.. tabs::
+.. procedure::
 
-   .. tab:: Flutter
-      :tabid: flutter
+   .. step:: Update the ``pubspec.yaml`` File
 
-      #. Add the new SDK version to your :file:`pubspec.yaml` file.
+      Update the package version in your :file:`pubspec.yaml` file dependencies.
 
-         .. code-block:: yaml
-           :caption: pubspec.yaml
+      .. tabs::
 
-           dependencies:
-             realm: <updated_version>
+         .. tab:: Flutter
+            :tabid: flutter
 
-      #. Install the updated version.
+            .. code-block:: yaml
+               :caption: pubspec.yaml
 
-         .. code-block::
+               dependencies:
+                  realm: <updated_version>
 
-            flutter pub upgrade realm
+         .. tab:: Dart Standalone
+            :tabid: dart
 
-      #. Regenerate your object models.
+            .. code-block:: yaml
+               :caption: pubspec.yaml
 
-         .. code-block::
+               dependencies:
+                  realm_dart: <updated_version>
 
-            dart run realm generate
+   .. step:: Install the Updated Package
 
-      These steps should make the updated SDK version work in your application.
-      If issues persist, you can delete the application from your linked client and
-      restart it. Note that this will also delete all data stored in the database
-      on that client.
+      .. tabs::
 
-   .. tab:: Dart Standalone
-      :tabid: dart
+         .. tab:: Flutter
+            :tabid: flutter
 
-      #. Add the new SDK version to your :file:`pubspec.yaml` file.
+            Run the following command to install the updated version:
 
-         .. code-block:: yaml
-           :caption: pubspec.yaml
+            .. code-block:: yaml
+               :caption: pubspec.yaml
 
-           dependencies:
-             realm_dart: <updated_version>
+               dependencies:
+                  realm: <updated_version>
 
-      #. Install the updated version.
+         .. tab:: Dart Standalone
+            :tabid: dart
 
-         .. code-block::
+            Run the following command to install the updated version:
 
-            dart pub upgrade realm_dart
+            .. code-block:: bash
 
-      #. Install the updated SDK's native binaries.
+               dart pub upgrade realm_dart
 
-         .. code-block::
+            Then, run the following command to install the updated SDK's native
+            binaries:
 
-            dart run realm_dart install
+            .. code-block:: bash
 
-      #. Regenerate your object models.
+               dart run realm_dart install
 
-         .. code-block::
+   .. step:: Regenerate Object Models
 
-            dart run realm_dart generate
+      .. tabs::
 
-      These steps should make the updated SDK version work in your application.
-      If issues persist, delete the ``.realm`` database file created by the SDK,
-      and restart the application.
-      Note that deleting the ``.realm`` file also deletes all data stored in
-      the database on that client.
+         .. tab:: Flutter
+            :tabid: flutter
+
+            .. code-block:: bash
+
+               dart run realm generate
+
+         .. tab:: Dart Standalone
+            :tabid: dart
+
+            .. code-block:: bash
+
+               dart run realm_dart generate
+
+      .. include:: /includes/flutter-v2-breaking-change.rst
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+If you have issues using the updated SDK version in your application, you can
+delete the ``.realm`` database file created by the SDK, and restart the
+application. Note that deleting the ``.realm`` file also deletes all data stored
+in the database on that client.
+
+For more information, refer to :ref:`flutter-delete-realm`.
 
 .. _flutter-apple-privacy-manifest:
 
@@ -284,18 +303,21 @@ Apple Privacy Manifest
 
 .. versionadded:: 2.2.0
 
-Apple requires apps that use required reason APIs to provide details about the
-SDK's data collection and use practices when submitting new apps or app updates
-to the App Store. For more details about Apple's requirements, refer to
-:apple:`support/third-party-SDK-requirements/` on the Apple Developer website.
+Apple requires any apps or third-party SDKs that use *required reasons APIs*
+to provide a privacy manifest containing details about their data collection
+and use practices. The bundled manifest file must be included when submitting
+new apps or app updates to the Apple App Store. For more details about these
+requirements, refer to
+:apple:`Upcoming third-party SDK requirements <support/third-party-SDK-requirements/>`
+on the Apple Developer website.
 
 Starting in Flutter SDK version 2.2.0, the SDK ships with a privacy manifest for
 ``iOS`` and ``macOS`` environments, contained in the ``realm`` package. Both
 privacy manifests contain Apple's required API disclosures and the reasons for
 using those APIs.
 
-You can view the privacy manifests in the package or the ``realm-dart``
-GitHub repository:
+You can view these privacy manifests in the SDK package or directly in the
+``realm-dart`` GitHub repository:
 
 - ``iOS``:
   `https://github.com/realm/realm-dart/blob/main/packages/realm/ios/Resources/PrivacyInfo.xcprivacy
@@ -309,15 +331,21 @@ The Flutter SDK does *not*:
 - Include analytics code in builds for the App Store.
 - Log into Atlas on its own behalf.
 
-If you write an app that uses any App Services functionality, you may need to
-add additional disclosures to your app's privacy manifest detailing your data
-collection and use practices when using these APIs.
-For example, if your app :ref:`initializes an App client
-<flutter-access-the-app-client>` to:
+.. important:: Additional Disclosures May Be Required for App Services
+
+   The Flutter SDK privacy manifest does *not* include disclosures for App
+   Services APIs.
+
+If your app uses any Atlas App Services functionality, such as user
+authentication or Device Sync, you may need to provide additional disclosures
+that detail your data collection and use practices when using these APIs.
+For example, if your app
+:ref:`initializes an App client <flutter-access-the-app-client>` to:
 
 - :ref:`Call an Atlas Function <flutter-call-function>`
 - :ref:`Authenticate and manage users <flutter-work-with-users>`
 - :ref:`Open a synced database <flutter-open-synced-realm>`
 
 For more information, refer to Apple's
-:apple:`documentation/bundleresources/privacy_manifest_files` documentation.
+:apple:`Privacy Manifest Files <documentation/bundleresources/privacy_manifest_files>`
+documentation.

--- a/source/sdk/flutter/install.txt
+++ b/source/sdk/flutter/install.txt
@@ -4,8 +4,8 @@
 Install the Flutter SDK
 =======================
 
-.. meta:: 
-   :description: Install the Atlas Device SDK with Flutter for Flutter or Dart applications. 
+.. meta::
+   :description: Install the Atlas Device SDK with Flutter for Flutter or Dart applications.
    :keywords: code example
 
 .. facet::
@@ -18,15 +18,29 @@ Install the Flutter SDK
    :depth: 2
    :class: singlecol
 
+You can use the Atlas Device SDK for Flutter in a Flutter project or in a
+standalone Dart project. This guide provides instructions for installing the
+SDK in both types of projects.
+
 Prerequisites
 -------------
 
-- `Install Flutter in your development environment <https://docs.flutter.dev/get-started/install>`__.
-  
-  To use the latest version of the Atlas Device SDK for Flutter, you must use:  
-  
-  - Flutter version 3.10.0 or later.
-  - Dart version 3.0.0 or later.
+To get started with the Atlas Device SDK for Flutter, you need to install
+Flutter or Dart:
+
+- For Flutter or Dart apps, install Flutter in your development environment.
+  Note that the Flutter installation includes the full Dart SDK. To learn
+  how, refer to the official `Flutter Installation Guide
+  <https://docs.flutter.dev/get-started/install>`__.
+
+- For standalone Dart apps, you can choose install Dart in your development
+  environment without Flutter. To learn how, refer to the official `Dart
+  Installation Guide <https://dart.dev/get-dart>`__.
+
+The latest version of the Device SDK for Flutter requires the following:
+
+- Flutter version 3.19.0 or later.
+- Dart version 3.3.0 or later.
 
 Supported Platforms
 ~~~~~~~~~~~~~~~~~~~
@@ -36,7 +50,7 @@ The Flutter SDK supports the following platforms:
 - iOS
 - Android
 - macOS
-- Windows running on 64-bit architecture 
+- Windows running on 64-bit architecture
 - Linux running on 64-bit architecture
 
 .. important:: Unsupported Platforms
@@ -47,129 +61,146 @@ The Flutter SDK supports the following platforms:
    - Windows running on ARM64 or 32-bit architectures
    - Linux running on ARM64 or 32-bit architectures
 
-
 .. _flutter-install-steps:
+.. _dart-install-steps:
 
 Installation
 ------------
 
-You can use the SDK in a Flutter project, or in a standalone Dart project.
+The Atlas Device SDK for Flutter has two packages available to install,
+depending on whether you are developing a Flutter or Dart standalone app:
+
+- ``realm``: The Flutter SDK package for use in Flutter applications.
+- ``realm_dart``: The standalone Dart SDK package for use in Dart applications,
+  such as CLI apps or running Dart in a server environment.
+
+The standalone Dart package has the same usage as the Flutter package except
+where otherwise noted.
 
 .. tip:: Atlas Device SDK and Realm
 
    The SDK uses Realm Core database for device data persistence. When you
-   install the Flutter or Dart standalone SDK, the package names reflect 
-   Realm naming.
-
-Install the SDK in a Flutter Project
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   install the Kotlin SDK, the package names reflect Realm naming.
 
 .. procedure::
 
-   .. step:: Create a Flutter Project
+   .. step:: Create a Project
 
-      Create a Flutter project. Follow the instructions in the `Flutter documentation
-      <https://docs.flutter.dev/get-started/test-drive?tab=terminal>`__.
+      .. tabs::
 
-      .. code-block::
+         .. tab:: Flutter
+            :tabid: flutter
 
-        flutter create <app_name>
-        cd <app_name>
+            To create a Flutter project, run the following commands:
+
+            .. code-block::
+
+               flutter create <app_name>
+               cd <app_name>
+
+            For more information, refer to Flutter's `Get Started Guide
+            <https://docs.flutter.dev/get-started/test-drive?tab=terminal>`__.
+
+         .. tab:: Standalone Dart
+            :tabid: dart
+
+            To create a Dart project, run the following commands:
+
+            .. code-block::
+
+               dart create <app_name>
+               cd <app_name>
+
+            For more information, refer to Dart's `Get Started Guide
+            <https://dart.dev/tutorials/server/get-started>`__ for standalone
+            Dart command-line and server applications.
 
    .. step:: Add the SDK to the Project
 
-      To add the `Flutter SDK <https://pub.dev/packages/realm>`__ to your project, run the command:
+      .. tabs::
 
-      .. code-block::
+         .. tab:: Flutter
+            :tabid: flutter
 
-        flutter pub add realm
+            To add the SDK to your project, run the following command:
 
-      This downloads the ``realm`` package and adds it to your project.
-      In your ``pubspec.yaml`` file, you should see:
+            .. code-block::
 
-      .. code-block:: yaml
-        :caption: pubspec.yaml
+               flutter pub add realm
 
-        dependencies:
-          realm: <latest_version>
+            This downloads the `realm <https://pub.dev/packages/realm>`__
+            package, and adds it to your project.
 
-   .. step:: Import the Package
+            In your ``pubspec.yaml`` file, you should see:
 
-      To use the Flutter SDK within your app, import the package
-      into files where you will use it:
+            .. code-block:: yaml
+               :caption: pubspec.yaml
 
-      .. code-block:: dart
+               dependencies:
+                  realm: <latest_version>
 
-        import 'package:realm/realm.dart';
+            .. tab:: Standalone Dart
+               :tabid: dart
+
+            To add the SDK to your project, run the  following command:
+
+            .. code-block::
+
+               dart pub add realm_dart
+
+            This downloads the `realm_dart
+            <https://pub.dev/packages/realm_dart>`__ package, and adds it to
+            your project.
+
+            In your ``pubspec.yaml`` file, you should see:
+
+            .. code-block:: yaml
+               :caption: pubspec.yaml
+
+               dependencies:
+                  realm_dart: <latest_version>
+
+            After the package is added, run the following command to install it:
+
+            .. code-block::
+
+               dart run realm_dart install
+
+            This downloads and copies the required native binaries to the app
+            directory.
+
+   .. step:: Import the Package into Files
+
+      .. tabs::
+
+         .. tab:: Flutter
+            :tabid: flutter
+
+            To use the Flutter SDK within your app, import the package into files where you will use it:
+
+            .. code-block:: dart
+               :caption: ExampleFile.dart
+
+               import 'package:realm/realm.dart';
+
+         .. tab:: Standalone Dart
+            :tabid: dart
+
+            To use the SDK within your Dart app, import the package into files where you will use it:
+
+            .. code-block:: dart
+               :caption: ExampleFile.dart
+
+               import 'package:realm_dart/realm.dart';
 
 .. note:: Using Networking in your macOS App
 
    If you are developing with the Flutter SDK in the macOS App Sandbox,
-   network requests do not work by default due to built-in macOS security settings.
-   To fix this, you must change the Flutter app's macOS network entitlements.
+   network requests do *not* work by default. This is due to the built-in macOS
+   security settings.
 
-   To learn how to do this, refer to :ref:`Use the SDK with the macOS App Sandbox
-   <flutter-macos-development>`.
-
-.. _dart-install-steps:
-
-Dart Standalone Installation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To use the SDK with Dart but not Flutter, there is a separate
-Dart SDK package with its own installation process.
-The Dart SDK can be used for CLI applications or when running Dart in a server environment.
-The Dart standalone package ``realm_dart`` has the same usage as the Flutter package
-except where otherwise noted.
-
-.. procedure::
-
-   .. step:: Create a Dart Project
-
-      Create a Dart project.
-
-      .. note:: Using Dart without Flutter
-
-        The official Dart docs have helpful getting started material
-        for using Dart without Flutter for CLI and server use cases.
-
-        `See the official documentation. <https://dart.dev/server>`__
-
-   .. step:: Add the SDK to the Project
-
-
-      To add the `Dart SDK <https://pub.dev/packages/realm_dart>`__ to your project, run the command:
-
-      .. code-block::
-
-        dart pub add realm_dart
-
-      This downloads the ``realm_dart`` package and adds it to your project.
-      In your ``pubspec.yaml`` file, you should see:
-
-      .. code-block:: yaml
-        :caption: pubspec.yaml
-
-        dependencies:
-          realm_dart: <latest_version>
-
-   .. step:: Install the SDK into the Application
-
-      Install the ``realm_dart`` package into the application.
-      This downloads and copies the required native binaries to the app directory.
-
-      .. code-block::
-
-        dart run realm_dart install
-
-   .. step:: Import the Package
-
-      To use the SDK within your Dart app, import the package
-      into files where you will use it:
-
-      .. code-block:: dart
-
-        import 'package:realm_dart/realm.dart';
+   To use networking in your macOS app, you must change your app's macOS network
+   entitlements. To learn how, refer to :ref:`flutter-macos-development`.
 
 .. _flutter-update-package:
 
@@ -178,8 +209,8 @@ Update Package Version
 
 .. include:: /includes/flutter-v2-breaking-change.rst
 
-To change the version of the Flutter SDK or Dart Standalone SDK in your project, 
-follow these steps.
+To change the version of the SDK in your project, perform the following steps,
+depending on whether you have a Flutter or Dart standalone app:
 
 .. tabs::
 
@@ -243,5 +274,5 @@ follow these steps.
       These steps should make the updated SDK version work in your application.
       If issues persist, delete the ``.realm`` database file created by the SDK,
       and restart the application.
-      Note that deleting the ``.realm`` file also deletes all data stored in 
+      Note that deleting the ``.realm`` file also deletes all data stored in
       the database on that client.

--- a/source/sdk/flutter/install.txt
+++ b/source/sdk/flutter/install.txt
@@ -5,7 +5,7 @@ Install the Flutter SDK
 =======================
 
 .. meta::
-   :description: Install the Atlas Device SDK with Flutter for Flutter or Dart applications.
+   :description: Install the Atlas Device SDK for Flutter to use in Flutter or Dart applications.
    :keywords: code example
 
 .. facet::
@@ -15,7 +15,7 @@ Install the Flutter SDK
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 1
    :class: singlecol
 
 You can use the Atlas Device SDK for Flutter in a Flutter project or in a
@@ -304,9 +304,9 @@ Apple Privacy Manifest
 .. versionadded:: 2.2.0
 
 Apple requires any apps or third-party SDKs that use *required reasons APIs*
-to provide a privacy manifest containing details about their data collection
-and use practices. The bundled manifest file must be included when submitting
-new apps or app updates to the Apple App Store. For more details about these
+provide a privacy manifest. The manifest contains details about the app's or SDK's
+data collection and use practices, and it must be included when submitting new
+apps or app updates to the Apple App Store. For more details about these
 requirements, refer to
 :apple:`Upcoming third-party SDK requirements <support/third-party-SDK-requirements/>`
 on the Apple Developer website.

--- a/source/sdk/flutter/realm-database/realm-files/delete.txt
+++ b/source/sdk/flutter/realm-database/realm-files/delete.txt
@@ -4,6 +4,14 @@
 Delete a Realm File - Flutter SDK
 =================================
 
+.. meta::
+   :description: Delete the local realm files from disk.
+   :keywords: code example
+
+.. facet::
+  :name: genre
+  :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/sdk/flutter/telemetry.txt
+++ b/source/sdk/flutter/telemetry.txt
@@ -4,4 +4,21 @@
 Telemetry - Flutter SDK
 =======================
 
+.. meta::
+   :description: Atlas Device SDK collects anonymized telemetry during app development but not in production builds.
+
+.. facet::
+   :name: genre
+   :values: reference
+
 .. include:: /includes/sdk-telemetry.rst
+
+Apple Privacy Manifest
+----------------------
+
+The Atlas Device SDK for Flutter does *not* include analytics in builds for the
+App Store. Because we do not collect telemetry on those builds, the SDK's Apple
+privacy manifest does not mention this telemetry. The SDK's Apple privacy
+manifest only covers Apple's API disclosure requirements.
+
+For more details, refer to :ref:`ios-apple-privacy-manifest`.

--- a/source/sdk/flutter/users.txt
+++ b/source/sdk/flutter/users.txt
@@ -1,3 +1,5 @@
+.. _flutter-work-with-users
+
 =============================
 User Management - Flutter SDK
 =============================

--- a/source/sdk/flutter/users.txt
+++ b/source/sdk/flutter/users.txt
@@ -1,3 +1,5 @@
+.. _flutter-work-with-users:
+
 =============================
 User Management - Flutter SDK
 =============================
@@ -96,11 +98,11 @@ refer to the following documentation:
 Listen for User Changes
 -----------------------
 
-You can listen for and react to changes to a user instance. For 
-example, receive notifications when a user state changes or a user 
+You can listen for and react to changes to a user instance. For
+example, receive notifications when a user state changes or a user
 access token is updated.
 
-For more information, refer to 
+For more information, refer to
 :ref:`Register a User Instance Change Listener <flutter-user-change-listener>`.
 
 .. _flutter-app-work-with-custom-user-data:

--- a/source/sdk/flutter/users.txt
+++ b/source/sdk/flutter/users.txt
@@ -1,4 +1,4 @@
-.. _flutter-work-with-users
+.. _flutter-work-with-users:
 
 =============================
 User Management - Flutter SDK

--- a/source/sdk/flutter/users.txt
+++ b/source/sdk/flutter/users.txt
@@ -1,5 +1,3 @@
-.. _flutter-work-with-users:
-
 =============================
 User Management - Flutter SDK
 =============================
@@ -49,7 +47,7 @@ data from the backend.
 
 .. include:: /includes/apple-account-deletion-requirements.rst
 
-.. _flutter-access-the-app-client:
+.. _flutter-log-users-in-and-out:
 
 Log Users In and Out
 --------------------

--- a/source/sdk/react-native/install.txt
+++ b/source/sdk/react-native/install.txt
@@ -10,14 +10,27 @@ Install the React Native SDK
    :depth: 2
    :class: singlecol
 
-The Atlas Device SDK for React Native enables development of `React Native 
+The Atlas Device SDK for React Native enables development of `React Native
 <https://facebook.github.io/react-native/>`__ applications using the JavaScript
-and TypeScript languages. React Native enables you to build cross-platform 
-iOS and Android apps with a single codebase using the 
+and TypeScript languages. React Native enables you to build cross-platform
+iOS and Android apps with a single codebase using the
 `React <https://react.dev/>`__ framework.
 
+Use the SDK with Expo
+---------------------
+
+You can use the React Native SDK with a bare React Native app or Expo. This page
+and the React Native SDK documentation generally assume that you're using a bare
+React Native app and not Expo.
+
+If you want to use the React Native SDK with Expo, check out the :ref:`Bootstrap
+with Expo <react-native-client-bootstrap-with-expo>` page.
+
+Install the SDK in a Bare React Native App
+------------------------------------------
+
 Prerequisites
--------------
+~~~~~~~~~~~~~
 
 Before getting started, ensure your development environment
 meets the following prerequisites. These are required for the latest version
@@ -36,18 +49,8 @@ of the React Native SDK:
    :doc:`build your application when using Mac Catalyst
    </sdk/react-native/integrations/mac-catalyst>`.
 
-Use the SDK with Expo
-~~~~~~~~~~~~~~~~~~~~~
-
-You can use the React Native SDK with a bare React Native app or Expo. This page
-and the React Native SDK documentation generally assume that you're using a bare
-React Native app and not Expo.
-
-If you want to use the React Native SDK with Expo, check out the :ref:`Bootstrap 
-with Expo <react-native-client-bootstrap-with-expo>` page.
-
-Install the SDK in a Bare React Native App
-------------------------------------------
+Install the SDK
+~~~~~~~~~~~~~~~
 
 Select the tab below that corresponds to your React Native
 version. Follow the steps to create a React Native project
@@ -142,7 +145,7 @@ and add the React Native SDK to it.
 
             :npm:`@realm/react <package/@realm/react>` is an npm package that
             streamlines common SDK operations like querying, writing to a
-            database, and listening for object change notifications. This reduces 
+            database, and listening for object change notifications. This reduces
             boilerplate code, like creating your own listeners and state management.
 
             ``@realm/react`` provides access to the SDK through a set of providers
@@ -167,12 +170,12 @@ and add the React Native SDK to it.
       :tabid: rn-pre-v-60
 
       .. note:: @realm/react Version Requirement
-         
-         The :npm:`@realm/react <package/@realm/react>` library requires 
-         react-native version ``>= 0.59``. If you are developing using older 
-         versions of React Native, you can use the SDK without ``@realm/react``. 
-         Since the React Native SDK documentation makes heavy use of the 
-         ``@realm/react`` package, you may want to refer to the 
+
+         The :npm:`@realm/react <package/@realm/react>` library requires
+         react-native version ``>= 0.59``. If you are developing using older
+         versions of React Native, you can use the SDK without ``@realm/react``.
+         Since the React Native SDK documentation makes heavy use of the
+         ``@realm/react`` package, you may want to refer to the
          :ref:`Node.js SDK documentation <node-intro>`.
 
       .. procedure::
@@ -274,7 +277,7 @@ and add the React Native SDK to it.
             .. include:: /includes/react-native-run-the-app.rst
 
 Import the SDK
---------------
+~~~~~~~~~~~~~~
 
 Add the following line to the top of your source files where
 you want to use the SDK:
@@ -282,3 +285,57 @@ you want to use the SDK:
 .. code-block:: typescript
 
    import Realm from "realm";
+
+.. _react-native-apple-privacy-manifest:
+
+Apple Privacy Manifest
+----------------------
+
+.. versionadded:: 2.2.0
+
+Apple requires any apps or third-party SDKs that use *required reasons APIs*
+to provide a privacy manifest containing details about their data collection
+and use practices. The bundled manifest file must be included when submitting
+new apps or app updates to the Apple App Store. For more details about these
+requirements, refer to
+:apple:`Upcoming third-party SDK requirements <support/third-party-SDK-requirements/>`
+on the Apple Developer website.
+
+Starting in Flutter SDK version 2.2.0, the SDK ships with a privacy manifest for
+``iOS`` and ``macOS`` environments, contained in the ``realm`` package. Both
+privacy manifests contain Apple's required API disclosures and the reasons for
+using those APIs.
+
+You can view these privacy manifests in the SDK package or directly in the
+``realm-dart`` GitHub repository:
+
+- ``iOS``:
+  `https://github.com/realm/realm-dart/blob/main/packages/realm/ios/Resources/PrivacyInfo.xcprivacy
+  <https://github.com/realm/realm-dart/blob/main/packages/realm/ios/Resources/PrivacyInfo.xcprivacy>`__
+- ``macOS``:
+  `https://github.com/realm/realm-dart/blob/main/packages/realm/macos/Resources/PrivacyInfo.xcprivacy
+  <https://github.com/realm/realm-dart/blob/main/packages/realm/macos/Resources/PrivacyInfo.xcprivacy>`__
+
+The Flutter SDK does *not*:
+
+- Include analytics code in builds for the App Store.
+- Log into Atlas on its own behalf.
+
+.. important:: Additional Disclosures May Be Required for App Services
+
+   The Flutter SDK privacy manifest does *not* include disclosures for App
+   Services APIs.
+
+If your app uses any Atlas App Services functionality, such as user
+authentication or Device Sync, you may need to provide additional disclosures
+that detail your data collection and use practices when using these APIs.
+For example, if your app
+:ref:`initializes an App client <flutter-access-the-app-client>` to:
+
+- :ref:`Call an Atlas Function <flutter-call-function>`
+- :ref:`Authenticate and manage users <flutter-work-with-users>`
+- :ref:`Open a synced database <flutter-open-synced-realm>`
+
+For more information, refer to Apple's
+:apple:`Privacy Manifest Files <documentation/bundleresources/privacy_manifest_files>`
+documentation.

--- a/source/sdk/react-native/install.txt
+++ b/source/sdk/react-native/install.txt
@@ -16,21 +16,8 @@ and TypeScript languages. React Native enables you to build cross-platform
 iOS and Android apps with a single codebase using the
 `React <https://react.dev/>`__ framework.
 
-Use the SDK with Expo
----------------------
-
-You can use the React Native SDK with a bare React Native app or Expo. This page
-and the React Native SDK documentation generally assume that you're using a bare
-React Native app and not Expo.
-
-If you want to use the React Native SDK with Expo, check out the :ref:`Bootstrap
-with Expo <react-native-client-bootstrap-with-expo>` page.
-
-Install the SDK in a Bare React Native App
-------------------------------------------
-
 Prerequisites
-~~~~~~~~~~~~~
+-------------
 
 Before getting started, ensure your development environment
 meets the following prerequisites. These are required for the latest version
@@ -49,8 +36,18 @@ of the React Native SDK:
    :doc:`build your application when using Mac Catalyst
    </sdk/react-native/integrations/mac-catalyst>`.
 
-Install the SDK
-~~~~~~~~~~~~~~~
+Use the SDK with Expo
+~~~~~~~~~~~~~~~~~~~~~
+
+You can use the React Native SDK with a bare React Native app or Expo. This page
+and the React Native SDK documentation generally assume that you're using a bare
+React Native app and not Expo.
+
+If you want to use the React Native SDK with Expo, check out the :ref:`Bootstrap
+with Expo <react-native-client-bootstrap-with-expo>` page.
+
+Install the SDK in a Bare React Native App
+------------------------------------------
 
 Select the tab below that corresponds to your React Native
 version. Follow the steps to create a React Native project
@@ -277,7 +274,7 @@ and add the React Native SDK to it.
             .. include:: /includes/react-native-run-the-app.rst
 
 Import the SDK
-~~~~~~~~~~~~~~
+--------------
 
 Add the following line to the top of your source files where
 you want to use the SDK:
@@ -285,57 +282,3 @@ you want to use the SDK:
 .. code-block:: typescript
 
    import Realm from "realm";
-
-.. _react-native-apple-privacy-manifest:
-
-Apple Privacy Manifest
-----------------------
-
-.. versionadded:: 2.2.0
-
-Apple requires any apps or third-party SDKs that use *required reasons APIs*
-to provide a privacy manifest containing details about their data collection
-and use practices. The bundled manifest file must be included when submitting
-new apps or app updates to the Apple App Store. For more details about these
-requirements, refer to
-:apple:`Upcoming third-party SDK requirements <support/third-party-SDK-requirements/>`
-on the Apple Developer website.
-
-Starting in Flutter SDK version 2.2.0, the SDK ships with a privacy manifest for
-``iOS`` and ``macOS`` environments, contained in the ``realm`` package. Both
-privacy manifests contain Apple's required API disclosures and the reasons for
-using those APIs.
-
-You can view these privacy manifests in the SDK package or directly in the
-``realm-dart`` GitHub repository:
-
-- ``iOS``:
-  `https://github.com/realm/realm-dart/blob/main/packages/realm/ios/Resources/PrivacyInfo.xcprivacy
-  <https://github.com/realm/realm-dart/blob/main/packages/realm/ios/Resources/PrivacyInfo.xcprivacy>`__
-- ``macOS``:
-  `https://github.com/realm/realm-dart/blob/main/packages/realm/macos/Resources/PrivacyInfo.xcprivacy
-  <https://github.com/realm/realm-dart/blob/main/packages/realm/macos/Resources/PrivacyInfo.xcprivacy>`__
-
-The Flutter SDK does *not*:
-
-- Include analytics code in builds for the App Store.
-- Log into Atlas on its own behalf.
-
-.. important:: Additional Disclosures May Be Required for App Services
-
-   The Flutter SDK privacy manifest does *not* include disclosures for App
-   Services APIs.
-
-If your app uses any Atlas App Services functionality, such as user
-authentication or Device Sync, you may need to provide additional disclosures
-that detail your data collection and use practices when using these APIs.
-For example, if your app
-:ref:`initializes an App client <flutter-access-the-app-client>` to:
-
-- :ref:`Call an Atlas Function <flutter-call-function>`
-- :ref:`Authenticate and manage users <flutter-work-with-users>`
-- :ref:`Open a synced database <flutter-open-synced-realm>`
-
-For more information, refer to Apple's
-:apple:`Privacy Manifest Files <documentation/bundleresources/privacy_manifest_files>`
-documentation.

--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -4,8 +4,8 @@
 Install the SDK for iOS, macOS, tvOS, and watchOS
 =================================================
 
-.. meta:: 
-   :description: Install Atlas Device SDK for Swift using popular package managers, or as a static framework. 
+.. meta::
+   :description: Install Atlas Device SDK for Swift using popular package managers, or as a static framework.
 
 .. facet::
   :name: genre
@@ -21,7 +21,7 @@ Overview
 --------
 
 Atlas Device SDK for Swift enables you to build iOS, macOS, tvOS,
-and watchOS applications using either the Swift or Objective-C programming 
+and watchOS applications using either the Swift or Objective-C programming
 languages. This page details how to install the SDK in your project and get
 started.
 
@@ -33,10 +33,10 @@ meets the following prerequisites:
 
 - Your project uses an Xcode version and minimum OS version listed in the
   :ref:`swift-os-support` section of this page.
-- Reflection is enabled in your project. The Swift SDK uses reflection to 
-  determine your model's properties. Your project must not set 
-  ``SWIFT_REFLECTION_METADATA_LEVEL = none``, or the SDK cannot see properties 
-  in your model. Reflection is enabled by default if your project does 
+- Reflection is enabled in your project. The Swift SDK uses reflection to
+  determine your model's properties. Your project must not set
+  ``SWIFT_REFLECTION_METADATA_LEVEL = none``, or the SDK cannot see properties
+  in your model. Reflection is enabled by default if your project does
   not specifically set a level for this setting.
 
 Installation
@@ -90,14 +90,14 @@ Swift SDK to your project.
 
             To use the Privacy Manifest supplied by the SDK, build ``RealmSwift``
             as a dynamic framework. If you build ``RealmSwift`` as a static
-            framework, you must supply your own Privacy Manifest. 
-            
+            framework, you must supply your own Privacy Manifest.
+
             To build ``RealmSwift`` as a dynamic framework:
 
             1. In your project :guilabel:`Targets`, select your build target.
             2. Go to the :guilabel:`General` tab.
             3. Expand the :guilabel:`Frameworks and Libraries` element.
-            4. For the ``RealmSwift`` framework, change the 
+            4. For the ``RealmSwift`` framework, change the
                :guilabel:`Embed` option from "Do Not Embed" to "Embed & Sign."
 
             Now, Xcode builds ``RealmSwift`` dynamically, and can provide the
@@ -283,15 +283,15 @@ Swift SDK to your project.
             target and go to the :guilabel:`Build Phases` tab. Under
             :guilabel:`Link Binary with Libraries`, click :guilabel:`+` and add
             ``libc++.tbd``, ``libz.tbd``, and ``libcompression.tbd``.
-       
+
       .. tip::
-      
-         If using the Objective-C API within a Swift project, we 
-         recommend you include both Realm Swift and Realm Objective-C in your 
-         project. Within your Swift files, you can access the Swift API and 
-         all required wrappers. Using the RealmSwift API in mixed 
-         Swift/Objective-C projects is possible because the vast majority of 
-         RealmSwift types are directly aliased from their Objective-C 
+
+         If using the Objective-C API within a Swift project, we
+         recommend you include both Realm Swift and Realm Objective-C in your
+         project. Within your Swift files, you can access the Swift API and
+         all required wrappers. Using the RealmSwift API in mixed
+         Swift/Objective-C projects is possible because the vast majority of
+         RealmSwift types are directly aliased from their Objective-C
          counterparts.
 
 Import the SDK
@@ -323,17 +323,17 @@ Add the following line at the top of your source files to use the SDK:
 App Download File Size
 ----------------------
 
-The SDK should only add around 5 to 8 MB to your app's download 
-size. The releases we distribute are significantly larger because they 
-include support for the iOS, watchOS and tvOS simulators, some debug symbols, 
-and bitcode, all of which are stripped by the App Store automatically when 
+The SDK should only add around 5 to 8 MB to your app's download
+size. The releases we distribute are significantly larger because they
+include support for the iOS, watchOS and tvOS simulators, some debug symbols,
+and bitcode, all of which are stripped by the App Store automatically when
 apps are downloaded.
 
 Troubleshooting
 ---------------
 
-If you have build issues after using one of these methods to install 
-the SDK, see :ref:`our troubleshooting guidelines <ios-resolve-build-issues>` 
+If you have build issues after using one of these methods to install
+the SDK, see :ref:`our troubleshooting guidelines <ios-resolve-build-issues>`
 for information about resolving those issues.
 
 .. _swift-os-support:
@@ -375,7 +375,7 @@ Xcode 15
 
    * - watchOS 4.0+
      - X
-     - 
+     -
 
    * - visionOS 1.0+
      - X
@@ -397,7 +397,7 @@ Swift Concurrency Support
 -------------------------
 
 The Swift SDK supports Swift's concurrency-related language features.
-For best practices on using the Swift SDK's concurrency features, refer 
+For best practices on using the Swift SDK's concurrency features, refer
 to the documentation below.
 
 Async/Await Support
@@ -422,9 +422,10 @@ Apple Privacy Manifest
 .. versionchanged:: 10.49.3
    Build RealmSwift as a dynamic framework to include the Privacy Manifest.
 
-Apple requires apps that use ``RealmSwift`` to provide details about the SDK's
-data collection and use practices when submitting new apps or app updates to 
-the App Store. For more details about Apple's requirements, refer to 
+Apple requires apps that use ``RealmSwift`` to provide a privacy manifest
+containing details about the SDK's data collection and use practices. The
+bundled manifest file must be included when submitting new apps or app updates
+to the App Store. For more details about Apple's requirements, refer to
 :apple:`Upcoming third-party SDK requirements <support/third-party-SDK-requirements/>`
 on the Apple Developer website.
 
@@ -432,7 +433,7 @@ Starting in Swift SDK version 10.46.0, the SDK ships with privacy manifests
 for ``Realm`` and ``RealmSwift``. Each package contains its own privacy manifest
 with Apple's required API disclosures and the reasons for using those APIs.
 
-You can view the privacy manifests in each package, or in the ``realm-swift`` 
+You can view the privacy manifests in each package, or in the ``realm-swift``
 GitHub repository:
 
 - ``Realm``: `https://github.com/realm/realm-swift/blob/master/Realm/PrivacyInfo.xcprivacy <https://github.com/realm/realm-swift/blob/master/Realm/PrivacyInfo.xcprivacy>`_
@@ -440,13 +441,13 @@ GitHub repository:
 
 To include these manifests in a build target that uses ``RealmSwift``, you must
 build ``RealmSwift`` as a dynamic framework. For details, refer to the Swift
-Package Manager Installation instructions step 
+Package Manager Installation instructions step
 **(Optional) Build RealmSwift as a Dynamic Framework**.
 
-The Swift SDK does not include analytics code in builds for the App Store. 
-The SDK does not log into Atlas on its own behalf. 
+The Swift SDK does not include analytics code in builds for the App Store.
+The SDK does not log into Atlas on its own behalf.
 
-If you write an app that uses any App Services functionality, such as 
+If you write an app that uses any App Services functionality, such as
 :ref:`initializing an App client <ios-init-appclient>` to:
 
 - :ref:`Call an Atlas Function <ios-call-a-function>`
@@ -454,8 +455,8 @@ If you write an app that uses any App Services functionality, such as
 - :ref:`Query MongoDB Atlas <ios-mongodb-remote-access>`
 - :ref:`Open a synced database <ios-configure-and-open-a-synced-realm>`
 
-You may need to add additional disclosures to your app's privacy manifest 
-detailing your data collection and use practices when using these APIs. 
+You may need to add additional disclosures to your app's privacy manifest
+detailing your data collection and use practices when using these APIs.
 
-For more information, refer to Apple's 
+For more information, refer to Apple's
 :apple:`Privacy manifest files documentation <documentation/bundleresources/privacy_manifest_files>`.


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-39270

- [Install - Flutter SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-39270-dart-privacy-manifest/sdk/flutter/install/): Add "Apple Privacy Manifest" section; reformat page to use tabs
- [Telemetry - Flutter SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/docsp-39270-dart-privacy-manifest/sdk/flutter/telemetry/): Add "Apple Privacy Manifest" section

### Reminder Checklist

Before merging your PR, make sure to check a few things.

- [x] Did you tag pages appropriately?
  - genre
  - meta.keywords
  - meta.description
- [x] Describe your PR's changes in the Release Notes section
- [x] Create a Jira ticket for related docs-app-services work, if any

### Release Notes

- **Flutter** SDK
  - Install: Add new "Apple Privacy Manifest" section with information on the manifest included with SDK v2.2.0.
  - SDK Telemetry: Add new "Apple Privacy Manifest" section to clarify the SDK does not collect telemetry on builds for the App Store.

### Review Guidelines

[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
