### PR TITLE
(DOCSP-40014): Update Swift 'static' framework install instructions

### DIFF
--- a/source/sdk/swift/install.txt
+++ b/source/sdk/swift/install.txt
@@ -253,11 +253,8 @@ Swift SDK to your project.
                :alt: Drag the xcframework files into the Xcode project.
                :lightbox:
 
-   .. tab:: Static Framework
-      :tabid: static-framework
-
-      Installing the the Swift SDK as a static framework is only available
-      for iOS targets.
+   .. tab:: Dynamic Framework
+      :tabid: dynamic-framework
 
       .. procedure::
 
@@ -267,22 +264,11 @@ Swift SDK to your project.
             Download the `latest release of the Swift SDK
             <https://github.com/realm/realm-swift/releases>`__ and extract the zip.
 
-
          .. step:: Copy Framework(s) Into Your Project
-
 
             Drag ``Realm.xcframework`` and ``RealmSwift.xcframework`` (if using)
             to the File Navigator of your Xcode project. Select the
             :guilabel:`Copy items if needed` checkbox and press :guilabel:`Finish`.
-
-
-         .. step:: Link Binaries
-
-
-            Select your project in the Xcode File Navigator. Select your app's
-            target and go to the :guilabel:`Build Phases` tab. Under
-            :guilabel:`Link Binary with Libraries`, click :guilabel:`+` and add
-            ``libc++.tbd``, ``libz.tbd``, and ``libcompression.tbd``.
 
       .. tip::
 


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOCSP-40014

*Staged Page*

- [Install - Swift SDK](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-40014/sdk/swift/install/): Remove outdated information. Rename "Static Framework" install instructions to "Dynamic Framework."

## Release Notes

- Swift SDK
  - Install: Remove outdated information. Rename "Static Framework" install instructions to "Dynamic Framework."
