### PR TITLE
Update Node Version to 18.x for Bluehawk

### DIFF
--- a/.github/workflows/bluehawk.yml
+++ b/.github/workflows/bluehawk.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 18.x
       - run: npx bluehawk check -i "*.md" -i "*.properties" -i "*.lock" examples tutorial


### PR DESCRIPTION
## Pull Request Info - SDK Docs Consolidation

Current Node version on 15.x. Need to update Node Version to 18.x for Bluehawk compatibility. 

