### PR TITLE
Update Swift test suite to 10.50.1

### DIFF
--- a/examples/ios/Examples/RealmApp.swift
+++ b/examples/ios/Examples/RealmApp.swift
@@ -109,11 +109,17 @@ class RealmAppTest: XCTestCase {
             let configuration = AppConfiguration(baseURL: "http://localhost:80")
             let edgeApp = App(id: EDGE_SERVER_APP_ID, configuration: configuration)
             
+            // You can check the `baseURL` of an app to define app logic.
+            if edgeApp.baseURL == "http://localhost:80" {
+                print("Client app is currently connected to a local Edge Server instance")
+            }
+            XCTAssertEqual(edgeApp.baseURL, "http://localhost:80") // :remove:
             // ... log in a user and use the app...
             // ... some time later...
             
             try await edgeApp.updateBaseUrl(to: "https://services.cloud.mongodb.com")
             // :snippet-end:
+            XCTAssertEqual(edgeApp.baseURL, "https://services.cloud.mongodb.com")
             let user = try await edgeApp.login(credentials: Credentials.anonymous)
             XCTAssertNotNil(user)
             XCTAssert(user.isLoggedIn)

--- a/examples/ios/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/RealmExamples.xcodeproj/project.pbxproj
@@ -1499,8 +1499,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
-				kind = exactVersion;
-				version = 10.49.3;
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.50.1;
 			};
 		};
 		917CA79427ECADC200F9BDDC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {

--- a/source/examples/generated/code/start/RealmApp.snippet.change-base-url.swift
+++ b/source/examples/generated/code/start/RealmApp.snippet.change-base-url.swift
@@ -1,9 +1,13 @@
 // Specify a baseURL to connect to a server other than the default.
 // In this case, an Edge Server instance running on the device.
 let configuration = AppConfiguration(baseURL: "http://localhost:80")
-let app = App(id: YOUR_APP_SERVICES_APP_ID, configuration: configuration)
+let edgeApp = App(id: EDGE_SERVER_APP_ID, configuration: configuration)
 
+// You can check the `baseURL` of an app to define app logic.
+if edgeApp.baseURL == "http://localhost:80" {
+    print("Client app is currently connected to a local Edge Server instance")
+}
 // ... log in a user and use the app...
 // ... some time later...
 
-try await app.updateBaseUrl(to: "https://services.cloud.mongodb.com")
+try await edgeApp.updateBaseUrl(to: "https://services.cloud.mongodb.com")

--- a/source/examples/generated/code/start/RealmApp.snippet.custom-base-url.swift
+++ b/source/examples/generated/code/start/RealmApp.snippet.custom-base-url.swift
@@ -2,4 +2,4 @@
 // In this case, an Edge Server instance running on the device.
 let configuration = AppConfiguration(baseURL: "http://localhost:80")
 
-let app = App(id: EDGE_SERVER_APP_ID, configuration: configuration)
+let edgeApp = App(id: EDGE_SERVER_APP_ID, configuration: configuration)


### PR DESCRIPTION
Fixes broken `baseURL` and SwiftUI property wrapper behavior.