### PR TITLE
(DOCSP-42045): Fix wrong C++ tab ID

### DIFF
--- a/source/help.txt
+++ b/source/help.txt
@@ -4,16 +4,33 @@
 Get Help
 ========
 
+.. meta::
+   :description: Get help for Atlas Device SDK through community forums, sharing feedback, or professional support.
+   :keywords: Realm, C++ SDK, Flutter SDK, Kotlin SDK, Java SDK, .NET SDK, Node.js SDK, Swift SDK
+
+.. facet::
+  :name: genre
+  :values: reference
+
+.. facet::
+   :name: programming_language
+   :values: cpp, csharp, dart, java, javascript/typescript, kotlin, objective-c, swift
+
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
-Overview
---------
+.. tabs-selector:: drivers
 
-MongoDB provides various resources for getting help with Atlas App Services.
+MongoDB provides various resources for getting help with Atlas Device SDK and
+Atlas App Services.
+
+.. tip:: Atlas Device SDK and Realm
+
+   While the SDK has been renamed to Atlas Device SDK, some resources still
+   reflect ``Realm`` naming.
 
 Professional Support
 --------------------
@@ -35,9 +52,9 @@ Community Forums
 The official `MongoDB Community Forums
 <https://www.mongodb.com/community/forums/c/realm/9>`__ are a great
 place to meet other developers, ask and answer questions, and stay
-up-to-date with the latest Realm and App Services features and releases. You can also
-interact with MongoDB employees, like our community team, engineers, and
-product managers, who are active forum contributors.
+up-to-date with the latest Atlas Device SDK and App Services features and
+releases. You can also interact with MongoDB employees, like our community
+team, engineers, and product managers, who are active forum contributors.
 
 Stack Overflow
 --------------
@@ -68,62 +85,56 @@ at the bottom right or right side of the page.
 Bug Reporting, and Changelogs
 -----------------------------
 
-.. tabs-realm-sdks::
+You can report bugs or view the changelog in the relevant ``realm-SDK``
+repository in GitHub. While the SDK has been renamed to Atlas Device SDK, the
+GitHub repositories still reflect ``realm`` naming.
+
+.. tabs-drivers::
 
    .. tab::
-      :tabid: android
+      :tabid: cpp-sdk
 
-      For the Java SDK:
-
-      - :github:`Report a bug <realm/realm-java/issues/new?template=bug_report.md>`
-      - :github:`View the changelog <realm/realm-java/blob/master/CHANGELOG.md>`
+      - :github:`Report a bug <realm/realm-cpp/issues/new>`
+      - :github:`View the changelog <realm/realm-cpp/blob/master/CHANGELOG.md>`
 
    .. tab::
-      :tabid: ios
-
-      For the Swift SDK:
-
-      - :github:`Report a bug <realm/realm-swift/issues/new>`
-      - :github:`View the changelog <realm/realm-swift/blob/master/CHANGELOG.md>`
-
-   .. tab::
-      :tabid: dotnet
-
-      For the .NET SDK:
+      :tabid: csharp
 
       - :github:`Report a bug <realm/realm-dotnet/issues/new>`
       - :github:`View the changelog <realm/realm-dotnet/blob/master/CHANGELOG.md>`
-
+      
    .. tab::
-      :tabid: javascript
-
-      For the Node.js, React Native, or Web SDKs:
-
-      - :github:`Report a bug <realm/realm-js/issues/new>`
-      - :github:`View the changelog <realm/realm-js/blob/master/CHANGELOG.md>`
-
-   .. tab::
-      :tabid: flutter
-
-      For the Flutter SDK:
+      :tabid: dart
 
       - :github:`Report a bug <realm/realm-dart/issues/new>`
       - :github:`View the changelog <realm/realm-dart/blob/master/CHANGELOG.md>`
 
    .. tab::
-      :tabid: kotlin
+      :tabid: javascript
 
-      For the Kotlin SDK:
+      - :github:`Report a bug <realm/realm-js/issues/new>`
+      - :github:`View the changelog <realm/realm-js/blob/master/CHANGELOG.md>`
+
+   .. tab::
+      :tabid: kotlin
 
       - :github:`Report a bug <realm/realm-kotlin/issues/new>`
       - :github:`View the changelog <realm/realm-kotlin/blob/master/CHANGELOG.md>`
 
    .. tab::
-      :tabid: cpp
+      :tabid: objectivec
 
-      For the C++ SDK:
+      - :github:`Report a bug <realm/realm-swift/issues/new>`
+      - :github:`View the changelog <realm/realm-swift/blob/master/CHANGELOG.md>`
 
