### PR TITLE
DOP-5064: Redirect glossary to docs homepage

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -9,7 +9,7 @@ raw: ${prefix}/mongodb/link-a-cluster -> ${base}/mongodb/link-a-data-source/
 raw: ${prefix}/node/remotely-access-mongodb -> ${base}/node/mongodb/
 raw: ${prefix}/react-native/remotely-access-mongodb -> ${base}/react-native/mongodb/
 raw: ${prefix}/web/remotely-access-mongodb -> ${base}/web/mongodb/
-raw: ${prefix}/import-export/realm-cli-reference -> ${base}/deploy/realm-cli-reference /
+raw: ${prefix}/import-export/realm-cli-reference -> ${base}/deploy/realm-cli-reference/
 raw: ${prefix}/admin/users-and-groups -> ${base}/security/
 raw: ${prefix}/authentication/linking -> ${base}/authentication/
 raw: ${prefix}/getting-started/configure-rules-based-access-to-mongodb -> ${base}/mongodb/define-roles-and-permissions/
@@ -508,6 +508,9 @@ raw: ${prefix}/sdk/react-native/advanced/client-reset -> ${base}/sdk/react-nativ
 
 # "MongoDB Realm" -> "Atlas App Services" migration
 
+raw: ${prefix}/get-started/glossary -> https://www.mongodb.com/docs/
+raw: ${prefix}/glossary -> https://www.mongodb.com/docs/
+
 raw: ${prefix}/admin/api/v3 -> ${appServicesBase}/admin/api/v3/
 raw: ${prefix}/alerts -> ${appServicesBase}/alerts/
 raw: ${prefix}/authentication -> ${appServicesBase}/authentication/
@@ -745,7 +748,6 @@ raw: ${prefix}/values-and-secrets/define-and-manage-secrets -> ${appServicesBase
 raw: ${prefix}/values-and-secrets/define-environment-values -> ${appServicesBase}/values-and-secrets/define-environment-values/
 raw: ${prefix}/get-started/find-your-project-or-app-id -> ${appServicesBase}/reference/find-your-project-or-app-id/
 raw: ${prefix}/get-started/getting-help -> ${base}/help/
-raw: ${prefix}/get-started/glossary -> ${base}/glossary/
 raw: ${prefix}/get-started/introduction-backend -> ${appServicesBase}/introduction/
 raw: ${prefix}/get-started/introduction-mobile -> ${base}/introduction/
 raw: ${prefix}/get-started/introduction-web -> ${appServicesBase}/introduction/


### PR DESCRIPTION
## Pull Request Info

Jira ticket: https://jira.mongodb.org/browse/DOP-5064

### Notes

Redirect/Remove realm glossary and redirect to Docs Homepage.

Also, fixed an error in redirect file.