### PR TITLE
Update "npm install realm" to use v12 explicitly

### DIFF
--- a/source/sdk/node/install.txt
+++ b/source/sdk/node/install.txt
@@ -69,7 +69,7 @@ Follow these steps to create a Node.js project and add the Node.js SDK to it.
 
       .. code-block:: bash
 
-         npm install realm
+         npm install realm@12
 
    .. step:: Enable TypeScript (optional)
 
@@ -125,7 +125,7 @@ running Raspberry Pi OS (formerly Raspbian), follow the steps below:
 
       .. code-block:: bash
 
-         npm install realm
+         npm install realm@12
 
    .. step:: Enable TypeScript (optional)
 

--- a/source/sdk/node/integrations/electron-cra.txt
+++ b/source/sdk/node/integrations/electron-cra.txt
@@ -240,7 +240,7 @@ To set up an Electron application using Realm use the following instructions:
 
       .. code-block:: shell
 
-         npm install realm
+         npm install realm@12
 
       Use realm in the **renderer process** by adding the following to the top
       of the ``src/App.js`` file (you will also need to import it in whichever

--- a/source/sdk/node/integrations/electron.txt
+++ b/source/sdk/node/integrations/electron.txt
@@ -164,7 +164,7 @@ Setup
       .. code-block:: shell
 
          npm install electron --save-dev
-         npm install realm --save
+         npm install realm@12 --save
 
 
    .. step:: Create a Script to Run Your Application

--- a/source/sdk/node/users/authenticate-users.txt
+++ b/source/sdk/node/users/authenticate-users.txt
@@ -219,7 +219,7 @@ to handle the user authentication and redirect flow from a Node.js client applic
    
    .. code-block::
 
-      npm install realm googleapis
+      npm install realm@12 googleapis
 
 #. Import the packages into your project.
 

--- a/source/sdk/react-native/install.txt
+++ b/source/sdk/react-native/install.txt
@@ -92,7 +92,7 @@ and add the React Native SDK to it.
 
             .. code-block:: bash
 
-               npm install realm
+               npm install realm@12
 
          .. step:: Enable Hermes
 
@@ -203,7 +203,7 @@ and add the React Native SDK to it.
 
             .. code-block:: bash
 
-               npm install realm
+               npm install realm@12
 
          .. step:: Link the SDK's Native Module
 


### PR DESCRIPTION
## Pull Request Info

The latest (non-sync) "community" edition of the Realm JS SDK was published on the "latest" channel to help migrate more off the sync-enabled v12. This means running `npm install realm` will download the community edition and not v12 as before.

With this PR I propose updating MongoDB related docs to explicitly install `realm@12` to avoid breaking existing content.
