### PR TITLE
(DOCSP-48512): Add redirect from introduction to deprecation

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1317,3 +1317,6 @@ raw: ${deviceSDKsPrefix}/sdk/node/examples/define-a-realm-object-model/#index-a-
 raw: ${deviceSDKsPrefix}/sdk/react-native/examples/define-a-realm-object-model/#index-a-property -> ${deviceSDKsBase}/sdk/react-native/model-data/define-a-realm-object-model/#index-a-property
 raw: ${deviceSDKsPrefix}/sdk/java/examples/define-a-realm-object-model/#index-a-field -> ${deviceSDKsBase}/sdk/java/model-data/define-a-realm-object-model/#index-a-field
 
+# DOCSP-48512 - introduction is gone in the repo but still available via direct URL
+https://www.mongodb.com/docs/atlas/device-sdks/introduction/
+raw: ${deviceSDKsPrefix}/introduction -> ${deviceSDKsBase}/deprecation/


### PR DESCRIPTION
Jira ticket: https://jira.mongodb.org/browse/DOCSP-48512

The former `Introduction` page had some outdated messaging. It has been removed from the repo, but was still available when browsed to via URL. Adding a redirect to make sure the outdated messaging is not available and it points to the correct content.