### PR TITLE
Fix incorrect Swift version number for Collections in Mixed feature

### DIFF
--- a/source/sdk/node/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/node/model-data/define-a-realm-object-model.txt
@@ -419,7 +419,7 @@ To learn more about Data Ingest, read :ref:`Optimize Sync with Data Ingest <opti
 .. _node-model-unstructured-data:
 
 Define Unstructured Data
------------------------
+------------------------
 
 .. versionadded:: 12.9.0
 

--- a/source/sdk/react-native/model-data/data-types/mixed.txt
+++ b/source/sdk/react-native/model-data/data-types/mixed.txt
@@ -52,7 +52,7 @@ To :ref:`set a property of your object model
 Collections as Mixed
 ~~~~~~~~~~~~~~~~~~~~
 
-In version ``realm@12.9.0`` and later, a mixed data type can hold collections (a list or
+In JS SDK v12.9.0 and later, a mixed data type can hold collections (a list or
 dictionary, but *not* a set) of mixed elements. You can use mixed collections to
 model unstructured or variable data. For more information, refer to
 :ref:`<react-native-model-unstructured-data>`.

--- a/source/sdk/react-native/model-data/define-a-realm-object-model.txt
+++ b/source/sdk/react-native/model-data/define-a-realm-object-model.txt
@@ -299,11 +299,11 @@ To learn more about Data Ingest, read :ref:`Stream Data to Atlas <react-native-s
 .. _react-native-model-unstructured-data:
 
 Define Unstructured Data
------------------------
+------------------------
 
 .. versionadded:: ``realm@12.9.0``
 
-Starting in SDK version 12.9.0, you can store :ref:`collections of mixed data <react-native-nested-collections-mixed>`
+Starting in JS SDK version 12.9.0, you can store :ref:`collections of mixed data <react-native-nested-collections-mixed>`
 within a ``mixed`` property. You can use this feature to model complex data
 structures, such as JSON or MongoDB documents, without having to define a
 strict data model.

--- a/source/sdk/swift/model-data/object-models.txt
+++ b/source/sdk/swift/model-data/object-models.txt
@@ -547,11 +547,11 @@ For more information, see: :ref:`Create an Asymmetric Object
 .. _ios-model-unstructured-data:
 
 Define Unstructured Data
------------------------
+------------------------
 
-.. versionadded:: 10.15.0
+.. versionadded:: 10.51.0
 
-Starting in SDK version 10.15.0, you can store :ref:`collections of mixed data <ios-nested-collections-realmanyvalue>`
+Starting in SDK version 10.51.0, you can store :ref:`collections of mixed data <ios-nested-collections-realmanyvalue>`
 within a ``AnyRealmValue`` property. You can use this feature to model complex data
 structures, such as JSON or MongoDB documents, without having to define a
 strict data model.

--- a/source/sdk/swift/model-data/supported-types.txt
+++ b/source/sdk/swift/model-data/supported-types.txt
@@ -731,7 +731,7 @@ You can declare a Map as a property of an object:
 AnyRealmValue
 ~~~~~~~~~~~~~
 
-.. versionchanged:: 10.15.0
+.. versionchanged:: 10.51.0
 
    ``AnyRealmValue`` properties can hold lists or maps of mixed data.
 
@@ -776,7 +776,7 @@ permitted value, you can't declare an ``AnyRealmValue`` as optional.
 Collections as Mixed
 ````````````````````
 
-In version 10.15.0 and later, a ``AnyRealmValue`` data type can
+In version 10.51.0 and later, a ``AnyRealmValue`` data type can
 contain collections (a list or map, but *not* a set) of ``AnyRealmValue``
 elements. You can use mixed collections to
 model unstructured or variable data. For more information, refer to


### PR DESCRIPTION
Quick fix: 
Correct version number for Collections in Mixed feature release (should be `10.51.0` instead of `10.15.0`) 

- [Supported Types - Swift SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/no-jira-fix-version-number/sdk/swift/model-data/supported-types/#anyrealmvalue)
- [Define an Object Model- Swift SDK](https://preview-mongodbcbullinger.gatsbyjs.io/realm/no-jira-fix-version-number/sdk/swift/model-data/object-models/#define-unstructured-data)

### Release Notes

**Swift SDK**
- Model Data > Define an Object Model: Correct the SDK version number specified for "Model Unstructured Data" section.
- Model Data > Supported Types: Correct the SDK version number specified for "RealmAny" section.