### PR TITLE
(DOCSP-40103): Fix typo on Flutter: Configure & Open a Realm page

### DIFF
--- a/source/sdk/flutter/realm-database/configure-and-open.txt
+++ b/source/sdk/flutter/realm-database/configure-and-open.txt
@@ -105,7 +105,7 @@ Add Initial Data to Realm
 
 Use :flutter-sdk:`initialDataCallback() <realm/InitialDataCallback.html>` to invoke
 a callback function the first time that you open a realm.
-The function only executes the first time that the realm on the device.
+The function only executes the first time you open that realm on the device.
 The realm instance passed to the callback function already has a write transaction open,
 so you do not need to wrap write operations in a ``Realm.write()`` transaction block.
 ``initialDataCallback`` can be useful for adding initial data to your application


### PR DESCRIPTION
## Pull Request Info - SDK Docs Consolidation

Jira ticket: https://jira.mongodb.org/browse/DOCSP-40103

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-3366--docs-realm.netlify.app/sdk/flutter/realm-database/configure-and-open>sdk/flutter/realm-database/configure-and-open</a></li>
<!-- end insert-links -->

### Release Notes

- Flutter SDK
  - Realm Database/Configure & Open a Realm: Fix typo in "Add Initial Data to Realm" section. 
