### PR TITLE
Add C++ template app and tutorial to SDK docs

### DIFF
--- a/source/example-projects.txt
+++ b/source/example-projects.txt
@@ -38,7 +38,8 @@ Learn about the core features of the Atlas Device SDKs with Atlas Device Sync an
     - A todo list mobile app that syncs data with App Services using Device Sync. See
       the App Services :ref:`Getting Started page <app-services-get-started>` for more information 
       and detailed tutorials.  
-    - - `Flutter <https://github.com/mongodb/template-app-dart-flutter-todo>`__
+    - - `C++ <https://github.com/mongodb/template-app-cpp-todo>`__
+      - `Flutter <https://github.com/mongodb/template-app-dart-flutter-todo>`__
       - `Kotlin <https://github.com/mongodb/template-app-kotlin-todo>`__
       - `.NET <https://github.com/mongodb/template-app-maui-todo>`__
       - `React Native <https://github.com/mongodb/template-app-react-native-todo>`__

--- a/source/sdk/cpp.txt
+++ b/source/sdk/cpp.txt
@@ -34,6 +34,45 @@ Atlas Device SDK for C++
 Use Atlas Device SDK for C++ to write applications that access data
 stored locally on devices and sync data with Atlas.
 
+.. kicker:: Learning Paths
+
+Get Started with the C++ SDK
+-----------------------------
+
+.. card-group::
+   :columns: 3
+   :style: extra-compact
+
+   .. card::
+      :headline: Quick Start
+      :cta: See Code Examples
+      :url: https://www.mongodb.com/docs/realm/sdk/cpp/quick-start/
+      :icon: /images/icons/branding_2022/Technical_ATLAS_Functions3x.png
+      :icon-alt: Functions Icon
+
+      Minimal-explanation code examples of how to work with the C++ SDK.
+      Write to the device database, and sync with other devices.
+
+   .. card::
+      :headline: Working Example App
+      :cta: Explore an Example App
+      :url: https://www.mongodb.com/docs/atlas/app-services/template-apps/
+      :icon: /images/icons/branding_2022/Technical_REALM_Mobile3x.png
+      :icon-alt: Atlas Device SDK Mobile Icon
+
+      Learn from example by dissecting a working terminal GUI client app that
+      uses the C++ SDK.
+
+   .. card::
+      :headline: Guided Tutorial
+      :cta: Follow the Tutorial
+      :url: https://mongodb.com/docs/atlas/app-services/tutorial/cpp/
+      :icon: /images/icons/branding_2022/General_CONTENT_Tutorial3x.png
+      :icon-alt: Tutorial Icon
+
+      Follow a guided tutorial to learn how to adapt the example app to
+      create your own working app.
+
 .. kicker:: What You Can Do
 
 Develop Apps with the SDK

--- a/source/sdk/cpp.txt
+++ b/source/sdk/cpp.txt
@@ -50,8 +50,8 @@ Get Started with the C++ SDK
       :icon: /images/icons/branding_2022/Technical_ATLAS_Functions3x.png
       :icon-alt: Functions Icon
 
-      Minimal-explanation code examples of how to work with the C++ SDK.
-      Write to the device database, and sync with other devices.
+      Minimal-explanation code examples of how to work with the C++ SDK,
+      write to the device database, and sync with other devices.
 
    .. card::
       :headline: Working Example App
@@ -60,7 +60,7 @@ Get Started with the C++ SDK
       :icon: /images/icons/branding_2022/Technical_REALM_Mobile3x.png
       :icon-alt: Atlas Device SDK Mobile Icon
 
-      Learn from example by dissecting a working terminal GUI client app that
+      Learn from a working terminal GUI client app that
       uses the C++ SDK.
 
    .. card::


### PR DESCRIPTION
## Pull Request Info - SDK Docs Consolidation

*Staged Pages*

- [C++ Landing Page](https://preview-mongodbdacharyc.gatsbyjs.io/realm/add-cpp-template-app/sdk/cpp/): Add "Learning Paths" section with links to the C++ quick start, template app, and tutorial, similar to the other SDKs.
- [Example Projects](https://preview-mongodbdacharyc.gatsbyjs.io/realm/add-cpp-template-app/example-projects/): Add C++ to the list of SDK example apps.

### Release Notes

- C++ SDK
  - Landing Page: Add "Learning Paths" section with links to the C++ quick start, template app, and tutorial.

- Example Projects: Add the C++ template app to the SDK template app list.
