### PR TITLE
Update PR template for the docs consolidation project

### DIFF
--- a/.github/pull_request_template-base.md
+++ b/.github/pull_request_template-base.md
@@ -1,0 +1,26 @@
+## Pull Request Info
+
+Jira ticket: https://jira.mongodb.org/browse/DOCSP-NNNNN
+
+### Staged Pages
+
+- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/BRANCH_NAME/): description of changes
+
+### Reminder Checklist
+
+Before merging your PR, did you:
+
+- [ ] Describe your PR's changes in the Release Notes section
+- [ ] Create a Jira ticket for related docs-app-services work, if any
+
+### Release Notes
+
+<!--
+- **Kotlin** SDK
+  - Realm/Manage Realm Files/Encrypt a Realm: Add information on encryption for
+    local and synced realms.
+-->
+
+### Review Guidelines
+
+[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@ Add links to every SDK's pages where you got the SDK-specific information:
 
 Before requesting a review for your PR, please check these items:
 
+- [ ] Did you open the PR against the `feature-consolidated-sdk-docs` branch instead of master? 
 - [ ] Did you tag pages appropriately?
   - genre
   - meta.keywords

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,19 +17,26 @@ Add links to every SDK's pages where you got the SDK-specific information:
 Before requesting a review for your PR, please check these items:
 
 - [ ] Did you open the PR against the `feature-consolidated-sdk-docs` branch instead of master? 
-- [ ] Did you tag pages appropriately?
+- [ ] Did you tag the consolidated appropriately?
   - genre
   - meta.keywords
   - meta.description
+
+#### Naming
 - [ ] Did you update Realm naming and the language around persistence layer/local/device per [this document](https://docs.google.com/document/d/126OczVxBWAwZ4P5ZsSM29WI3REvONEr1ald-mAwPtyQ/edit?usp=sharing)?
-- [ ] Have you created new consolidated SDK ref targets starting with "_sdks-" for relevant sections on the page?
+- [ ] Do all new include `.rst` files comply with [the naming guidelines](https://docs.google.com/document/d/1h8cr66zoEVeXytVfvDxlCSsUS5IZwvUQvfSCEXNMpek/edit#heading=h.ulh8b5f2hu9)?
+
+#### Links and Refs
+- [ ] Did you create new consolidated SDK ref targets starting with "_sdks-" for relevant sections on the page?
 - [ ] Did you remove or update any SDK-specific refs to use the new consolidated SDK ref targets?
 - [ ] Did you [update any Kotlin API links](https://jira.mongodb.org/browse/DOCSP-32519) to use the new Kotlin SDK roles?
+
+#### Content
 - [ ] Does every shared code box have snippets or placeholders for all 9 languages?
 - [ ] Does every API description section have API details or a generic placeholder for all 9 languages?
 - [ ] Have you checked related pages for any relevant content we should include on the consolidated page?
-- [ ] Do all new include files comply with [the naming guidelines](https://docs.google.com/document/d/1h8cr66zoEVeXytVfvDxlCSsUS5IZwvUQvfSCEXNMpek/edit#heading=h.ulh8b5f2hu9)?
-- [ ] Did you add tickets to the relevant SDK: Consolidation Gaps epic to add missing code examples?
+- [ ] If there were any missing code examples, did you create a ticket in the relevant SDK: Consolidation Gaps epic?
+
 
 ### Reviewer Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,33 +16,32 @@ Add links to every SDK's pages where you got the SDK-specific information:
 
 Before requesting a review for your PR, please check these items:
 
-- [ ] Did you open the PR against the `feature-consolidated-sdk-docs` branch instead of master? 
-- [ ] Did you tag the consolidated appropriately?
+- [ ] Open the PR against the `feature-consolidated-sdk-docs` branch instead of `master`
+- [ ] Tag the consolidated page for:
   - genre
   - meta.keywords
   - meta.description
 
 #### Naming
-- [ ] Did you update Realm naming and the language around persistence layer/local/device per [this document](https://docs.google.com/document/d/126OczVxBWAwZ4P5ZsSM29WI3REvONEr1ald-mAwPtyQ/edit?usp=sharing)?
-- [ ] Do all new include `.rst` files comply with [the naming guidelines](https://docs.google.com/document/d/1h8cr66zoEVeXytVfvDxlCSsUS5IZwvUQvfSCEXNMpek/edit#heading=h.ulh8b5f2hu9)?
+- [ ] Update Realm naming and the language around persistence layer/local/device per [this document](https://docs.google.com/document/d/126OczVxBWAwZ4P5ZsSM29WI3REvONEr1ald-mAwPtyQ/edit?usp=sharing)
+- [ ] Include `.rst` files comply with [the naming guidelines](https://docs.google.com/document/d/1h8cr66zoEVeXytVfvDxlCSsUS5IZwvUQvfSCEXNMpek/edit#heading=h.ulh8b5f2hu9)
 
 #### Links and Refs
-- [ ] Did you create new consolidated SDK ref targets starting with "_sdks-" for relevant sections on the page?
-- [ ] Did you remove or update any SDK-specific refs to use the new consolidated SDK ref targets?
-- [ ] Did you [update any Kotlin API links](https://jira.mongodb.org/browse/DOCSP-32519) to use the new Kotlin SDK roles?
+- [ ] Create new consolidated SDK ref targets starting with "_sdks-" for relevant sections
+- [ ] Remove or update any SDK-specific refs to use the new consolidated SDK ref targets
+- [ ] [Update any Kotlin API links](https://jira.mongodb.org/browse/DOCSP-32519) to use the new Kotlin SDK roles
 
 #### Content
-- [ ] Does every shared code box have snippets or placeholders for all 9 languages?
-- [ ] Does every API description section have API details or a generic placeholder for all 9 languages?
-- [ ] Have you checked related pages for any relevant content we should include on the consolidated page?
-- [ ] If there were any missing code examples, did you create a ticket in the relevant SDK: Consolidation Gaps epic?
-
+- [ ] Shared code boxes have snippets or placeholders for all 9 languages
+- [ ] API description sections have API details or a generic placeholder for all 9 languages
+- [ ] Check related pages for relevant content to include
+- [ ] Create a ticket for missing examples in each relevant SDK: Consolidation Gaps epic
 
 ### Reviewer Checklist
 
 As a reviewer, please check these items:
 
-- [ ] Do all of the shared code example boxes contain language-specific snippets or placeholders for every language?
-- [ ] Do all API reference details contain working API reference links or generic content?
-- [ ] Has all of the Realm naming/language been updated?
-- [ ] Is all relevant content from the individual SDK pages present on the consolidated page?
+- [ ] Shared code example boxes contain language-specific snippets or placeholders for every language
+- [ ] API reference details contain working API reference links or generic content
+- [ ] Realm naming/language has been updated
+- [ ] All relevant content from individual SDK pages is present on the consolidated page

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,40 @@
-## Pull Request Info
+## Pull Request Info - SDK Docs Consolidation
 
 Jira ticket: https://jira.mongodb.org/browse/DOCSP-NNNNN
 
-- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/BRANCH_NAME/): description of changes
+*Staged Page*
 
-### Reminder Checklist
+- [PAGE_NAME](https://docs-mongodbcom-staging.corp.mongodb.com/realm/docsworker-xlarge/BRANCH_NAME/)
 
-Before merging your PR, make sure to check a few things.
+*Page Source*
+
+Add links to every SDK's pages where you got the SDK-specific information:
+
+- [PAGE_NAME](https://www.mongodb.com/docs/atlas/device-sdks/LIVE-DOCS-LINK)
+
+### PR Author Checklist
+
+Before requesting a review for your PR, please check these items:
 
 - [ ] Did you tag pages appropriately?
   - genre
   - meta.keywords
   - meta.description
-- [ ] Describe your PR's changes in the Release Notes section
-- [ ] Create a Jira ticket for related docs-app-services work, if any
+- [ ] Did you update Realm naming and the language around persistence layer/local/device per [this document](https://docs.google.com/document/d/126OczVxBWAwZ4P5ZsSM29WI3REvONEr1ald-mAwPtyQ/edit?usp=sharing)?
+- [ ] Have you created new consolidated SDK ref targets starting with "_sdks-" for relevant sections on the page?
+- [ ] Did you remove or update any SDK-specific refs to use the new consolidated SDK ref targets?
+- [ ] Did you [update any Kotlin API links](https://jira.mongodb.org/browse/DOCSP-32519) to use the new Kotlin SDK roles?
+- [ ] Does every shared code box have snippets or placeholders for all 9 languages?
+- [ ] Does every API description section have API details or a generic placeholder for all 9 languages?
+- [ ] Have you checked related pages for any relevant content we should include on the consolidated page?
+- [ ] Do all new include files comply with [the naming guidelines](https://docs.google.com/document/d/1h8cr66zoEVeXytVfvDxlCSsUS5IZwvUQvfSCEXNMpek/edit#heading=h.ulh8b5f2hu9)?
+- [ ] Did you add tickets to the relevant SDK: Consolidation Gaps epic to add missing code examples?
 
-### Release Notes
+### Reviewer Checklist
 
-<!--
-- **Kotlin** SDK
-  - Realm/Manage Realm Files/Encrypt a Realm: Add information on encryption for
-    local and synced realms.
--->
+As a reviewer, please check these items:
 
-### Review Guidelines
-
-[REVIEWING.md](https://github.com/mongodb/docs-realm/blob/master/REVIEWING.md)
+- [ ] Do all of the shared code example boxes contain language-specific snippets or placeholders for every language?
+- [ ] Do all API reference details contain working API reference links or generic content?
+- [ ] Has all of the Realm naming/language been updated?
+- [ ] Is all relevant content from the individual SDK pages present on the consolidated page?


### PR DESCRIPTION
## Pull Request Info

This PR updates the PR template to add consolidation-specific checklists for the PR author and reviewer.

I've renamed the existing template to `pull_request_template-base.md` to preserve it in the repo, so we can easily switch back to it after the consolidation project is complete.
