### PR TITLE
DOCSP-40510 Add edge server template app to ex projects

### DIFF
--- a/source/example-projects.txt
+++ b/source/example-projects.txt
@@ -35,9 +35,9 @@ Learn about the core features of the Atlas Device SDKs with Atlas Device Sync an
     - Source Code for Available SDKs
 
   * - Template Apps
-    - A todo list mobile app that syncs data with App Services using Device Sync. See
-      the App Services :ref:`Getting Started page <app-services-get-started>` for more information 
-      and detailed tutorials.  
+    - A todo list mobile app that syncs data with App Services using Device Sync or Edge Server with 
+      the Node.js Driver. See the App Services :ref:`Tutorials page <app-services-get-started>`
+      for more information and detailed tutorials.  
     - - `C++ <https://github.com/mongodb/template-app-cpp-todo>`__
       - `Edge Server with Node.js Driver <https://github.com/mongodb/template-app-edge-server>`__ 
       - `Flutter <https://github.com/mongodb/template-app-dart-flutter-todo>`__

--- a/source/example-projects.txt
+++ b/source/example-projects.txt
@@ -39,6 +39,7 @@ Learn about the core features of the Atlas Device SDKs with Atlas Device Sync an
       the App Services :ref:`Getting Started page <app-services-get-started>` for more information 
       and detailed tutorials.  
     - - `C++ <https://github.com/mongodb/template-app-cpp-todo>`__
+      - `Edge Server with Node.js Driver <https://github.com/mongodb/template-app-edge-server>`__ 
       - `Flutter <https://github.com/mongodb/template-app-dart-flutter-todo>`__
       - `Kotlin <https://github.com/mongodb/template-app-kotlin-todo>`__
       - `.NET <https://github.com/mongodb/template-app-maui-todo>`__


### PR DESCRIPTION
## Pull Request Info - SDK Docs Consolidation

Jira ticket: https://jira.mongodb.org/browse/DOCSP-40510

*Staged Page*

- [Example Projects](https://preview-mongodblindseymoore.gatsbyjs.io/realm/DOCSP-40510/example-projects/)

### Reviewer Checklist

As a reviewer, please check these items:

- [ ] Shared code example boxes contain language-specific snippets or placeholders for every language
- [ ] API reference details contain working API reference links or generic content
- [ ] Realm naming/language has been updated
- [ ] All relevant content from individual SDK pages is present on the consolidated page

### Release Notes

- Example Projects: Add Edge Server template app to page under Template Apps entry. 