-      - :github:`Report a bug <realm/realm-cpp/issues/new>`
-      - :github:`View the changelog <realm/realm-cpp/blob/master/CHANGELOG.md>`
+   .. tab::
+      :tabid: swift
 
-   
+      - :github:`Report a bug <realm/realm-swift/issues/new>`
+      - :github:`View the changelog <realm/realm-swift/blob/master/CHANGELOG.md>`
+
+   .. tab::
+      :tabid: typescript
+
+      - :github:`Report a bug <realm/realm-js/issues/new>`
+      - :github:`View the changelog <realm/realm-js/blob/master/CHANGELOG.md>`

--- a/source/includes/sdk-examples/sync/manage-sync-sessions-check-network-connection.rst
+++ b/source/includes/sdk-examples/sync/manage-sync-sessions-check-network-connection.rst
@@ -1,7 +1,7 @@
 .. tabs-drivers::
 
    tabs:
-     - id: cpp
+     - id: cpp-sdk
        content: |
 
          .. literalinclude:: /examples/generated/cpp/sync-session.snippet.unregister-observation-token.cpp

--- a/source/includes/sdk-examples/sync/manage-sync-sessions-check-sync-state.rst
+++ b/source/includes/sdk-examples/sync/manage-sync-sessions-check-sync-state.rst
@@ -1,7 +1,7 @@
 .. tabs-drivers::
 
    tabs:
-     - id: cpp
+     - id: cpp-sdk
        content: |
 
          .. literalinclude:: /examples/generated/cpp/sync-session.snippet.sync-state.cpp

--- a/source/includes/sdk-examples/sync/manage-sync-sessions-check-upload-download-progress.rst
+++ b/source/includes/sdk-examples/sync/manage-sync-sessions-check-upload-download-progress.rst
@@ -1,7 +1,7 @@
 .. tabs-drivers::
 
    tabs:
-     - id: cpp
+     - id: cpp-sdk
        content: |
 
          .. literalinclude:: /examples/MissingPlaceholders/api.cpp

--- a/source/includes/sdk-examples/sync/manage-sync-sessions-get-sync-session.rst
+++ b/source/includes/sdk-examples/sync/manage-sync-sessions-get-sync-session.rst
@@ -1,7 +1,7 @@
 .. tabs-drivers::
 
    tabs:
-     - id: cpp
+     - id: cpp-sdk
        content: |
 
          .. literalinclude:: /examples/generated/cpp/sync-session.snippet.sync-session.cpp

--- a/source/includes/sdk-examples/sync/manage-sync-sessions-manually-reconnect-sync-sessions.rst
+++ b/source/includes/sdk-examples/sync/manage-sync-sessions-manually-reconnect-sync-sessions.rst
@@ -1,7 +1,7 @@
 .. tabs-drivers::
 
    tabs:
-     - id: cpp
+     - id: cpp-sdk
        content: |
 
          .. literalinclude:: /examples/generated/cpp/sync-session.snippet.reconnect.cpp

--- a/source/includes/sdk-examples/sync/manage-sync-sessions-pause-resume.rst
+++ b/source/includes/sdk-examples/sync/manage-sync-sessions-pause-resume.rst
@@ -1,7 +1,7 @@
 .. tabs-drivers::
 
    tabs:
-     - id: cpp
+     - id: cpp-sdk
        content: |
 
          .. literalinclude:: /examples/generated/cpp/sync-session.snippet.resume.cpp

--- a/source/includes/sdk-examples/sync/manage-sync-sessions-wait-for-changes-to-upload-or-download.rst
+++ b/source/includes/sdk-examples/sync/manage-sync-sessions-wait-for-changes-to-upload-or-download.rst
@@ -1,7 +1,7 @@
 .. tabs-drivers::
 
    tabs:
-     - id: cpp
+     - id: cpp-sdk
        content: |
 
          .. literalinclude:: /examples/generated/cpp/sync-session.snippet.wait-for-download.cpp


### PR DESCRIPTION
## Pull Request Info - SDK Docs Consolidation

Jira ticket: https://jira.mongodb.org/browse/DOCSP-42045

*Staged Page*

- [Manage Sync Sessions](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-42045/sdk/sync/manage-sync-sessions/): Page correctly changes code examples when you switch language tabs.
- [Help](https://preview-mongodbdacharyc.gatsbyjs.io/realm/DOCSP-42045/help/): The Help page was using realm-sdks tab set - I changed it to Drivers tab set so it would preserve the language selection when the user switched to the page. I also added a couple of notes related to naming because there are some naming things here that still reflect the old name, and we can't change them.

